### PR TITLE
Add Leaflet.js package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ build amazing User Experiences as quickly as we can now setup
     File input drag-and-drop zones for Symfony Forms
 -   [UX LazyImage](https://github.com/symfony/ux-lazy-image):
     Improve image loading performances through lazy-loading and data-uri thumbnails
+-   [UX Leaflet.js](https://github.com/symfony/ux-leafletjs):
+    [Leaflet](https://leafletjs.com/) map library integration for Symfony
 -   [UX Swup](https://github.com/symfony/ux-swup):
     [Swup](https://swup.js.org/) page transition library integration for Symfony
 

--- a/src/Leafletjs/.gitattributes
+++ b/src/Leafletjs/.gitattributes
@@ -1,0 +1,5 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore
+/assets/test export-ignore
+/tests export-ignore

--- a/src/Leafletjs/.gitignore
+++ b/src/Leafletjs/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+.phpunit.result.cache
+.php_cs.cache
+composer.lock

--- a/src/Leafletjs/Builder/LeafletBuilder.php
+++ b/src/Leafletjs/Builder/LeafletBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Builder;
+
+use Symfony\UX\Leafletjs\Model\Map;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @final
+ * @experimental
+ */
+class LeafletBuilder implements LeafletBuilderInterface
+{
+    public function createMap(float $lon, float $lat, int $zoom = 10): Map
+    {
+        return new Map($lon, $lat, $zoom);
+    }
+}

--- a/src/Leafletjs/Builder/LeafletBuilderInterface.php
+++ b/src/Leafletjs/Builder/LeafletBuilderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Builder;
+
+use Symfony\UX\Leafletjs\Model\Map;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @experimental
+ */
+interface LeafletBuilderInterface
+{
+    public function createMap(float $lon, float $lat, int $zoom = 10): Map;
+}

--- a/src/Leafletjs/DependencyInjection/LeafletjsExtension.php
+++ b/src/Leafletjs/DependencyInjection/LeafletjsExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\UX\Leafletjs\Builder\LeafletBuilder;
+use Symfony\UX\Leafletjs\Builder\LeafletBuilderInterface;
+use Symfony\UX\Leafletjs\Twig\LeafletExtension;
+use Twig\Environment;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @internal
+ */
+class LeafletjsExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $container
+            ->setDefinition('leafletjs.builder', new Definition(LeafletBuilder::class))
+            ->setPublic(false)
+        ;
+
+        $container
+            ->setAlias(LeafletBuilderInterface::class, 'leafletjs.builder')
+            ->setPublic(false)
+        ;
+
+        if (class_exists(Environment::class)) {
+            $container
+                ->setDefinition('leafletjs.twig_extension', new Definition(LeafletExtension::class))
+                ->addTag('twig.extension')
+                ->setPublic(false)
+            ;
+        }
+    }
+}

--- a/src/Leafletjs/LeafletjsBundle.php
+++ b/src/Leafletjs/LeafletjsBundle.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @final
+ * @experimental
+ */
+class LeafletjsBundle extends Bundle
+{
+}

--- a/src/Leafletjs/Model/Map.php
+++ b/src/Leafletjs/Model/Map.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Model;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @final
+ * @experimental
+ */
+class Map
+{
+    private $mapOptions = [];
+    private $attributes = [];
+    private $lon;
+    private $lat;
+    private $zoom;
+
+    public function __construct(float $lon, float $lat, int $zoom)
+    {
+        $this->lon = $lon;
+        $this->lat = $lat;
+        $this->zoom = $zoom;
+    }
+
+    public function setMapOptions(array $mapOptions): void
+    {
+        $this->mapOptions = $mapOptions;
+    }
+
+    public function setAttributes(array $attributes): void
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function getDataController(): ?string
+    {
+        return $this->attributes['data-controller'] ?? null;
+    }
+
+    public function getMapOptions(): array
+    {
+        return $this->mapOptions;
+    }
+
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    public function getLon(): float
+    {
+        return $this->lon;
+    }
+
+    public function getLat(): float
+    {
+        return $this->lat;
+    }
+
+    public function getZoom(): int
+    {
+        return $this->zoom;
+    }
+}

--- a/src/Leafletjs/README.md
+++ b/src/Leafletjs/README.md
@@ -1,0 +1,120 @@
+# Symfony UX Leaflet.js
+
+Symfony UX Leaflet.js is a Symfony bundle integrating the [Leaflet](https://leafletjs.com/)
+library in Symfony applications. It is part of [the Symfony UX initiative](https://symfony.com/ux).
+
+## Installation
+
+Symfony UX Leaflet requires PHP 7.2+ and Symfony 4.4+.
+
+Install this bundle using Composer and Symfony Flex:
+
+```sh
+composer require symfony/ux-leafletjs
+
+# Don't forget to install the JavaScript dependencies as well and compile
+yarn install --force
+yarn encore dev
+```
+
+## Usage
+
+To use Symfony UX Leaflet.js, inject the `LeafletBuilderInterface` service and
+create maps in PHP:
+
+```php
+// ...
+use Symfony\UX\Leafletjs\Builder\LeafletBuilderInterface;
+use Symfony\UX\Leafletjs\Model\Map;
+
+class HomeController extends AbstractController
+{
+    /**
+     * @Route("/", name="homepage")
+     */
+    public function index(LeafletBuilderInterface $mapBuilder): Response
+    {
+        $map = $mapBuilder->createMap(51.505, -0.09, 13);
+        $map->setMapOptions(['minZoom' => 1, 'maxZoom' => 8]);
+
+        return $this->render('home/index.html.twig', [
+            'map' => $map,
+        ]);
+    }
+}
+```
+
+Map options are provided as-is to Leaflet. You can read
+[Leaflet documentation](https://leafletjs.com/reference-1.7.1.html#map-factory) to discover them all.
+
+Once created in PHP, a map can be displayed using Twig:
+
+```twig
+{{ render_map(map) }}
+
+{# You can pass HTML attributes as a second argument to add them on the <div> tag #}
+{{ render_map(map, {'class': 'my-map'}) }}
+```
+
+### Extend the default behavior
+
+Symfony UX Leaflet.js allows you to extend its default behavior using a custom Stimulus controller:
+
+```js
+// mymap_controller.js
+
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+    connect() {
+        this.element.addEventListener('leafletjs:connect', this._onConnect);
+    }
+
+    disconnect() {
+        // You should always remove listeners when the controller is disconnected to avoid side effects
+        this.element.removeEventListener('leafletjs:connect', this._onConnect);
+    }
+
+    _onConnect(event) {
+        // The map was just created
+        console.log(event.detail.map); // You can access the map instance using the event details
+        console.log(event.detail.layer); // You can access the default layer instance using the event details
+
+        // For instance you can add additional markers to the map
+        new LLMarker([lat, lon]).addTo(event.detail.map);
+
+        // Changing the default URL for the default layer
+        event.detail.layer.setUrl('http://{s}.somedomain.com/blabla/{z}/{x}/{y}{r}.png');
+    }
+}
+```
+
+Then in your render call, add your controller as an HTML attribute:
+
+```twig
+{{ render_map(map, {'data-controller': 'mymap'}) }}
+```
+
+## Backward Compatibility promise
+
+This bundle aims at following the same Backward Compatibility promise as the Symfony framework:
+[https://symfony.com/doc/current/contributing/code/bc.html](https://symfony.com/doc/current/contributing/code/bc.html)
+
+However it is currently considered
+[**experimental**](https://symfony.com/doc/current/contributing/code/experimental.html),
+meaning it is not bound to Symfony's BC policy for the moment.
+
+## Run tests
+
+### PHP tests
+
+```sh
+php vendor/bin/phpunit
+```
+
+### JavaScript tests
+
+```sh
+cd Resources/assets
+yarn test
+```

--- a/src/Leafletjs/Resources/assets/.babelrc
+++ b/src/Leafletjs/Resources/assets/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["@babel/env"],
+    "plugins": ["@babel/plugin-proposal-class-properties"]
+}

--- a/src/Leafletjs/Resources/assets/dist/controller.js
+++ b/src/Leafletjs/Resources/assets/dist/controller.js
@@ -1,0 +1,119 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+'use strict';
+
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _stimulus = require("stimulus");
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var _default = /*#__PURE__*/function (_Controller) {
+  _inherits(_default, _Controller);
+
+  var _super = _createSuper(_default);
+
+  function _default() {
+    _classCallCheck(this, _default);
+
+    return _super.apply(this, arguments);
+  }
+
+  _createClass(_default, [{
+    key: "connect",
+    value: function connect() {
+      var _this = this;
+
+      Promise.resolve().then(function () {
+        return _interopRequireWildcard(require("leaflet"));
+      }).then(function (L) {
+        var mapOptions = _this._extractOptions('map-options');
+
+        _this.map = L.map(_this.placeholderTarget, mapOptions).setView(_this._coordinates(), _this.data.get('zoom'));
+        var layer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        });
+        layer.addTo(_this.map);
+        var map = _this.map;
+
+        _this._dispatchEvent('leafletjs:connect', {
+          map: map,
+          layer: layer
+        });
+      });
+    }
+  }, {
+    key: "disconnect",
+    value: function disconnect() {
+      this.map.off();
+      this.map.remove();
+    }
+  }, {
+    key: "_extractOptions",
+    value: function _extractOptions(dataName) {
+      var options = JSON.parse(this.data.get(dataName));
+
+      if (Array.isArray(options) && 0 === options.length) {
+        options = {};
+      }
+
+      return options;
+    }
+  }, {
+    key: "_coordinates",
+    value: function _coordinates() {
+      return [this.data.get("latitude"), this.data.get("longitude")];
+    }
+  }, {
+    key: "_dispatchEvent",
+    value: function _dispatchEvent(name) {
+      var payload = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+      var canBubble = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+      var cancelable = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+      var userEvent = document.createEvent('CustomEvent');
+      userEvent.initCustomEvent(name, canBubble, cancelable, payload);
+      this.element.dispatchEvent(userEvent);
+    }
+  }]);
+
+  return _default;
+}(_stimulus.Controller);
+
+exports["default"] = _default;
+
+_defineProperty(_default, "targets", ["placeholder"]);

--- a/src/Leafletjs/Resources/assets/package.json
+++ b/src/Leafletjs/Resources/assets/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@symfony/ux-leafletjs",
+    "description": "Leaflet integration for Symfony",
+    "license": "MIT",
+    "version": "1.1.0",
+    "symfony": {
+        "controllers": {
+            "map": {
+                "main": "dist/controller.js",
+                "webpackMode": "eager",
+                "enabled": true,
+                "autoimport": {
+                    "leaflet/dist/leaflet.css": true
+                }
+            }
+        }
+    },
+    "scripts": {
+        "build": "babel src -d dist",
+        "test": "babel src -d dist && jest",
+        "lint": "eslint src test"
+    },
+    "dependencies": {
+        "leaflet": "^1.7.1"
+    },
+    "peerDependencies": {
+        "stimulus": "^2.0.0"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.12.1",
+        "@babel/core": "^7.12.3",
+        "@babel/plugin-proposal-class-properties": "^7.12.1",
+        "@babel/preset-env": "^7.12.7",
+        "@symfony/stimulus-testing": "^1.1.0",
+        "jest-canvas-mock": "^2.3.0",
+        "stimulus": "^2.0.0"
+    },
+    "jest": {
+        "testRegex": "test/.*\\.test.js",
+        "setupFilesAfterEnv": [
+            "./test/setup.js"
+        ]
+    }
+}
+

--- a/src/Leafletjs/Resources/assets/src/controller.js
+++ b/src/Leafletjs/Resources/assets/src/controller.js
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+    static targets = ['placeholder'];
+
+    connect() {
+        import('leaflet').then((L) => {
+            let mapOptions = this._extractOptions('map-options');
+
+            this.map = L.map(this.placeholderTarget, mapOptions).setView(this._coordinates(), this.data.get('zoom'));
+
+            let layer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+            });
+
+            layer.addTo(this.map);
+
+            const map = this.map;
+            this._dispatchEvent('leafletjs:connect', { map: map, layer: layer });
+        });
+    }
+
+    disconnect() {
+        this.map.off();
+        this.map.remove();
+    }
+
+    _extractOptions(dataName) {
+        let options = JSON.parse(this.data.get(dataName));
+        if (Array.isArray(options) && 0 === options.length) {
+            options = {};
+        }
+        return options;
+    }
+
+    _coordinates() {
+        return [this.data.get('latitude'), this.data.get('longitude')];
+    }
+
+    _dispatchEvent(name, payload = null, canBubble = false, cancelable = false) {
+        const userEvent = document.createEvent('CustomEvent');
+        userEvent.initCustomEvent(name, canBubble, cancelable, payload);
+
+        this.element.dispatchEvent(userEvent);
+    }
+}

--- a/src/Leafletjs/Resources/assets/test/controller.test.js
+++ b/src/Leafletjs/Resources/assets/test/controller.test.js
@@ -1,0 +1,98 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Application, Controller } from 'stimulus';
+import { getByTestId, waitFor } from '@testing-library/dom';
+import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
+// import LeafletjsController from '../dist/controller';
+import LeafletjsController from '../src/controller';
+
+// Controller used to check the actual controller was properly booted
+class CheckController extends Controller {
+    connect() {
+        this.element.addEventListener('leafletjs:connect', (event) => {
+            this.element.classList.add('connected');
+            this.element.map = event.detail.map;
+            this.element.layer = event.detail.layer;
+        });
+    }
+}
+
+const startStimulus = () => {
+    const application = Application.start();
+    application.register('check', CheckController);
+    application.register('leafletjs', LeafletjsController);
+    return application;
+};
+
+describe('LeafletjsController', () => {
+    let container;
+
+    afterEach(() => {
+        clearDOM();
+    });
+
+    it('connect without options', async () => {
+        container = mountDOM(`
+            <div
+                data-testid="map"
+                data-controller="check leafletjs"
+                data-leafletjs-target="placeholder"
+                data-leafletjs-zoom="10"
+                data-leafletjs-latitude="51.505"
+                data-leafletjs-longitude="-0.09"
+            ></div>
+        `);
+
+        expect(getByTestId(container, 'map')).not.toHaveClass('connected');
+
+        let stimulus = startStimulus();
+        await waitFor(() => expect(getByTestId(container, 'map')).toHaveClass('connected'));
+
+        let byTestId = getByTestId(container, 'map');
+        expect(byTestId.layer).toBeDefined();
+        expect(byTestId.layer._url).toBe('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+
+        expect(byTestId.map).toBeDefined();
+        expect(byTestId.map._loaded).toBe(true);
+        expect(byTestId.map._zoom).toBe(10);
+        expect(byTestId.map._lastCenter.lat).toBe(51.505);
+        expect(byTestId.map._lastCenter.lng).toBe(-0.09);
+
+        stimulus.stop();
+    });
+
+    it('connect with options', async () => {
+        container = mountDOM(`
+            <div
+                data-testid="map"
+                data-controller="check leafletjs"
+                data-leafletjs-target="placeholder"
+                data-leafletjs-latitude="51.505"
+                data-leafletjs-longitude="-0.09"
+                data-leafletjs-zoom="10"
+                data-leafletjs-map-options="&#x7B;&quot;minZoom&quot;&#x3A;1,&quot;maxZoom&quot;&#x3A;5&#x7D;"
+            ></div>
+        `);
+
+        expect(getByTestId(container, 'map')).not.toHaveClass('connected');
+
+        let stimulus = startStimulus();
+        await waitFor(() => expect(getByTestId(container, 'map')).toHaveClass('connected'));
+
+        let byTestId = getByTestId(container, 'map');
+        expect(byTestId.map).toBeDefined();
+        expect(byTestId.map.options.minZoom).toBe(1);
+        expect(byTestId.map.options.maxZoom).toBe(5);
+
+        stimulus.stop();
+    });
+});

--- a/src/Leafletjs/Resources/assets/test/setup.js
+++ b/src/Leafletjs/Resources/assets/test/setup.js
@@ -1,0 +1,13 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import '@symfony/stimulus-testing/setup';
+import 'jest-canvas-mock';

--- a/src/Leafletjs/Tests/Kernel/AppKernelTrait.php
+++ b/src/Leafletjs/Tests/Kernel/AppKernelTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Tests\Kernel;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @internal
+ */
+trait AppKernelTrait
+{
+    public function getCacheDir()
+    {
+        return $this->createTmpDir('cache');
+    }
+
+    public function getLogDir()
+    {
+        return $this->createTmpDir('logs');
+    }
+
+    private function createTmpDir(string $type): string
+    {
+        $dir = sys_get_temp_dir().'/leafletjs_bundle/'.uniqid($type.'_', true);
+
+        if (!file_exists($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        return $dir;
+    }
+}

--- a/src/Leafletjs/Tests/Kernel/EmptyAppKernel.php
+++ b/src/Leafletjs/Tests/Kernel/EmptyAppKernel.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Tests\Kernel;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Leafletjs\LeafletjsBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @internal
+ */
+class EmptyAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles()
+    {
+        return [new LeafletjsBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+    }
+}

--- a/src/Leafletjs/Tests/Kernel/FrameworkAppKernel.php
+++ b/src/Leafletjs/Tests/Kernel/FrameworkAppKernel.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Leafletjs\LeafletjsBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @internal
+ */
+class FrameworkAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles()
+    {
+        return [new FrameworkBundle(), new LeafletjsBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true]);
+        });
+    }
+}

