### PR TITLE
[Twig][Live] add component attribute system/helper

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 -   Send live action arguments to backend
 
+-   [BC BREAK] Remove `init_live_component()` twig function, use `{{ attributes }}` instead:
+    ```diff
+    - <div {{ init_live_component() }}>
+    + <div {{ attributes }}>
+    ```
+
 ## 2.0.0
 
 -   Support for `stimulus` version 2 was removed and support for `@hotwired/stimulus`

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": ">=8.0",
-        "symfony/ux-twig-component": "^2.0"
+        "symfony/ux-twig-component": "^2.1"
     },
     "require-dev": {
         "doctrine/annotations": "^1.0",

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\ComponentValidator;
 use Symfony\UX\LiveComponent\ComponentValidatorInterface;
+use Symfony\UX\LiveComponent\EventListener\AddLiveAttributesSubscriber;
 use Symfony\UX\LiveComponent\EventListener\LiveComponentSubscriber;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\PropertyHydratorInterface;
@@ -46,6 +47,7 @@ final class LiveComponentExtension extends Extension
                         'key' => $attribute->name,
                         'template' => $attribute->template,
                         'default_action' => $attribute->defaultAction,
+                        'live' => true,
                     ]))
                     ->addTag('controller.service_arguments')
                 ;
@@ -78,6 +80,7 @@ final class LiveComponentExtension extends Extension
 
         $container->register('ux.live_component.twig.component_runtime', LiveComponentRuntime::class)
             ->setArguments([
+                new Reference('twig'),
                 new Reference('ux.live_component.component_hydrator'),
                 new Reference('ux.twig_component.component_factory'),
                 new Reference(UrlGeneratorInterface::class),
@@ -88,6 +91,11 @@ final class LiveComponentExtension extends Extension
 
         $container->register(ComponentValidator::class)
             ->addTag('container.service_subscriber', ['key' => 'validator', 'id' => 'validator'])
+        ;
+
+        $container->register('ux.live_component.add_attributes_subscriber', AddLiveAttributesSubscriber::class)
+            ->addTag('kernel.event_subscriber')
+            ->addTag('container.service_subscriber', ['key' => LiveComponentRuntime::class, 'id' => 'ux.live_component.twig.component_runtime'])
         ;
 
         $container->setAlias(ComponentValidatorInterface::class, ComponentValidator::class);

--- a/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
+++ b/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\EventListener;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\UX\LiveComponent\Twig\LiveComponentRuntime;
+use Symfony\UX\TwigComponent\ComponentAttributes;
+use Symfony\UX\TwigComponent\EventListener\PreRenderEvent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AddLiveAttributesSubscriber implements EventSubscriberInterface, ServiceSubscriberInterface
+{
+    public function __construct(private ContainerInterface $container)
+    {
+    }
+
+    public function onPreRender(PreRenderEvent $event): void
+    {
+        if (!$event->getMetadata()->get('live', false)) {
+            // not a live component, skip
+            return;
+        }
+
+        /** @var ComponentAttributes $attributes */
+        $attributes = $this->container->get(LiveComponentRuntime::class)
+            ->getLiveAttributes($event->getComponent(), $event->getMetadata())
+        ;
+
+        $variables = $event->getVariables();
+
+        if (isset($variables['attributes']) && $variables['attributes'] instanceof ComponentAttributes) {
+            // merge with existing attributes if available
+            $attributes = $attributes->defaults($variables['attributes']->all());
+        }
+
+        $variables['attributes'] = $attributes;
+
+        $event->setVariables($variables);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [PreRenderEvent::class => 'onPreRender'];
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            LiveComponentRuntime::class,
+        ];
+    }
+}

--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -43,10 +43,15 @@ A real-time product search component might look like this::
     The ability to reference local variables in the template (e.g. ``query``) was added in TwigComponents 2.1.
     Previously, all data needed to be referenced through ``this`` (e.g. ``this.query``).
 
+.. versionadded:: 2.1
+
+    The ability to initialize live component with the ``attributes`` twig variable was added in LiveComponents
+    2.1. Previously, the ``init_live_component()`` function was required (this function was removed in 2.1).
+
 .. code-block:: twig
 
     {# templates/components/product_search.html.twig #}
-    <div {{ init_live_component(this) }}>
+    <div {{ attributes }}>
         <input
             type="search"
             name="query"
@@ -159,13 +164,13 @@ re-rendered live on the frontend), replace the component's
       }
 
 Then, in the template, make sure there is *one* HTML element around your
-entire component and use the ``{{ init_live_component() }}`` function to
-initialize the Stimulus controller:
+entire component and use the ``{{ attributes }}`` variable to initialize
+the Stimulus controller:
 
 .. code-block:: diff
 
     - <div>
-    + <div {{ init_live_component(this) }}>
+    + <div {{ attributes }}>
           <strong>{{ this.randomNumber }}</strong>
       </div>
 
@@ -176,7 +181,7 @@ and give the user a new random number:
 
 .. code-block:: twig
 
-    <div {{ init_live_component(this) }}>
+    <div {{ attributes }}>
         <strong>{{ this.randomNumber }}</strong>
 
         <button
