### PR TITLE
Fix bootstrap.js path in README

### DIFF
--- a/src/LiveComponent/README.md
+++ b/src/LiveComponent/README.md
@@ -73,10 +73,10 @@ composer require symfony/ux-live-component
 
 This comes with an embedded JavaScript Stimulus controller. Unlike
 other Symfony UX packages, this needs to be enabled manually
-in your `config/bootstrap.js` file:
+in your `assets/bootstrap.js` file:
 
 ```js
-// config/bootstrap.js
+// assets/bootstrap.js
 import LiveController from '@symfony/ux-live-component';
 import '@symfony/ux-live-component/styles/live.css';
 // ...


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (only documentation)
| New feature?  | no
| Tickets       | 
| License       | MIT

See https://github.com/symfony/recipes/tree/master/symfony/webpack-encore-bundle/1.9/assets