### PR TITLE
Update index.rst

### DIFF
--- a/src/TwigComponent/src/Resources/doc/index.rst
+++ b/src/TwigComponent/src/Resources/doc/index.rst
@@ -80,8 +80,8 @@ as simple as possible::
     }
 
 Step 2 is to create a template for this component. By default, templates
-live in ``templates/components/{Component Name}.html.twig``, where
-``{Component Name}`` is whatever you passed as the first argument to the
+live in ``templates/components/{component_name}.html.twig``, where
+``{component_name}`` is whatever you passed as the first argument to the
 ``AsTwigComponent`` class attribute:
 
 .. code-block:: twig
@@ -230,6 +230,8 @@ All public component properties are available directly in your component
 template. You can use the ``ExposeInTemplate`` attribute to expose
 private/protected properties directly in a component template (``someProp``
 vs ``this.someProp``). These properties must be *accessible* (have a getter).
+
+.. code-block:: php
 
     // ...
     use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
@@ -586,7 +588,7 @@ PreRenderEvent
     The ``PreRenderEvent`` was added in TwigComponents 2.1.
 
 Subscribing to the ``PreRenderEvent`` gives the ability to modify
-the twig template and twig variables before components are rendered:
+the twig template and twig variables before components are rendered::
 
     use Symfony\UX\TwigComponent\EventListener\PreRenderEvent;
 


### PR DESCRIPTION
Some improvement while reading form https://symfony.com/bundles/ux-twig-component/current/index.html

I am unsure of the code render via `::`
For the component pattern I took as exemple the `{# templates/components/featured_products.html.twig #}` defined in the middle of the page doc

ℹ️ the button `edit this page` points to the readonly repo, perhaps it should be updated