### PR TITLE
[TwigComponent] Fix link for the picture in README

### DIFF
--- a/src/TwigComponent/README.md
+++ b/src/TwigComponent/README.md
@@ -40,7 +40,7 @@ Done! Now render it wherever you want:
 
 Enjoy your new component!
 
-![Example of the AlertComponent](https://github.com/symfony/ux-twig-component/blob/main/alert-example.png?raw=true)
+![Example of the AlertComponent](https://github.com/symfony/ux/blob/2.x/src/TwigComponent/alert-example.png?raw=true)
 
 This brings the familiar "component" system from client-side frameworks
 into Symfony. Combine this with [Live Components](https://github.com/symfony/ux-live-component),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

I fix the link for the picture alert-example in the README for TwigComponent.