--- a/src/Leafletjs/Tests/Kernel/TwigAppKernel.php
+++ b/src/Leafletjs/Tests/Kernel/TwigAppKernel.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Leafletjs\LeafletjsBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @internal
+ */
+class TwigAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles()
+    {
+        return [new FrameworkBundle(), new TwigBundle(), new LeafletjsBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true]);
+            $container->loadFromExtension('twig', ['default_path' => __DIR__.'/templates', 'strict_variables' => true, 'exception_controller' => null]);
+
+            $container->setAlias('test.leafletjs.builder', 'leafletjs.builder')->setPublic(true);
+            $container->setAlias('test.leafletjs.twig_extension', 'leafletjs.twig_extension')->setPublic(true);
+        });
+    }
+}

--- a/src/Leafletjs/Tests/LeafletjsBundleTest.php
+++ b/src/Leafletjs/Tests/LeafletjsBundleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Leafletjs\Tests\Kernel\EmptyAppKernel;
+use Symfony\UX\Leafletjs\Tests\Kernel\FrameworkAppKernel;
+use Symfony\UX\Leafletjs\Tests\Kernel\TwigAppKernel;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @internal
+ */
+class LeafletjsBundleTest extends TestCase
+{
+    public function provideKernels()
+    {
+        yield 'empty' => [new EmptyAppKernel('test', true)];
+        yield 'framework' => [new FrameworkAppKernel('test', true)];
+        yield 'twig' => [new TwigAppKernel('test', true)];
+    }
+
+    /**
+     * @dataProvider provideKernels
+     */
+    public function testBootKernel(Kernel $kernel)
+    {
+        $kernel->boot();
+        $this->assertArrayHasKey('LeafletjsBundle', $kernel->getBundles());
+    }
+}

