### PR TITLE
[LiveComponent] Add a required "default" action for live components

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NEXT
 
+-   Require live components have a default action (`__invoke()` by default) to enable
+    controller annotations/attributes (ie `@Security/@Cache`). Added `DefaultActionTrait`
+    helper.
+
 -   When a model is updated, a new `live:update-model` event is dispatched. Parent
     components (in a parent-child component setup) listen to this and automatically
     try to update any model with a matching name. A `data-model-map` was also added

--- a/src/LiveComponent/README.md
+++ b/src/LiveComponent/README.md
@@ -16,10 +16,13 @@ A real-time product search component might look like this:
 namespace App\Components;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
 
 #[AsLiveComponent('product_search')]
 class ProductSearchComponent
 {
+    use DefaultActionTrait;
+
     public string $query = '';
 
     private ProductRepository $productRepository;
@@ -130,18 +133,21 @@ class RandomNumberComponent
 
 To transform this into a "live" component (i.e. one that
 can be re-rendered live on the frontend), replace the
-component's `AsTwigComponent` attribute with `AsLiveComponent`:
+component's `AsTwigComponent` attribute with `AsLiveComponent`
+and add the `DefaultActionTrait`:
 
 ```diff
 // src/Components/RandomNumberComponent.php
 
 -use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 +use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
++use Symfony\UX\LiveComponent\DefaultActionTrait;
 
 -#[AsTwigComponent('random_number')]
 -#[AsLiveComponent('random_number')]
 class RandomNumberComponent
 {
++    use DefaultActionTrait;
 }
 ```
 
@@ -433,10 +439,18 @@ changes until loading has taken longer than a certain amount of time:
 
 ## Actions
 
-You can also trigger actions on your component. Let's pretend we
-want to add a "Reset Min/Max" button to our "random number"
-component that, when clicked, sets the min/max numbers back
-to a default value.
+Live components require a single "default action" that is
+used to re-render it. By default, this is an empty `__invoke()`
+method and can be added with the `DefaultActionTrait`.
+Live components are actually Symfony controllers so you
+can add the normal controller attributes/annotations (ie
+`@Cache`/`@Security`) to either the entire class just a
+single action.
+
+You can also trigger custom actions on your component. Let's
+pretend we want to add a "Reset Min/Max" button to our "random
+number" component that, when clicked, sets the min/max numbers
+back to a default value.
 
 First, add a method with a `LiveAction` attribute above it that
 does the work:

--- a/src/LiveComponent/src/DefaultActionTrait.php
+++ b/src/LiveComponent/src/DefaultActionTrait.php
@@ -15,24 +15,19 @@ namespace Symfony\UX\LiveComponent;
  * @author Kevin Bond <kevinbond@gmail.com>
  *
  * @experimental
- *
- * @internal
  */
-final class DefaultComponentController
+trait DefaultActionTrait
 {
-    private object $component;
-
-    public function __construct(object $component)
-    {
-        $this->component = $component;
-    }
-
+    /**
+     * The "default" action for a component.
+     *
+     * This is executed when your component is being re-rendered,
+     * but no custom action is being called. You probably don't
+     * want to do any work here because this method is *not*
+     * executed when a custom action is triggered.
+     */
     public function __invoke(): void
     {
-    }
-
-    public function getComponent(): object
-    {
-        return $this->component;
+        // noop - this is the default action
     }
 }

--- a/src/LiveComponent/src/DependencyInjection/Compiler/LiveComponentPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/LiveComponentPass.php
@@ -27,13 +27,18 @@ final class LiveComponentPass implements CompilerPassInterface
         $componentServiceMap = [];
 
         foreach (array_keys($container->findTaggedServiceIds('twig.component')) as $id) {
+            $class = $container->findDefinition($id)->getClass();
+
             try {
-                $attribute = AsLiveComponent::forClass($container->findDefinition($id)->getClass());
+                $attribute = AsLiveComponent::forClass($class);
             } catch (\InvalidArgumentException $e) {
                 continue;
             }
 
-            $componentServiceMap[$attribute->getName()] = $id;
+            $componentServiceMap[$attribute->getName()] = [$id, $class];
+
+            // Ensure default action method is configured correctly
+            AsLiveComponent::defaultActionFor($class);
         }
 
         $container->findDefinition('ux.live_component.event_subscriber')->setArgument(0, $componentServiceMap);

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -30,7 +30,6 @@ use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\PropertyHydratorInterface;
 use Symfony\UX\LiveComponent\Twig\LiveComponentExtension as LiveComponentTwigExtension;
 use Symfony\UX\LiveComponent\Twig\LiveComponentRuntime;
-use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentRenderer;
 
 /**
@@ -78,7 +77,6 @@ final class LiveComponentExtension extends Extension
                 class_exists(AbstractArgument::class) ? new AbstractArgument(sprintf('Added in %s.', LiveComponentPass::class)) : [],
             ])
             ->addTag('kernel.event_subscriber')
-            ->addTag('container.service_subscriber', ['key' => ComponentFactory::class, 'id' => 'ux.twig_component.component_factory'])
             ->addTag('container.service_subscriber', ['key' => ComponentRenderer::class, 'id' => 'ux.twig_component.component_renderer'])
             ->addTag('container.service_subscriber', ['key' => LiveComponentHydrator::class, 'id' => 'ux.live_component.component_hydrator'])
             ->addTag('container.service_subscriber')

--- a/src/LiveComponent/tests/Fixture/Component/Component1.php
+++ b/src/LiveComponent/tests/Fixture/Component/Component1.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\LiveComponent\Tests\Fixture\Component;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\LiveComponent\Tests\Fixture\Entity\Entity1;
 
 /**
@@ -22,6 +23,8 @@ use Symfony\UX\LiveComponent\Tests\Fixture\Entity\Entity1;
 #[AsLiveComponent('component1')]
 final class Component1
 {
+    use DefaultActionTrait;
+
     #[LiveProp]
     public ?Entity1 $prop1;
 

--- a/src/LiveComponent/tests/Fixture/Component/Component2.php
+++ b/src/LiveComponent/tests/Fixture/Component/Component2.php
@@ -23,7 +23,7 @@ use Symfony\UX\LiveComponent\Attribute\PreDehydrate;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-#[AsLiveComponent('component2')]
+#[AsLiveComponent('component2', defaultAction: 'defaultAction()')]
 final class Component2
 {
     #[LiveProp]
@@ -34,6 +34,10 @@ final class Component2
     public bool $postHydrateCalled = false;
 
     public bool $beforeReRenderCalled = false;
+
+    public function defaultAction(): void
+    {
+    }
 
     #[LiveAction]
     public function increase(): void

--- a/src/LiveComponent/tests/Fixture/Component/Component3.php
+++ b/src/LiveComponent/tests/Fixture/Component/Component3.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\LiveComponent\Tests\Fixture\Component;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -20,6 +21,8 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 #[AsLiveComponent('component3')]
 final class Component3
 {
+    use DefaultActionTrait;
+
     #[LiveProp(fieldName: 'myProp1')]
     public $prop1;
 

--- a/src/LiveComponent/tests/Fixture/Component/Component5.php
+++ b/src/LiveComponent/tests/Fixture/Component/Component5.php
@@ -11,9 +11,14 @@
 
 namespace Symfony\UX\LiveComponent\Tests\Fixture\Component;
 
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
+#[AsLiveComponent('component5')]
 final class Component5 extends Component4
 {
+    use DefaultActionTrait;
 }

--- a/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
@@ -59,5 +59,6 @@ final class AsLiveComponentTest extends TestCase
 
         $this->assertTrue(AsLiveComponent::isActionAllowed($component, 'method1'));
         $this->assertFalse(AsLiveComponent::isActionAllowed($component, 'method2'));
+        $this->assertTrue(AsLiveComponent::isActionAllowed($component, '__invoke'));
     }
 }

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -48,7 +48,7 @@ class AsTwigComponent
         $class = new \ReflectionClass($class);
 
         if (!$attribute = $class->getAttributes(static::class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not a Twig Component, did you forget to add the "%s" attribute?', $class, static::class));
+            throw new \InvalidArgumentException(sprintf('"%s" is not a Twig Component, did you forget to add the "%s" attribute?', $class->getName(), static::class));
         }
 
         return $attribute->newInstance();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | #102 (feature A/D)
| License       | MIT

In order to use the `@Security/@Cache` annotations for your components, we need the default action to be on the component itself. Currently, for the default action, the component is wrapped inside an internal callable `DefaultComponentController` object. This won't inherit these annotations from the component class. The best solution @weaverryan and I could think of is to enforce a "default action" method exists on your component itself. 

By default, `__invoke()` is used but this can be customized via the `AsLiveComponent::$defaultAction` property. A `DefaultActionTrait` is provided that just adds an empty `__invoke()` method.
