### PR TITLE
[Twig][Live] add ability to configure exposing public props and `attributes` variable name

### DIFF
--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -21,13 +21,25 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class AsLiveComponent extends AsTwigComponent
 {
-    public ?string $defaultAction;
+    public function __construct(
+        string $name,
+        ?string $template = null,
+        private ?string $defaultAction = null,
+        bool $exposePublicProps = true,
+        string $attributesVar = 'attributes'
+    ) {
+        parent::__construct($name, $template, $exposePublicProps, $attributesVar);
+    }
 
-    public function __construct(string $name, ?string $template = null, ?string $defaultAction = null)
+    /**
+     * @internal
+     */
+    public function serviceConfig(): array
     {
-        parent::__construct($name, $template);
-
-        $this->defaultAction = $defaultAction;
+        return array_merge(parent::serviceConfig(), [
+            'default_action' => $this->defaultAction,
+            'live' => true,
+        ]);
     }
 
     /**

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -39,12 +39,7 @@ final class LiveComponentExtension extends Extension
             AsLiveComponent::class,
             function (ChildDefinition $definition, AsLiveComponent $attribute) {
                 $definition
-                    ->addTag('twig.component', array_filter([
-                        'key' => $attribute->name,
-                        'template' => $attribute->template,
-                        'default_action' => $attribute->defaultAction,
-                        'live' => true,
-                    ]))
+                    ->addTag('twig.component', array_filter($attribute->serviceConfig()))
                     ->addTag('controller.service_arguments')
                 ;
             }

--- a/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
+++ b/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
@@ -31,13 +31,14 @@ final class AddLiveAttributesSubscriber implements EventSubscriberInterface, Ser
 
         $attributes = $this->getLiveAttributes($event->getMountedComponent());
         $variables = $event->getVariables();
+        $attributesKey = $event->getMetadata()->getAttributesVar();
 
-        if (isset($variables['attributes']) && $variables['attributes'] instanceof ComponentAttributes) {
+        if (isset($variables[$attributesKey]) && $variables[$attributesKey] instanceof ComponentAttributes) {
             // merge with existing attributes if available
-            $attributes = $attributes->defaults($variables['attributes']->all());
+            $attributes = $attributes->defaults($variables[$attributesKey]->all());
         }
 
-        $variables['attributes'] = $attributes;
+        $variables[$attributesKey] = $attributes;
 
         $event->setVariables($variables);
     }

--- a/src/LiveComponent/tests/Fixtures/Component/CustomAttributes.php
+++ b/src/LiveComponent/tests/Fixtures/Component/CustomAttributes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsLiveComponent('custom_attributes', attributesVar: '_custom_attributes')]
+final class CustomAttributes
+{
+
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/custom_attributes.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/custom_attributes.html.twig
@@ -1,0 +1,1 @@
+<div{{ _custom_attributes }}></div>

--- a/src/LiveComponent/tests/Fixtures/templates/render_custom_attributes.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/render_custom_attributes.html.twig
@@ -1,0 +1,1 @@
+{{ component('custom_attributes') }}

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -40,4 +40,22 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertSame(1, $data['count']);
         $this->assertArrayHasKey('_checksum', $data);
     }
+
+    public function testCanUseCustomAttributes(): void
+    {
+        $response = $this->browser()
+            ->visit('/render-template/render_custom_attributes')
+            ->assertSuccessful()
+            ->response()
+            ->assertHtml()
+        ;
+
+        $div = $response->crawler()->filter('div');
+        $data = json_decode($div->attr('data-live-data-value'), true);
+
+        $this->assertSame('live', $div->attr('data-controller'));
+        $this->assertSame('/_components/custom_attributes', $div->attr('data-live-url-value'));
+        $this->assertNotNull($div->attr('data-live-csrf-value'));
+        $this->assertArrayHasKey('_checksum', $data);
+    }
 }

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -19,13 +19,25 @@ namespace Symfony\UX\TwigComponent\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class AsTwigComponent
 {
-    public string $name;
-    public ?string $template;
+    public function __construct(
+        private string $name,
+        private ?string $template = null,
+        private bool $exposePublicProps = true,
+        private string $attributesVar = 'attributes'
+    ) {
+    }
 
-    public function __construct(string $name, ?string $template = null)
+    /**
+     * @internal
+     */
+    public function serviceConfig(): array
     {
-        $this->name = $name;
-        $this->template = $template;
+        return [
+            'key' => $this->name,
+            'template' => $this->template,
+            'expose_public_props' => $this->exposePublicProps,
+            'attributes_var' => $this->attributesVar,
+        ];
     }
 
     /**
@@ -44,6 +56,11 @@ class AsTwigComponent
         return array_reverse($methods);
     }
 
+    /**
+     * @internal
+     *
+     * @return \ReflectionMethod[]
+     */
     public static function postMountMethods(object $component): iterable
     {
         $methods = iterator_to_array(self::attributeMethodsFor(PostMount::class, $component));

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -66,8 +66,9 @@ final class ComponentFactory
         $data = $this->postMount($component, $data);
 
         // create attributes from "attributes" key if exists
-        $attributes = $data['attributes'] ?? [];
-        unset($data['attributes']);
+        $attributesVar = $this->metadataFor($name)->getAttributesVar();
+        $attributes = $data[$attributesVar] ?? [];
+        unset($data[$attributesVar]);
 
         // ensure remaining data is scalar
         foreach ($data as $key => $value) {

--- a/src/TwigComponent/src/ComponentMetadata.php
+++ b/src/TwigComponent/src/ComponentMetadata.php
@@ -54,6 +54,16 @@ final class ComponentMetadata
         return $this->config['service_id'];
     }
 
+    public function isPublicPropsExposed(): bool
+    {
+        return $this->get('expose_public_props', false);
+    }
+
+    public function getAttributesVar(): string
+    {
+        return $this->get('attributes_var', 'attributes');
+    }
+
     public function get(string $key, mixed $default = null): mixed
     {
         return $this->config[$key] ?? $default;

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -37,10 +37,7 @@ final class TwigComponentExtension extends Extension
         $container->registerAttributeForAutoconfiguration(
             AsTwigComponent::class,
             static function (ChildDefinition $definition, AsTwigComponent $attribute) {
-                $definition->addTag('twig.component', array_filter([
-                    'key' => $attribute->name,
-                    'template' => $attribute->template,
-                ]));
+                $definition->addTag('twig.component', array_filter($attribute->serviceConfig()));
             }
         );
 

--- a/src/TwigComponent/src/Resources/doc/index.rst
+++ b/src/TwigComponent/src/Resources/doc/index.rst
@@ -161,6 +161,17 @@ Behind the scenes, a new ``AlertComponent`` will be instantiated and the
 a property has a setter method (e.g. ``setMessage()``), that will be
 called instead of setting the property directly.
 
+.. note::
+
+    You can disable exposing public properties for a component. When disabled,
+    ``this.property`` must be used::
+
+        #[AsTwigComponent('alert', exposePublicProps: false)]
+        class AlertComponent
+        {
+            // ...
+        }
+
 Customize the Twig Template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -512,6 +523,16 @@ Set an attribute's value to ``null`` to exclude the value when rendering:
 
     {# renders as: #}
     <input type="text" value="" autofocus/>
+
+.. note::
+
+    You can adjust the attributes variable exposed in your template::
+
+        #[AsTwigComponent('alert', attributesVar: '_attributes')]
+        class AlertComponent
+        {
+            // ...
+        }
 
 Defaults & Merging
 ~~~~~~~~~~~~~~~~~~

--- a/src/TwigComponent/tests/Fixtures/Component/CustomAttributes.php
+++ b/src/TwigComponent/tests/Fixtures/Component/CustomAttributes.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsTwigComponent('custom_attributes', attributesVar: '_attributes')]
+final class CustomAttributes
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/NoPublicProps.php
+++ b/src/TwigComponent/tests/Fixtures/Component/NoPublicProps.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsTwigComponent(name: 'no_public_props', exposePublicProps: false)]
+final class NoPublicProps
+{
+    public $prop1 = 'value';
+}

--- a/src/TwigComponent/tests/Fixtures/templates/components/custom_attributes.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/custom_attributes.html.twig
@@ -1,0 +1,1 @@
+<div{{ _attributes }}></div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/no_public_props.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/no_public_props.html.twig
@@ -1,0 +1,1 @@
+NoPublicProp1: {{ prop1|default('default') }}

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -82,6 +82,13 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('<button class="foo baz" type="submit" style="color:red;">', $output);
     }
 
+    public function testCanSetCustomAttributesVariable(): void
+    {
+        $output = $this->renderComponent('custom_attributes', ['class' => 'from-custom']);
+
+        $this->assertStringContainsString('<div class="from-custom"></div>', $output);
+    }
+
     public function testRenderComponentWithExposedVariables(): void
     {
         $output = $this->renderComponent('with_exposed_variables');
@@ -102,6 +109,13 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('countComputed3: 3', $output);
         $this->assertStringContainsString('propDirect: value', $output);
         $this->assertStringContainsString('propComputed: value', $output);
+    }
+
+    public function testCanDisableExposingPublicProps(): void
+    {
+        $output = $this->renderComponent('no_public_props');
+
+        $this->assertStringContainsString('NoPublicProp1: default', $output);
     }
 
     private function renderComponent(string $name, array $data = []): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #275
| License       | MIT

To avoid possible collisions with other variables/libraries, it was requested to make the `attributes` variable configurable. Additionally, I added an option to disable exposing public props:

```php
#[AsTwigComponent('my_component', attributesVar: '_attributes', exposePublicProps: false)]
class MyComponent {}
```

In the component template, no public properties are available directly (unless explicitly marked with `ExposeInTemplate` and attributes are available as `_attributes`.
