### PR TITLE
Changing branch alias to 2.0

### DIFF
--- a/src/Chartjs/composer.json
+++ b/src/Chartjs/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "2.0-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "2.0-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/Dropzone/composer.json
+++ b/src/Dropzone/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "2.0-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/LazyImage/composer.json
+++ b/src/LazyImage/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "2.0-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "2.0-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/Swup/composer.json
+++ b/src/Swup/composer.json
@@ -22,7 +22,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "2.0-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/Turbo/Bridge/Mercure/composer.json
+++ b/src/Turbo/Bridge/Mercure/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "2.0-dev"
         },
         "thanks": {
             "name": "symfony/ux-turbo",

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -62,7 +62,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "2.0-dev"
         },
         "thanks": {
             "name": "symfony/ux",

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "2.0-dev"
         },
         "thanks": {
             "name": "symfony/ux",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yrs
| New feature?  | no
| Tickets       | none
| License       | MIT

Since we're going to skip 1.4 and go straight to 2.0, it is the next release.

Buuuut, a better solution is to create 1.x and 2.x branches. Then I believe we can remove this completely - e.g. Flex https://github.com/symfony/flex/commit/375e01daedd481501c29f3dea443cf885858382f#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34