### PR TITLE
Allow SVG elements in LiveComponent

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1080,6 +1080,9 @@ class default_1 extends Controller {
         return element.dataset.value || element.value;
     }
     _updateModelFromElement(element, value, shouldRender) {
+        if (!(element instanceof HTMLElement)) {
+            throw new Error('Could not update model for non HTMLElement');
+        }
         const model = element.dataset.model || element.getAttribute('name');
         if (!model) {
             const clonedElement = cloneHTMLElement(element);
@@ -1273,7 +1276,7 @@ class default_1 extends Controller {
     _getLoadingDirectives() {
         const loadingDirectives = [];
         this.element.querySelectorAll('[data-loading]').forEach((element => {
-            if (!(element instanceof HTMLElement)) {
+            if (!(element instanceof HTMLElement) && !(element instanceof SVGElement)) {
                 throw new Error('Invalid Element Type');
             }
             const directives = parseDirectives(element.dataset.loading || 'show');
@@ -1327,6 +1330,9 @@ class default_1 extends Controller {
         const newElement = htmlToElement(newHtml);
         morphdom(this.element, newElement, {
             onBeforeElUpdated: (fromEl, toEl) => {
+                if (!(fromEl instanceof HTMLElement) || !(toEl instanceof HTMLElement)) {
+                    return false;
+                }
                 if (fromEl.isEqualNode(toEl)) {
                     const normalizedFromEl = cloneHTMLElement(fromEl);
                     normalizeAttributesForComparison(normalizedFromEl);

--- a/src/LiveComponent/assets/test/clone_html_element.test.ts
+++ b/src/LiveComponent/assets/test/clone_html_element.test.ts
@@ -1,0 +1,23 @@
+import { cloneHTMLElement } from '../src/clone_html_element';
+
+const createElement = function(html: string): HTMLElement {
+    const template = document.createElement('template');
+    html = html.trim();
+    template.innerHTML = html;
+
+    const child = template.content.firstChild;
+    if (!child || !(child instanceof HTMLElement)) {
+        throw new Error('Child not found');
+    }
+
+    return child;
+}
+
+describe('cloneHTMLElement', () => {
+    it('allows to clone HTMLElement', () => {
+        const element = createElement('<div class="foo"></div>');
+        const clone = cloneHTMLElement(element);
+
+        expect(clone.outerHTML).toEqual('<div class="foo"></div>');
+    });
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | N/A
| License       | MIT

When the component contains svg elements then it throws error on rerender:
```
Uncaught (in promise) Error: Could not clone element
    at cloneHTMLElement (live_controller.js:977:15)
    at onBeforeElUpdated (live_controller.js:1331:46)
    at morphEl (live_controller.js:492:21)
    at morphChildren (live_controller.js:605:33)
    at morphEl (live_controller.js:507:15)
    at morphChildren (live_controller.js:605:33)
    at morphEl (live_controller.js:507:15)
    at morphChildren (live_controller.js:605:33)
    at morphEl (live_controller.js:507:15)
    at morphdom (live_controller.js:722:13)
```