### PR TITLE
[WIP][TwigComponent] add component attribute system/helper (alternative)

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @experimental
+ */
+final class ComponentAttributes
+{
+    /**
+     * @param array<string, string> $attributes
+     */
+    public function __construct(public array $attributes)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return \array_reduce(
+            \array_keys($this->attributes),
+            fn(string $carry, string $key) => \sprintf('%s %s="%s"', $carry, $key, $this->attributes[$key]),
+            ''
+        );
+    }
+
+    public function merge(array $with): self
+    {
+        foreach ($this->attributes as $key => $value) {
+            $with[$key] = isset($with[$key]) ? "{$with[$key]} {$value}" : $value;
+        }
+
+        return new self($with);
+    }
+
+    public function only(string ...$keys): self
+    {
+        $attributes = [];
+
+        foreach ($this->attributes as $key => $value) {
+            if (in_array($key, $keys, true)) {
+                $attributes[$key] = $value;
+            }
+        }
+
+        return new self($attributes);
+    }
+
+    public function without(string ...$keys): self
+    {
+        $clone = clone $this;
+
+        foreach ($keys as $key) {
+            unset($clone->attributes[$key]);
+        }
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string, string> $attributes
+     */
+    public function defaults(array $attributes): self
+    {
+        $clone = $this;
+
+        foreach ($attributes as $attribute => $value) {
+            $clone->attributes[$attribute] = $clone->attributes[$attribute] ?? $value;
+        }
+
+        return $clone;
+    }
+
+    public function default(string $attribute, string $value): self
+    {
+        return $this->defaults([$attribute => $value]);
+    }
+}

--- a/src/TwigComponent/src/ComponentContext.php
+++ b/src/TwigComponent/src/ComponentContext.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @experimental
+ */
+final class ComponentContext
+{
+    public function __construct(public object $component, public ComponentAttributes $attributes)
+    {
+    }
+}

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -78,7 +78,7 @@ final class ComponentFactory
     /**
      * Creates the component and "mounts" it with the passed data.
      */
-    public function create(string $name, array $data = []): object
+    public function create(string $name, array $data = []): ComponentContext
     {
         $component = $this->getComponent($name);
         $data = $this->preMount($component, $data);
@@ -88,13 +88,14 @@ final class ComponentFactory
         // set data that wasn't set in mount on the component directly
         foreach ($data as $property => $value) {
             if (!$this->propertyAccessor->isWritable($component, $property)) {
-                throw new \LogicException(sprintf('Unable to write "%s" to component "%s". Make sure this is a writable property or create a mount() with a $%s argument.', $property, \get_class($component), $property));
+                continue;
             }
 
             $this->propertyAccessor->setValue($component, $property, $value);
+            unset($data[$property]);
         }
 
-        return $component;
+        return new ComponentContext($component, new ComponentAttributes($data));
     }
 
     /**

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -27,9 +27,12 @@ final class ComponentRenderer
         $this->twig = $twig;
     }
 
-    public function render(object $component, string $template): string
+    public function render(ComponentContext $context, string $template): string
     {
         // TODO: Self-Rendering components?
-        return $this->twig->render($template, ['this' => $component]);
+        return $this->twig->render($template, [
+            'this' => $context->component,
+            'attributes' => $context->attributes,
+        ]);
     }
 }

--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -24,7 +24,11 @@ final class ComponentExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('component', [ComponentRuntime::class, 'render'], ['is_safe' => ['all']]),
+            new TwigFunction(
+                'component',
+                [ComponentRuntime::class, 'render'],
+                ['is_safe' => ['all'], 'needs_environment' => true]
+            ),
         ];
     }
 }

--- a/src/TwigComponent/src/Twig/ComponentRuntime.php
+++ b/src/TwigComponent/src/Twig/ComponentRuntime.php
@@ -11,8 +11,11 @@
 
 namespace Symfony\UX\TwigComponent\Twig;
 
+use Symfony\UX\TwigComponent\ComponentAttributes;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentRenderer;
+use Twig\Environment;
+use Twig\Extension\EscaperExtension;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -23,6 +26,7 @@ final class ComponentRuntime
 {
     private ComponentFactory $componentFactory;
     private ComponentRenderer $componentRenderer;
+    private bool $safeClassesRegistered = false;
 
     public function __construct(ComponentFactory $componentFactory, ComponentRenderer $componentRenderer)
     {
@@ -30,8 +34,14 @@ final class ComponentRuntime
         $this->componentRenderer = $componentRenderer;
     }
 
-    public function render(string $name, array $props = []): string
+    public function render(Environment $twig, string $name, array $props = []): string
     {
+        if (!$this->safeClassesRegistered) {
+            $twig->getExtension(EscaperExtension::class)->addSafeClass(ComponentAttributes::class, ['html']);
+
+            $this->safeClassesRegistered = true;
+        }
+
         return $this->componentRenderer->render(
             $this->componentFactory->create($name, $props),
             $this->componentFactory->configFor($name)['template']

--- a/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
@@ -31,10 +31,10 @@ final class ComponentFactoryTest extends KernelTestCase
         $factory = self::getContainer()->get('ux.twig_component.component_factory');
 
         /** @var ComponentA $componentA */
