### PR TITLE
Moving Turbo to be a peer dependency

### DIFF
--- a/src/Chartjs/Resources/assets/package.json
+++ b/src/Chartjs/Resources/assets/package.json
@@ -18,10 +18,8 @@
         "test": "babel src -d dist && jest",
         "lint": "eslint src test"
     },
-    "dependencies": {
-        "chart.js": "^2.9.4"
-    },
     "peerDependencies": {
+        "chart.js": "^2.9.4",
         "stimulus": "^2.0.0"
     },
     "devDependencies": {
@@ -30,6 +28,7 @@
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/preset-env": "^7.12.7",
         "@symfony/stimulus-testing": "^1.1.0",
+        "chart.js": "^2.9.4",
         "jest-canvas-mock": "^2.3.0",
         "stimulus": "^2.0.0"
     },

--- a/src/Chartjs/composer.json
+++ b/src/Chartjs/composer.json
@@ -37,6 +37,9 @@
         "symfony/twig-bundle": "^4.4.17|^5.0",
         "symfony/var-dumper": "^4.4.17|^5.0"
     },
+    "conflict": {
+        "symfony/flex": "<1.13"
+    },
     "extra": {
         "branch-alias": {
             "dev-main": "1.3-dev"

--- a/src/Cropperjs/Resources/assets/package.json
+++ b/src/Cropperjs/Resources/assets/package.json
@@ -22,10 +22,8 @@
         "test": "babel src -d dist && jest",
         "lint": "eslint src test"
     },
-    "dependencies": {
-        "cropperjs": "^1.5.9"
-    },
     "peerDependencies": {
+        "cropperjs": "^1.5.9",
         "stimulus": "^2.0.0"
     },
     "devDependencies": {
@@ -34,6 +32,7 @@
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/preset-env": "^7.12.7",
         "@symfony/stimulus-testing": "^1.1.0",
+        "cropperjs": "^1.5.9",
         "stimulus": "^2.0.0"
     },
     "jest": {

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -40,6 +40,9 @@
         "symfony/twig-bundle": "^4.4.17|^5.0",
         "symfony/var-dumper": "^4.4.17|^5.0"
     },
+    "conflict": {
+        "symfony/flex": "<1.13"
+    },
     "extra": {
         "branch-alias": {
             "dev-main": "1.3-dev"

--- a/src/Swup/Resources/assets/package.json
+++ b/src/Swup/Resources/assets/package.json
@@ -18,14 +18,12 @@
         "test": "babel src -d dist && jest",
         "lint": "eslint src test"
     },
-    "dependencies": {
+    "peerDependencies": {
         "@swup/fade-theme": "^1.0",
         "@swup/slide-theme": "^1.0",
         "@swup/forms-plugin": "^1.0",
         "@swup/debug-plugin": "^1.0",
-        "swup": "^2.0"
-    },
-    "peerDependencies": {
+        "swup": "^2.0",
         "stimulus": "^2.0.0"
     },
     "devDependencies": {
@@ -33,6 +31,11 @@
         "@babel/core": "^7.12.3",
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/preset-env": "^7.12.7",
+        "@swup/fade-theme": "^1.0",
+        "@swup/slide-theme": "^1.0",
+        "@swup/forms-plugin": "^1.0",
+        "@swup/debug-plugin": "^1.0",
+        "swup": "^2.0",
         "@symfony/stimulus-testing": "^1.1.0",
         "stimulus": "^2.0.0"
     },

--- a/src/Swup/composer.json
+++ b/src/Swup/composer.json
@@ -17,6 +17,9 @@
             "homepage": "https://symfony.com/contributors"
         }
     ],
+    "conflict": {
+        "symfony/flex": "<1.13"
+    },
     "extra": {
         "branch-alias": {
             "dev-main": "1.3-dev"

--- a/src/Turbo/README.md
+++ b/src/Turbo/README.md
@@ -21,9 +21,6 @@ Install this bundle using Composer and Symfony Flex:
 ```sh
 composer require symfony/ux-turbo
 
-# install turbo itself
-yarn add @hotwired/turbo --dev
-
 # Don't forget to install the JavaScript dependencies as well and compile
 yarn install --force
 yarn encore dev

--- a/src/Turbo/README.md
+++ b/src/Turbo/README.md
@@ -21,6 +21,9 @@ Install this bundle using Composer and Symfony Flex:
 ```sh
 composer require symfony/ux-turbo
 
+# install turbo itself
+yarn add @hotwired/turbo --dev
+
 # Don't forget to install the JavaScript dependencies as well and compile
 yarn install --force
 yarn encore dev

--- a/src/Turbo/Resources/assets/package.json
+++ b/src/Turbo/Resources/assets/package.json
@@ -19,10 +19,8 @@
         "test": "babel src -d dist && jest",
         "lint": "eslint src test"
     },
-    "dependencies": {
-        "@hotwired/turbo": "^7.0.0-beta.4"
-    },
     "peerDependencies": {
+        "@hotwired/turbo": "^7.0.0-beta.5",
         "stimulus": "^2.0.0"
     },
     "devDependencies": {
@@ -30,6 +28,7 @@
         "@babel/core": "^7.12.3",
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/preset-env": "^7.12.7",
+        "@hotwired/turbo": "^7.0.0-beta.5",
         "@symfony/stimulus-testing": "^1.1.0",
         "stimulus": "^2.0.0"
     },

--- a/src/Turbo/Tests/app/package.json
+++ b/src/Turbo/Tests/app/package.json
@@ -1,5 +1,6 @@
 {
     "devDependencies": {
+        "@hotwired/turbo": "^7.0.0-beta.5",
         "@symfony/ux-turbo": "file:../../Resources/assets",
         "@symfony/ux-turbo-mercure": "file:../../Bridge/Mercure/Resources/assets",
         "@symfony/webpack-encore": "^0.32.0",

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -57,6 +57,9 @@
         "symfony/twig-bundle": "^5.2",
         "symfony/web-profiler-bundle": "^5.2"
     },
+    "conflict": {
+        "symfony/flex": "<1.13"
+    },
     "extra": {
         "branch-alias": {
             "dev-main": "1.3-dev"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

Like with Stimulus itself, I believe this should be a peer dependency. The only downside is that users need to install it directly, which I don't see as a huge downside.

This should guarantee that the the same "turbo" module is used from both the symfony/ux-turbo package and the end-users code (as well as from any other libraries that could potentially list turbo as a peer dependency). It should also fix this annoying little line I get in PhpStorm ;) 

<img width="867" alt="Screen Shot 2021-05-06 at 11 31 18 AM" src="https://user-images.githubusercontent.com/121003/117325305-954de100-ae5e-11eb-8959-4ca150f6ed49.png">

Cheers!