### PR TITLE
Make adding a custom template more specific

### DIFF
--- a/src/TwigComponent/src/Resources/doc/index.rst
+++ b/src/TwigComponent/src/Resources/doc/index.rst
@@ -184,7 +184,7 @@ as the second argument to the ``AsTwigComponent`` attribute:
       // ...
 
     - #[AsTwigComponent('alert')]
-    + #[AsTwigComponent('alert', 'my/custom/template.html.twig')]
+    + #[AsTwigComponent('alert', template: 'my/custom/template.html.twig')]
       class AlertComponent
       {
           // ...


### PR DESCRIPTION
The docs are not wrong because 
 #[AsTwigComponent('alert',  'my/custom/template.html.twig')]

will indeed load the custom template.

But if you are using multiple parameters:
#[AsTwigComponent('alert', exposePublicProps:false,  'my/custom/template.html.twig')]
Just adding a value for the template won't work. You need specify it's a template.

The custom template works with the template parameter:
#[AsTwigComponent('alert', exposePublicProps:false,  template:'my/custom/template.html.twig')]

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
