### PR TITLE
Fix typo in the Swup options section

### DIFF
--- a/src/Swup/Resources/doc/index.rst
+++ b/src/Swup/Resources/doc/index.rst
@@ -110,7 +110,7 @@ added:
         <body
             {{ stimulus_controller('symfony/ux-swup/swup', {
                 containers: ['#swup', '#nav'],
-                animateHistoryBrowsing: true
+                animateHistoryBrowsing: true,
                 animationSelector: '[class*="transition-"]',
                 cache: true,
                 linkSelector: '...',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

Fixed a little typo issue in the Swup documentation in the Swup options section
