### PR TITLE
[LazyImage] Converting to values & renaming some options

### DIFF
--- a/src/LazyImage/CHANGELOG.md
+++ b/src/LazyImage/CHANGELOG.md
@@ -7,4 +7,6 @@
     for more details.
 -   The `data-hd-src` attribute was changed to use a Stimulus value called `src`. See the
     updated README for usage.
+-   For both JavaScript events - `lazy-image:connect` and `lazy-image:ready` -
+    the `event.detail.hd` `Image` instance was moved to `event.detail.image`.
 -   Support added for Symfony 6

--- a/src/LazyImage/CHANGELOG.md
+++ b/src/LazyImage/CHANGELOG.md
@@ -5,4 +5,6 @@
 -   Support for `stimulus` version 2 was removed and support for `@hotwired/stimulus`
     version 3 was added. See the [@symfony/stimulus-bridge CHANGELOG](https://github.com/symfony/stimulus-bridge/blob/main/CHANGELOG.md#300)
     for more details.
+-   The `data-hd-src` attribute was changed to use a Stimulus value called `src`. See the
+    updated README for usage.
 -   Support added for Symfony 6

--- a/src/LazyImage/README.md
+++ b/src/LazyImage/README.md
@@ -34,15 +34,35 @@ page has been rendered:
 ```twig
 <img
     src="{{ asset('image/small.png') }}"
-    {{ stimulus_controller('symfony/ux-lazy-image/lazy-image') }}
-    data-hd-src="{{ asset('image/large.png') }}"
-
-    srcset="{{ asset('image/small.png') }} 1x, {{ asset('image/small2x.png') }} 2x"
-    data-hd-srcset="{{ asset('image/large.png') }} 1x, {{ asset('image/large2x.png') }} 2x"
+    {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
+        hdSrc: asset('image/large.png')
+    }) }}
 
     {# Optional but avoids having a page jump when the image is loaded #}
     width="200"
     height="150"
+>
+```
+
+With this setup, the user will initially see `images/small.png`. Then,
+once the page has loaded and the user's browser has downloaded the larger
+image, the `src` attribute will change to `image/large.png`.
+
+There is also support for the `srcset` attribute by passing an
+`hdSrcset` value to the controller:
+
+```twig
+<img
+    src="{{ asset('image/small.png') }}"
+    srcset="{{ asset('image/small.png') }} 1x, {{ asset('image/small2x.png') }} 2x"
+
+    {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
+        hdSrc: asset('image/large.png'),
+        hdSrcset: {
+            '1x': asset('image/large.png'),
+            '2x': asset('image/large2x.png')
+        }
+    }) }}
 />
 ```
 
@@ -55,8 +75,9 @@ the BlurHash algorithm to create a light, blurred, data-uri thumbnail of the ima
 ```twig
 <img
     src="{{ data_uri_thumbnail('public/image/large.png', 100, 75) }}"
-    {{ stimulus_controller('symfony/ux-lazy-image/lazy-image') }}
-    data-hd-src="{{ asset('image/large.png') }}"
+    {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
+        hdSrc: asset('image/large.png')
+    }) }}
 
     {# Using BlurHash, the size is required #}
     width="200"
@@ -112,9 +133,10 @@ Then in your template, add your controller to the HTML attribute:
     src="{{ data_uri_thumbnail('public/image/large.png', 100, 75) }}"
     {{ stimulus_controller({
         mylazyimage: {},
-        'symfony/ux-lazy-image/lazy-image': {}
+        'symfony/ux-lazy-image/lazy-image': {
+            hdSrc: asset('image/large.png')
+        }
     }) }}
-    data-hd-src="{{ asset('image/large.png') }}"
 
     {# Using BlurHash, the size is required #}
     width="200"

--- a/src/LazyImage/README.md
+++ b/src/LazyImage/README.md
@@ -35,7 +35,7 @@ page has been rendered:
 <img
     src="{{ asset('image/small.png') }}"
     {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
-        hdSrc: asset('image/large.png')
+        src: asset('image/large.png')
     }) }}
 
     {# Optional but avoids having a page jump when the image is loaded #}
@@ -49,7 +49,7 @@ once the page has loaded and the user's browser has downloaded the larger
 image, the `src` attribute will change to `image/large.png`.
 
 There is also support for the `srcset` attribute by passing an
-`hdSrcset` value to the controller:
+`srcset` value to the controller:
 
 ```twig
 <img
@@ -57,8 +57,8 @@ There is also support for the `srcset` attribute by passing an
     srcset="{{ asset('image/small.png') }} 1x, {{ asset('image/small2x.png') }} 2x"
 
     {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
-        hdSrc: asset('image/large.png'),
-        hdSrcset: {
+        src: asset('image/large.png'),
+        srcset: {
             '1x': asset('image/large.png'),
             '2x': asset('image/large2x.png')
         }
@@ -76,7 +76,7 @@ the BlurHash algorithm to create a light, blurred, data-uri thumbnail of the ima
 <img
     src="{{ data_uri_thumbnail('public/image/large.png', 100, 75) }}"
     {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
-        hdSrc: asset('image/large.png')
+        src: asset('image/large.png')
     }) }}
 
     {# Using BlurHash, the size is required #}
@@ -134,7 +134,7 @@ Then in your template, add your controller to the HTML attribute:
     {{ stimulus_controller({
         mylazyimage: {},
         'symfony/ux-lazy-image/lazy-image': {
-            hdSrc: asset('image/large.png')
+            src: asset('image/large.png')
         }
     }) }}
 

--- a/src/LazyImage/Resources/assets/dist/controller.js
+++ b/src/LazyImage/Resources/assets/dist/controller.js
@@ -9,13 +9,13 @@ class default_1 extends Controller {
             if (srcsetString) {
                 this.element.srcset = srcsetString;
             }
-            this._dispatchEvent('lazy-image:ready', { hd });
+            this._dispatchEvent('lazy-image:ready', { image: hd });
         });
         hd.src = this.srcValue;
         if (srcsetString) {
             hd.srcset = srcsetString;
         }
