### PR TITLE
[Live] Rename `BeforeReRender` attribute to `PreReRender`

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -31,6 +31,8 @@
     is a BC break if you've created custom hydrators. They'll need to be converted to
     normalizers.
 
+-   [BC BREAK] Rename `BeforeReRender` attribute to `PreReRender`.
+
 ## 2.0.0
 
 -   Support for `stimulus` version 2 was removed and support for `@hotwired/stimulus`

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -86,9 +86,9 @@ final class AsLiveComponent extends AsTwigComponent
      *
      * @return \ReflectionMethod[]
      */
-    public static function beforeReRenderMethods(object $component): \Traversable
+    public static function preReRenderMethods(object $component): \Traversable
     {
-        yield from self::attributeMethodsFor(BeforeReRender::class, $component);
+        yield from self::attributeMethodsFor(PreReRender::class, $component);
     }
 
     /**

--- a/src/LiveComponent/src/Attribute/PreReRender.php
+++ b/src/LiveComponent/src/Attribute/PreReRender.php
@@ -20,6 +20,6 @@ namespace Symfony\UX\LiveComponent\Attribute;
  * @experimental
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
-final class BeforeReRender
+final class PreReRender
 {
 }

--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -15,8 +15,8 @@ use Symfony\Component\Form\ClearableErrorsInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
-use Symfony\UX\LiveComponent\Attribute\BeforeReRender;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\Util\LiveFormUtility;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 use Symfony\UX\TwigComponent\Attribute\PostMount;
@@ -99,7 +99,7 @@ trait ComponentWithFormTrait
      * But, in the event that there is an action and the form was
      * not submitted manually, it will be submitted here.
      */
-    #[BeforeReRender]
+    #[PreReRender]
     public function submitFormOnRender(): void
     {
         if (!$this->getFormInstance()->isSubmitted()) {

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -241,7 +241,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
     {
         $component = $mounted->getComponent();
 
-        foreach (AsLiveComponent::beforeReRenderMethods($component) as $method) {
+        foreach (AsLiveComponent::preReRenderMethods($component) as $method) {
             $component->{$method->name}();
         }
 

--- a/src/LiveComponent/tests/Fixtures/Component/Component2.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component2.php
@@ -14,7 +14,7 @@ namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
-use Symfony\UX\LiveComponent\Attribute\BeforeReRender;
+use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\Attribute\PostHydrate;
@@ -63,7 +63,7 @@ final class Component2
         $this->postHydrateCalled = true;
     }
 
-    #[BeforeReRender]
+    #[PreReRender]
     public function beforeReRenderMethod(): void
     {
         $this->beforeReRenderCalled = true;

--- a/src/LiveComponent/tests/Fixtures/Component/Component4.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component4.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 
-use Symfony\UX\LiveComponent\Attribute\BeforeReRender;
+use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\Attribute\PostHydrate;
@@ -39,7 +39,7 @@ class Component4
     {
     }
 
-    #[BeforeReRender]
+    #[PreReRender]
     public function method3()
     {
     }

--- a/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
@@ -47,7 +47,7 @@ final class AsLiveComponentTest extends TestCase
 
     public function testCanGetBeforeReRenderMethods(): void
     {
-        $methods = iterator_to_array(AsLiveComponent::beforeReRenderMethods(new Component5()));
+        $methods = iterator_to_array(AsLiveComponent::preReRenderMethods(new Component5()));
 
         $this->assertCount(1, $methods);
         $this->assertSame('method3', $methods[0]->getName());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | BC BREAK
| Tickets       | Fix n/a
| License       | MIT

Makes the naming consistent with the other attributes.
