### PR TITLE
Chart.js: add horizontalBar type to chart model

### DIFF
--- a/src/Chartjs/Model/Chart.php
+++ b/src/Chartjs/Model/Chart.php
@@ -21,6 +21,7 @@ class Chart
 {
     public const TYPE_LINE = 'line';
     public const TYPE_BAR = 'bar';
+    public const TYPE_BAR_HORIZONTAL = 'horizontalBar';
     public const TYPE_RADAR = 'radar';
     public const TYPE_PIE = 'pie';
     public const TYPE_DOUGHNUT = 'doughnut';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| License       | MIT

You can close [https://github.com/symfony/ux-chartjs/pull/1](https://github.com/symfony/ux-chartjs/pull/1).

[https://www.chartjs.org/docs/2.9.4/charts/bar.html#horizontal-bar-chart](https://www.chartjs.org/docs/2.9.4/charts/bar.html#horizontal-bar-chart
)
Add missing horizontal bar type.