### PR TITLE
[Twig] allow `ExposeInTemplate` to be used on public component methods

### DIFF
--- a/src/TwigComponent/src/Attribute/ExposeInTemplate.php
+++ b/src/TwigComponent/src/Attribute/ExposeInTemplate.php
@@ -20,7 +20,7 @@ namespace Symfony\UX\TwigComponent\Attribute;
  *
  * @experimental
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD)]
 final class ExposeInTemplate
 {
     /**

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -109,5 +109,22 @@ final class ComponentRenderer
 
             yield $attribute->name ?? $property->name => $value;
         }
+
+        foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if (!$attribute = $method->getAttributes(ExposeInTemplate::class)[0] ?? null) {
+                continue;
+            }
+
+            $attribute = $attribute->newInstance();
+
+            /** @var ExposeInTemplate $attribute */
+            $name = $attribute->name ?? (str_starts_with($method->name, 'get') ? lcfirst(substr($method->name, 3)) : $method->name);
+
+            if ($method->getNumberOfRequiredParameters()) {
+                throw new \LogicException(sprintf('Cannot use %s on methods with required parameters (%s::%s).', ExposeInTemplate::class, $component::class, $method->name));
+            }
+
+            yield $name => $component->{$method->name}();
+        }
     }
 }

--- a/src/TwigComponent/src/Resources/doc/index.rst
+++ b/src/TwigComponent/src/Resources/doc/index.rst
@@ -237,10 +237,16 @@ ExposeInTemplate Attribute
 
     The ``ExposeInTemplate`` attribute was added in TwigComponents 2.1.
 
+.. versionadded:: 2.3
+
+    The ``ExposeInTemplate`` attribute now be used on public methods.
+
 All public component properties are available directly in your component
 template. You can use the ``ExposeInTemplate`` attribute to expose
-private/protected properties directly in a component template (``someProp``
-vs ``this.someProp``). These properties must be *accessible* (have a getter).
+private/protected properties and public methods directly in a component
+template (``someProp`` vs ``this.someProp``, ``someMethod`` vs ``this.someMethod``).
+Properties must be *accessible* (have a getter). Methods *cannot have*
+required parameters.
 
 .. code-block:: php
 
@@ -283,8 +289,25 @@ vs ``this.someProp``). These properties must be *accessible* (have a getter).
             return $this->icon;
         }
 
+        #[ExposeInTemplate]
+        public function getActions(): array // available as `{{ actions }}` in the template
+        {
+            // ...
+        }
+
+        #[ExposeInTemplate('dismissable')]
+        public function canBeDismissed(): bool // available as `{{ dismissable }}` in the template
+        {
+            // ...
+        }
+
         // ...
     }
+
+.. note::
+
+    When using ``ExposeInTemplate`` on a method the value is fetched eagerly
+    before rendering.
 
 PreMount Hook
 ~~~~~~~~~~~~~

--- a/src/TwigComponent/tests/Fixtures/Component/WithExposedVariables.php
+++ b/src/TwigComponent/tests/Fixtures/Component/WithExposedVariables.php
@@ -34,4 +34,22 @@ final class WithExposedVariables
     {
         return $this->prop3;
     }
+
+    #[ExposeInTemplate]
+    public function getMethod1(): string
+    {
+        return 'method1 value';
+    }
+
+    #[ExposeInTemplate]
+    public function method2(): string
+    {
+        return 'method2 value';
+    }
+
+    #[ExposeInTemplate('customPropMethod')]
+    public function customMethod(): string
+    {
+        return 'customMethod value';
+    }
 }

--- a/src/TwigComponent/tests/Fixtures/templates/components/with_exposed_variables.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/with_exposed_variables.html.twig
@@ -1,3 +1,6 @@
 Prop1: {{ prop1 }}
 Prop2: {{ customProp2 }}
 Prop3: {{ customProp3 }}
+Method1: {{ method1 }}
+Method2: {{ method2 }}
+customMethod: {{ customPropMethod }}

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -96,6 +96,9 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('Prop1: prop1 value', $output);
         $this->assertStringContainsString('Prop2: prop2 value', $output);
         $this->assertStringContainsString('Prop3: prop3 value', $output);
+        $this->assertStringContainsString('Method1: method1 value', $output);
+        $this->assertStringContainsString('Method2: method2 value', $output);
+        $this->assertStringContainsString('customMethod: customMethod value', $output);
     }
 
     public function testCanUseComputedMethods(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | n/a
| License       | MIT

