### PR TITLE
[Dropzone] Fix prepend twig extension

### DIFF
--- a/src/Dropzone/DependencyInjection/DropzoneExtension.php
+++ b/src/Dropzone/DependencyInjection/DropzoneExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\UX\Dropzone\DependencyInjection;
 
-use Symfony\Bundle\TwigBundle\DependencyInjection\Configuration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -34,10 +33,7 @@ class DropzoneExtension extends Extension implements PrependExtensionInterface
             return;
         }
 
-        $config = $this->processConfiguration(new Configuration(), $container->getExtensionConfig('twig'));
-        $config['form_themes'][] = '@Dropzone/form_theme.html.twig';
-
-        $container->prependExtensionConfig('twig', $config);
+        $container->prependExtensionConfig('twig', ['form_themes' => ['@Dropzone/form_theme.html.twig']]);
     }
 
     public function load(array $configs, ContainerBuilder $container)

--- a/src/Dropzone/Tests/DropzoneBundleTest.php
+++ b/src/Dropzone/Tests/DropzoneBundleTest.php
@@ -39,4 +39,15 @@ class DropzoneBundleTest extends TestCase
         $kernel->boot();
         $this->assertArrayHasKey('DropzoneBundle', $kernel->getBundles());
     }
+
+    public function testFormThemeMerging()
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+        $this->assertEquals([
+            'form_div_layout.html.twig',
+            '@Dropzone/form_theme.html.twig',
+            'form_theme.html.twig',
+        ], $kernel->getContainer()->getParameter('twig.form.resources'));
+    }
 }

--- a/src/Dropzone/Tests/Kernel/TwigAppKernel.php
+++ b/src/Dropzone/Tests/Kernel/TwigAppKernel.php
@@ -36,7 +36,15 @@ class TwigAppKernel extends Kernel
     {
         $loader->load(function (ContainerBuilder $container) {
             $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true]);
-            $container->loadFromExtension('twig', ['default_path' => __DIR__.'/templates', 'strict_variables' => true, 'exception_controller' => null]);
+            $container->loadFromExtension('twig', [
+                'default_path' => __DIR__.'/templates',
+                'strict_variables' => true,
+                'form_themes' => [
+                    'form_theme.html.twig',
+                ],
+                'exception_controller' => null,
+                'debug' => '%kernel.debug%',
+            ]);
         });
     }
 }

--- a/src/Dropzone/Tests/Kernel/templates/form_theme.html.twig
+++ b/src/Dropzone/Tests/Kernel/templates/form_theme.html.twig
@@ -1,0 +1,1 @@
+{# dummy file #}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #66 
| License       | MIT

Hi :wave: 

Just prepend the form_themes needed instead of full configuration should fix issue #66 

BTW, I'm not sure how to add tests on this. Any clue ? 

Thanks :hugs: 
