### PR TITLE
[LiveComponent][doc] Document how to deal with locales

### DIFF
--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -99,6 +99,8 @@ Oh, and just one more step! Import a routing file from the bundle:
     # config/routes.yaml
     live_component:
         resource: '@LiveComponentBundle/Resources/config/routing/live_component.xml'
+        # uncomment to add localization to your components
+        #prefix: '/{_locale}'
 
 That's it! We're ready!
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Tickets       | Fix #231
| License       | MIT

Locale was lost after any live component action. It turns out that simply by adding `{_locale}` to the route fixes the issue even when no locales are configured (router still seems to inject `en`).