### PR TITLE
Streams documentation for Symfony 6

### DIFF
--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -309,7 +309,7 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
-    use Symfony\UX\Turbo\TurboBundle;
+    use Symfony\UX\Turbo\Stream\TurboStreamResponse;
     use App\Entity\Task;
 
     class TaskController extends AbstractController
@@ -325,9 +325,9 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
                 // ... perform some action, such as saving the task to the database
 
                 // 🔥 The magic happens here! 🔥
-                if (TurboBundle::STREAM_FORMAT === $request->getPreferredFormat()) {
+                if (TurboStreamResponse::STREAM_FORMAT === $request->getPreferredFormat()) {
                     // If the request comes from Turbo, set the content type as text/vnd.turbo-stream.html and only send the HTML to update
-                    $request->setFormat(TurboBundle::STREAM_FORMAT);
+                    $request->setFormat(TurboStreamResponse::STREAM_FORMAT);
                     return $this->render('task/success.stream.html.twig', ['task' => $task]);
                 }
 


### PR DESCRIPTION
I think Symfony\UX\Turbo\TurboBundle should be replaced with Symfony\UX\Turbo\Stream\TurboStreamResponse. This is down in the Turbo Frames section.
Thanks!

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
