### PR TITLE
Chart.js: remove unusable horizontalBar type in chart model

### DIFF
--- a/src/Chartjs/CHANGELOG.md
+++ b/src/Chartjs/CHANGELOG.md
@@ -6,6 +6,7 @@
     version 3 was added. See the [@symfony/stimulus-bridge CHANGELOG](https://github.com/symfony/stimulus-bridge/blob/main/CHANGELOG.md#300)
     for more details.
 -   Support added for Symfony 6
+-   Upgrade Chart.js to version 3
 
 ## 1.3
 

--- a/src/Chartjs/Model/Chart.php
+++ b/src/Chartjs/Model/Chart.php
@@ -21,7 +21,6 @@ class Chart
 {
     public const TYPE_LINE = 'line';
     public const TYPE_BAR = 'bar';
-    public const TYPE_BAR_HORIZONTAL = 'horizontalBar';
     public const TYPE_RADAR = 'radar';
     public const TYPE_PIE = 'pie';
     public const TYPE_DOUGHNUT = 'doughnut';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

[https://www.chartjs.org/docs/3.2.0/getting-started/v3-migration.html#chart-types](https://www.chartjs.org/docs/3.2.0/getting-started/v3-migration.html#chart-types)
I also added the chart.js update to the changelog.