### PR TITLE
[LiveComponent] Remove `@internal` from `extractFormValues` and `clearErrorsForNonValidatedFields`

### DIFF
--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -183,8 +183,6 @@ trait ComponentWithFormTrait
      * This is used to pass the initial values into the live component's
      * frontend, and it's meant to equal the raw POST data that would
      * be sent if the form were submitted without modification.
-     *
-     * @internal
      */
     private function extractFormValues(FormView $formView): array
     {
@@ -215,9 +213,6 @@ trait ComponentWithFormTrait
         return $values;
     }
 
-    /**
-     * @internal
-     */
     private function clearErrorsForNonValidatedFields(FormInterface $form, string $currentPath = ''): void
     {
         if ($form instanceof ClearableErrorsInterface && (!$currentPath || !\in_array($currentPath, $this->validatedFields, true))) {


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | https://github.com/symfony/ux-live-component/commit/a930f1e23ecf07e4b05de3127a4f8711ca5bc4e0#r69159680
| License       | MIT

In a multistep form live component, it's not enough for me just to use `ComponentWithFormTrait`, so I have some custom actions which are used instead of just submitting the form and these actions partially duplicates the functionality of `submitForm` which uses these methods that are marked as `@internal`