--- a/src/Leafletjs/Tests/Twig/LeafletExtensionTest.php
+++ b/src/Leafletjs/Tests/Twig/LeafletExtensionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Leafletjs\Builder\LeafletBuilderInterface;
+use Symfony\UX\Leafletjs\Tests\Kernel\TwigAppKernel;
+use Twig\Environment;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @internal
+ */
+class LeafletExtensionTest extends TestCase
+{
+    public function testRenderMap()
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var LeafletBuilderInterface $builder */
+        $builder = $container->get('test.leafletjs.builder');
+
+        $map = $builder->createMap(50, 0);
+        $map->setMapOptions(['minZoom' => 1, 'maxZoom' => 8]);
+
+        $rendered = $container->get('test.leafletjs.twig_extension')->renderMap(
+            $container->get(Environment::class),
+            $map,
+            ['data-controller' => 'mycontroller', 'class' => 'myclass']
+        );
+
+        $this->assertSame(
+            '<div
+                data-controller="mycontroller @symfony/ux-leafletjs/map"
+                data-leafletjs-target="placeholder"
+                data-leafletjs-longitude="50"
+                data-leafletjs-latitude="0"
+                data-leafletjs-zoom="10"
+                data-leafletjs-map-options="&#x7B;&quot;minZoom&quot;&#x3A;1,&quot;maxZoom&quot;&#x3A;8&#x7D;"
+        class="myclass"></div>',
+            $rendered
+        );
+    }
+}

