### PR TITLE
[ux/dropzone] Updated docs (deprecation warning)

### DIFF
--- a/src/Dropzone/README.md
+++ b/src/Dropzone/README.md
@@ -61,7 +61,7 @@ the `@symfony/ux-dropzone/src/style.css` autoimport to `false`:
         "@symfony/ux-dropzone": {
             "dropzone": {
                 "enabled": true,
-                "webpackMode": "eager",
+                "fetch": "eager",
                 "autoimport": {
                     "@symfony/ux-dropzone/src/style.css": false
                 }


### PR DESCRIPTION
Fixed following warning:
```
Module Warning (from ./node_modules/@symfony/stimulus-bridge/dist/webpack/loader.js):
The "webpackMode" config key is deprecated in controllers.json. Use "fetch" instead, set to either "eager" or "lazy".
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