-        $componentA = $factory->create('component_a', ['propA' => 'A', 'propB' => 'B']);
+        $componentA = $factory->create('component_a', ['propA' => 'A', 'propB' => 'B'])->component;
 
         /** @var ComponentA $componentB */
-        $componentB = $factory->create('component_a', ['propA' => 'C', 'propB' => 'D']);
+        $componentB = $factory->create('component_a', ['propA' => 'C', 'propB' => 'D'])->component;
 
         $this->assertNotSame(spl_object_id($componentA), spl_object_id($componentB));
         $this->assertSame(spl_object_id($componentA->getService()), spl_object_id($componentB->getService()));
@@ -79,7 +79,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $component = $factory->create('component_c', [
             'propA' => 'valueA',
             'propC' => 'valueC',
-        ]);
+        ])->component;
 
         $this->assertSame('valueA', $component->propA);
         $this->assertNull($component->propB);
@@ -89,7 +89,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $component = $factory->create('component_c', [
             'propA' => 'valueA',
             'propB' => 'valueB',
-        ]);
+        ])->component;
 
         $this->assertSame('valueA', $component->propA);
         $this->assertSame('valueB', $component->propB);
@@ -107,15 +107,15 @@ final class ComponentFactoryTest extends KernelTestCase
         $factory->create('component_c');
     }
 
-    public function testExceptionThrownIfUnableToWritePassedDataToProperty(): void
+    public function testExtraDataIsUsedForAttributes(): void
     {
         /** @var ComponentFactory $factory */
         $factory = self::getContainer()->get('ux.twig_component.component_factory');
 
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Unable to write "service" to component "Symfony\UX\TwigComponent\Tests\Fixture\Component\ComponentA". Make sure this is a writable property or create a mount() with a $service argument.');
+        $context = $factory->create('component_a', ['propB' => 'B', 'class' => 'mt-1']);
 
-        $factory->create('component_a', ['propB' => 'B', 'service' => 'invalid']);
+        $this->assertSame('B', $context->component->getPropB());
+        $this->assertSame(['class' => 'mt-1'], $context->attributes->attributes);
     }
 
     public function testTwigComponentServiceTagMustHaveKey(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | n/a
| License       | MIT

This is an alternative to #220. This version makes attributes a _primary_ feature (doesn't require a trait to use). In your components, an `attributes` object is always available. Properties passed to the `component` twig function that cannot be mounted to your component object are added to this object. This pattern is well established in blade/vue.

I haven't given a huge amount of thought yet to LiveComponent's. I'm thinking the attributes passed to the twig function will be passed back and forth via http with a special proprietary attribute.

This _will_ bring some BC breaks:
- Properties passed to the `component` twig function that do not exist on your component class will no longer throw an exception. Instead they are added to the `attributes` object. Since attributes are required to be string/scalar I could throw an exception if the passed extra values are not.
- Using `ComponentFactory::create()` directly (unlikely scenario imo). This method now returns a `ComponentContext` object instead of the component object.
- Assuming we release this feature to both `TwigComponent` and `LiveComponent` at the same time, if someone upgrades one without the other, there will be problems.

These seem fairly minor to me (we are still experimental) but any ideas to mitigate the above would be appreciated!

### TODO
- [ ] Tests
- [ ] `LiveComponent` support
- [ ] Documentation
- [ ] Finalize `ComponentAttributes` methods

### Usage

```twig
{# templates/components/my_component.html.twig #}

<div{{ attributes }}>
  My Component!
</div>

{# render component #}

{{ component('my_component', { class: 'foo', style: 'color:red' }) }}

{# renders as: #}
<div class="foo" style="color:red">
  My Component!
</div>
```

#### Defaults

Set default attributes that can be fully overridden by passed attributes

```twig
{# templates/components/my_component.html.twig #}

<div{{ attributes.defaults({ class: 'bar' }) }}>
  My Component!
</div>

{# render component #}
{{ component('my_component', { style: 'color:red' }) }}
{{ component('my_component', { class: 'foo', style: 'color:red' }) }}

{# renders as: #}
<div class="bar" style="color:red">
  My Component!
</div>
<div class="foo" style="color:red">
  My Component!
</div>
```

#### Merging Defaults

Set defaults but allow them to be appended to by passing these values to the `component` function:

```twig
{# templates/components/my_component.html.twig #}

<div{{ attributes.merge({ class: 'bar' }) }}>
  My Component!
</div>

{# render component #}
{{ component('my_component', { class: 'foo', style: 'color:red' }) }}

{# renders as: #}
<div class="bar foo" style="color:red">
  My Component!
</div>
```

#### Only

```twig
{# templates/components/my_component.html.twig #}

<div{{ attributes.only('class')) }}>
  My Component!
</div>

{# render component #}
{{ component('my_component', { class: 'foo', style: 'color:red' }) }}

{# renders as: #}
<div class="foo">
  My Component!
</div>
```

#### Without

```twig
{# templates/components/my_component.html.twig #}

<div{{ attributes.without('class')) }}>
  My Component!
</div>

{# render component #}
{{ component('my_component', { class: 'foo', style: 'color:red' }) }}

{# renders as: #}
<div style="color:red">
  My Component!
</div>
```