### PR TITLE
Ensure JS dist files are current in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,21 @@ jobs:
             - run: yarn check-lint
             - run: yarn check-format
 
+    js-dist-current:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - run: yarn && yarn build
+            - name: Check if js dist files are current
+              id: changes
+              uses: UnicornGlobal/has-changes-action@v1.0.11
+
+            - name: Ensure no changes
+              if: steps.changes.outputs.changed == 1
+              run: |
+                echo "JS dist files need to be rebuilt"
+                exit 1
+
     tests-php-low-deps:
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

This action job will fail if the dist files need to be rebuilt. [Failure example](https://github.com/symfony/ux/runs/5022158414?check_suite_focus=true).