--- a/src/Leafletjs/Twig/LeafletExtension.php
+++ b/src/Leafletjs/Twig/LeafletExtension.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Leafletjs\Twig;
+
+use Symfony\UX\Leafletjs\Model\Map;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Michael Cramer <michael@bigmichi1.de>
+ *
+ * @final
+ * @experimental
+ */
+class LeafletExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('render_map', [$this, 'renderMap'], ['needs_environment' => true, 'is_safe' => ['html']]),
+        ];
+    }
+
+    public function renderMap(Environment $env, Map $map, array $attributes = []): string
+    {
+        $map->setAttributes(array_merge($map->getAttributes(), $attributes));
+
+        $html = '
+            <div
+                data-controller="' . trim($map->getDataController() . ' @symfony/ux-leafletjs/map') . '"
+                data-leafletjs-target="placeholder"
+                data-leafletjs-longitude="'.$map->getLon().'"
+                data-leafletjs-latitude="'.$map->getLat().'"
+                data-leafletjs-zoom="'.$map->getZoom().'"
+                data-leafletjs-map-options="' . twig_escape_filter($env, json_encode($map->getMapOptions()), 'html_attr') . '"
+        ';
+
+        foreach ($map->getAttributes() as $name => $value) {
+            if ('data-controller' === $name) {
+                continue;
+            }
+
+            if (true === $value) {
+                $html .= $name . '="' . $name . '" ';
+            } elseif (false !== $value) {
+                $html .= $name . '="' . $value . '" ';
+            }
+        }
+
+        return trim($html) . '></div>';
+    }
+}

