### PR TITLE
[LiveComponent] add ability to have array props

### DIFF
--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -28,7 +28,7 @@ use Symfony\UX\LiveComponent\Exception\UnsupportedHydrationException;
 final class LiveComponentHydrator
 {
     private const CHECKSUM_KEY = '_checksum';
-    private const EXPOSED_PROP_KEY = 'id';
+    private const EXPOSED_PROP_KEY = '_id';
 
     /** @var PropertyHydratorInterface[] */
     private iterable $propertyHydrators;
@@ -197,7 +197,7 @@ final class LiveComponentHydrator
         // for read-only properties with "exposed" sub-parts,
         // only use the main value
         foreach ($properties as $key => $val) {
-            if (\in_array($key, $readonlyProperties) && \is_array($val)) {
+            if (\in_array($key, $readonlyProperties) && \is_array($val) && isset($val[self::EXPOSED_PROP_KEY])) {
                 $properties[$key] = $val[self::EXPOSED_PROP_KEY];
             }
         }

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\LiveComponent\Tests\Integration;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Tests\ContainerBC;
 use Symfony\UX\LiveComponent\Tests\Fixture\Component\Component1;
@@ -238,5 +239,30 @@ final class LiveComponentHydratorTest extends KernelTestCase
 
         $this->assertSame('value1', $component->prop1);
         $this->assertSame('value2', $component->prop2);
+    }
+
+    public function testCanDehydrateAndHydrateArrays(): void
+    {
+        /** @var LiveComponentHydrator $hydrator */
+        $hydrator = self::getContainer()->get('ux.live_component.component_hydrator');
+
+        $component = new class() {
+            #[LiveProp]
+            public array $prop;
+        };
+
+        $instance = clone $component;
+        $instance->prop = ['some', 'array'];
+
+        $dehydrated = $hydrator->dehydrate($instance);
+
+        $this->assertArrayHasKey('prop', $dehydrated);
+        $this->assertSame($instance->prop, $dehydrated['prop']);
+
+        $this->assertFalse(isset($component->prop));
+
+        $hydrator->hydrate($component, $dehydrated);
+
+        $this->assertSame($instance->prop, $component->prop);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | n/a
| License       | MIT

Discovered a bug when working on #220. You currently can't have `LiveProp`'s that are "arrays". This is because the [_expose_ system](https://symfony.com/bundles/ux-live-component/current/index.html#modifying-embedded-properties-with-the-exposed-option) uses arrays and we weren't strict enough in determining when this system was being used.
