### PR TITLE
Fix phpunit bridge with custom path

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,10 +2,6 @@ name: Symfony UX
 
 on: [push, pull_request]
 
-env:
-    SYMFONY_PHPUNIT_DIR: '/tmp/.phpunit'
-    SYMFONY_PHPUNIT_VERSION: '8.5'
-
 jobs:
     coding-style-php:
         runs-on: ubuntu-latest

--- a/src/Turbo/Doctrine/BroadcastListener.php
+++ b/src/Turbo/Doctrine/BroadcastListener.php
@@ -129,7 +129,6 @@ final class BroadcastListener implements ResetInterface
 
             if (\PHP_VERSION_ID >= 80000 && $options = ($r = new \ReflectionClass($class))->getAttributes(Broadcast::class)) {
                 $options = $options[0]->newInstance();
-                // @phpstan-ignore-next-line
                 $this->broadcastedClasses[$class] = $options->options;
             } elseif ($this->annotationReader && $options = $this->annotationReader->getClassAnnotation($r ?? new \ReflectionClass($class), Broadcast::class)) {
                 $this->broadcastedClasses[$class] = $options->options;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fixes tests!
| License       | MIT

A workaround for https://github.com/symfony/symfony/issues/43877 - though I'm not sure if we have a good reason for choosing a custom directory in the first place... so this might be completely fine.

Also, I'm not sure if we need the PHPUnit version - I had already removed it in another PR because (iirc) it was causing some issues.