--- a/src/Leafletjs/Twig/LeafletExtension.php
+++ b/src/Leafletjs/Twig/LeafletExtension.php
@@ -38,12 +38,12 @@ class LeafletExtension extends AbstractExtension
 
         $html = '
             <div
-                data-controller="' . trim($map->getDataController() . ' @symfony/ux-leafletjs/map') . '"
+                data-controller="'.trim($map->getDataController().' @symfony/ux-leafletjs/map').'"
                 data-leafletjs-target="placeholder"
                 data-leafletjs-longitude="'.$map->getLon().'"
                 data-leafletjs-latitude="'.$map->getLat().'"
                 data-leafletjs-zoom="'.$map->getZoom().'"
-                data-leafletjs-map-options="' . twig_escape_filter($env, json_encode($map->getMapOptions()), 'html_attr') . '"
+                data-leafletjs-map-options="'.twig_escape_filter($env, json_encode($map->getMapOptions()), 'html_attr').'"
         ';
 
         foreach ($map->getAttributes() as $name => $value) {
@@ -52,12 +52,12 @@ class LeafletExtension extends AbstractExtension
             }
 
             if (true === $value) {
-                $html .= $name . '="' . $name . '" ';
+                $html .= $name.'="'.$name.'" ';
             } elseif (false !== $value) {
-                $html .= $name . '="' . $value . '" ';
+                $html .= $name.'="'.$value.'" ';
             }
         }
 
