### PR TITLE
[Live] Always send HTML over the wire instead of JSON

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.1.0
+
+-   The Live Component AJAX endpoints now return HTML in all situations
+    instead of JSON.
+
 ## 2.0.0
 
 -   Support for `stimulus` version 2 was removed and support for `@hotwired/stimulus`

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -6,12 +6,6 @@ import { buildFormData, buildSearchParams } from './http_data_helper';
 import { setDeepData, doesDeepPropertyExist, normalizeModelName } from './set_deep_data';
 import { haveRenderedValuesChanged } from './have_rendered_values_changed';
 
-interface LiveResponseData {
-    redirect_url?: string,
-    html?: string,
-    data?: any,
-}
-
 interface ElementLoadingDirectives {
     element: HTMLElement,
     directives: Directive[]
@@ -195,20 +189,8 @@ export default class extends Controller {
         this._makeRequest(null);
     }
 
-    _getValueFromElement(element: HTMLElement){
-        const value = element.dataset.value || element.value;
-
-        if (!value) {
-            const clonedElement = (element.cloneNode());
-            // helps typescript know this is an HTMLElement
-            if (!(clonedElement instanceof HTMLElement)) {
-                throw new Error('cloneNode() produced incorrect type');
-            }
-
-            throw new Error(`The update() method could not be called for "${clonedElement.outerHTML}": the element must either have a "data-value" or "value" attribute set.`);
-        }
-
-        return value;
+    _getValueFromElement(element: HTMLElement) {
+        return element.dataset.value || element.value;
     }
 
     _updateModelFromElement(element: HTMLElement, value: string, shouldRender: boolean) {
@@ -320,7 +302,7 @@ export default class extends Controller {
 
         const fetchOptions: RequestInit = {};
         fetchOptions.headers = {
-            'Accept': 'application/vnd.live-component+json',
+            'Accept': 'application/vnd.live-component+html',
         };
 
         if (action) {
@@ -351,8 +333,8 @@ export default class extends Controller {
 
             const isMostRecent = this.renderPromiseStack.removePromise(thisPromise);
             if (isMostRecent) {
-                response.json().then((data) => {
-                    this._processRerender(data)
+                response.text().then((html) => {
+                    this._processRerender(html, response);
                 });
             }
         })
@@ -363,24 +345,24 @@ export default class extends Controller {
      *
      * @private
      */
-    _processRerender(data: LiveResponseData) {
+    _processRerender(html: string, response: Response) {
         // check if the page is navigating away
         if (this.isWindowUnloaded) {
             return;
         }
 
-        if (data.redirect_url) {
+        if (response.headers.get('Location')) {
             // action returned a redirect
             if (typeof Turbo !== 'undefined') {
-                Turbo.visit(data.redirect_url);
+                Turbo.visit(response.headers.get('Location'));
             } else {
-                window.location.href = data.redirect_url;
+                window.location.href = response.headers.get('Location');
             }
 
             return;
         }
 
-        if (!this._dispatchEvent('live:render', data, true, true)) {
+        if (!this._dispatchEvent('live:render', html, true, true)) {
             // preventDefault() was called
             return;
         }
@@ -390,15 +372,8 @@ export default class extends Controller {
         // elements to appear different unnecessarily
         this._onLoadingFinish();
 
-        if (!data.html) {
-            throw new Error('Missing html key on response JSON');
-        }
-
         // merge/patch in the new HTML
-        this._executeMorphdom(data.html);
-
-        // "data" holds the new, updated data
-        this.dataValue = data.data;
+        this._executeMorphdom(html);
     }
 
     _clearWaitingDebouncedRenders() {
@@ -644,7 +619,7 @@ export default class extends Controller {
         this.pollingIntervals.push(timer);
     }
 
-    _dispatchEvent(name: string, payload: object | null = null, canBubble = true, cancelable = false) {
+    _dispatchEvent(name: string, payload: object | string | null = null, canBubble = true, cancelable = false) {
         return this.element.dispatchEvent(new CustomEvent(name, {
             bubbles: canBubble,
             cancelable,

--- a/src/LiveComponent/assets/test/controller/action.test.ts
+++ b/src/LiveComponent/assets/test/controller/action.test.ts
@@ -48,10 +48,10 @@ describe('LiveController Action Tests', () => {
         const { element } = await startStimulus(template(data));
 
         // ONLY a post is sent, not a re-render GET
-        const postMock = fetchMock.postOnce('http://localhost/_components/my_component/save', {
-            html: template({ comments: 'hi weaver', isSaved: true }),
-            data: { comments: 'hi weaver', isSaved: true }
-        });
+        const postMock = fetchMock.postOnce(
+            'http://localhost/_components/my_component/save',
+            template({ comments: 'hi weaver', isSaved: true })
+        );
 
         await userEvent.type(getByLabelText(element, 'Comments:'), ' WEAVER');
 

--- a/src/LiveComponent/assets/test/controller/child.test.ts
+++ b/src/LiveComponent/assets/test/controller/child.test.ts
@@ -133,6 +133,7 @@ describe('LiveController parent -> child component tests', () => {
         const inputElement = getByLabelText(element, 'Content:');
         await userEvent.clear(inputElement);
         await userEvent.type(inputElement, 'changed content');
+        // change the rows on the server
         mockRerender({'value': 'changed content'}, childTemplate, (data) => {
             data.rows = 5;
         });

--- a/src/LiveComponent/assets/test/controller/csrf.test.ts
+++ b/src/LiveComponent/assets/test/controller/csrf.test.ts
@@ -47,10 +47,10 @@ describe('LiveController CSRF Tests', () => {
         const data = { comments: 'hi' };
         const { element } = await startStimulus(template(data));
 
-        const postMock = fetchMock.postOnce('http://localhost/_components/my_component/save', {
-            html: template({ comments: 'hi', isSaved: true }),
-            data: { comments: 'hi', isSaved: true }
-        });
+        const postMock = fetchMock.postOnce(
+            'http://localhost/_components/my_component/save',
+            template({ comments: 'hi', isSaved: true })
+        );
         getByText(element, 'Save').click();
 
         await waitFor(() => expect(element).toHaveTextContent('Comment Saved!'));

--- a/src/LiveComponent/assets/test/controller/render.test.ts
+++ b/src/LiveComponent/assets/test/controller/render.test.ts
@@ -61,12 +61,11 @@ describe('LiveController rendering Tests', () => {
         const data = { name: 'Ryan' };
         const { element } = await startStimulus(template(data));
 
-        fetchMock.get('http://localhost/_components/my_component?name=Ryan', {
-            html: template({ name: 'Kevin' }),
-            data: { name: 'Kevin' }
-        }, {
-            delay: 100
-        });
+        fetchMock.get(
+            'http://localhost/_components/my_component?name=Ryan',
+            template({ name: 'Kevin' }),
+            { delay: 100 }
+        );
         getByText(element, 'Reload').click();
         userEvent.type(getByLabelText(element, 'Comments:'), '!!');
 
@@ -84,12 +83,11 @@ describe('LiveController rendering Tests', () => {
             template(data, true)
         );
 
-        fetchMock.get('http://localhost/_components/my_component?name=Ryan', {
-            html: template({ name: 'Kevin' }, true),
-            data: { name: 'Kevin' }
-        }, {
-            delay: 100
-        });
+        fetchMock.get(
+            'http://localhost/_components/my_component?name=Ryan',
+            template({ name: 'Kevin' }, true),
+            { delay: 100 }
+        );
         getByText(element, 'Reload').click();
         userEvent.type(getByLabelText(element, 'Comments:'), '!!');
 
@@ -102,10 +100,7 @@ describe('LiveController rendering Tests', () => {
         const data = { name: 'Ryan' };
         const { element } = await startStimulus(template(data));
 
-        fetchMock.get('end:?name=Ryan', {
-            html: '<div>aloha!</div>',
-            data: { name: 'Kevin' }
-        }, {
+        fetchMock.get('end:?name=Ryan', '<div>aloha!</div>', {
             delay: 100
         });
 

--- a/src/LiveComponent/assets/test/tools.ts
+++ b/src/LiveComponent/assets/test/tools.ts
@@ -74,10 +74,7 @@ const mockRerender = (sentData, renderCallback, changeDataCallback = null) => {
         changeDataCallback(sentData);
     }
 
-    fetchMock.mock(url, {
-        html: renderCallback(sentData),
-        data: sentData
-    });
+    fetchMock.mock(url, renderCallback(sentData));
 }
 
 export { startStimulus, getControllerElement, initLiveComponent, mockRerender };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (one part of it is)
| New feature?  | yes
| Tickets       | None
| License       | MIT

Hi!

Currently, the LiveComponent controller expects to get JSON back from the server, containing `{ data: ..., html: '...' }`. But, Stimulus is so cool, that this isn't necessary! The LiveComponent Ajax requests can simply return HTML in all cases. The rendered element will have an updated `data-live-data-value` attribute with the latest data. And so, the Stimulus component instantly reads that updated data and incorporates it: there is no need to send back the "component data" on a separate key in the JSON.

This makes the live component system more boring in a good way: it's just a way to return HTML (and then we have fancy JavaScript that adds all the interactivity). It's also a bit faster now, as previously we were dehydrating the component data twice on re-render.

I can't think of any downsides to this approach - everything seems to work just fine.

Cheers!