### PR TITLE
[RFC][Twig] "Anonymous" components

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentRuntime.php
+++ b/src/TwigComponent/src/Twig/ComponentRuntime.php
@@ -32,6 +32,11 @@ final class ComponentRuntime
 
     public function render(string $name, array $props = []): string
     {
-        return $this->componentRenderer->render($this->componentFactory->create($name, $props));
+        try {
+            return $this->componentRenderer->render($this->componentFactory->create($name, $props));
+        } catch (\InvalidArgumentException) {
+            // component not found, try as anonymous component
+            return $this->componentRenderer->renderAnonymous($name, $props);
+        }
     }
 }

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\TwigComponent\Tests\Integration;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Twig\Environment;
+use Twig\Error\RuntimeError;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -116,6 +117,41 @@ final class ComponentExtensionTest extends KernelTestCase
         $output = $this->renderComponent('no_public_props');
 
         $this->assertStringContainsString('NoPublicProp1: default', $output);
+    }
+
+    public function testCanRenderAnonymousComponent(): void
+    {
+        $output = $this->renderComponent('components/with_attributes.html.twig', [
+            'prop' => 'prop value 1',
+            'attributes' => [
+                'class' => 'bar',
+                'style' => 'color:red;',
+                'value' => '',
+                'autofocus' => null,
+            ],
+        ]);
+
+        $this->assertStringContainsString('Component Content (prop value 1)', $output);
+        $this->assertStringContainsString('<button class="foo bar" type="button" style="color:red;" value="" autofocus>', $output);
+
+        $output = $this->renderComponent('components/with_attributes.html.twig', [
+            'prop' => 'prop value 2',
+            'attributes' => [
+                'class' => 'baz',
+                'type' => 'submit',
+                'style' => 'color:red;',
+            ],
+        ]);
+
+        $this->assertStringContainsString('Component Content (prop value 2)', $output);
+        $this->assertStringContainsString('<button class="foo baz" type="submit" style="color:red;">', $output);
+    }
+
+    public function testInvalidAnonymousComponent(): void
+    {
+        $this->expectException(RuntimeError::class);
+
+        $this->renderComponent('invalid.html.twig');
     }
 
     private function renderComponent(string $name, array $data = []): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | n/a
| License       | MIT

This is pretty rough still but looking for input. This is basically `include()` but with the `attributes` system available.

```twig
{# path/to/template.html.twig #}
<div{{ attributes }}>{{ prop1 }}</div>


{# render: (attributes *must* be sent as a "sub-key" #}
{{ component('path/to/template.html.twig', { prop1: 'value', { attributes: { class: 'mb-1' } } }) }}
```

This feature will be much more useful once/if embedded components are added. You'd be able to have anonymous components with slots.

**TODO:**
- [ ] since we have the convention of component templates living in `templates/components/*`, I think we should allow:
    ```twig
    {# if no "alert" component class, use "templates/components/alert.html.twig" #}
    {{ component('alert', {message: 'message...'}) }}
    ```