### PR TITLE
Adjust live-component CI to use twig-component release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,6 @@ jobs:
             - name: LiveComponent
               run: |
                   cd src/LiveComponent
-                  php ../../.github/build-packages.php
                   composer update --prefer-lowest --prefer-dist --no-interaction --no-ansi --no-progress
                   php vendor/bin/simple-phpunit
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

This changes the live-component deps in CI to use "real" releases and not a symlink to the directory in this repo. Doing this will better catch BC breaks.
