### PR TITLE
Fix small typo in Turbo code example

### DIFF
--- a/src/Turbo/README.md
+++ b/src/Turbo/README.md
@@ -101,7 +101,7 @@ automatically:
  */
 public function newProduct(Request $request): Response
 {
-    $form = this->createForm(ProductFormType::class, null, [
+    $form = $this->createForm(ProductFormType::class, null, [
         'action' => $this->generateUrl('product_new'),
     ]);
     $form->handleRequest($request);
@@ -110,7 +110,7 @@ public function newProduct(Request $request): Response
         // save...
 
         return $this->redirectToRoute('product_list');
-    );
+    }
 
     return $this->renderForm('product/new.html.twig', [
         'form' => $form,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT

An example from the Turbo README.md does not have the dollar `$` before `this` variable, and also a closing parenthesis instead of a closing curly brace.
