### PR TITLE
Add `link` utility to link Symfony UX packages to existing Symfony project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 yarn.lock
 yarn-error.log
+/composer.lock
+/vendor

--- a/README.md
+++ b/README.md
@@ -63,3 +63,18 @@ do in JavaScript could be done streamlined as a UX package.
 
 We have some ideas and we will release more packages in the coming days. The rest
 is on you: let's create an amazing ecosystem together!
+
+## Contributing
+
+If you want to test your code in an existing project that uses Symfony UX packages,
+you can use the `link` utility provided in this Git repository (that you have to clone).
+This tool scans the `vendor/` directory of your project, finds Symfony UX packages it uses,
+and replaces them by symbolic links to the ones in the Git repository.
+
+```shell
+# Install required dependencies
+$ composer install
+
+# And link Symfony UX packages to your project
+$ php link /path/to/your/project
+```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "symfony/ux",
+    "license": "MIT",
+    "require-dev": {
+        "symfony/filesystem": "^5.2"
+    }
+}

--- a/link
+++ b/link
@@ -1,0 +1,86 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+require __DIR__.'/vendor/autoload.php';
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Links dependencies of a project to a local clone of the main symfony/symfony GitHub repository.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+
+$copy = false !== $k = array_search('--copy', $argv, true);
+$copy && array_splice($argv, $k, 1);
+$rollback = false !== $k = array_search('--rollback', $argv, true);
+$rollback && array_splice($argv, $k, 1);
+$pathToProject = $argv[1] ?? getcwd();
+
+if (!is_dir("$pathToProject/vendor/symfony")) {
+    echo 'Links dependencies of a project to a local clone of the main symfony/ux GitHub repository.'.PHP_EOL.PHP_EOL;
+    echo "Usage: $argv[0] /path/to/the/project".PHP_EOL;
+    echo '       Use `--copy` to copy dependencies instead of symlink'.PHP_EOL.PHP_EOL;
+    echo '       Use `--rollback` to rollback'.PHP_EOL.PHP_EOL;
+    echo "The directory \"$pathToProject\" does not exist or the dependencies are not installed, did you forget to run \"composer install\" in your project?".PHP_EOL;
+    exit(1);
+}
+
+$sfPackages = array();
+
+$filesystem = new Filesystem();
+$directories = glob(__DIR__.'/src/*', GLOB_ONLYDIR | GLOB_NOSORT);
+
+foreach ($directories as $dir) {
+    if ($filesystem->exists($composer = "$dir/composer.json")) {
+        $sfPackages[json_decode(file_get_contents($composer))->name] = $dir;
+    }
+}
+
+foreach (glob("$pathToProject/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
+    $package = 'symfony/'.basename($dir);
+
+    if (!isset($sfPackages[$package])) {
+        continue;
+    }
+
+    if ($rollback) {
+        $filesystem->remove($dir);
+        echo "\"$package\" has been rollback from \"$sfPackages[$package]\".".PHP_EOL;
+        continue;
+    }
+
+    if (!$copy && is_link($dir)) {
+        echo "\"$package\" is already a symlink, skipping.".PHP_EOL;
+        continue;
+    }
+
+    $sfDir = ('\\' === DIRECTORY_SEPARATOR || $copy) ? $sfPackages[$package] : $filesystem->makePathRelative($sfPackages[$package], dirname(realpath($dir)));
+
+    $filesystem->remove($dir);
+
+    if ($copy) {
+        $filesystem->mirror($sfDir, $dir);
+        echo "\"$package\" has been copied from \"$sfPackages[$package]\".".PHP_EOL;
+    } else {
+        $filesystem->symlink($sfDir, $dir);
+        echo "\"$package\" has been linked to \"$sfPackages[$package]\".".PHP_EOL;
+    }
+}
+
+foreach (glob("$pathToProject/var/cache/*", GLOB_NOSORT) as $cacheDir) {
+    $filesystem->remove($cacheDir);
+}
+
+if ($rollback) {
+    echo PHP_EOL."Rollback done, do not forget to run \"composer install\" in your project \"$pathToProject\".".PHP_EOL;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #40 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR add a new `link` utility to link Symfony UX packages to an existing Symfony project. It's literally a copy/paste from [the `link` utility from `symfony/symfony`](https://github.com/symfony/symfony/blob/5.x/link) but with different directories and an explicit dependency on Symfony Filesystem component.

Demo: 
![image](https://user-images.githubusercontent.com/2103975/116757933-67583f00-aa0f-11eb-92d8-3e2d2673ae6e.png)
![image](https://user-images.githubusercontent.com/2103975/116758130-c0c06e00-aa0f-11eb-94fd-962f2b0f942c.png)