@@ -239,6 +244,44 @@ exceptions being properties that hold services (these don't need to be
 stateful because they will be autowired each time before the component
 is rendered) and `properties used for computed properties`_.
 
+Component Attributes
+--------------------
+
+.. versionadded:: 2.1
+
+    The ``HasAttributes`` trait was added in TwigComponents 2.1.
+
+`Component attributes`_ allows you to render your components with extra
+props that are are converted to html attributes and made available in
+your component's template as an ``attributes`` variable. When used on
+live components, these props are persisted between renders. You can enable
+this feature by having your live component use the ``HasAttributesTrait``:
+
+.. code-block:: diff
+
+      // ...
+      use Symfony\UX\LiveComponent\Attribute\LiveProp;
+    + use Symfony\UX\TwigComponent\HasAttributesTrait;
+
+      #[AsLiveComponent('random_number')]
+      class RandomNumberComponent
+      {
+    +     use HasAttributesTrait;
+
+          #[LiveProp]
+          public int $min = 0;
+
+Now, when rendering your component, you can pass html attributes
+as props and these will be added to ``attributes``:
+
+.. code-block:: twig
+
+    {{ component('random_number', { min: 5, max: 500, class: 'widget', style: 'color: black;' }) }}
+
+    {# renders as: #}
+    <div class="widget" style="color: black;" <!-- other live attributes -->>
+        <!-- ... -->
+
 data-action=“live#update”: Re-rendering on LiveProp Change
 ----------------------------------------------------------
 
@@ -251,7 +294,7 @@ Let's add two inputs to our template:
 .. code-block:: twig
 
     {# templates/components/random_number.html.twig #}
-    <div {{ init_live_component(this) }}>
+    <div {{ attributes }}>
         <input
             type="number"
             value="{{ min }}"
@@ -368,7 +411,7 @@ property. The following code works identically to the previous example:
 
 .. code-block:: diff
 
-      <div {{ init_live_component(this)>
+      <div {{ attributes }}>
           <input
               type="number"
               value="{{ min }}"
@@ -791,7 +834,7 @@ as ``this.form`` thanks to the trait:
 
     {# templates/components/post_form.html.twig #}
     <div
-        {{ init_live_component(this) }}
+        {{ attributes }}
         {#
             Automatically catch all "change" events from the fields
             below and re-render the component.
@@ -815,8 +858,7 @@ as ``this.form`` thanks to the trait:
     </div>
 
 Mostly, this is a pretty boring template! It includes the normal
-``init_live_component(this)`` and then you render the form however you
-want.
+``attributes`` and then you render the form however you want.
 
 But the result is incredible! As you finish changing each field, the
 component automatically re-renders - including showing any validation
@@ -1024,7 +1066,7 @@ section above) is to add:
 .. code-block:: diff
 
       <div
-          {{ init_live_component(this) }}
+          {{ attributes }}
     +     data-action="change->live#update"
       >
 
@@ -1056,7 +1098,7 @@ rendered the ``content`` through a Markdown filter from the
 
 .. code-block:: twig
 
-    <div {{init_live_component(this)}}>
+    <div {{ attributes }}>
         <input
             type="text"
             value="{{ post.title }}"
@@ -1221,7 +1263,7 @@ You can also use “polling” to continually refresh a component. On the
 .. code-block:: diff
 
       <div
-          {{ init_live_component(this) }}
+          {{ attributes }}
     +     data-poll
       >
 
@@ -1233,7 +1275,7 @@ delay for 500ms:
 .. code-block:: twig
 
     <div
-        {{ init_live_component(this) }}
+        {{ attributes }}
         data-poll="delay(500)|$render"
     >
 
@@ -1242,7 +1284,7 @@ You can also trigger a specific “action” instead of a normal re-render:
 .. code-block:: twig
 
     <div
-        {{ init_live_component(this) }}
+        {{ attributes }}
 
         data-poll="save"
         {#
@@ -1437,7 +1479,7 @@ In the ``EditPostComponent`` template, you render the
 .. code-block:: twig
 
     {# templates/components/edit_post.html.twig #}
-    <div {{ init_live_component(this) }}>
+    <div {{ attributes }}>
         <input
             type="text"
             name="post[title]"
@@ -1459,7 +1501,7 @@ In the ``EditPostComponent`` template, you render the
 
 .. code-block:: twig
 
-    <div {{ init_live_component(this) }} class="mb-3">
+    <div {{ attributes }} class="mb-3">
         <textarea
             name="{{ name }}"
             data-model="value"
@@ -1496,3 +1538,4 @@ bound to Symfony's BC policy for the moment.
 .. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`dependent form fields`: https://symfony.com/doc/current/form/dynamic_form_modification.html#dynamic-generation-for-submitted-forms
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _`Component attributes`: https://symfony.com/bundles/ux-twig-component/current/index.html#component-attributes

--- a/src/LiveComponent/src/Twig/LiveComponentExtension.php
+++ b/src/LiveComponent/src/Twig/LiveComponentExtension.php
@@ -24,7 +24,6 @@ final class LiveComponentExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('init_live_component', [LiveComponentRuntime::class, 'renderLiveAttributes'], ['needs_environment' => true, 'is_safe' => ['html_attr']]),
             new TwigFunction('component_url', [LiveComponentRuntime::class, 'getComponentUrl']),
         ];
     }

--- a/src/LiveComponent/tests/Fixture/Component/ComponentWithAttributes.php
+++ b/src/LiveComponent/tests/Fixture/Component/ComponentWithAttributes.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixture\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+use Symfony\UX\TwigComponent\HasAttributesTrait;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsLiveComponent('with_attributes')]
+final class ComponentWithAttributes
+{
+    use DefaultActionTrait;
+    use HasAttributesTrait;
+}

--- a/src/LiveComponent/tests/Fixture/Kernel.php
+++ b/src/LiveComponent/tests/Fixture/Kernel.php
@@ -26,6 +26,7 @@ use Symfony\UX\LiveComponent\Tests\Fixture\Component\Component1;
 use Symfony\UX\LiveComponent\Tests\Fixture\Component\Component2;
 use Symfony\UX\LiveComponent\Tests\Fixture\Component\Component3;
 use Symfony\UX\LiveComponent\Tests\Fixture\Component\Component6;
+use Symfony\UX\LiveComponent\Tests\Fixture\Component\ComponentWithAttributes;
 use Symfony\UX\TwigComponent\TwigComponentBundle;
 use Twig\Environment;
 
@@ -66,6 +67,7 @@ final class Kernel extends BaseKernel
         $c->register(Component2::class)->setAutoconfigured(true)->setAutowired(true);
         $c->register(Component3::class)->setAutoconfigured(true)->setAutowired(true);
         $c->register(Component6::class)->setAutoconfigured(true)->setAutowired(true);
+        $c->register(ComponentWithAttributes::class)->setAutoconfigured(true)->setAutowired(true);
 
         $c->loadFromExtension('framework', [
             'secret' => 'S3CRET',

--- a/src/LiveComponent/tests/Fixture/templates/components/component1.html.twig
+++ b/src/LiveComponent/tests/Fixture/templates/components/component1.html.twig
@@ -1,6 +1,4 @@
-<div
-    {{ init_live_component(this) }}
->
+<div{{ attributes }}>
     Prop1: {{ this.prop1.id }}
     Prop2: {{ this.prop2|date('Y-m-d g:i') }}
     Prop3: {{ this.prop3 }}

--- a/src/LiveComponent/tests/Fixture/templates/components/component2.html.twig
+++ b/src/LiveComponent/tests/Fixture/templates/components/component2.html.twig
@@ -1,6 +1,4 @@
-<div
-    {{ init_live_component(this) }}
->
+<div{{ attributes }}>
     Count: {{ this.count }}
     BeforeReRenderCalled: {{ this.beforeReRenderCalled ? 'Yes' : 'No' }}
 </div>

--- a/src/LiveComponent/tests/Fixture/templates/components/component6.html.twig
+++ b/src/LiveComponent/tests/Fixture/templates/components/component6.html.twig
@@ -1,6 +1,4 @@
-<div
-    {{ init_live_component(this) }}
->
+<div{{ attributes }}>
     Arg1: {{ this.called ? this.arg1 : 'not provided' }}
     Arg2: {{ this.called ? this.arg2 : 'not provided' }}
     Arg3: {{ this.called ? this.arg3 : 'not provided' }}

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\UX\LiveComponent\Tests\Functional\Twig;
+namespace Symfony\UX\LiveComponent\Tests\Functional\EventListener;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Browser\Test\HasBrowser;
@@ -17,7 +17,7 @@ use Zenstruck\Browser\Test\HasBrowser;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class LiveComponentExtensionTest extends KernelTestCase
+final class AddLiveAttributesSubscriberTest extends KernelTestCase
 {
     use HasBrowser;
 

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -17,6 +17,7 @@ use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Tests\Fixture\Component\Component1;
 use Symfony\UX\LiveComponent\Tests\Fixture\Component\Component2;
 use Symfony\UX\LiveComponent\Tests\Fixture\Component\Component3;
+use Symfony\UX\LiveComponent\Tests\Fixture\Component\ComponentWithAttributes;
 use Symfony\UX\LiveComponent\Tests\Fixture\Entity\Entity1;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use function Zenstruck\Foundry\create;
@@ -262,5 +263,53 @@ final class LiveComponentHydratorTest extends KernelTestCase
         $hydrator->hydrate($component, $dehydrated);
 
         $this->assertSame($instance->prop, $component->prop);
+    }
+
+    public function testCanDehydrateAndHydrateComponentsWithAttributes(): void
+    {
+        /** @var LiveComponentHydrator $hydrator */
+        $hydrator = self::getContainer()->get('ux.live_component.component_hydrator');
+
+        /** @var ComponentFactory $factory */
+        $factory = self::getContainer()->get('ux.twig_component.component_factory');
+
+        /** @var ComponentWithAttributes $component */
+        $component = $factory->create('with_attributes', $attributes = ['class' => 'foo']);
+
+        $this->assertSame($attributes, $component->attributes->all());
+
+        $dehydrated = $hydrator->dehydrate($component);
+
+        $this->assertArrayHasKey('attributes', $dehydrated);
+        $this->assertSame($attributes, $dehydrated['attributes']);
+
+        $hydrator->hydrate($component = $factory->get('with_attributes'), $dehydrated);
+
+        $this->assertSame($attributes, $component->attributes->all());
+    }
+
+    public function testCanDehydrateAndHydrateComponentsWithEmptyAttributes(): void
+    {
+        /** @var LiveComponentHydrator $hydrator */
+        $hydrator = self::getContainer()->get('ux.live_component.component_hydrator');
+
+        /** @var ComponentFactory $factory */
+        $factory = self::getContainer()->get('ux.twig_component.component_factory');
+
+        /** @var ComponentWithAttributes $component */
+        $component = $factory->create('with_attributes');
+
+        $this->assertSame([], $component->attributes->all());
+
+        $dehydrated = $hydrator->dehydrate($component);
+
+        $this->assertArrayHasKey('attributes', $dehydrated);
+        $this->assertSame([], $dehydrated['attributes']);
+
+        $component = $factory->get('with_attributes');
+
+        $hydrator->hydrate($component, $dehydrated);
+
+        $this->assertSame([], $component->attributes->all());
     }
 }

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 -   Add `PreMount` priority parameter.
 
+-   Add `PostMount` hook component hook to intercept extra props.
+
+-   Add `HasAttributesTrait` for components which makes `attributes` variable available
+    in component templates.
+
+-   Add `PreRenderEvent` to intercept/manipulate twig template/variables before rendering.
+
 ## 2.0.0
 
 -   Support for `stimulus` version 2 was removed and support for `@hotwired/stimulus`

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": ">=8.0",
         "symfony/dependency-injection": "^5.4|^6.0",
+        "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/property-access": "^5.4|^6.0",
         "twig/twig": "^2.0|^3.0"
     },

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -44,6 +44,17 @@ class AsTwigComponent
         return array_reverse($methods);
     }
 
+    public static function postMountMethods(object $component): iterable
+    {
+        $methods = iterator_to_array(self::attributeMethodsFor(PostMount::class, $component));
+
+        usort($methods, static function (\ReflectionMethod $a, \ReflectionMethod $b) {
+            return $a->getAttributes(PostMount::class)[0]->newInstance()->priority <=> $b->getAttributes(PostMount::class)[0]->newInstance()->priority;
+        });
+
+        return array_reverse($methods);
+    }
+
     /**
      * @internal
      *

--- a/src/TwigComponent/src/Attribute/PostMount.php
+++ b/src/TwigComponent/src/Attribute/PostMount.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\UX\TwigComponent\Attribute;
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @experimental
+ */
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class PostMount
+{
+    public int $priority;
+
+    /**
+     * @param int $priority If multiple hooks are registered in a component, use to configure
+     *                      the order in which they are called (higher called earlier)
+     */
+    public function __construct(int $priority = 0)
+    {
+        $this->priority = $priority;
+    }
+}

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @experimental
+ * @immutable
+ */
+final class ComponentAttributes
+{
+    /**
+     * @param array<string, string> $attributes
+     */
+    public function __construct(private array $attributes)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return array_reduce(
+            array_keys($this->attributes),
+            fn (string $carry, string $key) => sprintf('%s %s="%s"', $carry, $key, $this->attributes[$key]),
+            ''
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function all(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Set default attributes. These are used if they are not already
+     * defined. "class" is special, these defaults are prepended to
+     * the existing "class" attribute (if available).
+     */
+    public function defaults(array $attributes): self
+    {
+        foreach ($this->attributes as $key => $value) {
+            $attributes[$key] = isset($attributes[$key]) && 'class' === $key ? "{$attributes[$key]} {$value}" : $value;
+        }
+
+        return new self($attributes);
+    }
+
+    /**
+     * Extract only these attributes.
+     */
+    public function only(string ...$keys): self
+    {
+        $attributes = [];
+
+        foreach ($this->attributes as $key => $value) {
+            if (\in_array($key, $keys, true)) {
+                $attributes[$key] = $value;
+            }
+        }
+
+        return new self($attributes);
+    }
+
+    /**
+     * Extract all but these attributes.
+     */
+    public function without(string ...$keys): self
+    {
+        $clone = clone $this;
+
+        foreach ($keys as $key) {
+            unset($clone->attributes[$key]);
+        }
+
+        return $clone;
+    }
+}

--- a/src/TwigComponent/src/ComponentMetadata.php
+++ b/src/TwigComponent/src/ComponentMetadata.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @experimental
+ */
+final class ComponentMetadata
+{
+    /**
+     * @internal
+     */
+    public function __construct(private array $config)
+    {
+    }
+
+    public function getName(): string
+    {
+        return $this->config['key'];
+    }
+
+    /**
+     * @return string Component's twig template
+     */
+    public function getTemplate(): string
+    {
+        return $this->config['template'];
+    }
+
+    /**
+     * @return class-string The Component's FQCN
+     */
+    public function getClass(): string
+    {
+        return $this->config['class'];
+    }
+
+    /**
+     * @return string The Component's service id
+     */
+    public function getServiceId(): string
+    {
+        return $this->config['service_id'];
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->config[$key] ?? $default;
+    }
+}

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\UX\TwigComponent;
 
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\UX\TwigComponent\EventListener\PreRenderEvent;
 use Twig\Environment;
+use Twig\Extension\EscaperExtension;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -20,16 +23,28 @@ use Twig\Environment;
  */
 final class ComponentRenderer
 {
-    private Environment $twig;
+    private bool $safeClassesRegistered = false;
 
-    public function __construct(Environment $twig)
+    public function __construct(private Environment $twig, private EventDispatcherInterface $dispatcher)
     {
-        $this->twig = $twig;
     }
 
-    public function render(object $component, string $template): string
+    public function render(object $component, ComponentMetadata $metadata): string
     {
-        // TODO: Self-Rendering components?
-        return $this->twig->render($template, array_merge(['this' => $component], get_object_vars($component)));
+        if (!$this->safeClassesRegistered) {
+            $this->twig->getExtension(EscaperExtension::class)->addSafeClass(ComponentAttributes::class, ['html']);
+
+            $this->safeClassesRegistered = true;
+        }
+
+        $event = new PreRenderEvent(
+            $component,
+            $metadata,
+            array_merge(['this' => $component], get_object_vars($component))
+        );
+
+        $this->dispatcher->dispatch($event);
+
+        return $this->twig->render($event->getTemplate(), $event->getVariables());
     }
 }

--- a/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
+++ b/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
@@ -39,7 +39,6 @@ final class TwigComponentPass implements CompilerPassInterface
 
                 $tag['service_id'] = $id;
                 $tag['class'] = $definition->getClass();
-                $tag['name'] = $tag['key'];
                 $tag['template'] = $tag['template'] ?? "components/{$tag['key']}.html.twig";
                 $componentConfig[$tag['key']] = $tag;
             }

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -55,6 +55,7 @@ final class TwigComponentExtension extends Extension
         $container->register('ux.twig_component.component_renderer', ComponentRenderer::class)
             ->setArguments([
                 new Reference('twig'),
+                new Reference('event_dispatcher'),
             ])
         ;
 

--- a/src/TwigComponent/src/EventListener/PreRenderEvent.php
+++ b/src/TwigComponent/src/EventListener/PreRenderEvent.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\EventListener;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\UX\TwigComponent\ComponentMetadata;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @experimental
+ */
+final class PreRenderEvent extends Event
+{
+    private string $template;
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private object $component,
+        private ComponentMetadata $metadata,
+        private array $variables
+    ) {
+        $this->template = $this->metadata->getTemplate();
+    }
+
+    /**
+     * @return string The twig template used for the component
+     */
+    public function getTemplate(): string
+    {
+        return $this->template;
+    }
+
+    /**
+     * Change the twig template used.
+     */
+    public function setTemplate(string $template): self
+    {
+        $this->template = $template;
+
+        return $this;
+    }
+
+    public function getComponent(): object
+    {
+        return $this->component;
+    }
+
+    /**
+     * @return array the variables that will be available in the component's template
+     */
+    public function getVariables(): array
+    {
+        return $this->variables;
+    }
+
+    /**
+     * Change the twig variables used.
+     */
+    public function setVariables(array $variables): self
+    {
+        $this->variables = $variables;
+
+        return $this;
+    }
+
+    public function getMetadata(): ComponentMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/TwigComponent/src/HasAttributesTrait.php
+++ b/src/TwigComponent/src/HasAttributesTrait.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent;
+
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\TwigComponent\Attribute\PostMount;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @experimental
+ */
+trait HasAttributesTrait
+{
+    #[LiveProp(hydrateWith: 'hydrateAttributes', dehydrateWith: 'dehydrateAttributes')]
+    public ComponentAttributes $attributes;
+
+    public function setAttributes(array $attributes): void
+    {
+        $this->attributes = new ComponentAttributes($attributes);
+    }
+
+    /**
+     * This "catches" any extra props sent to `component()` and
+     * makes them available as "attributes".
+     *
+     * @internal
+     */
+    #[PostMount(priority: -1000)]
+    public function mountAttributes(array $data): array
+    {
+        if (isset($this->attributes)) {
+            // attributes might already be set if a user used an "attributes" prop
+            // when calling `component()`
+            $data = array_merge($this->attributes->all(), $data);
+        }
+
+        foreach ($data as $key => $value) {
+            if (!is_scalar($value)) {
+                throw new \LogicException(sprintf('Unable to use "%s" (%s) as an attribute. Attributes must be scalar. If you meant to mount this value on your component, make sure this is a writable property.', $key, get_debug_type($value)));
+            }
+        }
+
+        $this->attributes = new ComponentAttributes($data);
+
+        return [];
+    }
+
+    /**
+     * Required for dehydrating the attributes when used with live
+     * components.
+     *
+     * @internal
+     */
+    public static function dehydrateAttributes(ComponentAttributes $attributes): array
+    {
+        return $attributes->all();
+    }
+
+    /**
+     * This stub is required to prevent Symfony's normalizer system from
+     * being used for $attributes when the live component is hydrated.
+     *
+     * @internal
+     */
+    public static function hydrateAttributes(array $attributes): array
+    {
+        // todo, is there a more elegant solution?
+        return $attributes;
+    }
+}

--- a/src/TwigComponent/src/Twig/ComponentRuntime.php
+++ b/src/TwigComponent/src/Twig/ComponentRuntime.php
@@ -34,7 +34,7 @@ final class ComponentRuntime
     {
         return $this->componentRenderer->render(
             $this->componentFactory->create($name, $props),
-            $this->componentFactory->configFor($name)['template']
+            $this->componentFactory->metadataFor($name)
         );
     }
 }

--- a/src/TwigComponent/tests/Fixture/Component/ComponentB.php
+++ b/src/TwigComponent/tests/Fixture/Component/ComponentB.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\TwigComponent\Tests\Fixture\Component;
 
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\PostMount;
 use Symfony\UX\TwigComponent\Attribute\PreMount;
 
 /**
@@ -21,6 +22,7 @@ use Symfony\UX\TwigComponent\Attribute\PreMount;
 final class ComponentB
 {
     public string $value;
+    public string $postValue;
 
     #[PreMount]
     public function preMount(array $data): array
@@ -30,5 +32,13 @@ final class ComponentB
         }
 
         return $data;
+    }
+
+    #[PostMount]
+    public function postMount(array $data): array
+    {
+        $this->postValue = $data['extra'] ?? 'default';
+
+        return [];
     }
 }

--- a/src/TwigComponent/tests/Fixture/Component/WithAttributes.php
+++ b/src/TwigComponent/tests/Fixture/Component/WithAttributes.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixture\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\HasAttributesTrait;
+
+#[AsTwigComponent('with_attributes')]
+class WithAttributes
+{
+    use HasAttributesTrait;
+
+    public string $prop;
+}

--- a/src/TwigComponent/tests/Fixture/Kernel.php
+++ b/src/TwigComponent/tests/Fixture/Kernel.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\UX\TwigComponent\Tests\Fixture\Component\ComponentA;
 use Symfony\UX\TwigComponent\Tests\Fixture\Component\ComponentB;
 use Symfony\UX\TwigComponent\Tests\Fixture\Component\ComponentC;
+use Symfony\UX\TwigComponent\Tests\Fixture\Component\WithAttributes;
 use Symfony\UX\TwigComponent\Tests\Fixture\Service\ServiceA;
 use Symfony\UX\TwigComponent\TwigComponentBundle;
 
@@ -53,6 +54,7 @@ final class Kernel extends BaseKernel
         $c->register(ComponentA::class)->setAutoconfigured(true)->setAutowired(true);
         $c->register('component_b', ComponentB::class)->setAutoconfigured(true)->setAutowired(true);
         $c->register(ComponentC::class)->setAutoconfigured(true)->setAutowired(true);
+        $c->register(WithAttributes::class)->setAutoconfigured(true)->setAutowired(true);
         $c->register('component_d', ComponentB::class)->addTag('twig.component', [
             'key' => 'component_d',
             'template' => 'components/custom2.html.twig',

--- a/src/TwigComponent/tests/Fixture/templates/components/custom1.html.twig
+++ b/src/TwigComponent/tests/Fixture/templates/components/custom1.html.twig
@@ -1,2 +1,3 @@
 Custom template 1
 b value: {{ value }}
+post value: {{ postValue }}

--- a/src/TwigComponent/tests/Fixture/templates/components/with_attributes.html.twig
+++ b/src/TwigComponent/tests/Fixture/templates/components/with_attributes.html.twig
@@ -1,0 +1,1 @@
+<button{{ attributes.defaults({ class: 'foo', type: 'button' }) }}>Component Content ({{ prop }})</button>

--- a/src/TwigComponent/tests/Fixture/templates/template_a.html.twig
+++ b/src/TwigComponent/tests/Fixture/templates/template_a.html.twig
@@ -1,1 +1,3 @@
 {{ component('component_a', { propA: 'prop a value', propB: 'prop b value' }) }}
+{{ component('with_attributes', { prop: 'prop value 1', class: 'bar', style: 'color:red;' }) }}
+{{ component('with_attributes', { prop: 'prop value 2', attributes: { class: 'baz' }, type: 'submit', style: 'color:red;' }) }}

--- a/src/TwigComponent/tests/Fixture/templates/template_b.html.twig
+++ b/src/TwigComponent/tests/Fixture/templates/template_b.html.twig
@@ -1,3 +1,3 @@
 {{ component('component_a', { propA: 'prop a value 1', propB: 'prop b value 1' }) }}
 {{ component('component_a', { propA: 'prop a value 2', propB: 'prop b value 2' }) }}
-{{ component('component_b', { value: 'b value 1' }) }}
+{{ component('component_b', { value: 'b value 1', extra: 'value' }) }}

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -37,6 +37,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('propA: prop a value 2', $output);
         $this->assertStringContainsString('propB: prop b value 2', $output);
         $this->assertStringContainsString('b value: pre-mount b value 1', $output);
+        $this->assertStringContainsString('post value: value', $output);
         $this->assertStringContainsString('service: service a value', $output);
     }
 
@@ -52,5 +53,15 @@ final class ComponentExtensionTest extends KernelTestCase
         $output = self::getContainer()->get(Environment::class)->render('template_c.html.twig');
 
         $this->assertStringContainsString('Custom template 2', $output);
+    }
+
+    public function testCanRenderComponentWithAttributes(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('template_a.html.twig');
+
+        $this->assertStringContainsString('Component Content (prop value 1)', $output);
+        $this->assertStringContainsString('<button class="foo bar" type="button" style="color:red;">', $output);
+        $this->assertStringContainsString('Component Content (prop value 2)', $output);
+        $this->assertStringContainsString('<button class="foo baz" type="submit" style="color:red;">', $output);
     }
 }

--- a/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
@@ -124,83 +124,30 @@ final class ComponentFactoryTest extends KernelTestCase
         self::bootKernel(['environment' => 'missing_key']);
     }
 
-    public function testCanGetConfigForComponentByName(): void
+    public function testCanGetMetadataForComponentByName(): void
     {
         /** @var ComponentFactory $factory */
         $factory = self::getContainer()->get('ux.twig_component.component_factory');
 
-        $this->assertSame(
-            [
-                'key' => 'component_a',
-                'service_id' => ComponentA::class,
-                'class' => ComponentA::class,
-                'name' => 'component_a',
-                'template' => 'components/component_a.html.twig',
-            ],
-            $factory->configFor('component_a')
-        );
+        $metadata = $factory->metadataFor('component_a');
+
+        $this->assertSame('components/component_a.html.twig', $metadata->getTemplate());
+        $this->assertSame('component_a', $metadata->getName());
+        $this->assertSame(ComponentA::class, $metadata->getServiceId());
+        $this->assertSame(ComponentA::class, $metadata->getClass());
     }
 
-    public function testCanGetConfigForComponentByObject(): void
+    public function testCanGetMetadataForSameComponentWithDifferentName(): void
     {
         /** @var ComponentFactory $factory */
         $factory = self::getContainer()->get('ux.twig_component.component_factory');
 
-        $this->assertSame(
-            [
-                'key' => 'component_c',
-                'service_id' => ComponentC::class,
-                'class' => ComponentC::class,
-                'name' => 'component_c',
-                'template' => 'components/component_c.html.twig',
-            ],
-            $factory->configFor(new ComponentC())
-        );
-    }
+        $metadata = $factory->metadataFor('component_d');
 
-    public function testCanGetConfigForComponentByClass(): void
-    {
-        /** @var ComponentFactory $factory */
-        $factory = self::getContainer()->get('ux.twig_component.component_factory');
-
-        $this->assertSame(
-            [
-                'key' => 'component_a',
-                'service_id' => ComponentA::class,
-                'class' => ComponentA::class,
-                'name' => 'component_a',
-                'template' => 'components/component_a.html.twig',
-            ],
-            $factory->configFor(ComponentA::class)
-        );
-    }
-
-    public function testCanGetConfigForSameComponentWithDifferentName(): void
-    {
-        /** @var ComponentFactory $factory */
-        $factory = self::getContainer()->get('ux.twig_component.component_factory');
-
-        $this->assertSame(
-            [
-                'key' => 'component_d',
-                'template' => 'components/custom2.html.twig',
-                'service_id' => 'component_d',
-                'class' => ComponentB::class,
-                'name' => 'component_d',
-            ],
-            $factory->configFor(new ComponentB(), 'component_d')
-        );
-    }
-
-    public function testCannotGetConfigForComponentIfMultipleOfSameClass(): void
-    {
-        /** @var ComponentFactory $factory */
-        $factory = self::getContainer()->get('ux.twig_component.component_factory');
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectDeprecationMessage(sprintf('2 "%s" components registered with names "component_b, component_d". Use the $name parameter to explicitly choose one.', ComponentB::class));
-
-        $factory->configFor(new ComponentB());
+        $this->assertSame('components/custom2.html.twig', $metadata->getTemplate());
+        $this->assertSame('component_d', $metadata->getName());
+        $this->assertSame('component_d', $metadata->getServiceId());
+        $this->assertSame(ComponentB::class, $metadata->getClass());
     }
 
     public function testCannotGetConfigByNameForNonRegisteredComponent(): void
@@ -209,19 +156,19 @@ final class ComponentFactoryTest extends KernelTestCase
         $factory = self::getContainer()->get('ux.twig_component.component_factory');
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown component "invalid". The registered components are: component_a, component_b, component_c, component_d');
+        $this->expectExceptionMessage('Unknown component "invalid". The registered components are: component_a');
 
-        $factory->configFor('invalid');
+        $factory->metadataFor('invalid');
     }
 
-    public function testCannotGetConfigByClassForNonRegisteredComponent(): void
+    public function testCannotGetInvalidComponent(): void
     {
         /** @var ComponentFactory $factory */
         $factory = self::getContainer()->get('ux.twig_component.component_factory');
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown component class "Symfony\UX\TwigComponent\Tests\Integration\ComponentFactoryTest". The registered components are: component_a, component_b, component_c, component_d');
+        $this->expectExceptionMessage('Unknown component "invalid". The registered components are: component_a');
 
-        $factory->configFor(self::class);
+        $factory->get('invalid');
     }
 }

--- a/src/TwigComponent/tests/Unit/Attribute/AsTwigComponentTest.php
+++ b/src/TwigComponent/tests/Unit/Attribute/AsTwigComponentTest.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\TwigComponent\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\PostMount;
 use Symfony\UX\TwigComponent\Attribute\PreMount;
 
 /**
@@ -35,6 +36,33 @@ final class AsTwigComponentTest extends TestCase
                 }
 
                 #[PreMount]
+                public function hook3()
+                {
+                }
+            }
+        );
+
+        $this->assertCount(3, $hooks);
+        $this->assertSame('hook2', $hooks[0]->name);
+        $this->assertSame('hook3', $hooks[1]->name);
+        $this->assertSame('hook1', $hooks[2]->name);
+    }
+
+    public function testPostMountHooksAreOrderedByPriority(): void
+    {
+        $hooks = AsTwigComponent::postMountMethods(
+            new class() {
+                #[PostMount(priority: -10)]
+                public function hook1()
+                {
+                }
+
+                #[PostMount(priority: 10)]
+                public function hook2()
+                {
+                }
+
+                #[PostMount]
                 public function hook3()
                 {
                 }

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\TwigComponent\ComponentAttributes;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ComponentAttributesTest extends TestCase
+{
+    public function testCanConvertToString(): void
+    {
+        $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;']);
+
+        $this->assertSame(' class="foo" style="color:black;"', (string) $attributes);
+    }
+
+    public function testCanSetDefaults(): void
+    {
+        $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;']);
+
+        $this->assertSame(
+            ['class' => 'bar foo', 'style' => 'color:black;'],
+            $attributes->defaults(['class' => 'bar', 'style' => 'font-size: 10;'])->all()
+        );
+        $this->assertSame(
+            ' class="bar foo" style="color:black;"',
+            (string) $attributes->defaults(['class' => 'bar', 'style' => 'font-size: 10;'])
+        );
+
+        $this->assertSame(['class' => 'foo'], (new ComponentAttributes([]))->defaults(['class' => 'foo'])->all());
+    }
+
+    public function testCanGetOnly(): void
+    {
+        $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;']);
+
+        $this->assertSame(['class' => 'foo'], $attributes->only('class')->all());
+    }
+
+    public function testCanGetWithout(): void
+    {
+        $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;']);
+
+        $this->assertSame(['class' => 'foo'], $attributes->without('style')->all());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | n/a
| License       | MIT

A common pattern with other component library's (ie blade components/vue) is to pass html attributes to your component that are set on the component's root node. This proposal adds a way to do this with twig components. Enable on your component by adding the `HasAttributesTrait`. Attributes are any data passed to `component()` that cannot be mounted on the component itself. This extra data is added to a `ComponentAttributes` object that lives as a public property on your component (available as `attributes` in your component's template).

This should all work out-of-the box with live components.

Todo:
- [x] Tests
- [x] Documentation
- [x] #240
- [x] #241 
- [x] Merge `init_live_component()` into attributes when available
- [x] Document `PreRender` event.
- [x] Adjust `ComponentAttributes` api (defaults instead of merge)
- [ ] `attributes` always available in normal twig component templates (not sure about this - it would effectively make attributes _native_ but it a lame way)
- [x] replace `init_live_component()` with `attributes` in docs
- [x] Finalize docs (versionadded tags)

## Usage

To use, add the `HasAttributesTrait` to your component:

```php
#[AsTwigComponent('my_component')]
class MyComponent
{
    use HasAttributesTrait;
}
```

Then, in your component's template:

```twig
{# templates/components/my_component.html.twig #}

<div{{ attributes }}>
  My Component!
</div>
```

When rendering the component, you can pass an array of html attributes to add:

```twig
{{ component('my_component', { class: 'foo', style: 'color:red' }) }}

{# renders as: #}
<div class="foo" style="color:red">
  My Component!
</div>
```

### Defaults & Merging

In your component template, you can set defaults that are merged with
passed attributes. The passed attributes override the default with
the exception of *class*. For class, the defaults are prepended:

```twig
{# templates/components/my_component.html.twig #}

<button{{ attributes.defaults({ class: 'bar', type: 'button' }) }}>
  My Component!
</button>

{# render component #}
{{ component('my_component', { style: 'color:red' }) }}
{{ component('my_component', { class: 'foo', type: 'submit' }) }}

{# renders as: #}
<div class="bar" style="color:red">
  My Component!
</div>
<div class="bar foo" type="submit">
  My Component!
</div>
```

### Only

```twig
{# templates/components/my_component.html.twig #}

<div{{ attributes.only('class')) }}>
  My Component!
</div>

{# render component #}
{{ component('my_component', { class: 'foo', style: 'color:red' }) }}

{# renders as: #}
<div class="foo">
  My Component!
</div>
```

### Without

```twig
{# templates/components/my_component.html.twig #}

<div{{ attributes.without('class')) }}>
  My Component!
</div>

{# render component #}
{{ component('my_component', { class: 'foo', style: 'color:red' }) }}

{# renders as: #}
<div style="color:red">
  My Component!
</div>
```

### Live Components

We removed the `init_live_component()` twig function (**BC BREAK**) and replaced with the `attributes` variable which is always available (even if your component doesn't use `HasAttributesTrait`).

To upgrade, replace all calls to `init_live_component()` with `attributes`:

```diff
- <div {{ init_live_component() }}>
+ <div {{ attributes }}>
```