### PR TITLE
[Twig] throw error if twig-bundle is not installed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -108,7 +108,6 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.0'
-            - run: php .github/build-packages.php
 
             - name: TwigComponent Dependencies
               uses: ramsey/composer-install@v2

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
@@ -36,6 +37,10 @@ final class TwigComponentExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
+        if (!isset($container->getParameter('kernel.bundles')['TwigBundle'])) {
+            throw new LogicException('The TwigBundle is not registered in your application. Try running "composer require symfony/twig-bundle".');
+        }
+
         $container->registerAttributeForAutoconfiguration(
             AsTwigComponent::class,
             static function (ChildDefinition $definition, AsTwigComponent $attribute) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

Ran into an issue with `ContainerBuilder::willBeAvailable()` and `ux-live-component`'s test suite when requiring `symfony/twig-bundle` directly. Not perfect but throwing an exception on container build if `twig-bundle` is not available seemed like the easiest solution.
