### PR TITLE
Minor clarifications to TwigComponent doc examples

### DIFF
--- a/src/TwigComponent/src/Resources/doc/index.rst
+++ b/src/TwigComponent/src/Resources/doc/index.rst
@@ -27,8 +27,8 @@ And (2) a corresponding template:
 .. code-block:: twig
 
     {# templates/components/alert.html.twig #}
-    <div class="alert alert-{{ type }}">
-        {{ message }}
+    <div class="alert alert-{{ this.type }}">
+        {{ this.message }}
     </div>
 
 Done! Now render it wherever you want:
@@ -132,14 +132,11 @@ public property for each:
 
 In the template, the ``AlertComponent`` instance is available via
 the ``this`` variable and public properties are available directly.
-Use them to render the two new properties:
+Access the variable to render the two new properties:
 
 .. code-block:: twig
 
-    <div class="alert alert-{{ type }}">
-        {{ message }}
-
-        {# Same as above, but using "this", which is the component object #}
+    <div class="alert alert-{{ this.type }}">
         {{ this.message }}
     </div>
 
@@ -188,9 +185,9 @@ component's name (``alert``) and a ``template`` tag attribute
 The mount() Method
 ~~~~~~~~~~~~~~~~~~
 
-If, for some reason, you don't want an option to the ``component()``
-function to be set directly onto a property, you can, instead, create a
-``mount()`` method in your component::
+If, for some reason, you don't want an option passed to the
+``component()`` function to be set directly onto a property, you can, 
+instead, create a ``mount()`` method in your component::
 
     // src/Components/AlertComponent.php
     // ...


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->

The examples I've touched sounded a bit misleading to me at first comparing to the Live Component package. Having something available as `{{ message }}` isn't possible since an error is thrown since it's not a property nor does it exist in the `mount()` method. I feel like examples should just make the `this` variable very clear.