-        this._dispatchEvent('lazy-image:connect', { hd });
+        this._dispatchEvent('lazy-image:connect', { image: hd });
     }
     _calculateSrcsetString() {
         if (!this.hasSrcsetValue) {

--- a/src/LazyImage/Resources/assets/dist/controller.js
+++ b/src/LazyImage/Resources/assets/dist/controller.js
@@ -5,25 +5,25 @@ class default_1 extends Controller {
         const hd = new Image();
         const srcsetString = this._calculateSrcsetString();
         hd.addEventListener('load', () => {
-            this.element.src = this.hdSrcValue;
+            this.element.src = this.srcValue;
             if (srcsetString) {
                 this.element.srcset = srcsetString;
             }
             this._dispatchEvent('lazy-image:ready', { hd });
         });
-        hd.src = this.hdSrcValue;
+        hd.src = this.srcValue;
         if (srcsetString) {
             hd.srcset = srcsetString;
         }
         this._dispatchEvent('lazy-image:connect', { hd });
     }
     _calculateSrcsetString() {
-        if (!this.hasHdSrcsetValue) {
+        if (!this.hasSrcsetValue) {
             return '';
         }
-        const sets = Object.keys(this.hdSrcsetValue).map((size => {
-            return `${this.hdSrcsetValue[size]} ${size}`;
-        }));
+        const sets = Object.keys(this.srcsetValue).map((size) => {
+            return `${this.srcsetValue[size]} ${size}`;
+        });
         return sets.join(', ').trimEnd();
     }
     _dispatchEvent(name, payload = null, canBubble = false, cancelable = false) {
@@ -33,8 +33,8 @@ class default_1 extends Controller {
     }
 }
 default_1.values = {
-    hdSrc: String,
-    hdSrcset: Object
+    src: String,
+    srcset: Object,
 };
 
 export { default_1 as default };

--- a/src/LazyImage/Resources/assets/dist/controller.js
+++ b/src/LazyImage/Resources/assets/dist/controller.js
@@ -1,20 +1,30 @@
 import { Controller } from '@hotwired/stimulus';
 
-class controller extends Controller {
+class default_1 extends Controller {
     connect() {
         const hd = new Image();
+        const srcsetString = this._calculateSrcsetString();
         hd.addEventListener('load', () => {
-            this.element.src = this.element.getAttribute('data-hd-src');
-            if (this.element.getAttribute('data-hd-srcset')) {
-                this.element.srcset = this.element.getAttribute('data-hd-srcset');
+            this.element.src = this.hdSrcValue;
+            if (srcsetString) {
+                this.element.srcset = srcsetString;
             }
             this._dispatchEvent('lazy-image:ready', { hd });
         });
-        hd.src = this.element.getAttribute('data-hd-src');
-        if (this.element.getAttribute('data-hd-srcset')) {
-            hd.srcset = this.element.getAttribute('data-hd-srcset');
+        hd.src = this.hdSrcValue;
+        if (srcsetString) {
+            hd.srcset = srcsetString;
         }
         this._dispatchEvent('lazy-image:connect', { hd });
+    }
+    _calculateSrcsetString() {
+        if (!this.hasHdSrcsetValue) {
+            return '';
+        }
+        const sets = Object.keys(this.hdSrcsetValue).map((size => {
+            return `${this.hdSrcsetValue[size]} ${size}`;
+        }));
+        return sets.join(', ').trimEnd();
     }
     _dispatchEvent(name, payload = null, canBubble = false, cancelable = false) {
         const userEvent = document.createEvent('CustomEvent');
@@ -22,5 +32,9 @@ class controller extends Controller {
         this.element.dispatchEvent(userEvent);
     }
 }
+default_1.values = {
+    hdSrc: String,
+    hdSrcset: Object
+};
 
-export { controller as default };
+export { default_1 as default };

--- a/src/LazyImage/Resources/assets/src/controller.ts
+++ b/src/LazyImage/Resources/assets/src/controller.ts
@@ -13,8 +13,8 @@ import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
     static values = {
-        hdSrc: String,
-        hdSrcset: Object
+        src: String,
+        srcset: Object,
     };
 
     connect() {
@@ -23,14 +23,14 @@ export default class extends Controller {
         const srcsetString = this._calculateSrcsetString();
 
         hd.addEventListener('load', () => {
-            this.element.src = this.hdSrcValue;
+            this.element.src = this.srcValue;
             if (srcsetString) {
                 this.element.srcset = srcsetString;
             }
             this._dispatchEvent('lazy-image:ready', { hd });
         });
 
-        hd.src = this.hdSrcValue;
+        hd.src = this.srcValue;
         if (srcsetString) {
             hd.srcset = srcsetString;
         }
@@ -39,13 +39,13 @@ export default class extends Controller {
     }
 
     _calculateSrcsetString(): string {
-        if (!this.hasHdSrcsetValue) {
+        if (!this.hasSrcsetValue) {
             return '';
         }
 
-        const sets = Object.keys(this.hdSrcsetValue).map((size => {
-            return `${this.hdSrcsetValue[size]} ${size}`;
-        }));
+        const sets = Object.keys(this.srcsetValue).map((size) => {
+            return `${this.srcsetValue[size]} ${size}`;
+        });
 
         return sets.join(', ').trimEnd();
     }

--- a/src/LazyImage/Resources/assets/src/controller.ts
+++ b/src/LazyImage/Resources/assets/src/controller.ts
@@ -27,7 +27,7 @@ export default class extends Controller {
             if (srcsetString) {
                 this.element.srcset = srcsetString;
             }
-            this._dispatchEvent('lazy-image:ready', { hd });
+            this._dispatchEvent('lazy-image:ready', { image: hd });
         });
 
         hd.src = this.srcValue;
@@ -35,7 +35,7 @@ export default class extends Controller {
             hd.srcset = srcsetString;
         }
 
-        this._dispatchEvent('lazy-image:connect', { hd });
+        this._dispatchEvent('lazy-image:connect', { image: hd });
     }
 
     _calculateSrcsetString(): string {

--- a/src/LazyImage/Resources/assets/src/controller.ts
+++ b/src/LazyImage/Resources/assets/src/controller.ts
@@ -12,23 +12,42 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
+    static values = {
+        hdSrc: String,
+        hdSrcset: Object
+    };
+
     connect() {
         const hd = new Image();
 
+        const srcsetString = this._calculateSrcsetString();
+
         hd.addEventListener('load', () => {
-            this.element.src = this.element.getAttribute('data-hd-src');
-            if (this.element.getAttribute('data-hd-srcset')) {
-                this.element.srcset = this.element.getAttribute('data-hd-srcset');
+            this.element.src = this.hdSrcValue;
+            if (srcsetString) {
+                this.element.srcset = srcsetString;
             }
             this._dispatchEvent('lazy-image:ready', { hd });
         });
 
-        hd.src = this.element.getAttribute('data-hd-src');
-        if (this.element.getAttribute('data-hd-srcset')) {
-            hd.srcset = this.element.getAttribute('data-hd-srcset');
+        hd.src = this.hdSrcValue;
+        if (srcsetString) {
+            hd.srcset = srcsetString;
         }
 
         this._dispatchEvent('lazy-image:connect', { hd });
+    }
+
+    _calculateSrcsetString(): string {
+        if (!this.hasHdSrcsetValue) {
+            return '';
+        }
+
+        const sets = Object.keys(this.hdSrcsetValue).map((size => {
+            return `${this.hdSrcsetValue[size]} ${size}`;
+        }));
+
+        return sets.join(', ').trimEnd();
     }
 
     _dispatchEvent(name, payload = null, canBubble = false, cancelable = false) {

--- a/src/LazyImage/Resources/assets/test/controller.test.ts
+++ b/src/LazyImage/Resources/assets/test/controller.test.ts
@@ -17,7 +17,10 @@ import LazyImageController from '../src/controller';
 // Controller used to check the actual controller was properly booted
 class CheckController extends Controller {
     connect() {
-        this.element.addEventListener('lazy-image:connect', () => {
+        this.element.addEventListener('lazy-image:connect', (event) => {
+            // the Image won't natively have its "load" method in this test
+            // so we trigger it manually, to "fake" the Image loading.
+            event.detail.hd.dispatchEvent(new Event('load'));
             this.element.classList.add('connected');
         });
     }
@@ -38,8 +41,8 @@ describe('LazyImageController', () => {
               src="https://symfony.com/logos/symfony_black_02.png"
               srcset="https://symfony.com/logos/symfony_black_02.png 1x, https://symfony.com/logos/symfony_black_02.png 2x"
               data-testid="img"
-              data-hd-src="https://symfony.com/logos/symfony_black_03.png" 
-              data-hd-srcset="https://symfony.com/logos/symfony_black_03.png 1x, https://symfony.com/logos/symfony_black_03.png 2x"
+              data-lazy-image-hd-src-value="https://symfony.com/logos/symfony_black_03.png"
+              data-lazy-image-hd-srcset-value="{&quot;1x&quot;: &quot;https://symfony.com/logos/symfony_black_03.png&quot;, &quot;2x&quot;: &quot;https://symfony.com/logos/symfony_black_03_2x.png&quot;}"
               data-controller="check lazy-image" />
         `);
     });
@@ -49,9 +52,13 @@ describe('LazyImageController', () => {
     });
 
     it('connect', async () => {
-        expect(getByTestId(container, 'img')).not.toHaveClass('connected');
+        const img = getByTestId(container, 'img');
+        expect(img).not.toHaveClass('connected');
+        expect(img).toHaveAttribute('src', 'https://symfony.com/logos/symfony_black_02.png');
 
         startStimulus();
-        await waitFor(() => expect(getByTestId(container, 'img')).toHaveClass('connected'));
+        await waitFor(() => expect(img).toHaveClass('connected'));
+        expect(img).toHaveAttribute('src', 'https://symfony.com/logos/symfony_black_03.png');
+        expect(img).toHaveAttribute('srcset', 'https://symfony.com/logos/symfony_black_03.png 1x, https://symfony.com/logos/symfony_black_03_2x.png 2x');
     });
 });

--- a/src/LazyImage/Resources/assets/test/controller.test.ts
+++ b/src/LazyImage/Resources/assets/test/controller.test.ts
@@ -20,7 +20,7 @@ class CheckController extends Controller {
         this.element.addEventListener('lazy-image:connect', (event) => {
             // the Image won't natively have its "load" method in this test
             // so we trigger it manually, to "fake" the Image loading.
-            event.detail.hd.dispatchEvent(new Event('load'));
+            event.detail.image.dispatchEvent(new Event('load'));
             this.element.classList.add('connected');
         });
     }

--- a/src/LazyImage/Resources/assets/test/controller.test.ts
+++ b/src/LazyImage/Resources/assets/test/controller.test.ts
@@ -41,8 +41,8 @@ describe('LazyImageController', () => {
               src="https://symfony.com/logos/symfony_black_02.png"
               srcset="https://symfony.com/logos/symfony_black_02.png 1x, https://symfony.com/logos/symfony_black_02.png 2x"
               data-testid="img"
-              data-lazy-image-hd-src-value="https://symfony.com/logos/symfony_black_03.png"
-              data-lazy-image-hd-srcset-value="{&quot;1x&quot;: &quot;https://symfony.com/logos/symfony_black_03.png&quot;, &quot;2x&quot;: &quot;https://symfony.com/logos/symfony_black_03_2x.png&quot;}"
+              data-lazy-image-src-value="https://symfony.com/logos/symfony_black_03.png"
+              data-lazy-image-srcset-value="{&quot;1x&quot;: &quot;https://symfony.com/logos/symfony_black_03.png&quot;, &quot;2x&quot;: &quot;https://symfony.com/logos/symfony_black_03_2x.png&quot;}"
               data-controller="check lazy-image" />
         `);
     });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | none
| License       | MIT

3 changes here to prep for 2.0:

1) Changed to use the values API
2) When doing this, renamed `hdSrc` to just `src`. It feels better - the `hd` seems unnecessary.
3) Renaming a key on the event - `image` seems better than `hd`.

Cheers!