### PR TITLE
[Turbo] Add expression language to topics

### DIFF
--- a/src/Turbo/Bridge/Mercure/composer.json
+++ b/src/Turbo/Bridge/Mercure/composer.json
@@ -31,6 +31,9 @@
         "symfony/twig-bundle": "^5.2|^6.0",
         "symfony/ux-turbo": "^2.0"
     },
+    "suggest": {
+        "symfony/expression-language": "To use expression language in topics"
+    },
     "extra": {
         "thanks": {
             "name": "symfony/ux-turbo",

--- a/src/Turbo/CHANGELOG.md
+++ b/src/Turbo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.2
+
+-   The topics defined in the Broadcast attribute now support expression language when prefixed with `@=`.
+
 ## 2.1
 
 -   `TurboStreamResponse` and `AddTurboStreamFormatSubscriber` have been removed, use native content negotiation instead:

--- a/src/Turbo/CONTRIBUTING.md
+++ b/src/Turbo/CONTRIBUTING.md
@@ -26,6 +26,9 @@ Start the test app:
 -   `http://localhost:8000`: basic features
 -   `http://localhost:8000/chat`: chat using Turbo Streams
 -   `http://localhost:8000/books`: broadcast
+-   `http://localhost:8000/authors`: broadcast
+-   `http://localhost:8000/artists`: broadcast
+-   `http://localhost:8000/songs`: broadcast
 
 ## Run tests
 

--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -301,7 +301,7 @@ Forms
 ^^^^^
 
 .. versionadded:: 2.1
-  
+
     Prior to 2.1, ``TurboStreamResponse::STREAM_FORMAT`` was used instead of ``TurboBundle::STREAM_FORMAT``.
     Also, one had to return a new ``TurboStreamResponse()`` object as the third argument to ``$this->render()``.
 
@@ -616,13 +616,16 @@ The ``Broadcast`` attribute comes with a set of handy options:
    is derived from the FQCN of the entity and from its id
 -  ``template`` (``string``): Twig template to render (see above)
 
-Options are transport-sepcific. When using Mercure, some extra options
+Options are transport-specific. When using Mercure, some extra options
 are supported:
 
 -  ``private`` (``bool``): marks Mercure updates as private
 -  ``sse_id`` (``string``): ``id`` field of the SSE
 -  ``sse_type`` (``string``): ``type`` field of the SSE
 -  ``sse_retry`` (``int``): ``retry`` field of the SSE
+
+The Mercure broadcaster also supports `Expression Language`_ in topics
+by starting with `@=`.
 
 Example::
 
@@ -631,7 +634,7 @@ Example::
 
     use Symfony\UX\Turbo\Attribute\Broadcast;
 
-    #[Broadcast(template: 'foo.stream.html.twig', private: true)]
+    #[Broadcast(topics: ['@="books_by_author_" ~ entity.author?.id', 'books'], template: 'foo.stream.html.twig', private: true)]
     class Book
     {
         // ...
@@ -813,3 +816,4 @@ Symfony UX Turbo has been created by `Kévin Dunglas`_. It has been inspired by
 .. _`sroze/live-twig`: https://github.com/sroze/live-twig
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
 .. _`Moving <script> inside <head> and the "defer" Attribute`: https://symfony.com/blog/moving-script-inside-head-and-the-defer-attribute
+.. _`Expression Language`: https://symfony.com/doc/current/components/expression_language.html

--- a/src/Turbo/Tests/BroadcastTest.php
+++ b/src/Turbo/Tests/BroadcastTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\Turbo\Tests;
 
+use Facebook\WebDriver\WebDriverBy;
 use Symfony\Component\Panther\PantherTestCase;
 
 /**
@@ -19,16 +20,25 @@ use Symfony\Component\Panther\PantherTestCase;
 class BroadcastTest extends PantherTestCase
 {
     private const BOOK_TITLE = 'The Ecology of Freedom: The Emergence and Dissolution of Hierarchy';
+    private const SONG_TITLE = 'Bohemian Rhapsody';
+    private const ARTIST_NAME_1 = 'Queen';
+    private const ARTIST_NAME_2 = 'Elvis Presley';
 
-    public function testBroadcast(): void
+    protected function setUp(): void
     {
         if (!file_exists(__DIR__.'/app/public/build')) {
             throw new \Exception(sprintf('Move into %s and execute Encore before running this test.', realpath(__DIR__.'/app')));
         }
 
+        parent::setUp();
+    }
+
+    public function testBroadcast(): void
+    {
         ($client = self::createPantherClient())->request('GET', '/books');
 
         $crawler = $client->submitForm('Submit', ['title' => self::BOOK_TITLE]);
+        $client->waitForElementToContain('#books div', self::BOOK_TITLE);
 
         $this->assertSelectorWillContain('#books', self::BOOK_TITLE);
         if (!preg_match('/\(#(\d+)\)/', $crawler->filter('#books div')->text(), $matches)) {
@@ -40,5 +50,42 @@ class BroadcastTest extends PantherTestCase
 
         $client->submitForm('Submit', ['id' => $matches[1], 'remove' => 'remove']);
         $this->assertSelectorWillNotContain('#books', $matches[1]);
+    }
+
+    public function testExpressionLanguageBroadcast(): void
+    {
+        ($client = self::createPantherClient())->request('GET', '/artists');
+
+        $client->submitForm('Submit', ['name' => self::ARTIST_NAME_1]);
+        $client->waitForElementToContain('#artists div:nth-child(1)', self::ARTIST_NAME_1);
+        $client->submitForm('Submit', ['name' => self::ARTIST_NAME_2]);
+        $client->waitForElementToContain('#artists div:nth-child(2)', self::ARTIST_NAME_2);
+
+        $crawlerArtist = $client->getCrawler();
+
+        $this->assertSelectorWillContain('#artists', self::ARTIST_NAME_1);
+        if (!preg_match_all('/\(#(\d+)\)/', $crawlerArtist->filter('#artists')->text(), $matches)) {
+            $this->fail('IDs of artists not found');
+        }
+
+        $artist1Id = $matches[1][0];
+        $artist2Id = $matches[1][1];
+
+        ($clientArtist1 = self::createAdditionalPantherClient())->request('GET', '/artists/'.$artist1Id);
+        ($clientArtist2 = self::createAdditionalPantherClient())->request('GET', '/artists/'.$artist2Id);
+
+        $client->request('GET', '/songs');
+
+        $client->submitForm('Submit', ['title' => self::SONG_TITLE, 'artistId' => $artist1Id]);
+
+        $clientArtist1->waitForElementToContain('#songs div', self::SONG_TITLE);
+
+        $songsElement = $clientArtist2->findElement(WebDriverBy::cssSelector('#songs'));
+
+        $this->assertStringNotContainsString(
+            self::SONG_TITLE,
+            $songsElement->getText(),
+            'Artist 2 shows a song that does not belong to them'
+        );
     }
 }

--- a/src/Turbo/Tests/app/Entity/Artist.php
+++ b/src/Turbo/Tests/app/Entity/Artist.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\UX\Turbo\Attribute\Broadcast;
+
+/**
+ * @ORM\Entity
+ * @Broadcast
+ *
+ * @author Rick Kuipers <rick@levelup-it.com>
+ */
+#[Broadcast]
+class Artist
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null
+     */
+    public $id;
+
+    /**
+     * @ORM\Column
+     *
+     * @var string
+     */
+    public $name = '';
+
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\Song", mappedBy="artist")
+     *
+     * @var Song[]
+     */
+    public $songs;
+}

--- a/src/Turbo/Tests/app/Entity/Song.php
+++ b/src/Turbo/Tests/app/Entity/Song.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\UX\Turbo\Attribute\Broadcast;
+
+/**
+ * @ORM\Entity
+ * @Broadcast(topics={"@='songs_by_artist_' ~ (entity.artist ? entity.artist.id : null)", "songs"})
+ *
+ * @author Rick Kuipers <rick@levelup-it.com>
+ */
+#[Broadcast(topics: ['@="songs_by_artist_" ~ (entity.artist ? entity.artist.id : null)', 'songs'])]
+class Song
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null
+     */
+    public $id;
+
+    /**
+     * @ORM\Column
+     *
+     * @var string
+     */
+    public $title = '';
+
+    /**
+     * @ORM\ManyToOne(targetEntity="App\Entity\Artist", inversedBy="songs")
+     *
+     * @var Artist|null
+     */
+    public $artist;
+}

--- a/src/Turbo/Tests/app/templates/artist.html.twig
+++ b/src/Turbo/Tests/app/templates/artist.html.twig
@@ -1,0 +1,11 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <h1>Artist</h1>
+
+    {{ artist.name }} (#{{ artist.id }})
+
+    <h2>Songs</h2>
+    <div id="songs" {{ turbo_stream_listen('songs_by_artist_' ~ artist.id) }}></div>
+
+{% endblock %}

--- a/src/Turbo/Tests/app/templates/artists.html.twig
+++ b/src/Turbo/Tests/app/templates/artists.html.twig
@@ -1,0 +1,14 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <h1>Artists</h1>
+
+    <div id="artists" {{ turbo_stream_listen('App\\Entity\\Artist') }}></div>
+
+    <form method="post" enctype="application/x-www-form-urlencoded">
+        <input placeholder="ID" name="id">
+        <input placeholder="Name" name="name">
+        <label><input type="checkbox" name="remove" value="remove"> Remove</label>
+        <button>Submit</button>
+    </form>
+{% endblock %}

--- a/src/Turbo/Tests/app/templates/base.html.twig
+++ b/src/Turbo/Tests/app/templates/base.html.twig
@@ -12,6 +12,8 @@
                 <li><a href="{{ path('home') }}">Home</a></li>
                 <li><a href="{{ path('chat') }}">Chat</a></li>
                 <li><a href="{{ path('books') }}">Books (broadcast)</a></li>
+                <li><a href="{{ path('songs') }}">Songs (broadcast)</a></li>
+                <li><a href="{{ path('artists') }}">Artists (broadcast)</a></li>
             </ul>
         </nav>
 

--- a/src/Turbo/Tests/app/templates/broadcast/Artist.stream.html.twig
+++ b/src/Turbo/Tests/app/templates/broadcast/Artist.stream.html.twig
@@ -1,0 +1,19 @@
+{% block create %}
+    <turbo-stream action="append" target="artists">
+        <template>
+            <div id="{{ 'artist_' ~ id }}"><a href="{{ path('artist', {id: id}) }}">{{ entity.name }} (#{{ id }})</a></div>
+        </template>
+    </turbo-stream>
+{% endblock %}
+
+{% block update %}
+    <turbo-stream action="update" target="artist_{{ id }}">
+        <template>
+            {{ entity.name }} (#{{ id }}, updated)
+        </template>
+    </turbo-stream>
+{% endblock %}
+
+{% block remove %}
+    <turbo-stream action="remove" target="artist_{{ id }}"></turbo-stream>
+{% endblock %}

--- a/src/Turbo/Tests/app/templates/broadcast/Song.stream.html.twig
+++ b/src/Turbo/Tests/app/templates/broadcast/Song.stream.html.twig
@@ -1,0 +1,19 @@
+{% block create %}
+    <turbo-stream action="append" target="songs">
+        <template>
+            <div id="{{ 'song_' ~ id }}">{{ entity.title }} (#{{ id }}){% if entity.artist %} by {{ entity.artist.name }} (#{{ entity.artist.id }}){% endif %}</div>
+        </template>
+    </turbo-stream>
+{% endblock %}
+
+{% block update %}
+    <turbo-stream action="update" target="song_{{ id }}">
+        <template>
+            {{ entity.title }} (#{{ id }}, updated)
+        </template>
+    </turbo-stream>
+{% endblock %}
+
+{% block remove %}
+    <turbo-stream action="remove" target="song_{{ id }}"></turbo-stream>
+{% endblock %}

--- a/src/Turbo/Tests/app/templates/songs.html.twig
+++ b/src/Turbo/Tests/app/templates/songs.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <h1>Songs</h1>
+
+    <div id="songs" {{ turbo_stream_listen('songs') }}></div>
+
+    <form method="post" enctype="application/x-www-form-urlencoded">
+        <input placeholder="ID" name="id">
+        <input placeholder="Title" name="title">
+        <input placeholder="Artist ID" name="artistId">
+        <label><input type="checkbox" name="remove" value="remove"> Remove</label>
+        <button>Submit</button>
+    </form>
+{% endblock %}

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -55,7 +55,8 @@
         "symfony/security-core": "^5.2|^6.0",
         "symfony/stopwatch": "^5.2|^6.0",
         "symfony/twig-bundle": "^5.2|^6.0",
-        "symfony/web-profiler-bundle": "^5.2|^6.0"
+        "symfony/web-profiler-bundle": "^5.2|^6.0",
+        "symfony/expression-language": "^5.4|^6.0"
     },
     "conflict": {
         "symfony/flex": "<1.13"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | 
| License       | MIT

## Why
With the current implementation of the Broadcast attribute there's no way to scope newly added entities. A newly added entity will be broadcasted to anywhere that uses `turbo_stream_listen("App\\Entity\\Book")`. But there are use-cases where you want to limit this.

For one, imagine having a template `author/show.html.twig` where you want to show all the books belonging to a specific author. A newly added Book entity would show up on all the author pages because there's no way to supply a scope to turbo_stream_listen.

Secondly, there's currently no way to limit access based on the logged in user. For simplicity's sake let's imagine every author belongs to a publisher. The publisher can login and add/edit/remove authors that belong to them. Now let's say we have a template called `author/list.html.twig` on which we use `turbo_stream_listen("App\\Entity\\Author")`. In the current implementation, this would also show all newly created Authors created by other Publishers.

~~So adding a scope is both useful for showing specific listings as well as listings that should only be shown to a specific user.~~

Adding expression language support to topics makes it possible to scope these topics based on a relationship or some other context.

## ~~How~~
~~We can achieve the above by changing two points in the code.~~

~~https://github.com/rskuipers/ux/blob/feature/add-scope-option-to-broadcast/src/Turbo/Tests/app/Entity/Book.php#L23~~

~~Expanding the Broadcast attribute with a `scope` option that supports Expression Language. This will be executed when an entity is created/changed typically in order to retrieve an ID of a parent entity that will function as a scope.~~

~~Note: this expression has null checking because the relationship is optional. Also in Expression Language 6.1 you can use the [null-safe operator](https://symfony.com/doc/current/components/expression_language/syntax.html#null-safe-operator): `entity.author?.id`~~

~~https://github.com/rskuipers/ux/blob/feature/add-scope-option-to-broadcast/src/Turbo/Twig/TwigExtension.php#L44~~

~~Adding a third parameter `$scope = null` here so that you can provide a value used to add a scope to the topic you're listening to.~~

~~https://github.com/rskuipers/ux/blob/feature/add-scope-option-to-broadcast/src/Turbo/Twig/ScopedTurboStreamListenRendererInterface.php~~

~~Adding a separate interface with a method supporting a third parameter `?string $scope = null` here so that this can be integrated into the topic to listen for a scoped topic.~~