### PR TITLE
Preventing malicious version of coa to install in CI

### DIFF
--- a/src/Turbo/Tests/app/package.json
+++ b/src/Turbo/Tests/app/package.json
@@ -9,6 +9,7 @@
         "stimulus": "^2.0.0",
         "webpack-notifier": "^1.6.0"
     },
+    "resolutions": { "coa": "2.0.2" },
     "license": "MIT",
     "private": true,
     "scripts": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | none
| License       | MIT

See: https://github.com/veged/coa/issues/99

**This is not an end-user security issue**. Simply, we don't want to allow malicious code to be executed inside our own CI system.