### PR TITLE
Fix the URL of the Stimulus project

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ to build the chart in PHP. The JavaScript is handled for you automatically.
 
 ## Components of UX
 
-Symfony UX leverages [Stimulus](https://stimulus.hotwire.dev/) for JavaScript
+Symfony UX leverages [Stimulus](https://stimulus.hotwired.dev/) for JavaScript
 and the [Stimulus Bridge](https://github.com/symfony/stimulus-bridge) for
 integrating it into [Webpack Encore](https://github.com/symfony/webpack-encore).
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | -
| License       | MIT

The original URL now redirects to a different website ... so let's use the new official Stimulus URL.