### PR TITLE
Removing branch-alias

### DIFF
--- a/src/Chartjs/composer.json
+++ b/src/Chartjs/composer.json
@@ -41,9 +41,6 @@
         "symfony/flex": "<1.13"
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.3-dev"
-        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -44,9 +44,6 @@
         "symfony/flex": "<1.13"
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.3-dev"
-        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Dropzone/composer.json
+++ b/src/Dropzone/composer.json
@@ -39,9 +39,6 @@
         "symfony/var-dumper": "^4.4.17|^5.0"
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.3-dev"
-        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/LazyImage/composer.json
+++ b/src/LazyImage/composer.json
@@ -40,9 +40,6 @@
         "symfony/var-dumper": "^4.4.17|^5.0"
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.3-dev"
-        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Swup/composer.json
+++ b/src/Swup/composer.json
@@ -21,9 +21,6 @@
         "symfony/flex": "<1.13"
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.3-dev"
-        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Turbo/Bridge/Mercure/composer.json
+++ b/src/Turbo/Bridge/Mercure/composer.json
@@ -32,9 +32,6 @@
         "symfony/ux-turbo": "^1.3"
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.3-dev"
-        },
         "thanks": {
             "name": "symfony/ux-turbo",
             "url": "https://github.com/symfony/ux"

--- a/src/Turbo/Doctrine/BroadcastListener.php
+++ b/src/Turbo/Doctrine/BroadcastListener.php
@@ -129,7 +129,6 @@ final class BroadcastListener implements ResetInterface
 
             if (\PHP_VERSION_ID >= 80000 && $options = ($r = new \ReflectionClass($class))->getAttributes(Broadcast::class)) {
                 $options = $options[0]->newInstance();
-                // @phpstan-ignore-next-line
                 $this->broadcastedClasses[$class] = $options->options;
             } elseif ($this->annotationReader && $options = $this->annotationReader->getClassAnnotation($r ?? new \ReflectionClass($class), Broadcast::class)) {
                 $this->broadcastedClasses[$class] = $options->options;

--- a/src/Turbo/Tests/BroadcastTest.php
+++ b/src/Turbo/Tests/BroadcastTest.php
@@ -22,6 +22,10 @@ class BroadcastTest extends PantherTestCase
 
     public function testBroadcast(): void
     {
+        if (!file_exists(__DIR__.'/app/public/build')) {
+            throw new \Exception(sprintf('Move into %s and execute Encore before running this test.', realpath(__DIR__.'/app')));
+        }
+
         ($client = self::createPantherClient())->request('GET', '/books');
 
         $crawler = $client->submitForm('Submit', ['title' => self::BOOK_TITLE]);

--- a/src/Turbo/Tests/app/Kernel.php
+++ b/src/Turbo/Tests/app/Kernel.php
@@ -13,7 +13,6 @@ namespace App;
 
 use App\Entity\Book;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
-use Doctrine\Bundle\DoctrineBundle\Mapping\MappingDriver;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
@@ -90,10 +89,6 @@ class Kernel extends BaseKernel
                 ],
             ],
         ];
-
-        if (class_exists(MappingDriver::class)) {
-            $doctrineConfig['dbal']['override_url'] = true;
-        }
 
         $container
             ->extension('doctrine', $doctrineConfig);

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.12",
         "doctrine/doctrine-bundle": "^2.2",
-        "doctrine/orm": "~2.8.0",
+        "doctrine/orm": "^2.8.0",
         "phpstan/phpstan": "^0.12",
         "symfony/debug-bundle": "^5.2",
         "symfony/form": "^5.2",

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -61,9 +61,6 @@
         "symfony/flex": "<1.13"
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.3-dev"
-        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

We now have named branches, so no need to have branch-alias, I beileve.