### PR TITLE
Setting branch alias to correct 1.4

### DIFF
--- a/src/Chartjs/composer.json
+++ b/src/Chartjs/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.3-dev"
+            "dev-main": "1.4-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.3-dev"
+            "dev-main": "1.4-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/Dropzone/composer.json
+++ b/src/Dropzone/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.3-dev"
+            "dev-main": "1.4-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/LazyImage/composer.json
+++ b/src/LazyImage/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.3-dev"
+            "dev-main": "1.4-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/Swup/composer.json
+++ b/src/Swup/composer.json
@@ -22,7 +22,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.3-dev"
+            "dev-main": "1.4-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/Turbo/Bridge/Mercure/composer.json
+++ b/src/Turbo/Bridge/Mercure/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.3-dev"
+            "dev-main": "1.4-dev"
         },
         "thanks": {
             "name": "symfony/ux-turbo",

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -62,7 +62,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.3-dev"
+            "dev-main": "1.4-dev"
         },
         "thanks": {
             "name": "symfony/ux",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | none
| License       | MIT

Next release is 1.4, so this is correct.

When we tag 2.0, it would be easier if we went to 2.x/1.x style branches like symfony/symfony. Then, I believe, we can just remove this and not worry about it. Or perhaps we should just remove this now? I'm not sure what practical purpose it has.

Cheers!
