### PR TITLE
[Chart.js] Add "pre-connect" event

### DIFF
--- a/src/Chartjs/README.md
+++ b/src/Chartjs/README.md
@@ -79,12 +79,32 @@ import { Controller } from 'stimulus';
 
 export default class extends Controller {
     connect() {
+        this.element.addEventListener('chartjs:pre-connect', this._onPreConnect);
         this.element.addEventListener('chartjs:connect', this._onConnect);
     }
 
     disconnect() {
         // You should always remove listeners when the controller is disconnected to avoid side effects
+        this.element.removeEventListener('chartjs:pre-connect', this._onPreConnect);
         this.element.removeEventListener('chartjs:connect', this._onConnect);
+    }
+
+    _onPreConnect(event) {
+        // The chart is not yet created
+        console.log(event.detail.options); // You can access the chart options using the event details
+
+        // For instance you can format Y axis
+        event.detail.options.scales = {
+            yAxes: [
+                {
+                    ticks: {
+                        callback: function (value, index, values) {
+                            /* ... */
+                        },
+                    },
+                },
+            ],
+        };
     }
 
     _onConnect(event) {

--- a/src/Chartjs/Resources/assets/dist/controller.js
+++ b/src/Chartjs/Resources/assets/dist/controller.js
@@ -59,6 +59,10 @@ var _default = /*#__PURE__*/function (_Controller) {
         payload.options = {};
       }
 
+      this._dispatchEvent('chartjs:pre-connect', {
+        options: payload.options
+      });
+
       var chart = new _chart.Chart(this.element.getContext('2d'), payload);
 
       this._dispatchEvent('chartjs:connect', {

--- a/src/Chartjs/Resources/assets/src/controller.js
+++ b/src/Chartjs/Resources/assets/src/controller.js
@@ -19,6 +19,8 @@ export default class extends Controller {
             payload.options = {};
         }
 
+        this._dispatchEvent('chartjs:pre-connect', { options: payload.options });
+
         const chart = new Chart(this.element.getContext('2d'), payload);
 
         this._dispatchEvent('chartjs:connect', { chart });

--- a/src/Chartjs/Resources/assets/test/controller.test.js
+++ b/src/Chartjs/Resources/assets/test/controller.test.js
@@ -17,6 +17,10 @@ import ChartjsController from '../dist/controller';
 // Controller used to check the actual controller was properly booted
 class CheckController extends Controller {
     connect() {
+        this.element.addEventListener('chartjs:pre-connect', () => {
+            this.element.classList.add('pre-connected');
+        });
+
         this.element.addEventListener('chartjs:connect', (event) => {
             this.element.classList.add('connected');
             this.element.chart = event.detail.chart;
@@ -46,10 +50,14 @@ describe('ChartjsController', () => {
             ></canvas>
         `);
 
+        expect(getByTestId(container, 'canvas')).not.toHaveClass('pre-connected');
         expect(getByTestId(container, 'canvas')).not.toHaveClass('connected');
 
         startStimulus();
-        await waitFor(() => expect(getByTestId(container, 'canvas')).toHaveClass('connected'));
+        await waitFor(() => {
+            expect(getByTestId(container, 'canvas')).toHaveClass('pre-connected');
+            expect(getByTestId(container, 'canvas')).toHaveClass('connected');
+        });
 
         const chart = getByTestId(container, 'canvas').chart;
         expect(chart.options.showLines).toBe(true);
@@ -64,10 +72,14 @@ describe('ChartjsController', () => {
             ></canvas>
         `);
 
+        expect(getByTestId(container, 'canvas')).not.toHaveClass('pre-connected');
         expect(getByTestId(container, 'canvas')).not.toHaveClass('connected');
 
         startStimulus();
-        await waitFor(() => expect(getByTestId(container, 'canvas')).toHaveClass('connected'));
+        await waitFor(() => {
+            expect(getByTestId(container, 'canvas')).toHaveClass('pre-connected');
+            expect(getByTestId(container, 'canvas')).toHaveClass('connected');
+        });
 
         const chart = getByTestId(container, 'canvas').chart;
         expect(chart.options.showLines).toBe(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Tickets       |
| License       | MIT


Added event pre-connect to chartjs. 
Will be useful when the options are [Scriptable](https://www.chartjs.org/docs/latest/general/options.html#scriptable-options) and must be passed before creating an object `chart`


