### PR TITLE
Make turbo stream format subscriber opt-in and not enabled automatically

### DIFF
--- a/src/Turbo/Stream/AddTurboStreamFormatSubscriber.php
+++ b/src/Turbo/Stream/AddTurboStreamFormatSubscriber.php
@@ -28,6 +28,11 @@ final class AddTurboStreamFormatSubscriber implements EventSubscriberInterface
     public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
+
+        if (!$request->attributes->get('turbo', false)) {
+            return;
+        }
+
         if (!($accept = $request->headers->get('Accept')) || 0 !== strpos($accept, TurboStreamResponse::STREAM_MEDIA_TYPE)) {
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

The subscriber should be opt-in. As it currently manipulates the requestFormat which is not expected by all applications (e.g. Sulu or any other application, working with $request->getRequestFormat() for getting its template). A controller handling the turbo can activate the listener with:

```yaml
my_route:
    defaults:
       turbo: true
```

This indicates this routes  handles turbo route and so request format is set to turbo, for all other routes it behaves the symfony way and the request format is not manipulated in this case.