### PR TITLE
Changing webpackMode to fetch - see symfony/stimulus-bridge#15

### DIFF
--- a/src/Chartjs/Resources/assets/package.json
+++ b/src/Chartjs/Resources/assets/package.json
@@ -8,6 +8,7 @@
             "chart": {
                 "main": "dist/controller.js",
                 "webpackMode": "eager",
+                "fetch": "eager",
                 "enabled": true
             }
         }

--- a/src/Cropperjs/Resources/assets/package.json
+++ b/src/Cropperjs/Resources/assets/package.json
@@ -8,6 +8,7 @@
             "cropper": {
                 "main": "dist/controller.js",
                 "webpackMode": "eager",
+                "fetch": "eager",
                 "enabled": true,
                 "autoimport": {
                     "cropperjs/dist/cropper.min.css": true,

--- a/src/Dropzone/Resources/assets/package.json
+++ b/src/Dropzone/Resources/assets/package.json
@@ -8,6 +8,7 @@
             "dropzone": {
                 "main": "dist/controller.js",
                 "webpackMode": "eager",
+                "fetch": "eager",
                 "enabled": true,
                 "autoimport": {
                     "@symfony/ux-dropzone/src/style.css": true

--- a/src/LazyImage/Resources/assets/package.json
+++ b/src/LazyImage/Resources/assets/package.json
@@ -8,6 +8,7 @@
             "lazy-image": {
                 "main": "dist/controller.js",
                 "webpackMode": "eager",
+                "fetch": "eager",
                 "enabled": true
             }
         }

--- a/src/Swup/Resources/assets/package.json
+++ b/src/Swup/Resources/assets/package.json
@@ -8,6 +8,7 @@
             "swup": {
                 "main": "dist/controller.js",
                 "webpackMode": "eager",
+                "fetch": "eager",
                 "enabled": true
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes(ish)
| New feature?  | no
| Tickets       | none
| License       | MIT

Hi!

If https://github.com/symfony/stimulus-bridge/pull/15 is merged, this updates the keys for all the UX packages.

The old `webpackMode` is kept for now. This will prevent errors if you're using an "old" Flex version (a version before this PR https://github.com/symfony/flex/pull/735). We can remove that... eventually...

Cheers!