### PR TITLE
Use correct method to set the Request Format

### DIFF
--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -332,7 +332,7 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
                 // 🔥 The magic happens here! 🔥
                 if (TurboBundle::STREAM_FORMAT === $request->getPreferredFormat()) {
                     // If the request comes from Turbo, set the content type as text/vnd.turbo-stream.html and only send the HTML to update
-                    $request->setFormat(TurboBundle::STREAM_FORMAT);
+                    $request->setRequestFormat(TurboBundle::STREAM_FORMAT);
                     return $this->render('task/success.stream.html.twig', ['task' => $task]);
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes, docs
| New feature?  | no
| Tickets       | n/a
| License       | MIT

The `Request::setFormat()` signature is `public function setFormat(?string $format, $mimeTypes)` in Symfony 5.4 and `public function setFormat(?string $format, string|array $mimeTypes)` in Symfony 6. Both versions require two arguments to be passed. The example appears to be calling an incorrect method. Shouldn't it call `Request::setRequestFormat()` instead?