### PR TITLE
Introduce Symfony UX Turbo

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,31 +72,26 @@ jobs:
             - name: Chartjs
               run: |
                   cd src/Chartjs
-                  composer config platform.php 7.4.99
                   composer update --prefer-dist --no-interaction --no-ansi --no-progress
                   php vendor/bin/simple-phpunit
             - name: Cropperjs
               run: |
                   cd src/Cropperjs
-                  composer config platform.php 7.4.99
                   composer update --prefer-dist --no-interaction --no-ansi --no-progress
                   php vendor/bin/simple-phpunit
             - name: Dropzone
               run: |
                   cd src/Dropzone
-                  composer config platform.php 7.4.99
                   composer update --prefer-dist --no-interaction --no-ansi --no-progress
                   php vendor/bin/simple-phpunit
             - name: LazyImage
               run: |
                   cd src/LazyImage
-                  composer config platform.php 7.4.99
                   composer update --prefer-dist --no-interaction --no-ansi --no-progress
                   php vendor/bin/simple-phpunit
             - name: Turbo
               run: |
                   cd src/Turbo
-                  composer config platform.php 7.4.99
                   composer update --prefer-dist --no-interaction --no-ansi --no-progress
                   php vendor/bin/simple-phpunit
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '7.2'
+                  extensions: gd
             - name: Chartjs
               run: |
                   cd src/Chartjs
@@ -52,6 +53,11 @@ jobs:
             - name: LazyImage
               run: |
                   cd src/LazyImage
+                  composer update --prefer-lowest --prefer-dist --no-interaction --no-ansi --no-progress
+                  php vendor/bin/simple-phpunit
+            - name: Turbo
+              run: |
+                  cd src/Turbo
                   composer update --prefer-lowest --prefer-dist --no-interaction --no-ansi --no-progress
                   php vendor/bin/simple-phpunit
 
@@ -62,6 +68,7 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.0'
+                  extensions: gd
             - name: Chartjs
               run: |
                   cd src/Chartjs
@@ -83,6 +90,12 @@ jobs:
             - name: LazyImage
               run: |
                   cd src/LazyImage
