### PR TITLE
[bug] remove duplicated doctrine/annotations entry

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -41,8 +41,7 @@
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.7",
         "zenstruck/foundry": "^1.10",
-        "zenstruck/browser": "^0.5.0",
-        "doctrine/annotations": "^1.0"
+        "zenstruck/browser": "^0.5.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | n/a
| License       | MIT

Looks like 2 different PR's added this. (https://github.com/symfony/ux/pull/111 and https://github.com/symfony/ux/pull/106)
