### PR TITLE
Use "symfony/ux" tag

### DIFF
--- a/src/Chartjs/composer.json
+++ b/src/Chartjs/composer.json
@@ -3,6 +3,7 @@
     "type": "symfony-bundle",
     "description": "Chart.js integration for Symfony",
     "keywords": [
+        "symfony/ux",
         "symfony",
         "ux",
         "chart",

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -3,6 +3,7 @@
     "type": "symfony-bundle",
     "description": "Cropper.js integration for Symfony",
     "keywords": [
+        "symfony/ux",
         "symfony",
         "ux",
         "cropper",

--- a/src/Dropzone/composer.json
+++ b/src/Dropzone/composer.json
@@ -3,6 +3,7 @@
     "type": "symfony-bundle",
     "description": "File input dropzones for Symfony Forms",
     "keywords": [
+        "symfony/ux",
         "symfony",
         "ux",
         "dropzone"

--- a/src/LazyImage/composer.json
+++ b/src/LazyImage/composer.json
@@ -3,9 +3,11 @@
     "type": "symfony-bundle",
     "description": "Lazy image loader and utilities for Symfony",
     "keywords": [
+        "symfony/ux",
         "symfony",
         "ux",
-        "dropzone"
+        "lazy-image",
+        "image"
     ],
     "homepage": "https://symfony.com",
     "license": "MIT",

--- a/src/Swup/composer.json
+++ b/src/Swup/composer.json
@@ -3,6 +3,7 @@
     "type": "symfony-bundle",
     "description": "Swup integration for Symfony",
     "keywords": [
+        "symfony/ux",
         "symfony",
         "ux",
         "swup"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | -
| License       | MIT

As advised by @stof in https://github.com/symfony/ux/pull/23#discussion_r537572307, here's using a tag instead of a "provide" entry.

This should allow:
1. to have flex install packages as ux-components if-and-only-if they have the tag,
2. to help discover ux-related packages by linking to https://packagist.org/?tags=symfony/ux