### PR TITLE
[LiveComponent] use "full" serializer for NormalizerBridgePropertyHydrator

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -62,12 +62,12 @@ final class LiveComponentExtension extends Extension
 
         $container->register('ux.live_component.doctrine_entity_property_hydrator', DoctrineEntityPropertyHydrator::class)
             ->setArguments([[new Reference('doctrine')]])
-            ->addTag('twig.component.property_hydrator', ['priority' => -200])
+            ->addTag('twig.component.property_hydrator', ['priority' => -100])
         ;
 
-        $container->register('ux.live_component.datetime_property_hydrator', NormalizerBridgePropertyHydrator::class)
-            ->setArguments([new Reference('serializer.normalizer.datetime')])
-            ->addTag('twig.component.property_hydrator', ['priority' => -100])
+        $container->register('ux.live_component.serializer_property_hydrator', NormalizerBridgePropertyHydrator::class)
+            ->setArguments([new Reference('serializer')])
+            ->addTag('twig.component.property_hydrator', ['priority' => -200])
         ;
 
         $container->register('ux.live_component.component_hydrator', LiveComponentHydrator::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #152, #133
| License       | MIT

This injects the entire serializer into `NormalizerBridgePropertyHydrator`. Previously, it was just the `DateTimeNormalizer`. We originally decided it would be best to "pick and choose" which normalizers we would enable by default. The reasoning was we wanted to prevent the `DoctrineEntityPropertyHydrator` being called when hydrating/dehydrating every live prop. This hydrator requires checking with doctrine if the property's type-hint is a doctrine entity. I believe we were concerned about the performance overhead. Maybe this is negligible? Maybe we can adjust this hydrator to be more performant?
