### PR TITLE
Fix Turbo Mercure bridge dependency

### DIFF
--- a/src/Turbo/Bridge/Mercure/composer.json
+++ b/src/Turbo/Bridge/Mercure/composer.json
@@ -29,7 +29,7 @@
         "php": ">=7.2.5",
         "symfony/mercure-bundle": "^0.3",
         "symfony/twig-bundle": "^5.2|^6.0",
-        "symfony/ux-turbo": "^1.3"
+        "symfony/ux-turbo": "^2.0"
     },
     "extra": {
         "thanks": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix https://github.com/symfony/ux/issues/198
| License       | MIT

I think the package should be able to handle both 1.x and 2.x without change. @weaverryan I guess this will require a dedicated tag right?