### PR TITLE
[LiveComponent] docs: `array_splice` instead of `unset`

### DIFF
--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -1137,7 +1137,7 @@ Now, create a Twig component to render the form::
         #[LiveAction]
         public function removeComment(#[LiveArg] int $index)
         {
-            unset($this->formValues['comments'][$index]);
+            array_splice($this->formValues['comments'], $index, 1);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | N/A
| License       | MIT

When using unset, then the array keys are not re-indexed, which leaves gaps in the structure, while `array_splice` re-indexes