### PR TITLE
[LiveComponent][RFC] Simple file upload handling

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1422,9 +1422,6 @@ class default_1 extends Controller {
                 if (fromEl.hasAttribute('data-live-ignore')) {
                     return false;
                 }
-                if (this.fileTargets.includes(fromEl)) {
-                    return false;
-                }
                 return true;
             }
         });

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1071,7 +1071,16 @@ class default_1 extends Controller {
     updateDefer(event) {
         this._updateModelFromElement(event.target, this._getValueFromElement(event.target), false);
     }
-    action(event) {
+    uploadFile(event) {
+        this._updateModelFromElement(event.target, this._getValueFromElement(event.target), false);
+        const model = event.target.dataset.model || event.target.getAttribute('name');
+        const modifier = {
+            name: 'upload_files',
+            value: model
+        };
+        this.action(event, [modifier]);
+    }
+    action(event, autoModifiers = []) {
         const rawAction = event.currentTarget.dataset.actionName;
         const directives = parseDirectives(rawAction);
         const files = {};
@@ -1081,7 +1090,8 @@ class default_1 extends Controller {
                 this._makeRequest(directive.action, directive.named, files);
             };
             let handled = false;
-            directive.modifiers.forEach((modifier) => {
+            const modifiers = [...autoModifiers, ...directive.modifiers];
+            modifiers.forEach((modifier) => {
                 switch (modifier.name) {
                     case 'prevent':
                         event.preventDefault();

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1182,7 +1182,7 @@ class default_1 extends Controller {
             }, this.debounceValue || DEFAULT_DEBOUNCE);
         }
     }
-    _makeRequest(action, args) {
+    _makeRequest(action, args, files = {}) {
         const splitUrl = this.urlValue.split('?');
         let [url] = splitUrl;
         const [, queryString] = splitUrl;
@@ -1210,9 +1210,16 @@ class default_1 extends Controller {
             }
         }
         if (!dataAdded) {
+            const formData = new FormData();
+            formData.append('data', JSON.stringify(this.dataValue));
             fetchOptions.method = 'POST';
-            fetchOptions.body = JSON.stringify(this.dataValue);
-            fetchOptions.headers['Content-Type'] = 'application/json';
+            fetchOptions.body = formData;
+            for (const [key, value] of Object.entries(files)) {
+                const length = value.length;
+                for (let i = 0; i < length; ++i) {
+                    formData.append(length > 1 ? key + '[]' : key, value[i]);
+                }
+            }
         }
         this._onLoadingStart();
         const paramsString = params.toString();

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1419,6 +1419,9 @@ class default_1 extends Controller {
                 if (fromEl.hasAttribute('data-live-ignore')) {
                     return false;
                 }
+                if (this.fileTargets.includes(fromEl)) {
+                    return false;
+                }
                 return true;
             }
         });

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1112,6 +1112,9 @@ class default_1 extends Controller {
                                 files[input.name] = input.files;
                             }
                         });
+                        if (modifier.value && !files[modifier.value]) {
+                            throw new Error(`Could not find the file input foo. Did you remember to make this element a Stimulus target (e.g. {{ stimulus_target('live', 'file') }}).`);
+                        }
                         break;
                     default:
                         console.warn(`Unknown modifier ${modifier.name} in action ${rawAction}`);

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1106,7 +1106,7 @@ class default_1 extends Controller {
                         handled = true;
                         break;
                     }
-                    case 'files':
+                    case 'upload_files':
                         this.fileTargets.forEach(input => {
                             if (!modifier.value || input.name === modifier.value) {
                                 files[input.name] = input.files;

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1106,13 +1106,9 @@ class default_1 extends Controller {
                         handled = true;
                         break;
                     }
-                    case 'file':
-                        if (!modifier.value) {
-                            console.warn(`Modifier file requires value in action ${rawAction}`);
-                            break;
-                        }
+                    case 'files':
                         this.fileTargets.forEach(input => {
-                            if (input.name === modifier.value) {
+                            if (!modifier.value || input.name === modifier.value) {
                                 files[input.name] = input.files;
                             }
                         });

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1073,10 +1073,11 @@ class default_1 extends Controller {
     action(event) {
         const rawAction = event.currentTarget.dataset.actionName;
         const directives = parseDirectives(rawAction);
+        const files = {};
         directives.forEach((directive) => {
             const _executeAction = () => {
                 this._clearWaitingDebouncedRenders();
-                this._makeRequest(directive.action, directive.named);
+                this._makeRequest(directive.action, directive.named, files);
             };
             let handled = false;
             directive.modifiers.forEach((modifier) => {
@@ -1105,6 +1106,17 @@ class default_1 extends Controller {
                         handled = true;
                         break;
                     }
+                    case 'file':
+                        if (!modifier.value) {
+                            console.warn(`Modifier file requires value in action ${rawAction}`);
+                            break;
+                        }
+                        this.fileTargets.forEach(input => {
+                            if (input.name === modifier.value) {
+                                files[input.name] = input.files;
+                            }
+                        });
+                        break;
                     default:
                         console.warn(`Unknown modifier ${modifier.name} in action ${rawAction}`);
                 }
@@ -1546,6 +1558,7 @@ class default_1 extends Controller {
         });
     }
 }
+default_1.targets = ['file'];
 default_1.values = {
     url: String,
     data: Object,

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1225,7 +1225,7 @@ class default_1 extends Controller {
             for (const [key, value] of Object.entries(files)) {
                 const length = value.length;
                 for (let i = 0; i < length; ++i) {
-                    formData.append(length > 1 ? key + '[]' : key, value[i]);
+                    formData.append(key, value[i]);
                 }
             }
         }

--- a/src/LiveComponent/assets/src/directives_parser.ts
+++ b/src/LiveComponent/assets/src/directives_parser.ts
@@ -1,7 +1,7 @@
 /**
  * A modifier for a directive
  */
-interface DirectiveModifier {
+export interface DirectiveModifier {
     /**
      * The name of the modifier (e.g. delay)
      */

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -648,11 +648,6 @@ export default class extends Controller {
                     return false;
                 }
 
-                // Don't update file targets
-                if (this.fileTargets.includes(fromEl)) {
-                    return false;
-                }
-
                 return true;
             }
         });

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -372,7 +372,7 @@ export default class extends Controller {
             for (const [key, value] of Object.entries(files)) {
                 const length = value.length;
                 for (let i=0; i < length; ++i) {
-                    formData.append(length > 1 ? key+'[]' : key, value[i]);
+                    formData.append(key, value[i]);
                 }
             }
         }

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -18,6 +18,7 @@ declare const Turbo: any;
 const DEFAULT_DEBOUNCE = 150;
 
 export default class extends Controller {
+    static targets = [ 'file' ]
     static values = {
         url: String,
         data: Object,
@@ -132,6 +133,8 @@ export default class extends Controller {
         // data-action-name="prevent|debounce(1000)|save"
         const directives = parseDirectives(rawAction);
 
+        const files: Record<string, FileList> = {};
+
         directives.forEach((directive) => {
             // set here so it can be delayed with debouncing below
             const _executeAction = () => {
@@ -144,7 +147,7 @@ export default class extends Controller {
                 // taking precedence
                 this._clearWaitingDebouncedRenders();
 
-                this._makeRequest(directive.action, directive.named);
+                this._makeRequest(directive.action, directive.named, files);
             }
 
             let handled = false;
@@ -179,6 +182,20 @@ export default class extends Controller {
 
                         break;
                     }
+                    case 'file':
+                        if (!modifier.value) {
+                            console.warn(`Modifier file requires value in action ${rawAction}`);
+
+                            break;
+                        }
+
+                        this.fileTargets.forEach(input => {
+                            if (input.name === modifier.value) {
+                                files[input.name] = input.files;
+                            }
+                        })
+
+                        break;
 
                     default:
                         console.warn(`Unknown modifier ${modifier.name} in action ${rawAction}`);

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -1,13 +1,12 @@
 import { Controller } from '@hotwired/stimulus';
 import morphdom from 'morphdom';
-import { parseDirectives, Directive } from './directives_parser';
+import { parseDirectives, Directive, DirectiveModifier } from './directives_parser';
 import { combineSpacedArray } from './string_utils';
 import { setDeepData, doesDeepPropertyExist, normalizeModelName, parseDeepData } from './set_deep_data';
 import { haveRenderedValuesChanged } from './have_rendered_values_changed';
 import { normalizeAttributesForComparison } from './normalize_attributes_for_comparison';
 import { cloneHTMLElement } from './clone_html_element';
 import { updateArrayDataFromChangedElement } from "./update_array_data";
-import * as assert from "assert";
 
 interface ElementLoadingDirectives {
     element: HTMLElement|SVGElement,
@@ -124,7 +123,17 @@ export default class extends Controller {
         this._updateModelFromElement(event.target, this._getValueFromElement(event.target), false);
     }
 
-    action(event: any) {
+    uploadFile(event: any) {
+        this._updateModelFromElement(event.target, this._getValueFromElement(event.target), false);
+        const model = event.target.dataset.model || event.target.getAttribute('name');
+        const modifier = {
+            name: 'upload_files',
+            value: model
+        }
+        this.action(event, [modifier]);
+    }
+
+    action(event: any, autoModifiers: DirectiveModifier[] = []) {
         // using currentTarget means that the data-action and data-action-name
         // must live on the same element: you can't add
         // data-action="click->live#action" on a parent element and
@@ -153,7 +162,8 @@ export default class extends Controller {
             }
 
             let handled = false;
-            directive.modifiers.forEach((modifier) => {
+            const modifiers: DirectiveModifier[] = [...autoModifiers, ...directive.modifiers];
+            modifiers.forEach((modifier) => {
                 switch (modifier.name) {
                     case 'prevent':
                         event.preventDefault();

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -318,7 +318,7 @@ export default class extends Controller {
         }
     }
 
-    _makeRequest(action: string|null, args: Record<string, string>) {
+    _makeRequest(action: string|null, args: Record<string, string>, files: Record<string, FileList> = {}) {
         const splitUrl = this.urlValue.split('?');
         let [url] = splitUrl
         const [, queryString] = splitUrl;
@@ -357,6 +357,13 @@ export default class extends Controller {
             formData.append('data', JSON.stringify(this.dataValue));
             fetchOptions.method = 'POST';
             fetchOptions.body = formData;
+
+            for (const [key, value] of Object.entries(files)) {
+                const length = value.length;
+                for (let i=0; i < length; ++i) {
+                    formData.append(length > 1 ? key+'[]' : key, value[i]);
+                }
+            }
         }
 
         this._onLoadingStart();

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -353,9 +353,10 @@ export default class extends Controller {
 
         // if GET can't be used, fallback to POST
         if (!dataAdded) {
+            const formData = new FormData();
+            formData.append('data', JSON.stringify(this.dataValue));
             fetchOptions.method = 'POST';
-            fetchOptions.body = JSON.stringify(this.dataValue);
-            fetchOptions.headers['Content-Type'] = 'application/json';
+            fetchOptions.body = formData;
         }
 
         this._onLoadingStart();

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -645,6 +645,11 @@ export default class extends Controller {
                     return false;
                 }
 
+                // Don't update file targets
+                if (this.fileTargets.includes(fromEl)) {
+                    return false;
+                }
+
                 return true;
             }
         });

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -182,7 +182,7 @@ export default class extends Controller {
 
                         break;
                     }
-                    case 'files':
+                    case 'upload_files':
                         this.fileTargets.forEach(input => {
                             if (!modifier.value || input.name === modifier.value) {
                                 files[input.name] = input.files;

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -182,15 +182,9 @@ export default class extends Controller {
 
                         break;
                     }
-                    case 'file':
-                        if (!modifier.value) {
-                            console.warn(`Modifier file requires value in action ${rawAction}`);
-
-                            break;
-                        }
-
+                    case 'files':
                         this.fileTargets.forEach(input => {
-                            if (input.name === modifier.value) {
+                            if (!modifier.value || input.name === modifier.value) {
                                 files[input.name] = input.files;
                             }
                         })

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -188,6 +188,9 @@ export default class extends Controller {
                                 files[input.name] = input.files;
                             }
                         })
+                        if (modifier.value && !files[modifier.value]) {
+                            throw new Error(`Could not find the file input foo. Did you remember to make this element a Stimulus target (e.g. {{ stimulus_target('live', 'file') }}).`);
+                        }
 
                         break;
 

--- a/src/LiveComponent/assets/test/controller/action.test.ts
+++ b/src/LiveComponent/assets/test/controller/action.test.ts
@@ -65,7 +65,7 @@ describe('LiveController Action Tests', () => {
         await waitFor(() => expect(element).toHaveTextContent('Comment Saved!'));
         expect(getByLabelText(element, 'Comments:')).toHaveValue('hi weaver');
 
-        const bodyData = JSON.parse(postMock.lastOptions().body);
+        const bodyData = JSON.parse(postMock.lastOptions().body.get('data'));
         expect(bodyData.comments).toEqual('hi WEAVER');
     });
 

--- a/src/LiveComponent/src/Attribute/LiveFileArg.php
+++ b/src/LiveComponent/src/Attribute/LiveFileArg.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Attribute;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ *
+ * @experimental
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class LiveFileArg
+{
+    public function __construct(
+        public ?string $name = null,
+        public bool $multiple = false,
+        public array $constraints = []
+    )
+    {
+    }
+
+    /**
+     * @internal
+     *
+     * @return array<string, self>
+     */
+    public static function liveFileArgs(object $component, string $action): array
+    {
+        $method = new \ReflectionMethod($component, $action);
+        $liveFileArgs = [];
+
+        foreach ($method->getParameters() as $parameter) {
+            foreach ($parameter->getAttributes(self::class) as $liveArg) {
+                /** @var LiveFileArg $attr */
+                $attr = $liveArg->newInstance();
+                $parameterName = $parameter->getName();
+
+                $attr->name ??= $parameterName;
+
+                $liveFileArgs[$parameterName] = $attr;
+            }
+        }
+
+        return $liveFileArgs;
+    }
+}

--- a/src/LiveComponent/src/Attribute/LiveFileArg.php
+++ b/src/LiveComponent/src/Attribute/LiveFileArg.php
@@ -21,8 +21,7 @@ final class LiveFileArg
 {
     public function __construct(
         public ?string $name = null,
-        public bool $multiple = false,
-        public array $constraints = []
+        public bool $multiple = false
     ) {
     }
 

--- a/src/LiveComponent/src/Attribute/LiveFileArg.php
+++ b/src/LiveComponent/src/Attribute/LiveFileArg.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\UX\LiveComponent\Attribute;
 
-
-use ReflectionNamedType;
-
 /**
  * @author Jakub Caban <kuba.iluvatar@gmail.com>
  *
@@ -24,21 +21,21 @@ final class LiveFileArg
 {
     private ?array $types = null;
 
-    public function __construct(
-        public ?string $name = null
-    ) {
+    public function __construct(public ?string $name = null)
+    {
     }
 
-    public function isValueCompatible(mixed $value): bool {
+    public function isValueCompatible(mixed $value): bool
+    {
         if (null === $this->types) {
             return true;
         }
-        $type = gettype($value);
+        $type = \gettype($value);
         if ('object' === $type) {
             $type = $value::class;
         }
 
-        return in_array($type, $this->types, true);
+        return \in_array($type, $this->types, true);
     }
 
     /**
@@ -59,11 +56,11 @@ final class LiveFileArg
 
                 $attr->name ??= $parameterName;
                 if ($type = $parameter->getType()) {
-                    if ($type instanceof ReflectionNamedType) {
+                    if ($type instanceof \ReflectionNamedType) {
                         $attr->types = [$type->getName()];
                     } else {
                         $attr->types = array_map(
-                            static fn (ReflectionNamedType $type) => $type->getName(),
+                            static fn (\ReflectionNamedType $type) => $type->getName(),
                             $type->getTypes()
                         );
                     }

--- a/src/LiveComponent/src/Attribute/LiveFileArg.php
+++ b/src/LiveComponent/src/Attribute/LiveFileArg.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\UX\LiveComponent\Attribute;
 
+
+use ReflectionNamedType;
+
 /**
  * @author Jakub Caban <kuba.iluvatar@gmail.com>
  *
@@ -19,10 +22,23 @@ namespace Symfony\UX\LiveComponent\Attribute;
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 final class LiveFileArg
 {
+    private ?array $types = null;
+
     public function __construct(
-        public ?string $name = null,
-        public bool $multiple = false
+        public ?string $name = null
     ) {
+    }
+
+    public function isValueCompatible(mixed $value): bool {
+        if (null === $this->types) {
+            return true;
+        }
+        $type = gettype($value);
+        if ('object' === $type) {
+            $type = $value::class;
+        }
+
+        return in_array($type, $this->types, true);
     }
 
     /**
@@ -42,6 +58,16 @@ final class LiveFileArg
                 $parameterName = $parameter->getName();
 
                 $attr->name ??= $parameterName;
+                if ($type = $parameter->getType()) {
+                    if ($type instanceof ReflectionNamedType) {
+                        $attr->types = [$type->getName()];
+                    } else {
+                        $attr->types = array_map(
+                            static fn (ReflectionNamedType $type) => $type->getName(),
+                            $type->getTypes()
+                        );
+                    }
+                }
 
                 $liveFileArgs[$parameterName] = $attr;
             }

--- a/src/LiveComponent/src/Attribute/LiveFileArg.php
+++ b/src/LiveComponent/src/Attribute/LiveFileArg.php
@@ -25,11 +25,6 @@ final class LiveFileArg
     ) {
     }
 
-    public function getPropertyPath(): string
-    {
-        return preg_replace('/^([^[]+)/', '[$1]', $this->name);
-    }
-
     /**
      * @internal
      *

--- a/src/LiveComponent/src/Attribute/LiveFileArg.php
+++ b/src/LiveComponent/src/Attribute/LiveFileArg.php
@@ -27,6 +27,11 @@ final class LiveFileArg
     {
     }
 
+    public function getPropertyPath(): string
+    {
+        return preg_replace('/^([^[]+)/', '[$1]', $this->name);
+    }
+
     /**
      * @internal
      *

--- a/src/LiveComponent/src/Attribute/LiveFileArg.php
+++ b/src/LiveComponent/src/Attribute/LiveFileArg.php
@@ -23,8 +23,7 @@ final class LiveFileArg
         public ?string $name = null,
         public bool $multiple = false,
         public array $constraints = []
-    )
-    {
+    ) {
     }
 
     public function getPropertyPath(): string

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -152,13 +152,15 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
         $request->attributes->set('_mounted_component', $mounted);
 
         // autowire live file arguments
-        foreach (LiveFileArg::liveFileArgs($component, $action) as $parameter => $fileArg) {
-            if ($request->files->has($fileArg->name)) {
-                $files = $request->files->get($fileArg->name);
-                $request->attributes->set(
-                    $parameter,
-                    $fileArg->multiple ? $files : $files[0]
-                );
+        if ($request->files->count()) {
+            foreach (LiveFileArg::liveFileArgs($component, $action) as $parameter => $fileArg) {
+                if ($request->files->has($fileArg->name)) {
+                    $files = $request->files->get($fileArg->name);
+                    $request->attributes->set(
+                        $parameter,
+                        $fileArg->multiple ? $files : $files[0]
+                    );
+                }
             }
         }
 

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -121,9 +121,11 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
         if ($request->query->has('data')) {
             // ?data=
             $data = json_decode($request->query->get('data'), true, 512, \JSON_THROW_ON_ERROR);
-        } else {
+        } elseif ($request->request->has('data')) {
             // OR body of the request is JSON
-            $data = json_decode($request->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+            $data = json_decode($request->request->get('data'), true, 512, \JSON_THROW_ON_ERROR);
+        } else {
+            $data = $request->query->all();
         }
 
         if (!\is_array($controller = $event->getController()) || 2 !== \count($controller)) {

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -167,11 +167,6 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
                         $parameter,
                         $fileArg->multiple ? $files : $files[0]
                     );
-                } else {
-                    $request->attributes->set(
-                        $parameter,
-                        $fileArg->multiple ? [] : null
-                    );
                 }
             }
         }

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -143,6 +143,8 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
             throw new NotFoundHttpException(sprintf('The action "%s" either doesn\'t exist or is not allowed in "%s". Make sure it exist and has the LiveAction attribute above it.', $action, \get_class($component)));
         }
 
+        $data[LiveComponentHydrator::FILES_KEY] = $request->files->all();
+
         $mounted = $this->container->get(LiveComponentHydrator::class)->hydrate(
             $component,
             $data,

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -157,10 +157,14 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
                 if (
                     $request->files->has($fileArg->name)
                 ) {
-                    $files = $request->files->all($fileArg->name);
+                    $files = $request->files->get($fileArg->name);
 
                     $value = null;
-                    if (1 === \count($files) && $fileArg->isValueCompatible($files[0])) {
+                    if (
+                        is_array($files)
+                        && 1 === \count($files)
+                        && $fileArg->isValueCompatible($files[0])
+                    ) {
                         $value = $files[0];
                     } elseif ($fileArg->isValueCompatible($files)) {
                         $value = $files;

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -163,7 +163,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
                     throw new \RuntimeException(sprintf('File path "%s" for parameter "%s" is invalid', $fileArg->name, $parameter));
                 }
 
-                if ($files = $accessor->getValue($allFiles, $fileArg->getPropertyPath())) {
+                if ($files = $accessor->getValue($allFiles, $path)) {
                     $request->attributes->set(
                         $parameter,
                         $fileArg->multiple ? $files : $files[0]

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -161,7 +161,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
 
                     $value = null;
                     if (
-                        is_array($files)
+                        \is_array($files)
                         && 1 === \count($files)
                         && $fileArg->isValueCompatible($files[0])
                     ) {

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -154,15 +154,12 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
 
         // autowire live file arguments
         if ($request->files->count()) {
-            $allFiles = $request->files->all();
-            $accessor = PropertyAccess::createPropertyAccessor();
             foreach (LiveFileArg::liveFileArgs($component, $action) as $parameter => $fileArg) {
-                $path = $fileArg->getPropertyPath();
-
                 if (
-                    $accessor->isReadable($allFiles, $path)
-                    && ($files = $accessor->getValue($allFiles, $path))
+                    $request->files->has($fileArg->name)
                 ) {
+                    $files = $request->files->all($fileArg->name);
+
                     $request->attributes->set(
                         $parameter,
                         $fileArg->multiple ? $files : $files[0]

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -159,11 +159,10 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
             foreach (LiveFileArg::liveFileArgs($component, $action) as $parameter => $fileArg) {
                 $path = $fileArg->getPropertyPath();
 
-                if (!$accessor->isReadable($allFiles, $path)) {
-                    throw new \RuntimeException(sprintf('File path "%s" for parameter "%s" is invalid', $fileArg->name, $parameter));
-                }
-
-                if ($files = $accessor->getValue($allFiles, $path)) {
+                if (
+                    $accessor->isReadable($allFiles, $path)
+                    && ($files = $accessor->getValue($allFiles, $path))
+                ) {
                     $request->attributes->set(
                         $parameter,
                         $fileArg->multiple ? $files : $files[0]

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -160,9 +160,17 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
                 ) {
                     $files = $request->files->all($fileArg->name);
 
+                    $value = null;
+                    if (count($files) === 1 && $fileArg->isValueCompatible($files[0])) {
+                        $value = $files[0];
+                    } else if ($fileArg->isValueCompatible($files)) {
+                        $value = $files;
+                    } else {
+                        throw new BadRequestHttpException("Could not autowire uploaded files for {$fileArg->name} parameter.");
+                    }
                     $request->attributes->set(
                         $parameter,
-                        $fileArg->multiple ? $files : $files[0]
+                        $value
                     );
                 }
             }

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -122,10 +122,10 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
             // ?data=
             $data = json_decode($request->query->get('data'), true, 512, \JSON_THROW_ON_ERROR);
         } elseif ($request->request->has('data')) {
-            // OR body of the request is JSON
+            // OR data key from POST data
             $data = json_decode($request->request->get('data'), true, 512, \JSON_THROW_ON_ERROR);
         } else {
-            $data = $request->query->all();
+            throw new BadRequestHttpException('Missing live component data.');
         }
 
         if (!\is_array($controller = $event->getController()) || 2 !== \count($controller)) {

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -29,6 +29,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveFileArg;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentMetadata;
@@ -149,6 +150,17 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
         );
 
         $request->attributes->set('_mounted_component', $mounted);
+
+        // autowire live file arguments
+        foreach (LiveFileArg::liveFileArgs($component, $action) as $parameter => $fileArg) {
+            if ($request->files->has($fileArg->name)) {
+                $files = $request->files->get($fileArg->name);
+                $request->attributes->set(
+                    $parameter,
+                    $fileArg->multiple ? $files : $files[0]
+                );
+            }
+        }
 
         if (!\is_string($queryString = $request->query->get('args'))) {
             return;

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -24,7 +24,6 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
@@ -161,9 +160,9 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
                     $files = $request->files->all($fileArg->name);
 
                     $value = null;
-                    if (count($files) === 1 && $fileArg->isValueCompatible($files[0])) {
+                    if (1 === \count($files) && $fileArg->isValueCompatible($files[0])) {
                         $value = $files[0];
-                    } else if ($fileArg->isValueCompatible($files)) {
+                    } elseif ($fileArg->isValueCompatible($files)) {
                         $value = $files;
                     } else {
                         throw new BadRequestHttpException("Could not autowire uploaded files for {$fileArg->name} parameter.");

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -34,6 +34,7 @@ final class LiveComponentHydrator
     private const CHECKSUM_KEY = '_checksum';
     private const EXPOSED_PROP_KEY = '_id';
     private const ATTRIBUTES_KEY = '_attributes';
+    public const FILES_KEY = '_files';
 
     public function __construct(
         private NormalizerInterface|DenormalizerInterface $normalizer,
@@ -200,7 +201,7 @@ final class LiveComponentHydrator
         }
 
         foreach (AsLiveComponent::postHydrateMethods($component) as $method) {
-            $component->{$method->name}();
+            $component->{$method->name}($data);
         }
 
         return new MountedComponent($componentName, $component, $attributes);

--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -571,6 +571,7 @@ Actions & Arguments
 You can also provide custom arguments to your action::
 
 .. code-block:: twig
+
     <form>
         <button data-action="live#action" data-action-name="addItem(id={{ item.id }}, name=CustomItem)">Add Item</button>
     </form>
@@ -596,6 +597,36 @@ args but inject to your defined parameter with another name.::
             $this->name = $name;
         }
     }
+
+Actions and file uploads
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.2
+
+    The ability to pass arguments to actions was added in version 2.2.
+
+If you want live component to track and send files you first need
+to mark file upload inputs as ``file`` Stimulus target.::
+
+.. code-block:: twig
+
+    <input type="file" {{ stimulus_target('live', 'file') }} name="my_file" />
+
+Then, when defining action you need to use special ``files(name)`` modifier.::
+
+.. code-block:: twig
+
+    <div
+        data-action="change->live#action"
+        data-action-name="prevent|files(my_file)|upload"
+        <input type="file" {{ stimulus_target('live', 'file') }} name="my_file" />
+    </div>
+
+This will send files from ``my_file`` file input. When used without argument
+it would send all files from all ``file`` targets of the controller.
+
+If you want to send multiple files from a single input remember to suffix its' name
+with ``[]`` - both in HTML name attribute and ``files`` modifier argument.
 
 Actions and CSRF Protection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/LiveComponent/tests/Fixtures/Component/Component2.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component2.php
@@ -14,11 +14,11 @@ namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
-use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\Attribute\PostHydrate;
 use Symfony\UX\LiveComponent\Attribute\PreDehydrate;
+use Symfony\UX\LiveComponent\Attribute\PreReRender;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/LiveComponent/tests/Fixtures/Component/Component4.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component4.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 
-use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\Attribute\PostHydrate;
 use Symfony\UX\LiveComponent\Attribute\PreDehydrate;
+use Symfony\UX\LiveComponent\Attribute\PreReRender;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -71,7 +71,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             })
             ->post('/_components/component2/increase', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode($dehydrated),
+                'body' => ['data' => json_encode($dehydrated)],
             ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
@@ -183,7 +183,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             // with no custom header, it redirects like a normal browser
             ->post('/_components/component2/redirect', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode($dehydrated),
+                'body' => ['data' => json_encode($dehydrated)],
             ])
             ->assertRedirectedTo('/')
 
@@ -193,7 +193,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
                     'Accept' => 'application/vnd.live-component+html',
                     'X-CSRF-TOKEN' => $token,
                 ],
-                'body' => json_encode($dehydrated),
+                'body' => ['data' => json_encode($dehydrated)],
             ])
             ->assertStatus(204)
             ->assertHeaderEquals('Location', '/')
@@ -220,7 +220,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             })
             ->post('/_components/component6/inject?'.$argsQueryParams, [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode($dehydrated),
+                'body' => ['data' => json_encode($dehydrated)],
             ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -122,7 +122,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
                 ->throwExceptions()
                 ->post('/_components/component2/increase', [
                     'headers' => ['X-CSRF-TOKEN' => 'invalid'],
-                    'body' => ['data' => '[]']
+                    'body' => ['data' => '[]'],
                 ])
             ;
         } catch (BadRequestHttpException $e) {

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -122,6 +122,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
                 ->throwExceptions()
                 ->post('/_components/component2/increase', [
                     'headers' => ['X-CSRF-TOKEN' => 'invalid'],
+                    'body' => ['data' => '[]']
                 ])
             ;
         } catch (BadRequestHttpException $e) {
@@ -144,7 +145,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Count: 1')
             ->post('/_components/disabled_csrf/increase', [
-                'body' => json_encode($dehydrated),
+                'body' => ['data' => json_encode($dehydrated)],
             ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -50,7 +50,7 @@ class ComponentWithFormTest extends KernelTestCase
 
             // post to action, which will add a new embedded comment
             ->post('/_components/form_with_collection_type/addComment', [
-                'body' => json_encode($dehydrated),
+                'body' => ['data' => json_encode($dehydrated)],
                 'headers' => ['X-CSRF-TOKEN' => $token],
             ])
             ->assertStatus(422)
@@ -86,7 +86,7 @@ class ComponentWithFormTest extends KernelTestCase
 
             // post to action, which will remove the original embedded comment
             ->post('/_components/form_with_collection_type/removeComment?'.http_build_query(['args' => 'index=0']), [
-                'body' => json_encode($dehydrated),
+                'body' => ['data' => json_encode($dehydrated)],
                 'headers' => ['X-CSRF-TOKEN' => $token],
             ])
             ->assertStatus(422)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #289 
| License       | MIT

This is a proof of concept for very simplistic file upload support within live components. It is by no mean finished (docs and tests are missing for sure), but due to a few design choices I've made I want to get some feedback before finishing it :)

Summary of changes:
- data will be sent to server as a "data" key withing `FormData` object instead of directly in body. This is required to make multipart form sending easily doable.
- file inputs require to be marked as `file` target within Stimulus live controller to be handled in a special way. I did it because I believe it's a good stimulus way and also to allow user to be able to handle some file inputs their own way.
- there is a new modifier to action string - `files`. When set without any parameter it will send all files from all targets to the server. When passed parameter it will only send target with name matching parameter. So it is possible to specify for example: `<input type="file" name="file" data-live-target="file" data-action="change->live#action" data-action-name="stop|files(file)|action" />` that will send just this file(s) as soon as they're chosen and let backend handle it and skip it for any other actions.

This allows for simple cases of file uploads, no forms integration at this point and I believe it'd be a good idea to get this in a good shape first and then think about possible form extension. There is a good chance this change with good documentation will even be enough :)