### PR TITLE
[LiveComponent] Smooth out parent-child component relationship

### DIFF
--- a/src/LiveComponent/assets/src/have_rendered_values_changed.js
+++ b/src/LiveComponent/assets/src/have_rendered_values_changed.js
@@ -1,0 +1,70 @@
+export function haveRenderedValuesChanged(originalDataJson, currentDataJson, newDataJson) {
+    /*
+     * Right now, if the "data" on the new value is different than
+     * the "original data" on the child element, then we force re-render
+     * the child component. There may be some other cases that we
+     * add later if they come up. Either way, this is probably the
+     * behavior we want most of the time, but it's not perfect. For
+     * example, if the child component has some a writable prop that
+     * has changed since the initial render, re-rendering the child
+     * component from the parent component will "eliminate" that
+     * change.
+     */
+
+    // if the original data matches the new data, then the parent
+    // hasn't changed how they render the child.
+    if (originalDataJson === newDataJson) {
+        return false;
+    }
+
+    // The child component IS now being rendered in a "new way".
+    // This means that at least one of the "data" pieces used
+    // to render the child component has changed.
+    // However, the piece of data that changed might simply
+    // match the "current data" of that child component. In that case,
+    // there is no point to re-rendering.
+    // And, to be safe (in case the child has some "private LiveProp"
+    // that has been modified), we want to avoid rendering.
+
+
+    // if the current data exactly matches the new data, then definitely
+    // do not re-render.
+    if (currentDataJson === newDataJson) {
+        return false;
+    }
+
+    // here, we will compare the original data for the child component
+    // with the new data. What we're looking for are they keys that
+    // have changed between the original "child rendering" and the
+    // new "child rendering".
+    const originalData = JSON.parse(originalDataJson);
+    const newData = JSON.parse(newDataJson);
+    const changedKeys = Object.keys(newData);
+    Object.entries(originalData).forEach(([key, value]) => {
+        // if any key in the new data is different than a key in the
+        // current data, then we *should* re-render. But if all the
+        // keys in the new data equal
+        if (value === newData[key]) {
+            // value is equal, remove from changedKeys
+            changedKeys.splice(changedKeys.indexOf(key), 1);
+        }
+    });
+
+    // now that we know which keys have changed between originally
+    // rendering the child component and this latest render, we
+    // can check to see if the the child component *already* has
+    // the latest value for those keys.
+
+    const currentData = JSON.parse(currentDataJson)
+    let keyHasChanged = false;
+    changedKeys.forEach((key) => {
+        // if any key in the new data is different than a key in the
+        // current data, then we *should* re-render. But if all the
+        // keys in the new data equal
+        if (currentData[key] !== newData[key]) {
+            keyHasChanged = true;
+        }
+    });
+
+    return keyHasChanged;
+}

--- a/src/LiveComponent/assets/src/set_deep_data.js
+++ b/src/LiveComponent/assets/src/set_deep_data.js
@@ -25,15 +25,14 @@ export function setDeepData(data, propertyPath, value) {
     }
 
     // represents a situation where the key you're setting *is* an object,
-    // but the key we're setting is a new key. This, perhaps, could be
-    // allowed. But right now, all keys should be initialized with the
-    // initial data.
+    // but the key we're setting is a new key. Currently, all keys should
+    // be initialized with the initial data.
     if (currentLevelData[finalKey] === undefined) {
         const lastPart = parts.pop();
         if (parts.length > 0) {
-            console.warn(`The property used in data-model="${propertyPath}" was never initialized. Did you forget to add exposed={"${lastPart}"} to its LiveProp?`)
+            throw new Error(`The property used in data-model="${propertyPath}" was never initialized. Did you forget to add exposed={"${lastPart}"} to its LiveProp?`)
         } else {
-            console.warn(`The property used in data-model="${propertyPath}" was never initialized. Did you forget to expose "${lastPart}" as a LiveProp?`)
+            throw new Error(`The property used in data-model="${propertyPath}" was never initialized. Did you forget to expose "${lastPart}" as a LiveProp? Available models values are: ${Object.keys(data).length > 0 ? Object.keys(data).join(', ') : '(none)'}`)
         }
     }
 

--- a/src/LiveComponent/assets/test/controller/action.test.js
+++ b/src/LiveComponent/assets/test/controller/action.test.js
@@ -10,7 +10,7 @@
 'use strict';
 
 import { clearDOM } from '@symfony/stimulus-testing';
