### PR TITLE
[TwigComponent] add priority to PreMount hook

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,8 +1,10 @@
 # CHANGELOG
 
-# 2.1
+## 2.1
 
 -   Make public component properties available directly in the template (`{{ prop }}` vs `{{ this.prop }}`).
+
+-   Add `PreMount` priority parameter.
 
 ## 2.0.0
 

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -33,9 +33,15 @@ class AsTwigComponent
      *
      * @return \ReflectionMethod[]
      */
-    public static function preMountMethods(object $component): \Traversable
+    public static function preMountMethods(object $component): iterable
     {
-        yield from self::attributeMethodsFor(PreMount::class, $component);
+        $methods = iterator_to_array(self::attributeMethodsFor(PreMount::class, $component));
+
+        usort($methods, static function (\ReflectionMethod $a, \ReflectionMethod $b) {
+            return $a->getAttributes(PreMount::class)[0]->newInstance()->priority <=> $b->getAttributes(PreMount::class)[0]->newInstance()->priority;
+        });
+
+        return array_reverse($methods);
     }
 
     /**

--- a/src/TwigComponent/src/Attribute/PreMount.php
+++ b/src/TwigComponent/src/Attribute/PreMount.php
@@ -19,4 +19,14 @@ namespace Symfony\UX\TwigComponent\Attribute;
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class PreMount
 {
+    public int $priority;
+
+    /**
+     * @param int $priority If multiple hooks are registered in a component, use to configure
+     *                      the order in which they are called (higher called earlier)
+     */
+    public function __construct(int $priority = 0)
+    {
+        $this->priority = $priority;
+    }
 }

--- a/src/TwigComponent/src/Resources/doc/index.rst
+++ b/src/TwigComponent/src/Resources/doc/index.rst
@@ -258,6 +258,12 @@ component use a ``PreMount`` hook::
         // ...
     }
 
+.. note::
+
+    If your component has multiple ``PreMount`` hooks, and you'd like to control
+    the order in which they're called, use the ``priority`` attribute parameter:
+    ``PreMount(priority: 10)`` (higher called earlier).
+
 Fetching Services
 -----------------
 

--- a/src/TwigComponent/tests/Unit/Attribute/AsTwigComponentTest.php
+++ b/src/TwigComponent/tests/Unit/Attribute/AsTwigComponentTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\PreMount;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AsTwigComponentTest extends TestCase
+{
+    public function testPreMountHooksAreOrderedByPriority(): void
+    {
+        $hooks = AsTwigComponent::preMountMethods(
+            new class() {
+                #[PreMount(priority: -10)]
+                public function hook1()
+                {
+                }
+
+                #[PreMount(priority: 10)]
+                public function hook2()
+                {
+                }
+
+                #[PreMount]
+                public function hook3()
+                {
+                }
+            }
+        );
+
+        $this->assertCount(3, $hooks);
+        $this->assertSame('hook2', $hooks[0]->name);
+        $this->assertSame('hook3', $hooks[1]->name);
+        $this->assertSame('hook1', $hooks[2]->name);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | n/a
| License       | MIT

Adds the ability to control the order in which `PreMount` methods are called via a priority parameter on the attribute.
