### PR TITLE
[TwigComponent] Allow to pass stringable object as non mapped component attribute

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.2
+
+-   Allow to pass stringable object as non mapped component attribute
+
 ## 2.1
 
 -   Make public component properties available directly in the template (`{{ prop }}` vs `{{ this.prop }}`).

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -71,6 +71,10 @@ final class ComponentFactory
 
         // ensure remaining data is scalar
         foreach ($data as $key => $value) {
+            if ($value instanceof \Stringable) {
+                continue;
+            }
+
             if (!\is_scalar($value) && null !== $value) {
                 throw new \LogicException(sprintf('Unable to use "%s" (%s) as an attribute. Attributes must be scalar or null. If you meant to mount this value on "%s", make sure "$%1$s" is a writable property or create a mount() method with a "$%1$s" argument.', $key, get_debug_type($value), $component::class));
             }

--- a/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
@@ -98,6 +98,18 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->createComponent('component_a', ['propB' => 'B', 'service' => new \stdClass()]);
     }
 
+    public function testStringableObjectCanBePassedToComponent(): void
+    {
+        $attributes = (string) $this->factory()->create('component_a', ['propB' => 'B', 'data-item-id-param' => new class() {
+            public function __toString(): string
+            {
+                return 'test';
+            }
+        }])->getAttributes();
+
+        self::assertSame(' data-item-id-param="test"', $attributes);
+    }
+
     public function testTwigComponentServiceTagMustHaveKey(): void
     {
         $this->expectException(LogicException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | N/A
| License       | MIT

Sometimes we have some value objects that are meant to be provided as stimulus controller values and when using `{{ component('..', { 'data-item-id-param': objectUuid }) }}` it throws an exception that attribute must be scalar.

Now it will allow to accept these objects.

cc @kbond
