### PR TITLE
Adding 2 links to Symfonycasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ to build the chart in PHP. The JavaScript is handled for you automatically.
 
 [Read all the details about the Symfony UX initiative](https://symfony.com/ux)
 
+Or watch the [Stimulus Screencast on SymfonyCasts](https://symfonycasts.com/screencast/stimulus).
+
 ## Components of UX
 
 Symfony UX leverages [Stimulus](https://stimulus.hotwired.dev/) for JavaScript

--- a/src/Turbo/README.md
+++ b/src/Turbo/README.md
@@ -12,6 +12,8 @@ or any other transports to broadcast DOM changes to all currently connected user
 You're in a hurry? Take a look at [the chat example](#sending-async-changes-using-mercure-a-chat)
 to discover the full potential of Symfony UX Turbo.
 
+Or watch the [Turbo Screencast on SymfonyCasts](https://symfonycasts.com/screencast/turbo).
+
 ## Installation
 
 Symfony UX Turbo requires PHP 7.2+ and Symfony 5.2+.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | none
| License       | MIT

I'm re-working the official Encore/frontend docs right now to talk more about Symfony UX. Along with that effort, Symfonycasts has two nice tutorials that I think we should link to.

Thanks!