### PR TITLE
[Live] fix bug when trying to hydrate nullable Doctrine Entity

### DIFF
--- a/src/LiveComponent/src/Normalizer/DoctrineObjectNormalizer.php
+++ b/src/LiveComponent/src/Normalizer/DoctrineObjectNormalizer.php
@@ -66,7 +66,7 @@ final class DoctrineObjectNormalizer implements NormalizerInterface, Denormalize
 
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): ?object
     {
-        return $this->objectManagerFor($type)->find($type, $data);
+        return null === $data ? null : $this->objectManagerFor($type)->find($type, $data);
     }
 
     public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = [])

--- a/src/LiveComponent/tests/Fixtures/Component/WithNullableEntity.php
+++ b/src/LiveComponent/tests/Fixtures/Component/WithNullableEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity1;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsLiveComponent('with_nullable_entity')]
+final class WithNullableEntity
+{
+    use DefaultActionTrait;
+
+    #[LiveProp]
+    public ?Entity1 $prop1 = null;
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/with_nullable_entity.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/with_nullable_entity.html.twig
@@ -1,0 +1,1 @@
+Prop1: {{ prop1.id|default('default') }}

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -210,4 +210,16 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ->assertContains('Arg3: 33.3')
         ;
     }
+
+    public function testWithNullableEntity(): void
+    {
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('with_nullable_entity'));
+
+        $this->browser()
+            ->throwExceptions()
+            ->get('/_components/with_nullable_entity?data='.urlencode(json_encode($dehydrated)))
+            ->assertSuccessful()
+            ->assertContains('Prop1: default')
+        ;
+    }
 }

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -71,7 +71,7 @@ final class ComponentFactory
 
         // ensure remaining data is scalar
         foreach ($data as $key => $value) {
-            if (!is_scalar($value) && null !== $value) {
+            if (!\is_scalar($value) && null !== $value) {
                 throw new \LogicException(sprintf('Unable to use "%s" (%s) as an attribute. Attributes must be scalar or null. If you meant to mount this value on "%s", make sure "$%1$s" is a writable property or create a mount() method with a "$%1$s" argument.', $key, get_debug_type($value), $component::class));
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | n/a
| License       | MIT

Fixes a regression in 2.1 where a nullable entity is attempted to be loaded from Doctrine. In 2.0, `null` was dropped from the component data loading the entity wasn't attempted.
