### PR TITLE
Add step to import Turbo in your javascript

### DIFF
--- a/src/Turbo/README.md
+++ b/src/Turbo/README.md
@@ -20,7 +20,15 @@ Install this bundle using Composer and Symfony Flex:
 
 ```sh
 composer require symfony/ux-turbo
+```
 
+Import turbo in your javascript:
+
+```javascript
+import * as Turbo from '@hotwired/turbo';
+```
+
+```sh
 # Don't forget to install the JavaScript dependencies as well and compile
 yarn install --force
 yarn encore dev


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| License       | MIT

Added a small step in the documentation to make sure that the Turbo import is placed in the javascript. Was searching a while to figure this out 😊
