### PR TITLE
[LiveComponent] LiveProps: writable instead of modifiable attribute

### DIFF
--- a/src/LiveComponent/README.md
+++ b/src/LiveComponent/README.md
@@ -1056,7 +1056,7 @@ class EditPostComponent
 
 With this, both the `title` and the `content` properties of the
 `$post` property _can_ be modified by the user. However, notice
-that the `LiveProp` does _not_ have `modifiable=true`. This
+that the `LiveProp` does _not_ have `writable=true`. This
 means that while the `title` and `content` properties can be
 changed, the `Post` object itself **cannot** be changed. In other
 words, if the component was originally created with a Post


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | 
| License       | MIT

I read the whole documentation on Twig Component and Live Component (thanks ❤️!) and found a small typo. Well, I think it's a typo as I don't already tested the component :)

