### PR TITLE
Update Form example

### DIFF
--- a/src/Turbo/README.md
+++ b/src/Turbo/README.md
@@ -102,11 +102,9 @@ automatically:
 public function newProduct(Request $request): Response
 {
     return $this->handleForm(
-        $this->createForm(ProductFormType::class, null,
-        [
+        $this->createForm(ProductFormType::class, null, [
             'action' => $this->generateUrl('product_new'),
-        ]
-        ),
+        ]),
         $request,
         function (FormInterface $form) {
             // save...
@@ -179,17 +177,6 @@ $builder
             'value' => 'save-and-add'
         ]
     ]);
-```
-> **NOTE Turbo ^7.0.0-beta.5:**
-> If Turbo ^7.0.0-beta.5 or lower (may be still valid with future version), there is a bug with turbo-frame and form submit. F.e., a link to add a product will work the 1st time, the frame will have the new product form, on submit, the frame will be updated using the products listing. At this point the new link won't work anymore. This is cache issue in Turbo. To avoid it add a ramdom value as get parameter, microtime(true) will make it unique for one client:
-
-```php
-return $this->redirectToRoute('school', ['rmd' => time()], Response::HTTP_SEE_OTHER);
-```
-and in the listing template:
-
-```php
-<a data-turbo-action="replace" href="/school/new?rdm={{ rdm }}">Add Product</a>
 ```
 
 #### More Turbo Drive Info

--- a/src/Turbo/README.md
+++ b/src/Turbo/README.md
@@ -97,12 +97,16 @@ automatically:
 
 ```php
 /**
- * @Route("/product/new")
+ * @Route("/product/new", name="product_new")
  */
 public function newProduct(Request $request): Response
 {
     return $this->handleForm(
-        $this->createForm(ProductFormType::class),
+        $this->createForm(ProductFormType::class, null,
+        [
+            'action' => $this->generateUrl('product_new'),
+        ]
+        ),
         $request,
         function (FormInterface $form) {
             // save...
@@ -175,6 +179,17 @@ $builder
             'value' => 'save-and-add'
         ]
     ]);
+```
+> **NOTE Turbo ^7.0.0-beta.5:**
+> If Turbo ^7.0.0-beta.5 or lower (may be still valid with future version), there is a bug with turbo-frame and form submit. F.e., a link to add a product will work the 1st time, the frame will have the new product form, on submit, the frame will be updated using the products listing. At this point the new link won't work anymore. This is cache issue in Turbo. To avoid it add a ramdom value as get parameter, microtime(true) will make it unique for one client:
+
+```php
+return $this->redirectToRoute('school', ['rmd' => time()], Response::HTTP_SEE_OTHER);
+```
+and in the listing template:
+
+```php
+<a data-turbo-action="replace" href="/school/new?rdm={{ rdm }}">Add Product</a>
 ```
 
 #### More Turbo Drive Info


### PR DESCRIPTION
Without specifying the action, Turbo redirect the full page to /.

name="product_new" is not necessary in this specific example, it however may help newcomer to understand they can have separate route for this action (even if not recommended by the Symfony Form docs).

Not sure if it is a bug in turbo or me doing wrong, adding this fixes it.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
