### PR TITLE
Implement normalized controller names

### DIFF
--- a/src/Chartjs/Tests/Twig/ChartExtensionTest.php
+++ b/src/Chartjs/Tests/Twig/ChartExtensionTest.php
@@ -59,7 +59,7 @@ class ChartExtensionTest extends TestCase
 
         $this->assertSame(
             '<canvas
-                data-controller="mycontroller @symfony/ux-chartjs/chart"
+                data-controller="mycontroller symfony--ux-chartjs--chart"
                 data-view="&#x7B;&quot;type&quot;&#x3A;&quot;line&quot;,&quot;data&quot;&#x3A;&#x7B;&quot;labels&quot;&#x3A;&#x5B;&quot;January&quot;,&quot;February&quot;,&quot;March&quot;,&quot;April&quot;,&quot;May&quot;,&quot;June&quot;,&quot;July&quot;&#x5D;,&quot;datasets&quot;&#x3A;&#x5B;&#x7B;&quot;label&quot;&#x3A;&quot;My&#x20;First&#x20;dataset&quot;,&quot;backgroundColor&quot;&#x3A;&quot;rgb&#x28;255,&#x20;99,&#x20;132&#x29;&quot;,&quot;borderColor&quot;&#x3A;&quot;rgb&#x28;255,&#x20;99,&#x20;132&#x29;&quot;,&quot;data&quot;&#x3A;&#x5B;0,10,5,2,20,30,45&#x5D;&#x7D;&#x5D;&#x7D;,&quot;options&quot;&#x3A;&#x7B;&quot;showLines&quot;&#x3A;false&#x7D;&#x7D;"
         class="myclass"></canvas>',
             $rendered

--- a/src/Chartjs/Twig/ChartExtension.php
+++ b/src/Chartjs/Twig/ChartExtension.php
@@ -37,7 +37,7 @@ class ChartExtension extends AbstractExtension
 
         $html = '
             <canvas
-                data-controller="'.trim($chart->getDataController().' @symfony/ux-chartjs/chart').'"
+                data-controller="'.trim($chart->getDataController().' symfony--ux-chartjs--chart').'"
                 data-view="'.twig_escape_filter($env, json_encode($chart->createView()), 'html_attr').'"
         ';
 

--- a/src/Cropperjs/Form/CropperType.php
+++ b/src/Cropperjs/Form/CropperType.php
@@ -33,7 +33,7 @@ class CropperType extends AbstractType
             ->add('options', HiddenType::class, [
                 'error_bubbling' => true,
                 'attr' => [
-                    'data-controller' => trim(($options['attr']['data-controller'] ?? '').' @symfony/ux-cropperjs/cropper'),
+                    'data-controller' => trim(($options['attr']['data-controller'] ?? '').' symfony--ux-cropperjs--cropper'),
                     'data-public-url' => $options['public_url'],
                     'data-view-mode' => $options['view_mode'],
                     'data-drag-mode' => $options['drag_mode'],

--- a/src/Cropperjs/Resources/assets/dist/controller.js
+++ b/src/Cropperjs/Resources/assets/dist/controller.js
@@ -8,6 +8,8 @@
  */
 'use strict';
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
@@ -18,8 +20,6 @@ var _stimulus = require("stimulus");
 var _cropperjs = _interopRequireDefault(require("cropperjs"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/src/Cropperjs/Tests/Form/CropperTypeTest.php
+++ b/src/Cropperjs/Tests/Form/CropperTypeTest.php
@@ -77,7 +77,7 @@ class CropperTypeTest extends TestCase
                     '<div>'.
                         '<div id="form_photo" class="cropperjs">'.
                             '<input type="hidden" id="form_photo_options" name="form[photo][options]" '.
-                                'data-controller="mycropper @symfony/ux-cropperjs/cropper" '.
+                                'data-controller="mycropper symfony--ux-cropperjs--cropper" '.
                                 'data-public-url="/public/url.jpg" '.
                                 'data-view-mode="1" '.
                                 'data-drag-mode="move" '.
@@ -141,7 +141,7 @@ class CropperTypeTest extends TestCase
                     '<div>'.
                         '<div id="form_photo" class="cropperjs">'.
                             '<input type="hidden" id="form_photo_options" name="form[photo][options]" '.
-                                'data-controller="mycropper @symfony/ux-cropperjs/cropper" '.
+                                'data-controller="mycropper symfony--ux-cropperjs--cropper" '.
                                 'data-public-url="/public/url.jpg" '.
                                 'data-view-mode="0" '.
                                 'data-drag-mode="crop"   '.

--- a/src/Dropzone/Resources/views/form_theme.html.twig
+++ b/src/Dropzone/Resources/views/form_theme.html.twig
@@ -1,24 +1,24 @@
 {% block dropzone_widget -%}
-    {%- set dataController = (attr['data-controller']|default('') ~ ' @symfony/ux-dropzone/dropzone')|trim -%}
+    {%- set dataController = (attr['data-controller']|default('') ~ ' symfony--ux-dropzone--dropzone')|trim -%}
     {%- set attr = attr|merge({ 'data-controller': '', class: (attr.class|default('') ~ ' dropzone-input')|trim}) -%}
 
     <div class="dropzone-container" data-controller="{{ dataController }}">
-        <input type="file" {{ block('widget_attributes') }} data-target="@symfony/ux-dropzone/dropzone.input" />
+        <input type="file" {{ block('widget_attributes') }} data-symfony--ux-dropzone--dropzone-target="input" />
 
-        <div class="dropzone-placeholder" data-target="@symfony/ux-dropzone/dropzone.placeholder">
+        <div class="dropzone-placeholder" data-symfony--ux-dropzone--dropzone-target="placeholder">
             {%- if attr.placeholder is defined and attr.placeholder is not none -%}
                 {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
             {%- endif -%}
         </div>
 
-        <div class="dropzone-preview" data-target="@symfony/ux-dropzone/dropzone.preview" style="display: none">
+        <div class="dropzone-preview" data-symfony--ux-dropzone--dropzone-target="preview" style="display: none">
             <button class="dropzone-preview-button" type="button"
-                    data-target="@symfony/ux-dropzone/dropzone.previewClearButton"></button>
+                    data-symfony--ux-dropzone--dropzone-target="previewClearButton"></button>
 
             <div class="dropzone-preview-image" style="display: none"
-                 data-target="@symfony/ux-dropzone/dropzone.previewImage"></div>
+                 data-symfony--ux-dropzone--dropzone-target="previewImage"></div>
 
-            <div data-target="@symfony/ux-dropzone/dropzone.previewFilename" class="dropzone-preview-filename"></div>
+            <div data-symfony--ux-dropzone--dropzone-target="previewFilename" class="dropzone-preview-filename"></div>
         </div>
     </div>
 {%- endblock %}

--- a/src/Dropzone/Tests/Form/DropzoneTypeTest.php
+++ b/src/Dropzone/Tests/Form/DropzoneTypeTest.php
@@ -38,19 +38,19 @@ class DropzoneTypeTest extends TestCase
         $rendered = $container->get(Environment::class)->render('dropzone_form.html.twig', ['form' => $form->createView()]);
 
         $this->assertSame(
-            '<form name="form" method="post" enctype="multipart/form-data"><div id="form"><div><label for="form_photo" class="required">Photo</label><div class="dropzone-container" data-controller="mydropzone @symfony/ux-dropzone/dropzone">
-        <input type="file" id="form_photo" name="form[photo]" required="required" data-controller="" class="dropzone-input" data-target="@symfony/ux-dropzone/dropzone.input" />
+            '<form name="form" method="post" enctype="multipart/form-data"><div id="form"><div><label for="form_photo" class="required">Photo</label><div class="dropzone-container" data-controller="mydropzone symfony--ux-dropzone--dropzone">
+        <input type="file" id="form_photo" name="form[photo]" required="required" data-controller="" class="dropzone-input" data-symfony--ux-dropzone--dropzone-target="input" />
 
-        <div class="dropzone-placeholder" data-target="@symfony/ux-dropzone/dropzone.placeholder"></div>
+        <div class="dropzone-placeholder" data-symfony--ux-dropzone--dropzone-target="placeholder"></div>
 
-        <div class="dropzone-preview" data-target="@symfony/ux-dropzone/dropzone.preview" style="display: none">
+        <div class="dropzone-preview" data-symfony--ux-dropzone--dropzone-target="preview" style="display: none">
             <button class="dropzone-preview-button" type="button"
-                    data-target="@symfony/ux-dropzone/dropzone.previewClearButton"></button>
+                    data-symfony--ux-dropzone--dropzone-target="previewClearButton"></button>
 
             <div class="dropzone-preview-image" style="display: none"
-                 data-target="@symfony/ux-dropzone/dropzone.previewImage"></div>
+                 data-symfony--ux-dropzone--dropzone-target="previewImage"></div>
 
-            <div data-target="@symfony/ux-dropzone/dropzone.previewFilename" class="dropzone-preview-filename"></div>
+            <div data-symfony--ux-dropzone--dropzone-target="previewFilename" class="dropzone-preview-filename"></div>
         </div>
     </div></div></div></form>
 ',

--- a/src/LazyImage/README.md
+++ b/src/LazyImage/README.md
@@ -31,7 +31,7 @@ page has been rendered:
 ```twig
 <img
     src="{{ asset('image/small.png') }}"
-    data-controller="@symfony/ux-lazy-image/lazy-image"
+    data-controller="symfony--ux-lazy-image--lazy-image"
     data-hd-src="{{ asset('image/large.png') }}"
 
     {# Optional but avoids having a page jump when the image is loaded #}
@@ -46,7 +46,7 @@ the BlurHash algorithm to create a light, blurred, data-uri thumbnail of the ima
 ```twig
 <img
     src="{{ data_uri_thumbnail('public/image/large.png', 100, 75) }}"
-    data-controller="@symfony/ux-lazy-image/lazy-image"
+    data-controller="symfony--ux-lazy-image--lazy-image"
     data-hd-src="{{ asset('image/large.png') }}"
 
     {# Using BlurHash, the size is required #}
@@ -101,7 +101,7 @@ Then in your template, add your controller to the HTML attribute:
 ```twig
 <img
     src="{{ data_uri_thumbnail('public/image/large.png', 100, 75) }}"
-    data-controller="mylazyimage @symfony/ux-lazy-image/lazy-image"
+    data-controller="mylazyimage symfony--ux-lazy-image--lazy-image"
     data-hd-src="{{ asset('image/large.png') }}"
 
     {# Using BlurHash, the size is required #}

--- a/src/LazyImage/Resources/assets/dist/controller.js
+++ b/src/LazyImage/Resources/assets/dist/controller.js
@@ -8,14 +8,14 @@
  */
 'use strict';
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
 
 var _stimulus = require("stimulus");
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 

--- a/src/Swup/README.md
+++ b/src/Swup/README.md
@@ -36,7 +36,7 @@ The main usage of Symfony UX Swup is to use its Stimulus controller to initializ
     <head>
         <title>Swup</title>
     </head>
-    <body data-controller="@symfony/ux-swup/swup">
+    <body data-controller="symfony--ux-swup--swup">
         {# ... #}
 
         <main id="swup">
@@ -62,7 +62,7 @@ additional containers, for instance to have a navigation menu that updates when 
         <title>Swup</title>
     </head>
     <body
-        data-controller="@symfony/ux-swup/swup"
+        data-controller="symfony--ux-swup--swup"
         data-containers="#swup #nav" {# list of selectors separated by spaces #}
     >
         {# ... #}
@@ -90,7 +90,7 @@ You can configure several other options using data-attributes on the `body` tag:
         <title>Swup</title>
     </head>
     <body
-        data-controller="@symfony/ux-swup/swup"
+        data-controller="symfony--ux-swup--swup"
         data-containers="#swup #nav"
         data-theme="slide" {# or "fade", the default #}
         data-debug="data-debug" {# add this attribute to enable debug #}
@@ -136,7 +136,7 @@ Then in your template, add your controller to the HTML attribute:
     <head>
         <title>Swup</title>
     </head>
-    <body data-controller="myswup @symfony/ux-swup/swup">
+    <body data-controller="myswup symfony--ux-swup--swup">
         {# ... #}
     </body>
 </html>

--- a/src/Swup/Resources/assets/dist/controller.js
+++ b/src/Swup/Resources/assets/dist/controller.js
@@ -8,6 +8,8 @@
  */
 'use strict';
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
@@ -26,8 +28,6 @@ var _fadeTheme = _interopRequireDefault(require("@swup/fade-theme"));
 var _slideTheme = _interopRequireDefault(require("@swup/slide-theme"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -67,7 +67,7 @@ var _default = /*#__PURE__*/function (_Controller) {
         containers: ['#swup'],
         cache: this.element.hasAttribute('data-cache'),
         animateHistoryBrowsing: this.element.hasAttribute('data-animate-history-browsing'),
-        plugins: ['slide' === this.element.hasAttribute('data-theme') ? new _slideTheme["default"]() : new _fadeTheme["default"](), new _formsPlugin["default"]()]
+        plugins: ['slide' === this.element.getAttribute('data-theme') ? new _slideTheme["default"]() : new _fadeTheme["default"](), new _formsPlugin["default"]()]
       };
 
       if (this.element.getAttribute('data-containers')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix https://github.com/symfony/ux/issues/33
| License       | MIT

Following https://github.com/symfony/stimulus-bridge/pull/12, implement controller names normalizing.

This will be a BC break for lazy-image and Swup users but it only requires a small change and is necessary for the development of additional UX packages based on Stimulus 2.
