### PR TITLE
Always re-extract formValues in LiveComponent

### DIFF
--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -126,9 +126,7 @@ trait ComponentWithFormTrait
 
     public function getFormValues(): array
     {
-        if (null === $this->formValues) {
-            $this->formValues = $this->extractFormValues($this->getForm());
-        }
+        $this->formValues = $this->extractFormValues($this->getForm());
 
         return $this->formValues;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | N/A
| License       | MIT

When creating a form builder with LiveComponent I've found out that proper values are not populated when form changes.
For example:
  1. Form has many questions;
  1. Question have a `type` field (text/choice/date/datetime, etc) and then dynamically added `options` field based on it's `type`;
  1. Date/datetime has min/max options;
  1. I change type to datetime:
     1. Component renders min/max option inputs with name like `form_builder[questions][0][options][minDateTime][date][year]`;
     1. It gets two levels deeper with `[date][year]` because that how Symfony renders datetime by default;
     1. Trying to change value of an option - get UI LiveController error that it's not exposed;
     1. And that's because formValues were already extracted without that deep nested data.

Not sure about the reason why it was done this way previously. My guess would be for perf? Maybe this could live as some trait option by which `getFormValues` would decide to always re-extract or take from cache?