-import { startStimulus } from '../tools';
+import { initLiveComponent, startStimulus } from '../tools';
 import { getByLabelText, getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock-jest';
@@ -18,8 +18,7 @@ import fetchMock from 'fetch-mock-jest';
 describe('LiveController Action Tests', () => {
     const template = (data) => `
         <div
-            data-controller="live"
-            data-live-url-value="http://localhost/_components/my_component"
+            ${initLiveComponent('/_components/my_component', data)}
         >
             <label>
                 Comments:
@@ -46,10 +45,7 @@ describe('LiveController Action Tests', () => {
 
     it('Sends an action and cancels any re-renders', async () => {
         const data = { comments: 'hi' };
-        const { element } = await startStimulus(
-            template(data),
-            data
-        );
+        const { element } = await startStimulus(template(data));
 
         // ONLY a post is sent, not a re-render GET
         const postMock = fetchMock.postOnce('http://localhost/_components/my_component/save', {

--- a/src/LiveComponent/assets/test/controller/basic.test.js
+++ b/src/LiveComponent/assets/test/controller/basic.test.js
@@ -26,7 +26,6 @@ describe('LiveController Basic Tests', () => {
         })
         const { element } = await startStimulus(
             '<div data-controller="live"></div>',
-            {},
             container
         );
 

--- a/src/LiveComponent/assets/test/controller/child.test.js
+++ b/src/LiveComponent/assets/test/controller/child.test.js
@@ -1,0 +1,192 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { clearDOM } from '@symfony/stimulus-testing';
+import { initLiveComponent, mockRerender, startStimulus } from '../tools';
+import { getByLabelText, getByText, waitFor } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock-jest';
+
+describe('LiveController parent -> child component tests', () => {
+    const parentTemplate = (data) => {
+        const errors = data.errors || { post: {} };
+
+        return `
+            <div
+                ${initLiveComponent('/_components/parent', data)}
+            >
+                <span>Title: ${data.post.title}</span>
+                <span>Description in Parent: ${data.post.content}</span>
+
+                <label>
+                    Title:
+                    <input
+                        type="text"
+                        name="post[title]"
+                        value="${data.post.title}"
+                        data-action="live#update"
+                    >
+                </label>
+
+                ${childTemplate({ value: data.post.content, error: errors.post.content })}
+
+                <button
+                    data-action="live#$render"
+                >Parent Re-render</button>
+            </div>
+        `
+    }
+
+    const childTemplate = (data) => `
+        <div
+            ${initLiveComponent('/_components/child', data)}
+        >
+            <label>
+                Content:
+                <textarea
+                    data-model="value"
+                    name="post[content]"
+                    data-action="live#update"
+                    rows="${data.rows ? data.rows : '3'}"
+                >${data.value}</textarea>
+            </label>
+
+            <div>Value in child: ${data.value}</div>
+            <div>Error in child: ${data.error ? data.error : 'none'}</div>
+            {# Rows represents a writable prop that's private to the child component #}
+            <div>Rows in child: ${data.rows ? data.rows : 'not set'}</div>
+
+            <button
+                data-action="live#$render"
+            >Child Re-render</button>
+        </div>
+    `;
+
+    afterEach(() => {
+        clearDOM();
+        fetchMock.reset();
+    });
+
+    it('renders parent component without affecting child component', async () => {
+        const data = { post: { title: 'Parent component', content: 'i love' } };
+        const { element } = await startStimulus(parentTemplate(data));
+
+        // on child re-render, expect the new value, change rows on the server
+        mockRerender({ value: 'i love popcorn' }, childTemplate, (data) => {
+            // change the "rows" data on the "server"
+            data.rows = 5;
+        });
+        await userEvent.type(getByLabelText(element, 'Content:'), ' popcorn');
+
+        await waitFor(() => expect(element).toHaveTextContent('Value in child: i love popcorn'));
+        expect(element).toHaveTextContent('Rows in child: 5');
+
+        // when the parent re-renders, expect the changed title AND content (from child)
+        // but, importantly, the only "changed" data that will be passed into
+        // the child component will be "content", which will match what the
+        // child already has. This will NOT trigger a re-render.
+        mockRerender(
+            { post: { title: 'Parent component changed', content: 'i love popcorn' } },
+            parentTemplate
+        )
+        await userEvent.type(getByLabelText(element, 'Title:'), ' changed');
+        await waitFor(() => expect(element).toHaveTextContent('Title: Parent component changed'));
+
+        // the child component should *not* have updated
+        expect(element).toHaveTextContent('Rows in child: 5');
+    });
+
+    it('updates child model and parent model in a deferred way', async () => {
+        const data = { post: { title: 'Parent component', content: 'i love' } };
+        const { element, controller } = await startStimulus(parentTemplate(data));
+
+        // verify the child request contains the correct description & re-render
+        mockRerender({ value: 'i love turtles' }, childTemplate);
+
+        // change the description in the child
+        const inputElement = getByLabelText(element, 'Content:');
+        await userEvent.type(inputElement, ' turtles');
+
+        // wait for the render to complete
+        await waitFor(() => expect(element).toHaveTextContent('Value in child: i love turtles'));
+
+        // the parent should not re-render
+        expect(element).not.toHaveTextContent('Content in parent: i love turtles');
+        // but the value DID update on the parent component
+        // this is because the name="post[content]" in the child matches the parent model
+        expect(controller.dataValue.post.content).toEqual('i love turtles');
+    });
+
+    it('updates re-renders a child component if data has changed from initial', async () => {
+        const data = { post: { title: 'Parent component', content: 'initial content' } };
+        const { element } = await startStimulus(parentTemplate(data));
+
+        // allow the child to re-render, but change the "rows" value
+        const inputElement = getByLabelText(element, 'Content:');
+        await userEvent.clear(inputElement);
+        await userEvent.type(inputElement, 'changed content');
+        mockRerender({'value': 'changed content'}, childTemplate, (data) => {
+            data.rows = 5;
+        });
+
+        // reload, which will give us rows=5
+        getByText(element, 'Child Re-render').click();
+        await waitFor(() => expect(element).toHaveTextContent('Rows in child: 5'));
+
+        // simulate an action in the parent component where "errors" changes
+        mockRerender({'post': { title: 'Parent component', content: 'changed content' }}, parentTemplate, (data) => {
+            data.post.title = 'Changed title';
+            data.errors = { post: { content: 'the content is not interesting enough' }};
+        });
+
+        getByText(element, 'Parent Re-render').click();
+        await waitFor(() => expect(element).toHaveTextContent('Title: Changed title'));
+        // the child, of course, still has the "changed content" value
+        expect(element).toHaveTextContent('Value in child: changed content');
+        // but because some child data *changed* from its original value, the child DOES re-render
+        expect(element).toHaveTextContent('Error in child: the content is not interesting enough');
+        // however, this means that the updated "rows" data on the child is lost
+        expect(element).toHaveTextContent('Rows in child: not set');
+    });
+
+    it('uses data-model-map to map child models to parent models', async () => {
+        const parentTemplateDifferentModel = (data) => `
+            <div
+                ${initLiveComponent('/_components/parent', data)}
+            >
+                <span>Parent textarea content: ${data.textareaContent}</span>
+
+                <div
+                    data-model-map="from(value)|textareaContent"
+                >
+                    ${childTemplate({ value: data.textareaContent, error: null })}
+                </div>
+
+                <button
+                    data-action="live#$render"
+                >Parent Re-render</button>
+            </div>
+        `;
+
+        const data = { textareaContent: 'Original content' };
+        const { element, controller } = await startStimulus(parentTemplateDifferentModel(data));
+
+        // update & re-render the child component
+        const inputElement = getByLabelText(element, 'Content:');
+        await userEvent.clear(inputElement);
+        await userEvent.type(inputElement, 'changed content');
+        mockRerender({value: 'changed content'}, childTemplate);
+
+        await waitFor(() => expect(element).toHaveTextContent('Value in child: changed content'));
+
+        expect(controller.dataValue).toEqual({ textareaContent: 'changed content' });
+   });
+});

--- a/src/LiveComponent/assets/test/controller/csrf.test.js
+++ b/src/LiveComponent/assets/test/controller/csrf.test.js
@@ -10,15 +10,14 @@
 'use strict';
 
 import { clearDOM } from '@symfony/stimulus-testing';
-import { startStimulus } from '../tools';
-import { getByLabelText, getByText, waitFor } from '@testing-library/dom';
+import { initLiveComponent, startStimulus } from '../tools';
+import { getByText, waitFor } from '@testing-library/dom';
 import fetchMock from 'fetch-mock-jest';
 
 describe('LiveController CSRF Tests', () => {
     const template = (data) => `
         <div
-            data-controller="live"
-            data-live-url-value="http://localhost/_components/my_component"
+            ${initLiveComponent('/_components/my_component', data)}
             data-live-csrf-value="123TOKEN"
         >
             <label>
@@ -46,10 +45,7 @@ describe('LiveController CSRF Tests', () => {
 
     it('Sends the CSRF token on an action', async () => {
         const data = { comments: 'hi' };
-        const { element } = await startStimulus(
-            template(data),
-            data
-        );
+        const { element } = await startStimulus(template(data));
 
         const postMock = fetchMock.postOnce('http://localhost/_components/my_component/save', {
             html: template({ comments: 'hi', isSaved: true }),

--- a/src/LiveComponent/assets/test/have_rendered_values_changed.test.js
+++ b/src/LiveComponent/assets/test/have_rendered_values_changed.test.js
@@ -1,0 +1,93 @@
+import { haveRenderedValuesChanged } from '../src/have_rendered_values_changed';
+
+const runTest = (originalData, currentData, newData, expected) => {
+    const result = haveRenderedValuesChanged(
+        JSON.stringify(originalData),
+        JSON.stringify(currentData),
+        JSON.stringify(newData),
+    );
+
+    expect(result).toBe(expected);
+};
+
+describe('haveRenderedValuesChanged', () => {
+    it('returns false if the "new" data matches the "original" data', () => {
+        runTest(
+            // original
+            { value: 'original' },
+            // current
+            { value: 'child component did change' },
+            // new
+            { value: 'original' },
+            false
+        );
+    });
+
+    it('returns false if the "new" data matches the "current" data', () => {
+        // in this case, the component is already aware of the data
+
+        runTest(
+            // original
+            { value: 'original' },
+            // current
+            { value: 'updated' },
+            // new
+            { value: 'updated' },
+            false
+        );
+    });
+
+    it('returns false if the new data that *has* changed vs original is equal to current data', () => {
+        // This is a combination of the first two cases - each key
+        // represents one of the first two test situations.
+
+        // we see that the "firstName" key has changed between the
+        // new data vs the original. But, we also see that "firstName"
+        // is equal between new & current, meaning the component is already
+        // aware of this change.
+
+        // the "lastName" key has changed between current and new, but we
+        // don't care, because this hasn't changed since the original render
+
+        runTest(
+            // original
+            { firstName: 'Beckett', lastName: 'Weaver' },
+            // current
+            { firstName: 'Ryan', lastName: 'Pelham' },
+            // new
+            { firstName: 'Ryan', lastName: 'Weaver' },
+            false
+        );
+    });
+
+    it('returns true correctly even with rearranged key', () => {
+        // same as previous case, but keys rearranged
+
+        runTest(
+            // original
+            { firstName: 'Beckett', lastName: 'Weaver', favoriteColor: 'orange' },
+            // current
+            { firstName: 'Beckett', favoriteColor: 'orange', lastName: 'Weaver' },
+            // new
+            { favoriteColor: 'orange', lastName: 'Weaver', firstName: 'Beckett' },
+            false
+        );
+    });
+
+    it('returns true if at least one key in the new data has changed since the original data *and* it is not equal to the current data', () => {
+        // something truly changed in how the component is rendered that
+        // the component isn't aware of yet
+
+        runTest(
+            // original
+            { firstName: 'Beckett', lastName: 'Weaver', error: null },
+            // current
+            { firstName: 'Ryan', lastName: 'Pelham', error: null },
+            // new
+            { firstName: 'Ryan', lastName: 'Weaver', error: 'That sounds like a fake name' },
+            true
+        );
+    });
+
+    // todo - test with missing keys
+});

--- a/src/LiveComponent/assets/test/tools.js
+++ b/src/LiveComponent/assets/test/tools.js
@@ -1,6 +1,8 @@
 import { Application } from 'stimulus';
 import LiveController from '../src/live_controller';
 import { waitFor } from '@testing-library/dom';
+import fetchMock from 'fetch-mock-jest';
+import { buildSearchParams } from '../src/http_data_helper';
 
 const TestData = class {
     constructor(controller, element) {
@@ -11,7 +13,7 @@ const TestData = class {
 
 let application;
 
-const startStimulus = async (html, data, container = null) => {
+const startStimulus = async (html, container = null) => {
     // start the Stimulus app just once per test suite
     if (!application) {
         application = Application.start();
@@ -26,8 +28,6 @@ const startStimulus = async (html, data, container = null) => {
     document.body.appendChild(container);
 
     const element = getControllerElement(container);
-    element.dataset.liveDataValue = JSON.stringify(data);
-
     await waitFor(() => application.getControllerForElementAndIdentifier(element, 'live'));
     const controller = application.getControllerForElementAndIdentifier(element, 'live');
 
@@ -38,4 +38,44 @@ const getControllerElement = (container) => {
     return container.querySelector('[data-controller="live"]');
 };
 
-export { startStimulus, getControllerElement };
+const dataToJsonAttribute = (data) => {
+    const container = document.createElement('div');
+    container.dataset.foo = JSON.stringify(data);
+
+    // returns the now-escaped string, ready to be used in an HTML attribute
+    return container.outerHTML.match(/data\-foo="(.+)\"/)[1]
+}
+
+const initLiveComponent = (url, data) => {
+    return `
+        data-controller="live"
+        data-live-url-value="http://localhost${url}"
+        data-live-data-value="${dataToJsonAttribute(data)}"
+    `;
+}
+
+/**
+ * Allows you to easily mock a re-render Ajax request.
+ *
+ * The renderCallback() is called and passed the "sentData" as the only
+ * argument. If you want to change the "sentData" slightly before the
+ * template is rendered, pass the changeDataCallback and modify it there.
+ *
+ * @param {Object} sentData The *expected* data that should be sent to the server
+ * @param {function} renderCallback Function that will render the component
+ * @param {function} changeDataCallback Specify if you want to change the data before rendering
+ */
+const mockRerender = (sentData, renderCallback, changeDataCallback = (data) => {}) => {
+    const params = new URLSearchParams('');
+
+    const url = `end:?${buildSearchParams(params, sentData).toString()}`;
+
+    changeDataCallback(sentData);
+
+    fetchMock.mock(url, {
+        html: renderCallback(sentData),
+        data: sentData
+    });
+}
+
+export { startStimulus, getControllerElement, initLiveComponent, mockRerender };

--- a/src/TwigComponent/README.md
+++ b/src/TwigComponent/README.md
@@ -324,6 +324,14 @@ class FeaturedProductsComponent
 }
 ```
 
+## Embedded Components
+
+It's totally possible to embed one component into another. When you do
+this, there's nothing special to know: both components render independently.
+If you're using [Live Components](https://github.com/symfony/ux-live-component),
+then there _are_ some guidelines related to how the re-rendering of parent
+and child components works. Read [Live Embedded Components](https://github.com/symfony/ux-live-component#embedded-components).
+
 ## Contributing
 
 Interested in contributing? Visit the main source for this repository:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Tickets       | #102 addresses **Bug C** and **Bug F**
| License       | MIT

This PR is to address a few outstanding issues related to nested or "parent/child" components:

* [X] #102 Bug C: When a model is updated in a child component, that parent component does not receive that component update (e.g. imagine a form that renders a component... and one field is rendered inside another component - when the child component's model is updated, it should also update that same model in the parent component [the form]).
* [X] Change `data-model` to take priority over `name` so that child components can use `data-model` and allow parent components to still use the `name` attribute to match up with their model.
* [X] Change the new `live:update-model` event to also (when possible) pass the relevant element so that the listener can look at both the `name` and `data-model` attribute to find a match. Or find an alternative solution.
* [X] Document how parent/child components work (e.g. that when a parent re-renders, the child does not re-render)
* [X] #102 Bug F:  Add a way to "force" a child component to re-render
* [x] Document a known edge case: if a child component re-renders, and the shared model value (shared with a parent component) CHANGES in the AJAX response (e.g. `content=foo` is sent to the server but `content=FOO` is returned, and so `FOO` is now the new value of the `content` model), a parent will not be aware of this change.
* [x] Add way to "map" a child model onto a parent model so that you can "map" a private `LiveProp` from a child onto a parent so that it's not lost if the parent renders over the child.
* [x] Standardize / cleanup more tests with `mockRerender()`.