### PR TITLE
Fix UX Turbo usage without Streams

### DIFF
--- a/src/Turbo/Resources/assets/.babelrc
+++ b/src/Turbo/Resources/assets/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["@babel/env"],
+    "plugins": ["@babel/plugin-proposal-class-properties"]
+}

--- a/src/Turbo/Resources/assets/dist/turbo_controller.js
+++ b/src/Turbo/Resources/assets/dist/turbo_controller.js
@@ -1,0 +1,56 @@
+"use strict";
+
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _stimulus = require("stimulus");
+
+var Turbo = _interopRequireWildcard(require("@hotwired/turbo"));
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+// Expose Turbo to the rest of the app to allow for dynamic Turbo calls
+window.Turbo = Turbo;
+/**
+ * Empty Stimulus controller only used for Symfony Flex wiring.
+ *
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+
+var _default = /*#__PURE__*/function (_Controller) {
+  _inherits(_default, _Controller);
+
+  var _super = _createSuper(_default);
+
+  function _default() {
+    _classCallCheck(this, _default);
+
+    return _super.apply(this, arguments);
+  }
+
+  return _default;
+}(_stimulus.Controller);
+
+exports["default"] = _default;

--- a/src/Turbo/Resources/assets/package.json
+++ b/src/Turbo/Resources/assets/package.json
@@ -4,12 +4,39 @@
     "license": "MIT",
     "private": true,
     "version": "0.1.0",
+    "symfony": {
+        "controllers": {
+            "turbo-core": {
+                "main": "dist/turbo_controller.js",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": true
+            }
+        }
+    },
     "scripts": {
-        "build": "echo skip",
-        "test": "echo skip",
-        "lint": "echo skip"
+        "build": "babel src -d dist",
+        "test": "babel src -d dist && jest",
+        "lint": "eslint src test"
     },
     "dependencies": {
         "@hotwired/turbo": "^7.0.0-beta.4"
+    },
+    "peerDependencies": {
+        "stimulus": "^2.0.0"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.12.1",
+        "@babel/core": "^7.12.3",
+        "@babel/plugin-proposal-class-properties": "^7.12.1",
+        "@babel/preset-env": "^7.12.7",
+        "@symfony/stimulus-testing": "^1.1.0",
+        "stimulus": "^2.0.0"
+    },
+    "jest": {
+        "testRegex": "test/.*\\.test.js",
+        "setupFilesAfterEnv": [
+            "./test/setup.js"
+        ]
     }
 }

--- a/src/Turbo/Resources/assets/src/turbo_controller.js
+++ b/src/Turbo/Resources/assets/src/turbo_controller.js
@@ -1,0 +1,21 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { Controller } from 'stimulus';
+import * as Turbo from '@hotwired/turbo';
+
+// Expose Turbo to the rest of the app to allow for dynamic Turbo calls
+window.Turbo = Turbo;
+
+/**
+ * Empty Stimulus controller only used for Symfony Flex wiring.
+ *
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+export default class extends Controller {}

--- a/src/Turbo/Resources/assets/test/setup.js
+++ b/src/Turbo/Resources/assets/test/setup.js
@@ -1,0 +1,10 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import '@symfony/stimulus-testing/setup';

--- a/src/Turbo/Resources/assets/test/turbo_controller.test.js
+++ b/src/Turbo/Resources/assets/test/turbo_controller.test.js
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Application } from 'stimulus';
+import { getByTestId } from '@testing-library/dom';
+import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
+import TurboController from '../src/turbo_controller';
+
+const startStimulus = () => {
+    const application = Application.start();
+    application.register('symfony--ux-turbo--turbo', TurboController);
+};
+
+/* eslint-disable no-undef */
+describe('TurboStreamController', () => {
+    let container;
+
+    beforeEach(() => {
+        container = mountDOM('<div data-testid="turbo-core" data-controller="symfony--ux-turbo--turbo"></div>');
+    });
+
+    afterEach(() => {
+        clearDOM();
+    });
+
+    it('connects', async () => {
+        startStimulus();
+
+        // smoke test
+        expect(getByTestId(container, 'turbo-core')).toHaveAttribute('data-controller', 'symfony--ux-turbo--turbo');
+    });
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | -
| Tickets       | -
| License       | MIT

Currently, UX Turbo doesn't work without the Mercure bridge installed and configured as it requires JS to load it. This adds some JS in the UX Turbo package to automatically load Turbo when installed using an empty Stimulus controller.