### PR TITLE
[LiveComponent] Allow to disable CSRF per component

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.2.0
+
+-   Allow to disable CSRF per component
+
 ## 2.1.0
 
 -   Your component's live "data" is now send over Ajax as a JSON string.

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -26,7 +26,8 @@ final class AsLiveComponent extends AsTwigComponent
         ?string $template = null,
         private ?string $defaultAction = null,
         bool $exposePublicProps = true,
-        string $attributesVar = 'attributes'
+        string $attributesVar = 'attributes',
+        public bool $csrf = true,
     ) {
         parent::__construct($name, $template, $exposePublicProps, $attributesVar);
     }
@@ -39,6 +40,7 @@ final class AsLiveComponent extends AsTwigComponent
         return array_merge(parent::serviceConfig(), [
             'default_action' => $this->defaultAction,
             'live' => true,
+            'csrf' => $this->csrf,
         ]);
     }
 

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -107,6 +107,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
 
         if (
             $this->container->has(CsrfTokenManagerInterface::class) &&
+            $metadata->get('csrf') &&
             !$this->container->get(CsrfTokenManagerInterface::class)->isTokenValid(new CsrfToken($componentName, $request->headers->get('X-CSRF-TOKEN')))) {
             throw new BadRequestHttpException('Invalid CSRF token.');
         }

--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -629,6 +629,20 @@ Your only job is to make sure that the CSRF component is installed:
 
     $ composer require symfony/security-csrf
 
+If you want to disable CSRF for a single component you can set
+``csrf`` option to ``false``::
+
+    namespace App\Twig\Components;
+
+    use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+    use Symfony\UX\LiveComponent\Attribute\LiveProp;
+
+    #[AsLiveComponent('my_live_component', csrf: false)]
+    class MyLiveComponent
+    {
+        // ...
+    }
+
 Actions, Redirecting and AbstractController
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/LiveComponent/tests/Fixtures/Component/DisabledCsrf.php
+++ b/src/LiveComponent/tests/Fixtures/Component/DisabledCsrf.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+
+/**
+ * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+ */
+#[AsLiveComponent('disabled_csrf', defaultAction: 'defaultAction()', csrf: false)]
+final class DisabledCsrf
+{
+    #[LiveProp]
+    public int $count = 1;
+
+    #[LiveAction]
+    public function increase(): void
+    {
+        ++$this->count;
+    }
+
+    public function defaultAction(): void
+    {
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/disabled_csrf.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/disabled_csrf.html.twig
@@ -1,0 +1,3 @@
+<div{{ attributes }}>
+    Count: {{ this.count }}
+</div>

--- a/src/LiveComponent/tests/Fixtures/templates/csrf.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/csrf.html.twig
@@ -1,0 +1,1 @@
+{{ component('disabled_csrf') }}

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -58,4 +58,20 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertNotNull($div->attr('data-live-csrf-value'));
         $this->assertArrayHasKey('_checksum', $data);
     }
+
+    public function testCanDisableCsrf(): void
+    {
+        $response = $this->browser()
+            ->visit('/render-template/csrf')
+            ->assertSuccessful()
+            ->response()
+            ->assertHtml()
+        ;
+
+        $div = $response->crawler()->filter('div');
+
+        $this->assertSame('live', $div->attr('data-controller'));
+        $this->assertSame('/_components/disabled_csrf', $div->attr('data-live-url-value'));
+        $this->assertNull($div->attr('data-live-csrf-value'));
+    }
 }

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -133,6 +133,25 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         $this->fail('Expected exception not thrown.');
     }
 
+    public function testDisabledCsrfTokenForComponentDoesNotFail(): void
+    {
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('disabled_csrf'));
+
+        $this->browser()
+            ->throwExceptions()
+            ->get('/_components/disabled_csrf?data='.urlencode(json_encode($dehydrated)))
+            ->assertSuccessful()
+            ->assertHeaderContains('Content-Type', 'html')
+            ->assertContains('Count: 1')
+            ->post('/_components/disabled_csrf/increase', [
+                'body' => json_encode($dehydrated),
+            ])
+            ->assertSuccessful()
+            ->assertHeaderContains('Content-Type', 'html')
+            ->assertContains('Count: 2')
+        ;
+    }
+
     public function testBeforeReRenderHookOnlyExecutedDuringAjax(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('component2'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #320
| License       | MIT

This allows to configure `#[AsLiveComponent('..', csrf: false)` to disable CSRF protection per component like we can do in Symfony Forms.