### PR TITLE
[LiveComponent] consider data-value attribute

### DIFF
--- a/src/LiveComponent/README.md
+++ b/src/LiveComponent/README.md
@@ -370,6 +370,27 @@ code works identically to the previous example:
 If an element has _both_ `data-model` and `name` attributes, the
 `data-model` attribute takes precedence.
 
+### Using data-value="" for non input elements
+
+If you want to set the value of a model with an element that is not an input element and does not have a `value` attribute you can use `data-value`
+
+```twig
+<div {{ init_live_component(this)>
+
+    <a
+        data-action="live#update"
+        data-model="min"
+        data-value="10">
+        Set min to 10
+    </a>
+
+    // ...
+</div>
+```
+
+If an element has _both_ `data-value` and `value` attributes, the
+`data-value` attribute takes precedence.
+
 ## Loading States
 
 Often, you'll want to show (or hide) an element while a component is

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1057,11 +1057,11 @@ class default_1 extends Controller {
         window.removeEventListener('beforeunload', this.markAsWindowUnloaded);
     }
     update(event) {
-        const value = event.target.value;
+        const value = this._getValueFromElement(event.target);
         this._updateModelFromElement(event.target, value, true);
     }
     updateDefer(event) {
-        const value = event.target.value;
+        const value = this._getValueFromElement(event.target);
         this._updateModelFromElement(event.target, value, false);
     }
     action(event) {
@@ -1110,6 +1110,17 @@ class default_1 extends Controller {
     }
     $render() {
         this._makeRequest(null);
+    }
+    _getValueFromElement(element) {
+        const value = element.dataset.value || element.value;
+        if (!value) {
+            const clonedElement = (element.cloneNode());
+            if (!(clonedElement instanceof HTMLElement)) {
+                throw new Error('cloneNode() produced incorrect type');
+            }
+            throw new Error(`The update() method could not be called for "${clonedElement.outerHTML}": the element must either have a "data-value" or "value" attribute set.`);
+        }
+        return value;
     }
     _updateModelFromElement(element, value, shouldRender) {
         const model = element.dataset.model || element.getAttribute('name');

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -110,13 +110,13 @@ export default class extends Controller {
      * Called to update one piece of the model
      */
     update(event: any) {
-        const value = event.target.value;
+        const value = this._getValueFromElement(event.target);
 
         this._updateModelFromElement(event.target, value, true);
     }
 
     updateDefer(event: any) {
-        const value = event.target.value;
+        const value = this._getValueFromElement(event.target);
 
         this._updateModelFromElement(event.target, value, false);
     }
@@ -193,6 +193,22 @@ export default class extends Controller {
 
     $render() {
         this._makeRequest(null);
+    }
+
+    _getValueFromElement(element: HTMLElement){
+        const value = element.dataset.value || element.value;
+
+        if (!value) {
+            const clonedElement = (element.cloneNode());
+            // helps typescript know this is an HTMLElement
+            if (!(clonedElement instanceof HTMLElement)) {
+                throw new Error('cloneNode() produced incorrect type');
+            }
+
+            throw new Error(`The update() method could not be called for "${clonedElement.outerHTML}": the element must either have a "data-value" or "value" attribute set.`);
+        }
+
+        return value;
     }
 
     _updateModelFromElement(element: HTMLElement, value: string, shouldRender: boolean) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       |  #195 
| License       | MIT

Allow to set the value using data-value. This can be handy if the model is updated from an \<a\> or \<button\> to set it to a fixed value for example.