-        return trim($html) . '></div>';
+        return trim($html).'></div>';
     }
 }

--- a/src/Leafletjs/composer.json
+++ b/src/Leafletjs/composer.json
@@ -1,0 +1,54 @@
+{
+    "name": "symfony/ux-leafletjs",
+    "type": "symfony-bundle",
+    "description": "Leaflet integration for Symfony",
+    "keywords": [
+        "symfony-ux"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Michael Cramer",
+            "email": "michael@bigmichi1.de"
+        },
+        {
+            "name": "Titouan Galopin",
+            "email": "galopintitouan@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Symfony\\UX\\Leafletjs\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/config": "^4.4.17|^5.0",
+        "symfony/dependency-injection": "^4.4.17|^5.0",
+        "symfony/http-kernel": "^4.4.17|^5.0"
+    },
+    "require-dev": {
+        "symfony/framework-bundle": "^4.4.17|^5.0",
+        "symfony/phpunit-bridge": "^5.2",
+        "symfony/twig-bundle": "^4.4.17|^5.0",
+        "symfony/var-dumper": "^4.4.17|^5.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.1-dev"
+        },
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Leafletjs/phpunit.xml.dist
+++ b/src/Leafletjs/phpunit.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true">
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <ini name="intl.default_locale" value="en" />
+        <ini name="intl.error_level" value="0" />
+        <ini name="memory_limit" value="-1" />
+        <env name="SHELL_VERBOSITY" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./Resources</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #38 
| License       | MIT

This is a basic implementation for rendering a map with Leaflet, which allows further customization in a custom user controller.

This implementation adds a new Map with one Layer based on OpenStreetMap and displays the provided coordinates from PHP. 