+                  composer config platform.php 7.4.99
+                  composer update --prefer-dist --no-interaction --no-ansi --no-progress
+                  php vendor/bin/simple-phpunit
+            - name: Turbo
+              run: |
+                  cd src/Turbo
                   composer config platform.php 7.4.99
                   composer update --prefer-dist --no-interaction --no-ansi --no-progress
                   php vendor/bin/simple-phpunit

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ integrating it into Webpack Encore.
     Improve image loading performances through lazy-loading and data-uri thumbnails
 -   [UX Swup](https://github.com/symfony/ux-swup):
     [Swup](https://swup.js.org/) page transition library integration for Symfony
+-   [UX Turbo](https://github.com/symfony/ux-turbo):
+    [Turbo](https://turbo.hotwire.dev) interactive and real-time UI library integration for Symfony
 
 ## Stimulus Tools around the World
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "overrides": [
             {
                 "files": [
-                    "src/*/Resources/assets/test/*.js"
+                    "src/*/Resources/assets/test/**/*.js"
                 ],
                 "extends": [
                     "plugin:jest/recommended"

--- a/src/Turbo/.gitattributes
+++ b/src/Turbo/.gitattributes
@@ -1,0 +1,5 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore
+/assets/test export-ignore
+/tests export-ignore

--- a/src/Turbo/.gitignore
+++ b/src/Turbo/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+.phpunit.result.cache
+.php_cs.cache
+composer.lock

--- a/src/Turbo/DependencyInjection/Configuration.php
+++ b/src/Turbo/DependencyInjection/Configuration.php
@@ -39,6 +39,7 @@ class Configuration implements ConfigurationInterface
                             ->info('Key/value options passed to the adapter to create Turbo Streams')
                             ->normalizeKeys(false)
                             ->variablePrototype()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Turbo/DependencyInjection/Configuration.php
+++ b/src/Turbo/DependencyInjection/Configuration.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('turbo');
+        $rootNode = $treeBuilder->getRootNode();
+
+        $rootNode
+            ->children()
+                ->arrayNode('streams')
+                    ->info('Enable this section to use Turbo Streams')
+                    ->children()
+                        ->scalarNode('adapter')
+                            ->defaultNull()
+                            ->info('The service to use to create Turbo Streams')
+                        ->end()
+                        ->arrayNode('options')
+                            ->info('Key/value options passed to the adapter to create Turbo Streams')
+                            ->normalizeKeys(false)
+                            ->variablePrototype()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/Turbo/DependencyInjection/TurboExtension.php
+++ b/src/Turbo/DependencyInjection/TurboExtension.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\UX\Turbo\Streams\MercureStreamAdapter;
+use Symfony\UX\Turbo\Twig\FrameTwigExtension;
+use Symfony\UX\Turbo\Twig\StreamTwigExtension;
+use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
+use Twig\Environment;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class TurboExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        // Register Turbo Streams config
+        if (!empty($config['streams']['adapter'])) {
+            $this->registerStreamsConfig($config, $container);
+        }
+
+        // Add Twig extension
+        if (class_exists(Environment::class)) {
+            $container
+                ->setDefinition('turbo.twig.frame_extension', new Definition(FrameTwigExtension::class))
+                ->addTag('twig.extension')
+                ->setPublic(false)
+            ;
+
+            if (!empty($config['streams']['adapter']) && class_exists(StimulusTwigExtension::class)) {
+                $container
+                    ->setDefinition('turbo.twig.stream_extension', new Definition(StreamTwigExtension::class))
+                    ->addArgument(new Reference('webpack_encore.twig_stimulus_extension'))
+                    ->addArgument(new Reference('turbo.streams.adapter'))
+                    ->addArgument($config['streams']['options'] ?? [])
+                    ->addTag('twig.extension')
+                    ->setPublic(false)
+                ;
+            }
+        }
+    }
+
+    private function registerStreamsConfig(array $config, ContainerBuilder $container)
+    {
+        // Register native stream adapters
+        $container->setDefinition('turbo.streams.adapter.mercure', new Definition(MercureStreamAdapter::class))
+            ->setPublic(false);
+
+        // Wire configured adapter
+        $container->setAlias('turbo.streams.adapter', $config['streams']['adapter'])->setPublic(false);
+    }
+}

--- a/src/Turbo/DependencyInjection/TurboExtension.php
+++ b/src/Turbo/DependencyInjection/TurboExtension.php
@@ -16,8 +16,8 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\UX\Turbo\Streams\MercureStreamAdapter;
-use Symfony\UX\Turbo\Twig\FrameTwigExtension;
-use Symfony\UX\Turbo\Twig\StreamTwigExtension;
+use Symfony\UX\Turbo\Twig\TurboFrameExtension;
+use Symfony\UX\Turbo\Twig\TurboStreamExtension;
 use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
 use Twig\Environment;
 
@@ -41,14 +41,14 @@ class TurboExtension extends Extension
         // Add Twig extension
         if (class_exists(Environment::class)) {
             $container
-                ->setDefinition('turbo.twig.frame_extension', new Definition(FrameTwigExtension::class))
+                ->setDefinition('turbo.twig.frame_extension', new Definition(TurboFrameExtension::class))
                 ->addTag('twig.extension')
                 ->setPublic(false)
             ;
 
             if (!empty($config['streams']['adapter']) && class_exists(StimulusTwigExtension::class)) {
                 $container
-                    ->setDefinition('turbo.twig.stream_extension', new Definition(StreamTwigExtension::class))
+                    ->setDefinition('turbo.twig.stream_extension', new Definition(TurboStreamExtension::class))
                     ->addArgument(new Reference('webpack_encore.twig_stimulus_extension'))
                     ->addArgument(new Reference('turbo.streams.adapter'))
                     ->addArgument($config['streams']['options'] ?? [])

--- a/src/Turbo/LICENSE
+++ b/src/Turbo/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020-2021 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Turbo/README.md
+++ b/src/Turbo/README.md
@@ -1,0 +1,267 @@
+# Symfony UX Turbo
+
+Symfony UX Turbo is a Symfony bundle integrating the [Turbo](https://turbo.hotwire.dev)
+library in Symfony applications. It is part of [the Symfony UX initiative](https://symfony.com/ux).
+
+## Installation
+
+Symfony UX Turbo requires PHP 7.2+ and Symfony 4.4+.
+
+Install this bundle using Composer and Symfony Flex:
+
+```sh
+composer require symfony/ux-turbo
+
+# Don't forget to install the JavaScript dependencies as well and compile
+yarn install --force
+yarn encore dev
+```
+
+## Usage
+
+Turbo is a library that provides several key features which help building interactive
+applications with the least amount of JavaScript possible.
+
+The way Turbo works is by relying as much as possible on HTML and the backend server.
+It provides 3 features to achieve this:
+
+### 1. Navigate with Turbo Drive
+
+[Turbo Drive](https://turbo.hotwire.dev/handbook/drive) creates a "single-page app" feel
+for traditional server-side applications. It transforms links clicks and forms submissions
+in AJAX calls in order to re-render the page without any page load. It's an evolution of
+the legacy Turbolinks library.
+
+When using Symfony UX Turbo, Turbo Drive is enabled by default and automatically
+watches for links and forms in your application. Read the
+[Turbo Drive documentation](https://turbo.hotwire.dev/handbook/drive) to learn how to
+configure it.
+
+### 2. Create interactive components with Turbo Frames
+
+[Turbo Frames](https://turbo.hotwire.dev/handbook/frames) allows to decompose pages in parts that
+can be updated interactively. Any links and forms inside a frame are captured, and the frame
+content is automatically updated after receiving a response. Only that particular section of the page
+will be extracted from the response to replace the existing content, regardless of whether the server
+provides a full document, or just a fragment containing an updated version of the requested
+frame.
+
+This behavior allows to build interactive components that mimic the behaviors of single-page
+applications without any added complexity.
+
+For example, using the helpers to build frames:
+
+```twig
+{# messages_list.html.twig #}
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<div id="navigation">Links targeting the entire page</div>
+
+<!-- Start a frame: the ID is the way Turbo will update the frame from AJAX responses -->
+{{ turbo_frame_start('message_1') }}
+
+    <h1>My message title</h1>
+    <p>My message content</p>
+
+    <!--
+    When clicking this link, Turbo will catch the link, make an AJAX call to
+    /messages/1/edit, find the "message_1" frame in the body of the response and
+    replace this frame's content with the new frame's content.
+
+    Here, if /messages/1/edit renders messages_edit.html.twig, the form will be
+    displayed inline in the frame.
+    -->
+    <a href="/messages/1/edit">Edit this message</a>
+
+<!-- End the frame -->
+{{ turbo_frame_end() }}
+
+</body>
+```
+
+```twig
+{# messages_edit.html.twig #}
+<body>
+
+<!-- By using the same ID, this response will update the original content to this new one -->
+{{ turbo_frame_start('message_1') }}
+
+    <!--
+    This form is in a frame: Turbo will catch the form submission, make an AJAX call instead and
+    replace the frame's content with the next frame's content.
+    -->
+    {{ form(message_form) }}
+
+    <!--
+    We can also display another link to go back to the list: the original HTML from frame
+    "message_1" in the list will be displayed again.
+    -->
+    <a href="/messages">Back</a>
+
+<!-- End the frame -->
+{{ turbo_frame_end() }}
+</body>
+```
+
+### 3. Create real-time applications with Turbo Streams
+
+[Turbo Streams](https://turbo.hotwire.dev/handbook/streams) are a way to update the content
+of HTML pages in real-time (server push) with no JavaScript coding required.
+
+Turbo Streams work by relying on a transport (a way to push messages from the server to
+the client in real-time), like websockets or [Symfony Mercure](https://symfony.com/doc/current/mercure.html).
+
+Then, Turbo Streams defines a protocol to **describe changes to apply to a page using HTML**.
+For instance, the following snippet of code could be sent over the real-time transport:
+
+```html
+<turbo-stream action="append" target="messages">
+    <template>
+        <div id="message_1">This div will be appended to the element with the DOM ID "messages".</div>
+    </template>
+</turbo-stream>
+```
+
+When this code will be received by the client, Turbo will apply the change to the page. In this example,
+a div will be appended to the DOM element with ID "messages".
+
+There are 5 native actions available in Turbo Streams: **append**, **prepend**, **replace**,
+**update**, and **remove**. In addition to these 5 actions, you can add custom behavior by using
+[Stimulus](https://stimulus.hotwire.dev/), which is native to Symfony UX.
+
+Symfony UX Turbo helps setting up Turbo Streams by providing native adapters for transports (like
+Mercure) and by providing helpers to create streams.
+
+**Example: a chat**
+
+For instance, let's imagine we want to build a simple chat system: we want to display messages in real-time
+to all clients currently connected when a message is posted. To do so, we can leverage Turbo Streams.
+
+First, we need to configure a transport. In the Symfony ecosystem, we recommend to use
+[Mercure](https://symfony.com/doc/current/mercure.html), a protocol based on Server-Sent Events which
+provides many very useful features on top of them (authentication, security, topics, ...).
+
+To configure it, [install Mercure](https://symfony.com/doc/current/mercure.html) and configure UX Turbo
+to use it:
+
+```yaml
+# config/packages/turbo.yaml
+turbo:
+    streams:
+        adapter: turbo.streams.adapter.mercure
+        options:
+            hub: '%env(MERCURE_PUBLISH_URL)%'
+```
+
+Then, let's build the chat view and configure it to listen to the "chat" topic on Mercure:
+
+```php
+class ChatController extends AbstractController
+{
+    /**
+     * @Route("/chat", name="chat")
+     */
+    public function chat(): Response
+    {
+        return $this->render('chat.html.twig');
+    }
+}
+```
+
+```twig
+{# chat.html.twig #}
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    {# This line configures Turbo to listen to the "chat" topic on Mercure #}
+    {{ turbo_stream_from('chat') }}
+
+    <h1>Chats</h1>
+
+    <div id="messages"></div>
+{% endblock %}
+```
+
+When a message is posted, we can now send the new DOM to append as a Turbo Stream snippet:
+
+```php
+namespace App\Controller;
+
+// ...
+use Symfony\Component\Mercure\PublisherInterface;
+use Symfony\Component\Mercure\Update;
+
+class ChatController extends AbstractController
+{
+    // ...
+
+    /**
+     * @Route("/publish", name="publish")
+     */
+    public function publish(PublisherInterface $publisher, Request $request): Response
+    {
+        // Let's imagine $message is the message received from the request (form, query param, ...)
+
+        $publisher(new Update('chat', '
+            <turbo-stream action="append" target="messages">
+              <template>
+                <p>'.$message.'</p>
+              </template>
+            </turbo-stream>
+        '));
+
+        // Then redirect, display a success message, ...
+    }
+}
+```
+
+Additionnally, to send messages easily in the chat without reloading the page, we could add a Frame around
+the message form (not related to Streams but useful still):
+
+```twig
+{# chat.html.twig #}
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    {# This line configures Turbo to listen to the "chat" topic on Mercure #}
+    {{ turbo_stream_from('chat') }}
+
+    <h1>Chats</h1>
+
+    <div id="messages"></div>
+
+    {{ turbo_frame_start('message_form') }}
+        <!--
+        Because this form is in a frame, when it's submitted, the page won't reload.
+        Instead Turbo will send an AJAX request and replace the content of this frame by
+        the frame "message_form" in the AJAX response.
+        -->
+        {{ form(message_form) }}
+    {{ turbo_frame_end() }}
+{% endblock %}
+```
+
+## Backward Compatibility promise
+
+This bundle aims at following the same Backward Compatibility promise as the Symfony framework:
+[https://symfony.com/doc/current/contributing/code/bc.html](https://symfony.com/doc/current/contributing/code/bc.html)
+
+However it is currently considered
+[**experimental**](https://symfony.com/doc/current/contributing/code/experimental.html),
+meaning it is not bound to Symfony's BC policy for the moment.
+
+## Run tests
+
+### PHP tests
+
+```sh
+php vendor/bin/phpunit
+```
+
+### JavaScript tests
+
+```sh
+cd Resources/assets
+yarn test
+```

--- a/src/Turbo/Resources/assets/.babelrc
+++ b/src/Turbo/Resources/assets/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["@babel/env"],
+    "plugins": ["@babel/plugin-proposal-class-properties"]
+}

--- a/src/Turbo/Resources/assets/.gitignore
+++ b/src/Turbo/Resources/assets/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+yarn.lock

--- a/src/Turbo/Resources/assets/dist/adapters/mercure-controller.js
+++ b/src/Turbo/Resources/assets/dist/adapters/mercure-controller.js
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+'use strict';
+
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _stimulus = require("stimulus");
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var _default = /*#__PURE__*/function (_Controller) {
+  _inherits(_default, _Controller);
+
+  var _super = _createSuper(_default);
+
+  function _default() {
+    _classCallCheck(this, _default);
+
+    return _super.apply(this, arguments);
+  }
+
+  _createClass(_default, [{
+    key: "connect",
+    value: function connect() {
+      var _this = this;
+
+      this.element.addEventListener('turbo:pre-connect', function (event) {
+        var url = new URL(_this.hubValue);
+        url.searchParams.append('topic', _this.topicValue);
+
+        event.detail.createSource = function () {
+          return new EventSource(url);
+        };
+
+        event.detail.disconnect = function (eventSource) {
+          eventSource.close();
+        };
+      });
+    }
+  }]);
+
+  return _default;
+}(_stimulus.Controller);
+
+exports["default"] = _default;
+
+_defineProperty(_default, "values", {
+  hub: String,
+  topic: String
+});

--- a/src/Turbo/Resources/assets/dist/core-controller.js
+++ b/src/Turbo/Resources/assets/dist/core-controller.js
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+'use strict';
+
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _stimulus = require("stimulus");
+
+var Turbo = _interopRequireWildcard(require("@hotwired/turbo"));
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+var _default = /*#__PURE__*/function (_Controller) {
+  _inherits(_default, _Controller);
+
+  var _super = _createSuper(_default);
+
+  function _default() {
+    _classCallCheck(this, _default);
+
+    return _super.apply(this, arguments);
+  }
+
+  _createClass(_default, [{
+    key: "connect",
+    value: function connect() {
+      this.streamSource = null;
+
+      this.disconnectSource = function () {};
+
+      var factory = {
+        createSource: null,
+        disconnect: null
+      };
+
+      this._dispatchEvent('turbo:pre-connect', factory, true);
+
+      if (!factory.createSource) {
+        throw new Error('No adapter has been configured to receive Turbo Streams. You should enable one in assets/controllers.json and configure it in config/packages/turbo.yaml.');
+        return;
+      }
+
+      if (factory.disconnect) {
+        this.disconnectSource = factory.disconnect;
+      }
+
+      var source = factory.createSource();
+
+      if (source) {
+        this.streamSource = Turbo.connectStreamSource(source);
+      }
+
+      this._dispatchEvent('turbo:connect');
+    }
+  }, {
+    key: "disconnect",
+    value: function disconnect() {
+      if (this.streamSource) {
+        Turbo.disconnectStreamSource(this.streamSource);
+      }
+
+      if (this.disconnectSource) {
+        this.disconnectSource(this.streamSource);
+      }
+    }
+  }, {
+    key: "_dispatchEvent",
+    value: function _dispatchEvent(name) {
+      var payload = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+      var canBubble = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+      var cancelable = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+      var userEvent = document.createEvent('CustomEvent');
+      userEvent.initCustomEvent(name, canBubble, cancelable, payload);
+      this.element.dispatchEvent(userEvent);
+    }
+  }]);
+
+  return _default;
+}(_stimulus.Controller);
+
+exports["default"] = _default;

--- a/src/Turbo/Resources/assets/package.json
+++ b/src/Turbo/Resources/assets/package.json
@@ -1,0 +1,47 @@
+{
+    "name": "@symfony/ux-turbo",
+    "description": "Turbo integration for Symfony",
+    "license": "MIT",
+    "version": "1.0.0",
+    "symfony": {
+        "controllers": {
+            "mercure": {
+                "main": "dist/adapters/mercure-controller.js",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": true
+            },
+            "core": {
+                "main": "dist/core-controller.js",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": true
+            }
+        }
+    },
+    "scripts": {
+        "build": "babel src -d dist",
+        "test": "babel src -d dist && jest",
+        "lint": "eslint src test"
+    },
+    "dependencies": {
+        "@hotwired/turbo": "^7.0.0-beta.4"
+    },
+    "peerDependencies": {
+        "stimulus": "^2.0.0"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.12.1",
+        "@babel/core": "^7.12.3",
+        "@babel/plugin-proposal-class-properties": "^7.12.1",
+        "@babel/preset-env": "^7.12.7",
+        "@symfony/stimulus-testing": "^1.1.0",
+        "stimulus": "^2.0.0"
+    },
+    "jest": {
+        "testRegex": "test/.*\\.test.js",
+        "setupFilesAfterEnv": [
+            "./test/setup.js"
+        ]
+    }
+}

--- a/src/Turbo/Resources/assets/src/adapters/mercure-controller.js
+++ b/src/Turbo/Resources/assets/src/adapters/mercure-controller.js
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+    static values = {
+        hub: String,
+        topic: String,
+    };
+
+    connect() {
+        this.element.addEventListener('turbo:pre-connect', (event) => {
+            const url = new URL(this.hubValue);
+            url.searchParams.append('topic', this.topicValue);
+
+            event.detail.createSource = () => {
+                return new EventSource(url);
+            };
+
+            event.detail.disconnect = (eventSource) => {
+                eventSource.close();
+            };
+        });
+    }
+}

--- a/src/Turbo/Resources/assets/src/adapters/mercure-controller.js
+++ b/src/Turbo/Resources/assets/src/adapters/mercure-controller.js
@@ -22,8 +22,12 @@ export default class extends Controller {
             const url = new URL(this.hubValue);
             url.searchParams.append('topic', this.topicValue);
 
+            let eventSource;
+
             event.detail.createSource = () => {
-                return new EventSource(url);
+                eventSource = new EventSource(url);
+
+                return eventSource;
             };
 
             event.detail.disconnect = (eventSource) => {

--- a/src/Turbo/Resources/assets/src/core-controller.js
+++ b/src/Turbo/Resources/assets/src/core-controller.js
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Controller } from 'stimulus';
+import * as Turbo from '@hotwired/turbo';
+
+export default class extends Controller {
+    connect() {
+        this.streamSource = null;
+        this.disconnectSource = () => {};
+
+        let factory = { createSource: null, disconnect: null };
+        this._dispatchEvent('turbo:pre-connect', factory, true);
+
+        if (!factory.createSource) {
+            throw new Error(
+                'No adapter has been configured to receive Turbo Streams. You should enable one in assets/controllers.json and configure it in config/packages/turbo.yaml.'
+            );
+
+            return;
+        }
+
+        if (factory.disconnect) {
+            this.disconnectSource = factory.disconnect;
+        }
+
+        const source = factory.createSource();
+        if (source) {
+            this.streamSource = Turbo.connectStreamSource(source);
+        }
+
+        this._dispatchEvent('turbo:connect');
+    }
+
+    disconnect() {
+        if (this.streamSource) {
+            Turbo.disconnectStreamSource(this.streamSource);
+        }
+
+        if (this.disconnectSource) {
+            this.disconnectSource(this.streamSource);
+        }
+    }
+
+    _dispatchEvent(name, payload = null, canBubble = false, cancelable = false) {
+        const userEvent = document.createEvent('CustomEvent');
+        userEvent.initCustomEvent(name, canBubble, cancelable, payload);
+
+        this.element.dispatchEvent(userEvent);
+    }
+}

--- a/src/Turbo/Resources/assets/src/core-controller.js
+++ b/src/Turbo/Resources/assets/src/core-controller.js
@@ -24,8 +24,6 @@ export default class extends Controller {
             throw new Error(
                 'No adapter has been configured to receive Turbo Streams. You should enable one in assets/controllers.json and configure it in config/packages/turbo.yaml.'
             );
-
-            return;
         }
 
         if (factory.disconnect) {

--- a/src/Turbo/Resources/assets/test/adapters/mercure-controller.test.js
+++ b/src/Turbo/Resources/assets/test/adapters/mercure-controller.test.js
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Application, Controller } from 'stimulus';
+import { getByTestId, waitFor } from '@testing-library/dom';
+import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
+import MercureController from '../../dist/adapters/mercure-controller';
+
+// Controller used to check the actual controller was properly booted
+class CheckController extends Controller {
+    connect() {
+        let factory = { createSource: null };
+        this._dispatchEvent('turbo:pre-connect', factory);
+        this.element.createSource = factory.createSource;
+
+        this.element.classList.add('connected');
+    }
+
+    _dispatchEvent(name, payload = null, canBubble = false, cancelable = false) {
+        const userEvent = document.createEvent('CustomEvent');
+        userEvent.initCustomEvent(name, canBubble, cancelable, payload);
+
+        this.element.dispatchEvent(userEvent);
+    }
+}
+
+const startStimulus = () => {
+    const application = Application.start();
+    application.register('check', CheckController);
+    application.register('mercure', MercureController);
+};
+
+describe('MercureController', () => {
+    let container;
+
+    afterEach(() => {
+        clearDOM();
+    });
+
+    it('connect', async () => {
+        container = mountDOM(`
+            <div data-testid="mercure"
+                 data-controller="mercure check" 
+                 data-mercure-hub-value="http://localhost/.well-known/mercure"
+                 data-mercure-topic-value="atopic"
+            ></div>
+        `);
+
+        startStimulus();
+        await waitFor(() => {
+            expect(getByTestId(container, 'mercure')).toHaveClass('connected');
+        });
+
+        const createSource = getByTestId(container, 'mercure').createSource;
+        expect(typeof createSource).toBe('function');
+
+        const eventSource = createSource();
+        expect(eventSource.url + '').toEqual('http://localhost/.well-known/mercure?topic=atopic');
+    });
+});

--- a/src/Turbo/Resources/assets/test/core-controller.test.js
+++ b/src/Turbo/Resources/assets/test/core-controller.test.js
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Application, Controller } from 'stimulus';
+import { getByTestId, waitFor } from '@testing-library/dom';
+import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
+import CoreController from '../dist/core-controller';
+
+// Controller used to check the actual controller was properly booted
+class CheckController extends Controller {
+    connect() {
+        this.element.createSourceCalled = false;
+        this.element.disconnectCalled = false;
+
+        this.element.addEventListener('turbo:pre-connect', (event) => {
+            this.element.classList.add('pre-connected');
+
+            event.detail.createSource = () => {
+                this.element.createSourceCalled = true;
+
+                return null;
+            };
+
+            event.detail.disconnect = () => {
+                this.element.disconnectCalled = true;
+
+                return null;
+            };
+        });
+
+        this.element.addEventListener('turbo:connect', () => {
+            this.element.classList.add('connected');
+        });
+    }
+
+    disconnect() {
+        this.element.classList.add('disconnected');
+    }
+}
+
+const startStimulus = () => {
+    const application = Application.start();
+    application.register('check', CheckController);
+    application.register('turbo', CoreController);
+};
+
+describe('TurboController', () => {
+    let container;
+
+    afterEach(() => {
+        clearDOM();
+    });
+
+    it('connect', async () => {
+        container = mountDOM(`<div data-testid="turbo" data-controller="check turbo"></div>`);
+
+        expect(getByTestId(container, 'turbo')).not.toHaveClass('pre-connected');
+        expect(getByTestId(container, 'turbo')).not.toHaveClass('connected');
+
+        startStimulus();
+        await waitFor(() => {
+            expect(getByTestId(container, 'turbo')).toHaveClass('pre-connected');
+            expect(getByTestId(container, 'turbo')).toHaveClass('connected');
+        });
+
+        const element = getByTestId(container, 'turbo');
+        expect(element.createSourceCalled).toBe(true);
+        expect(element.disconnectCalled).toBe(false);
+
+        element.parentNode.removeChild(element);
+        await waitFor(() => {
+            expect(element).toHaveClass('disconnected');
+        });
+        expect(element.disconnectCalled).toBe(true);
+    });
+});

--- a/src/Turbo/Resources/assets/test/setup.js
+++ b/src/Turbo/Resources/assets/test/setup.js
@@ -1,0 +1,23 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import '@symfony/stimulus-testing/setup';
+
+// Tiny mock of EventSource for nodejs
+if (typeof EventSource == 'undefined') {
+    class EventSource {
+        constructor(url) {
+            this.url = url;
+        }
+    }
+
+    window.EventSource = EventSource;
+}

--- a/src/Turbo/Streams/MercureStreamAdapter.php
+++ b/src/Turbo/Streams/MercureStreamAdapter.php
@@ -14,7 +14,7 @@ namespace Symfony\UX\Turbo\Streams;
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
- * @internal
+ * @experimental
  */
 class MercureStreamAdapter implements StreamAdapterInterface
 {

--- a/src/Turbo/Streams/MercureStreamAdapter.php
+++ b/src/Turbo/Streams/MercureStreamAdapter.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Streams;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class MercureStreamAdapter implements StreamAdapterInterface
+{
+    public function getStimulusControllerName(): string
+    {
+        return 'symfony--ux-turbo--mercure';
+    }
+
+    public function createDataValues(array $options): array
+    {
+        if (!($options['hub'] ?? null)) {
+            throw new \InvalidArgumentException('To use the Mercure Turbo Stream adapter, a Mercure hub URL must be provided. Try configuring a hub URL in config/packages/turbo.yaml.');
+        }
+
+        return [
+            'hub' => $options['hub'],
+            'topic' => $options['id'],
+        ];
+    }
+}

--- a/src/Turbo/Streams/StreamAdapterInterface.php
+++ b/src/Turbo/Streams/StreamAdapterInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\UX\Turbo\Streams;
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
- * @internal
+ * @experimental
  */
 interface StreamAdapterInterface
 {

--- a/src/Turbo/Streams/StreamAdapterInterface.php
+++ b/src/Turbo/Streams/StreamAdapterInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Streams;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+interface StreamAdapterInterface
+{
+    public function getStimulusControllerName(): string;
+
+    public function createDataValues(array $options): array;
+}

--- a/src/Turbo/Tests/Kernel/AppKernelTrait.php
+++ b/src/Turbo/Tests/Kernel/AppKernelTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Kernel;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+trait AppKernelTrait
+{
+    public function getCacheDir()
+    {
+        return $this->createTmpDir('cache');
+    }
+
+    public function getLogDir()
+    {
+        return $this->createTmpDir('logs');
+    }
+
+    private function createTmpDir(string $type): string
+    {
+        $dir = sys_get_temp_dir().'/Turbo_bundle/'.uniqid($type.'_', true);
+
+        if (!file_exists($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        return $dir;
+    }
+}

--- a/src/Turbo/Tests/Kernel/EmptyAppKernel.php
+++ b/src/Turbo/Tests/Kernel/EmptyAppKernel.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Kernel;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Turbo\TurboBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class EmptyAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles()
+    {
+        return [new TurboBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+    }
+}

--- a/src/Turbo/Tests/Kernel/FrameworkAppKernel.php
+++ b/src/Turbo/Tests/Kernel/FrameworkAppKernel.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Turbo\TurboBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class FrameworkAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles()
+    {
+        return [new FrameworkBundle(), new TurboBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true]);
+        });
+    }
+}

--- a/src/Turbo/Tests/Kernel/FullAppKernel.php
+++ b/src/Turbo/Tests/Kernel/FullAppKernel.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Turbo\TurboBundle;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class FullAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles()
+    {
+        return [new FrameworkBundle(), new WebpackEncoreBundle(), new TwigBundle(), new TurboBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true]);
+            $container->loadFromExtension('twig', ['default_path' => __DIR__.'/templates', 'strict_variables' => true, 'exception_controller' => null]);
+            $container->loadFromExtension('webpack_encore', ['output_path' => '%kernel.project_dir%/public/build']);
+
+            $container->loadFromExtension('turbo', [
+                'streams' => [
+                    'adapter' => 'turbo.streams.adapter.mercure',
+                    'options' => ['hub' => 'http://localhost/.well-know/mecure'],
+                ],
+            ]);
+        });
+    }
+}

--- a/src/Turbo/Tests/Kernel/TwigAppKernel.php
+++ b/src/Turbo/Tests/Kernel/TwigAppKernel.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Turbo\TurboBundle;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class TwigAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles()
+    {
+        return [new FrameworkBundle(), new WebpackEncoreBundle(), new TwigBundle(), new TurboBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true]);
+            $container->loadFromExtension('twig', ['default_path' => __DIR__.'/templates', 'strict_variables' => true, 'exception_controller' => null]);
+            $container->loadFromExtension('webpack_encore', ['output_path' => '%kernel.project_dir%/public/build']);
+        });
+    }
+}

--- a/src/Turbo/Tests/TurboBundleTest.php
+++ b/src/Turbo/Tests/TurboBundleTest.php
@@ -18,8 +18,8 @@ use Symfony\UX\Turbo\Tests\Kernel\EmptyAppKernel;
 use Symfony\UX\Turbo\Tests\Kernel\FrameworkAppKernel;
 use Symfony\UX\Turbo\Tests\Kernel\FullAppKernel;
 use Symfony\UX\Turbo\Tests\Kernel\TwigAppKernel;
-use Symfony\UX\Turbo\Twig\FrameTwigExtension;
-use Symfony\UX\Turbo\Twig\StreamTwigExtension;
+use Symfony\UX\Turbo\Twig\TurboFrameExtension;
+use Symfony\UX\Turbo\Twig\TurboStreamExtension;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
@@ -58,7 +58,7 @@ class TurboBundleTest extends TestCase
 
         // Check Twig extensions were loaded
         $twig = $container->get('twig');
-        $this->assertNotNull($twig->getExtension(FrameTwigExtension::class));
-        $this->assertNotNull($twig->getExtension(StreamTwigExtension::class));
+        $this->assertNotNull($twig->getExtension(TurboFrameExtension::class));
+        $this->assertNotNull($twig->getExtension(TurboStreamExtension::class));
     }
 }

--- a/src/Turbo/Tests/TurboBundleTest.php
+++ b/src/Turbo/Tests/TurboBundleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Turbo\Streams\MercureStreamAdapter;
+use Symfony\UX\Turbo\Tests\Kernel\EmptyAppKernel;
+use Symfony\UX\Turbo\Tests\Kernel\FrameworkAppKernel;
+use Symfony\UX\Turbo\Tests\Kernel\FullAppKernel;
+use Symfony\UX\Turbo\Tests\Kernel\TwigAppKernel;
+use Symfony\UX\Turbo\Twig\FrameTwigExtension;
+use Symfony\UX\Turbo\Twig\StreamTwigExtension;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class TurboBundleTest extends TestCase
+{
+    public function provideKernels()
+    {
+        yield 'empty' => [new EmptyAppKernel('test', true)];
+        yield 'framework' => [new FrameworkAppKernel('test', true)];
+        yield 'twig' => [new TwigAppKernel('test', true)];
+    }
+
+    /**
+     * @dataProvider provideKernels
+     */
+    public function testBootKernel(Kernel $kernel)
+    {
+        $kernel->boot();
+        $this->assertArrayHasKey('TurboBundle', $kernel->getBundles());
+    }
+
+    public function testFull()
+    {
+        $kernel = new FullAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        $this->assertArrayHasKey('TurboBundle', $kernel->getBundles());
+
+        // Check Turbo Streams adapter was wired
+        $adapter = $container->get('turbo.streams.adapter');
+        $this->assertInstanceOf(MercureStreamAdapter::class, $adapter);
+
+        // Check Twig extensions were loaded
+        $twig = $container->get('twig');
+        $this->assertNotNull($twig->getExtension(FrameTwigExtension::class));
+        $this->assertNotNull($twig->getExtension(StreamTwigExtension::class));
+    }
+}

--- a/src/Turbo/Tests/Twig/FrameTwigExtensionTest.php
+++ b/src/Turbo/Tests/Twig/FrameTwigExtensionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Turbo\Tests\Kernel\FullAppKernel;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class FrameTwigExtensionTest extends TestCase
+{
+    public function provideStartFrame()
+    {
+        yield 'without-attrs' => [
+            'id' => 'frame1',
+            'attr' => [],
+            'expected' => '<turbo-frame id="frame1">',
+        ];
+
+        yield 'with-attrs' => [
+            'id' => 'frame1',
+            'attr' => ['class' => 'myframe', 'title' => 'mytitle'],
+            'expected' => '<turbo-frame id="frame1" class="myframe" title="mytitle">',
+        ];
+    }
+
+    /**
+     * @dataProvider provideStartFrame
+     */
+    public function testStartFrame(string $id, array $attrs, string $expected)
+    {
+        $container = $this->bootFullKernel();
+
+        $this->assertSame(
+            $expected,
+            $container->get('turbo.twig.frame_extension')->startFrame($container->get('twig'), $id, $attrs)
+        );
+    }
+
+    public function testEndFrame()
+    {
+        $this->assertSame('</turbo-frame>', $this->bootFullKernel()->get('turbo.twig.frame_extension')->endFrame());
+    }
+
+    private function bootFullKernel()
+    {
+        $kernel = new FullAppKernel('test', true);
+        $kernel->boot();
+
+        return $kernel->getContainer()->get('test.service_container');
+    }
+}

--- a/src/Turbo/Tests/Twig/StreamTwigExtensionTest.php
+++ b/src/Turbo/Tests/Twig/StreamTwigExtensionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Turbo\Tests\Kernel\FullAppKernel;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class StreamTwigExtensionTest extends TestCase
+{
+    public function provideStreamFrom()
+    {
+        yield 'without-attrs' => [
+            'id' => 'mytopic',
+            'attr' => [],
+            'expected' => '<div data-controller="symfony--ux-turbo--mercure symfony--ux-turbo--core" data-symfony--ux-turbo--mercure-hub-value="http&#x3A;&#x2F;&#x2F;localhost&#x2F;.well-know&#x2F;mecure" data-symfony--ux-turbo--mercure-topic-value="mytopic"></div>',
+        ];
+
+        yield 'with-attrs' => [
+            'id' => 'mytopic',
+            'attr' => ['class' => 'myframe', 'title' => 'mytitle'],
+            'expected' => '<div data-controller="symfony--ux-turbo--mercure symfony--ux-turbo--core" data-symfony--ux-turbo--mercure-hub-value="http&#x3A;&#x2F;&#x2F;localhost&#x2F;.well-know&#x2F;mecure" data-symfony--ux-turbo--mercure-topic-value="mytopic" class="myframe" title="mytitle"></div>',
+        ];
+    }
+
+    /**
+     * @dataProvider provideStreamFrom
+     */
+    public function testStreamFrom(string $id, array $attrs, string $expected)
+    {
+        $kernel = new FullAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        $this->assertSame(
+            $expected,
+            $container->get('turbo.twig.stream_extension')->streamFrom($container->get('twig'), $id, $attrs)
+        );
+    }
+}

--- a/src/Turbo/TurboBundle.php
+++ b/src/Turbo/TurboBundle.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @final
+ * @experimental
+ */
+class TurboBundle extends Bundle
+{
+}

--- a/src/Turbo/Twig/FrameTwigExtension.php
+++ b/src/Turbo/Twig/FrameTwigExtension.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Twig;
+
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @final
+ * @experimental
+ */
+class FrameTwigExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('turbo_frame_start', [$this, 'startFrame'], ['needs_environment' => true, 'is_safe' => ['html']]),
+            new TwigFunction('turbo_frame_end', [$this, 'endFrame'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function startFrame(Environment $env, string $id, array $attrs = []): string
+    {
+        $html = '<turbo-frame id="'.twig_escape_filter($env, $id, 'html_attr').'" ';
+
+        foreach ($attrs as $name => $value) {
+            $name = twig_escape_filter($env, $name, 'html_attr');
+            $value = twig_escape_filter($env, $value, 'html_attr');
+
+            if (true === $value) {
+                $html .= $name.'="'.$name.'" ';
+            } elseif (false !== $value) {
+                $html .= $name.'="'.$value.'" ';
+            }
+        }
+
+        return trim($html).'>';
+    }
+
+    public function endFrame(): string
+    {
+        return '</turbo-frame>';
+    }
+}

--- a/src/Turbo/Twig/StreamTwigExtension.php
+++ b/src/Turbo/Twig/StreamTwigExtension.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Twig;
+
+use Symfony\UX\Turbo\Streams\StreamAdapterInterface;
+use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @final
+ * @experimental
+ */
+class StreamTwigExtension extends AbstractExtension
+{
+    /**
+     * @var StimulusTwigExtension
+     */
+    private $stimulus;
+
+    /**
+     * @var StreamAdapterInterface
+     */
+    private $adapter;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(StimulusTwigExtension $stimulus, StreamAdapterInterface $adapter, array $options)
+    {
+        $this->stimulus = $stimulus;
+        $this->adapter = $adapter;
+        $this->options = $options;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('turbo_stream_from', [$this, 'streamFrom'], ['needs_environment' => true, 'is_safe' => ['html']]),
+        ];
+    }
+
+    public function streamFrom(Environment $env, string $id, array $attrs = []): string
+    {
+        $options = array_merge($this->options, ['id' => $id]);
+
+        $html = '<div ';
+        $html .= $this->stimulus->renderStimulusController($env, [
+            $this->adapter->getStimulusControllerName() => $this->adapter->createDataValues($options),
+            'symfony--ux-turbo--core' => [],
+        ]).' ';
+
+        foreach ($attrs as $name => $value) {
+            $name = twig_escape_filter($env, $name, 'html_attr');
+            $value = twig_escape_filter($env, $value, 'html_attr');
+
+            if (true === $value) {
+                $html .= $name.'="'.$name.'" ';
+            } elseif (false !== $value) {
+                $html .= $name.'="'.$value.'" ';
+            }
+        }
+
+        return trim($html).'></div>';
+    }
+}

--- a/src/Turbo/Twig/TurboFrameExtension.php
+++ b/src/Turbo/Twig/TurboFrameExtension.php
@@ -21,7 +21,7 @@ use Twig\TwigFunction;
  * @final
  * @experimental
  */
-class FrameTwigExtension extends AbstractExtension
+class TurboFrameExtension extends AbstractExtension
 {
     public function getFunctions(): array
     {

--- a/src/Turbo/Twig/TurboStreamExtension.php
+++ b/src/Turbo/Twig/TurboStreamExtension.php
@@ -23,7 +23,7 @@ use Twig\TwigFunction;
  * @final
  * @experimental
  */
-class StreamTwigExtension extends AbstractExtension
+class TurboStreamExtension extends AbstractExtension
 {
     /**
      * @var StimulusTwigExtension

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -1,0 +1,51 @@
+{
+    "name": "symfony/ux-turbo",
+    "type": "symfony-bundle",
+    "description": "Tubor integration for Symfony",
+    "keywords": [
+        "symfony-ux"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Titouan Galopin",
+            "email": "galopintitouan@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Symfony\\UX\\Turbo\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/config": "^4.4.17|^5.0",
+        "symfony/dependency-injection": "^4.4.17|^5.0",
+        "symfony/http-kernel": "^4.4.17|^5.0",
+        "symfony/webpack-encore-bundle": "^v1.10.0"
+    },
+    "require-dev": {
+        "symfony/framework-bundle": "^4.4.17|^5.0",
+        "symfony/phpunit-bridge": "^5.2",
+        "symfony/twig-bundle": "^4.4.17|^5.0",
+        "symfony/var-dumper": "^4.4.17|^5.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.1-dev"
+        },
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -30,7 +30,7 @@
         "symfony/config": "^4.4.17|^5.0",
         "symfony/dependency-injection": "^4.4.17|^5.0",
         "symfony/http-kernel": "^4.4.17|^5.0",
-        "symfony/webpack-encore-bundle": "^v1.10.0"
+        "symfony/webpack-encore-bundle": "^1.10"
     },
     "require-dev": {
         "symfony/framework-bundle": "^4.4.17|^5.0",

--- a/src/Turbo/phpunit.xml.dist
+++ b/src/Turbo/phpunit.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true">
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <ini name="intl.default_locale" value="en" />
+        <ini name="intl.error_level" value="0" />
+        <ini name="memory_limit" value="-1" />
+        <env name="SHELL_VERBOSITY" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./Resources</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | -
| License       | MIT

This PR introduces a new package to Symfony UX: UX Turbo, integrating the [Hotwire Turbo](https://turbo.hotwire.dev) library with Symfony. It is based on an initial prototype made by Kevin Dunglas (@dunglas) as a [Mercure](https://mercure.rocks/) project.

Hotwire is an aggregation of several technologies developed by the Ruby on Rails ecosystem and the Bascamp company to build interactive applications with as less JavaScript code as possible. Stimulus, as the foundation of Symfony UX, is already well integrated into Symfony. This PR goes to the next step: integrating Turbo.

You can learn more about the Hotwire intiative on https://twitter.com/dhh/status/1341420143239450624. You can also read the [README in this PR](https://github.com/tgalopin/ux/blob/31e064fb2ab6801fd6bd62b9a1505c6125fb67da/src/Turbo/README.md) to better understand the usage in a Symfony application.

TLDR: Turbo is a generic way to build reactive applications (inline form edition, DOM changes without reload, real-time display of chat messages, etc.) without the need to develop any JavaScript (or at least as little as possible). This has two big advantages: it reduces dramatically the time necessary to build a reactive app and it eliminates in many places the need for a client-side state which could be a source of issues.

This PR is loosely based on the equivalent gem in Ruby that integrates Turbo in RoR. It has however a few key differences:

* it leverages Symfony Mercure by default for Streams instead of Websockets (as PHP isn't a long running process)
* it build upon other tools in Symfony like the `stimulus_controller` [helper introduced a few days ago in Webpack Encore](https://github.com/symfony/webpack-encore-bundle/pull/109)