### PR TITLE
Removing deprecation notices

### DIFF
--- a/src/Turbo/Tests/app/Kernel.php
+++ b/src/Turbo/Tests/app/Kernel.php
@@ -13,7 +13,6 @@ namespace App;
 
 use App\Entity\Book;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
-use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
@@ -91,10 +90,6 @@ class Kernel extends BaseKernel
             ],
         ];
 
-        if (class_exists(MappingDriver::class)) {
-            $doctrineConfig['dbal']['override_url'] = true;
-        }
-
         $container
             ->extension('doctrine', $doctrineConfig);
 
@@ -105,7 +100,6 @@ class Kernel extends BaseKernel
         ]);
 
         $container->extension('mercure', [
-            'enable_profiler' => '%kernel.debug%',
             'hubs' => [
                 'default' => [
                     'url' => $_SERVER['MERCURE_PUBLISH_URL'] ?? 'http://127.0.0.1:3000/.well-known/mercure',

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.12",
         "doctrine/doctrine-bundle": "^2.2",
-        "doctrine/orm": "~2.8.0",
+        "doctrine/orm": "^2.8 | 3.0",
         "phpstan/phpstan": "^0.12",
         "symfony/debug-bundle": "^5.2",
         "symfony/form": "^5.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None - but aiming to get the tests green again!
| License       | MIT

TODOS:

* [ ] Debug the remaining direct deprecation - related to DoctrineProvider cache
