### PR TITLE
Upgrade php-cs-fixer used in gh action and run on php 8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,11 +9,10 @@ jobs:
             - uses: actions/checkout@master
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: '7.4'
+                  php-version: '8.0'
+                  tools: php-cs-fixer, cs2pr
             - name: php-cs-fixer
-              run: |
-                  wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.2/php-cs-fixer.phar -q
-                  php php-cs-fixer.phar fix --dry-run --diff
+              run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
     coding-style-js:
         runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.php_cs.cache
+.php-cs-fixer.cache
 node_modules
 yarn.lock
 yarn-error.log

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,7 @@ if (!file_exists(__DIR__.'/src')) {
     exit(0);
 }
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

Currently, php-cs-fixer doesn't like the php 8 syntax (ie unions/promoted properties) we'd like to use in twig/live components.
