### PR TITLE
Fixing the URL for ChartJS documentation version

### DIFF
--- a/src/Chartjs/Model/Chart.php
+++ b/src/Chartjs/Model/Chart.php
@@ -51,7 +51,7 @@ class Chart
     /**
      * Sets Chart.js options.
      *
-     * @see https://www.chartjs.org/docs/latest/
+     * @see https://www.chartjs.org/docs/2.9.4
      *
      * <code>
      *    $chart->setOptions([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | 
| License       | MIT

As `symfony/ux-chartjs` supports ChartJS 2.9.4 and the last version of ChartJS is 3.2.1, this URL was pointing to a too recent version of the documentation and it was source of non working options.