### PR TITLE
[LiveComponent] fix `component_url` twig function

### DIFF
--- a/src/LiveComponent/src/Twig/LiveComponentRuntime.php
+++ b/src/LiveComponent/src/Twig/LiveComponentRuntime.php
@@ -59,10 +59,10 @@ final class LiveComponentRuntime
         );
     }
 
-    public function getComponentUrl(object $component, string $name = null): string
+    public function getComponentUrl(string $name, array $props = []): string
     {
-        $data = $this->hydrator->dehydrate($component);
-        $params = ['component' => $this->nameFor($component, $name)] + $data;
+        $component = $this->factory->create($name, $props);
+        $params = ['component' => $name] + $this->hydrator->dehydrate($component);
 
         return $this->urlGenerator->generate('live_component', $params);
     }

--- a/src/LiveComponent/tests/Fixture/templates/component_url.html.twig
+++ b/src/LiveComponent/tests/Fixture/templates/component_url.html.twig
@@ -1,0 +1,1 @@
+{{ component_url('component1', { prop1: null, prop2: date }) }}

--- a/src/LiveComponent/tests/Integration/Twig/LiveComponentExtensionTest.php
+++ b/src/LiveComponent/tests/Integration/Twig/LiveComponentExtensionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\LiveComponent\Tests\ContainerBC;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LiveComponentExtensionTest extends KernelTestCase
+{
+    use ContainerBC;
+
+    public function testGetComponentUrl(): void
+    {
+        $rendered = self::getContainer()->get('twig')->render('component_url.html.twig', [
+            'date' => new \DateTime('2022-10-06-0'),
+        ]);
+
+        $this->assertStringContainsString('/_components/component1?prop2=2022-10-06T00:00:00', $rendered);
+        $this->assertStringContainsString('_checksum=', $rendered);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes (kind of)
| Tickets       | n/a
| License       | MIT

Previously, it didn't work as intended. It required a component instance. It was supposed to work like `component()` (from twig-components), except generate a url to the live component (instead of rendering).
