### PR TITLE
Wrong class used in turbo streams

### DIFF
--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -309,7 +309,8 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
-    use Symfony\UX\Turbo\TurboBundle;
+    use Symfony\UX\Turbo\Stream\TurboStreamResponse;
+    
     use App\Entity\Task;
 
     class TaskController extends AbstractController
@@ -325,10 +326,10 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
                 // ... perform some action, such as saving the task to the database
 
                 // 🔥 The magic happens here! 🔥
-                if (TurboBundle::STREAM_FORMAT === $request->getPreferredFormat()) {
+                if (TurboStreamResponse::STREAM_FORMAT === $request->getPreferredFormat()) {
                     // If the request comes from Turbo, set the content type as text/vnd.turbo-stream.html and only send the HTML to update
-                    $request->setFormat(TurboBundle::STREAM_FORMAT);
-                    return $this->render('task/success.stream.html.twig', ['task' => $task]);
+                    $request->setFormat(TurboStreamResponse::STREAM_FORMAT);
+                    return $this->render('task/success.stream.html.twig', ['task' => $task], new TurboStreamResponse());
                 }
 
                 // If the client doesn't support JavaScript, or isn't using Turbo, the form still works as usual.

--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -309,7 +309,7 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
-    use Symfony\UX\Turbo\Stream\TurboStreamResponse;
+    use Symfony\UX\Turbo\Stream\TurboBundle;
     
     use App\Entity\Task;
 
@@ -326,10 +326,10 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
                 // ... perform some action, such as saving the task to the database
 
                 // 🔥 The magic happens here! 🔥
-                if (TurboStreamResponse::STREAM_FORMAT === $request->getPreferredFormat()) {
+                if (TurboBundle::STREAM_FORMAT === $request->getPreferredFormat()) {
                     // If the request comes from Turbo, set the content type as text/vnd.turbo-stream.html and only send the HTML to update
-                    $request->setFormat(TurboStreamResponse::STREAM_FORMAT);
-                    return $this->render('task/success.stream.html.twig', ['task' => $task], new TurboStreamResponse());
+                    $request->setFormat(TurboBundle::STREAM_FORMAT);
+                    return $this->render('task/success.stream.html.twig', ['task' => $task]);
                 }
 
                 // If the client doesn't support JavaScript, or isn't using Turbo, the form still works as usual.
@@ -337,7 +337,12 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
                 return $this->redirectToRoute('task_success', [], Response::HTTP_SEE_OTHER);
             }
 
-            // Symfony 5.3+
+  .. versionadded:: 2.1
+  
+  In versions prior to 2.1, TurboStreamResponse::STREAM_FORMAT was used instead of TurboBundle::STREAM_FORMAT. Also, one had to return a new TurboStreamResponse() object as the third argument for this->render().
+  
+        
+        // Symfony 5.3+
             return $this->renderForm('task/new.html.twig', [
                 'form' => $form,
             ]);

--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -302,6 +302,11 @@ Forms
 
 Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
 
+  .. versionadded:: 2.1
+  
+  In versions prior to 2.1, `TurboStreamResponse::STREAM_FORMAT` was used instead of `TurboBundle::STREAM_FORMAT`. Also, one had to return a new
+  `TurboStreamResponse()` object as the third argument for this->render().
+
     // src/Controller/TaskController.php
     namespace App\Controller;
 
@@ -309,7 +314,7 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
-    use Symfony\UX\Turbo\Stream\TurboBundle;
+    use Symfony\UX\Turbo\TurboBundle;
     
     use App\Entity\Task;
 
@@ -337,9 +342,7 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
                 return $this->redirectToRoute('task_success', [], Response::HTTP_SEE_OTHER);
             }
 
-  .. versionadded:: 2.1
-  
-  In versions prior to 2.1, TurboStreamResponse::STREAM_FORMAT was used instead of TurboBundle::STREAM_FORMAT. Also, one had to return a new TurboStreamResponse() object as the third argument for this->render().
+
   
         
         // Symfony 5.3+

--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -300,12 +300,12 @@ clients. There are two main ways to receive the updates:
 Forms
 ^^^^^
 
-Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
-
-  .. versionadded:: 2.1
+.. versionadded:: 2.1
   
-  In versions prior to 2.1, `TurboStreamResponse::STREAM_FORMAT` was used instead of `TurboBundle::STREAM_FORMAT`. Also, one had to return a new
-  `TurboStreamResponse()` object as the third argument for this->render().
+    Prior to 2.1, ``TurboStreamResponse::STREAM_FORMAT`` was used instead of ``TurboBundle::STREAM_FORMAT``.
+    Also, one had to return a new ``TurboStreamResponse()`` object as the third argument to ``$this->render()``.
+
+Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
 
     // src/Controller/TaskController.php
     namespace App\Controller;
@@ -315,7 +315,6 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\UX\Turbo\TurboBundle;
-    
     use App\Entity\Task;
 
     class TaskController extends AbstractController
@@ -342,10 +341,7 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
                 return $this->redirectToRoute('task_success', [], Response::HTTP_SEE_OTHER);
             }
 
-
-  
-        
-        // Symfony 5.3+
+            // Symfony 5.3+
             return $this->renderForm('task/new.html.twig', [
                 'form' => $form,
             ]);


### PR DESCRIPTION
TurboBundle::STREAM_FORMAT doesn't exist, that static variable was moved to TurboStreamResponse::STREAM_FORMAT.
Also the stream didn't work for me unless I changed:
$this->render('task/success.stream.html.twig', ['task' => $task]); to $this->render('task/success.stream.html.twig', ['task' => $task], new TurboStreamResponse());

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
