### PR TITLE
Typo in code $variables['custom'] => 'value';

### DIFF
--- a/src/TwigComponent/src/Resources/doc/index.rst
+++ b/src/TwigComponent/src/Resources/doc/index.rst
@@ -623,7 +623,7 @@ the twig template and twig variables before components are rendered::
 
         // manipulate the variables:
         $variables = $event->getVariables();
-        $variables['custom'] => 'value';
+        $variables['custom'] = 'value';
 
         $event->setVariables($variables); // {{ custom }} will be available in your template
     }


### PR DESCRIPTION
$variables['custom'] => 'value' is a typo, should read $variables['custom'] = 'value';

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
