### PR TITLE
Introduce UX React component

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,6 +101,15 @@ jobs:
               run: php vendor/bin/simple-phpunit
               working-directory: src/LazyImage
 
+            - name: React Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                  working-directory: src/React
+                  dependency-versions: lowest
+            - name: React Tests
+              run: php vendor/bin/simple-phpunit
+              working-directory: src/React
+
     tests-php8-low-deps:
         runs-on: ubuntu-latest
         steps:
@@ -182,6 +191,14 @@ jobs:
                   working-directory: src/LiveComponent
             - name: LiveComponent Tests
               working-directory: src/LiveComponent
+              run: php vendor/bin/simple-phpunit
+
+            - name: React Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                  working-directory: src/React
+            - name: React Tests
+              working-directory: src/React
               run: php vendor/bin/simple-phpunit
 
     tests-php81-high-deps:

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,7 @@
 module.exports = {
     presets: [
         ['@babel/preset-env', {targets: {node: 'current'}}],
+        '@babel/react',
         '@babel/preset-typescript',
     ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,6 @@ module.exports = {
         path.join(__dirname, 'test/setup.js'),
     ],
     transform: {
-        '\\.(j|t)s$': ['babel-jest', { configFile: path.join(__dirname, './babel.config.js') }]
+        '\\.(j|t)s': ['babel-jest', { configFile: path.join(__dirname, './babel.config.js') }]
     },
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "devDependencies": {
         "@babel/core": "^7.15.8",
         "@babel/preset-env": "^7.15.8",
-        "@babel/preset-typescript": "^7.15.0",
+        "@babel/preset-react": "^7.15.8",
+        "@babel/preset-typescript": "^7.15.8",
         "@rollup/plugin-node-resolve": "^13.0.0",
         "@rollup/plugin-typescript": "^8.3.0",
         "@symfony/stimulus-testing": "^2.0.1",

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -971,11 +971,14 @@ function haveRenderedValuesChanged(originalDataJson, currentDataJson, newDataJso
 }
 
 function normalizeAttributesForComparison(element) {
-    if (element.value) {
-        element.setAttribute('value', element.value);
-    }
-    else if (element.hasAttribute('value')) {
-        element.setAttribute('value', '');
+    const isFileInput = element instanceof HTMLInputElement && element.type === 'file';
+    if (!isFileInput) {
+        if (element.value) {
+            element.setAttribute('value', element.value);
+        }
+        else if (element.hasAttribute('value')) {
+            element.setAttribute('value', '');
+        }
     }
     Array.from(element.children).forEach((child) => {
         normalizeAttributesForComparison(child);

--- a/src/React/.gitattributes
+++ b/src/React/.gitattributes
@@ -1,0 +1,5 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore
+/Resources/assets/test export-ignore
+/Tests export-ignore

--- a/src/React/.gitignore
+++ b/src/React/.gitignore
@@ -1,0 +1,4 @@
+vendor
+composer.lock
+.php_cs.cache
+.phpunit.result.cache

--- a/src/React/.symfony.bundle.yaml
+++ b/src/React/.symfony.bundle.yaml
@@ -1,0 +1,3 @@
+branches: ["2.x"]
+maintained_branches: ["2.x"]
+doc_dir: "Resources/doc"

--- a/src/React/CHANGELOG.md
+++ b/src/React/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 2.2
+
+-   Component added

--- a/src/React/DependencyInjection/ReactExtension.php
+++ b/src/React/DependencyInjection/ReactExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\React\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\UX\React\Twig\ReactComponentExtension;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class ReactExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $container
+            ->setDefinition('twig.extension.react', new Definition(ReactComponentExtension::class))
+            ->setArgument(0, new Reference('webpack_encore.twig_stimulus_extension'))
+            ->addTag('twig.extension')
+            ->setPublic(false)
+        ;
+    }
+}

--- a/src/React/LICENSE
+++ b/src/React/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020-2021 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/React/README.md
+++ b/src/React/README.md
@@ -1,0 +1,14 @@
+# Symfony UX React
+
+Symfony UX React integrates [React](https://reactjs.org/) into Symfony applications.
+It provides tools to render React components from Twig.
+
+**This repository is a READ-ONLY sub-tree split**. See
+https://github.com/symfony/ux to create issues or submit pull requests.
+
+## Resources
+
+-   [Documentation](https://symfony.com/bundles/ux-react/current/index.html)
+-   [Report issues](https://github.com/symfony/ux/issues) and
+    [send Pull Requests](https://github.com/symfony/ux/pulls)
+    in the [main Symfony UX repository](https://github.com/symfony/ux)

--- a/src/React/ReactBundle.php
+++ b/src/React/ReactBundle.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\React;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @final
+ * @experimental
+ */
+class ReactBundle extends Bundle
+{
+}

--- a/src/React/Resources/assets/dist/register_controller.js
+++ b/src/React/Resources/assets/dist/register_controller.js
@@ -1,0 +1,16 @@
+function registerReactControllerComponents(context) {
+    const reactControllers = {};
+    const importAllReactComponents = (r) => {
+        r.keys().forEach((key) => (reactControllers[key] = r(key).default));
+    };
+    importAllReactComponents(context);
+    window.resolveReactComponent = (name) => {
+        const component = reactControllers['./' + name + '.jsx'] || reactControllers['./' + name + '.tsx'];
+        if (typeof component === 'undefined') {
+            throw new Error('React controller "' + name + '" does not exist');
+        }
+        return component;
+    };
+}
+
+export { registerReactControllerComponents };

--- a/src/React/Resources/assets/dist/render_controller.js
+++ b/src/React/Resources/assets/dist/render_controller.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Controller } from '@hotwired/stimulus';
+
+class default_1 extends Controller {
+    connect() {
+        this._dispatchEvent('react:connect', { component: this.componentValue, props: this.propsValue });
+        const component = window.resolveReactComponent(this.componentValue);
+        this._renderReactElement(React.createElement(component, this.propsValue, null));
+        this._dispatchEvent('react:mount', {
+            componentName: this.componentValue,
+            component: component,
+            props: this.propsValue,
+        });
+    }
+    disconnect() {
+        this.element.unmount();
+        this._dispatchEvent('react:unmount', { component: this.componentValue, props: this.propsValue });
+    }
+    _renderReactElement(reactElement) {
+        if (parseInt(React.version) >= 18) {
+            const root = require('react-dom/client').createRoot(this.element);
+            root.render(reactElement);
+            this.element.unmount = () => {
+                root.unmount();
+            };
+            return;
+        }
+        const reactDom = require('react-dom');
+        reactDom.render(reactElement, this.element);
+        this.element.unmount = () => {
+            reactDom.unmountComponentAtNode(this.element);
+        };
+    }
+    _dispatchEvent(name, payload) {
+        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    }
+}
+default_1.values = {
+    component: String,
+    props: Object,
+};
+
+export { default_1 as default };

--- a/src/React/Resources/assets/jest.config.js
+++ b/src/React/Resources/assets/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../../jest.config.js');

--- a/src/React/Resources/assets/package.json
+++ b/src/React/Resources/assets/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "@symfony/ux-react",
+    "description": "Integration of React in Symfony",
+    "license": "MIT",
+    "version": "1.0.0",
+    "main": "dist/register_controller.js",
+    "symfony": {
+        "controllers": {
+            "react": {
+                "main": "dist/render_controller.js",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": true
+            }
+        }
+    },
+    "peerDependencies": {
+        "@hotwired/stimulus": "^3.0.0",
+        "react": "^18.0",
+        "react-dom": "^18.0"
+    },
+    "devDependencies": {
+        "@hotwired/stimulus": "^3.0.0",
+        "@types/react": "^18.0",
+        "@types/react-dom": "^18.0",
+        "@types/webpack-env": "^1.16",
+        "react": "^18.0",
+        "react-dom": "^18.0"
+    }
+}

--- a/src/React/Resources/assets/src/register_controller.ts
+++ b/src/React/Resources/assets/src/register_controller.ts
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+export function registerReactControllerComponents(context: __WebpackModuleApi.RequireContext) {
+    const reactControllers: { [key: string]: object } = {};
+
+    const importAllReactComponents = (r: __WebpackModuleApi.RequireContext) => {
+        r.keys().forEach((key) => (reactControllers[key] = r(key).default));
+    };
+
+    importAllReactComponents(context);
+
+    // Expose a global React loader to allow rendering from the Stimulus controller
+    (window as any).resolveReactComponent = (name: string): object => {
+        const component = reactControllers[`./${name}.jsx`] || reactControllers[`./${name}.tsx`];
+        if (typeof component === 'undefined') {
+            throw new Error('React controller "' + name + '" does not exist');
+        }
+
+        return component;
+    };
+}

--- a/src/React/Resources/assets/src/render_controller.ts
+++ b/src/React/Resources/assets/src/render_controller.ts
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import React, { ReactElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    readonly componentValue: string;
+    readonly propsValue: object;
+
+    static values = {
+        component: String,
+        props: Object,
+    };
+
+    connect() {
+        this._dispatchEvent('react:connect', { component: this.componentValue, props: this.propsValue });
+
+        const component = window.resolveReactComponent(this.componentValue);
+        this._renderReactElement(React.createElement(component, this.propsValue, null));
+
+        this._dispatchEvent('react:mount', {
+            componentName: this.componentValue,
+            component: component,
+            props: this.propsValue,
+        });
+    }
+
+    disconnect() {
+        (this.element as any).root.unmount();
+        this._dispatchEvent('react:unmount', { component: this.componentValue, props: this.propsValue });
+    }
+
+    _renderReactElement(reactElement: ReactElement) {
+        const root = createRoot(this.element);
+        root.render(reactElement);
+
+        (this.element as any).root = root;
+    }
+
+    _dispatchEvent(name: string, payload: any) {
+        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    }
+}

--- a/src/React/Resources/assets/test/fixtures/MyJsxComponent.jsx
+++ b/src/React/Resources/assets/test/fixtures/MyJsxComponent.jsx
@@ -1,0 +1,3 @@
+export default function () {
+    return <div>Hello</div>;
+}

--- a/src/React/Resources/assets/test/fixtures/MyTsxComponent.tsx
+++ b/src/React/Resources/assets/test/fixtures/MyTsxComponent.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function () {
+    return <div>Hello</div>;
+}

--- a/src/React/Resources/assets/test/register_controller.test.tsx
+++ b/src/React/Resources/assets/test/register_controller.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import {registerReactControllerComponents} from '../src/register_controller';
+import MyTsxComponent from './fixtures/MyTsxComponent';
+import {createRequireContextPolyfill} from './util/require_context_poylfill';
+
+require.context = createRequireContextPolyfill(__dirname);
+
+describe('registerReactControllerComponents', () => {
+    it('test', () => {
+        registerReactControllerComponents(require.context('./fixtures', true, /\.(j|t)sx$/));
+        const resolveComponent = (window as any).resolveReactComponent;
+
+        expect(resolveComponent).not.toBeUndefined();
+        expect(resolveComponent('MyTsxComponent')).toBe(MyTsxComponent);
+        expect(resolveComponent('MyJsxComponent')).not.toBeUndefined();
+    });
+});

--- a/src/React/Resources/assets/test/render_controller.test.tsx
+++ b/src/React/Resources/assets/test/render_controller.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import React from 'react';
+import { Application, Controller } from '@hotwired/stimulus';
+import { getByTestId, waitFor } from '@testing-library/dom';
+import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
+import ReactController from '../src/render_controller';
+
+// Controller used to check the actual controller was properly booted
+class CheckController extends Controller {
+    connect() {
+        this.element.addEventListener('react:connect', () => {
+            this.element.classList.add('connected');
+        });
+
+        this.element.addEventListener('react:mount', () => {
+            this.element.classList.add('mounted');
+        });
+    }
+}
+
+const startStimulus = () => {
+    const application = Application.start();
+    application.register('check', CheckController);
+    application.register('react', ReactController);
+};
+
+function ReactComponent(props: { fullName: string }) {
+    return <div>Hello {props.fullName}</div>;
+}
+
+(window as any).resolveReactComponent = () => {
+    return ReactComponent;
+};
+
+describe('ReactController', () => {
+    let container: any;
+
+    beforeEach(() => {
+        container = mountDOM(`
+          <div data-testid="component"
+              data-controller="check react"
+              data-react-component-value="ReactComponent"
+              data-react-props-value="{&quot;fullName&quot;: &quot;Titouan Galopin&quot;}" />
+        `);
+    });
+
+    afterEach(() => {
+        clearDOM();
+    });
+
+    it('connect', async () => {
+        const component = getByTestId(container, 'component');
+        expect(component).not.toHaveClass('connected');
+        expect(component).not.toHaveClass('mounted');
+
+        startStimulus();
+        await waitFor(() => expect(component).toHaveClass('connected'));
+        await waitFor(() => expect(component).toHaveClass('mounted'));
+        await waitFor(() => expect(component.innerHTML).toEqual('<div>Hello Titouan Galopin</div>'));
+    });
+});

--- a/src/React/Resources/assets/test/util/require_context_poylfill.ts
+++ b/src/React/Resources/assets/test/util/require_context_poylfill.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+
+export function createRequireContextPolyfill (rootDir: string) {
+    return (base: string, deep: boolean, filter: RegExp): __WebpackModuleApi.RequireContext => {
+        const basePrefix = path.resolve(rootDir, base);
+        const files: { [key: string]: boolean } = {};
+
+        function readDirectory(directory: string) {
+            fs.readdirSync(directory).forEach((file: string) => {
+                const fullPath = path.resolve(directory, file);
+
+                if (fs.statSync(fullPath).isDirectory()) {
+                    if (deep) {
+                        readDirectory(fullPath);
+                    }
+
+                    return;
+                }
+
+                if (!filter.test(fullPath)) {
+                    return;
+                }
+
+                files[fullPath.replace(basePrefix, '.')] = true;
+            });
+        }
+
+        readDirectory(path.resolve(rootDir, base));
+
+        function Module(file: string) {
+            return require(basePrefix + '/' + file);
+        }
+
+        Module.keys = () => Object.keys(files);
+
+        return (Module as __WebpackModuleApi.RequireContext);
+    };
+}

--- a/src/React/Resources/doc/index.rst
+++ b/src/React/Resources/doc/index.rst
@@ -1,0 +1,90 @@
+Symfony UX React
+================
+
+Symfony UX React is a Symfony bundle integrating `React`_ in
+Symfony applications. It is part of `the Symfony UX initiative`_.
+
+React is a JavaScript library for building user interfaces.
+Symfony UX React provides tools to render React components from Twig,
+handling rendering and data transfers.
+
+Symfony UX React supports React 18+.
+
+Installation
+------------
+
+Before you start, make sure you have `Symfony UX configured in your app`_.
+
+Then install the bundle using Composer and Symfony Flex:
+
+.. code-block:: terminal
+
+    $ composer require symfony/ux-react
+
+    # Don't forget to install the JavaScript dependencies as well and compile
+    $ yarn install --force
+    $ yarn encore dev
+
+You also need to add the following lines at the end to your ``assets/app.js`` file:
+
+.. code-block:: javascript
+
+    // assets/app.js
+    import { registerReactControllerComponents } from '@symfony/ux-react';
+
+    // Registers React controller components to allow loading them from Twig
+    //
+    // React controller components are components that are meant to be rendered
+    // from Twig. These component then rely on other components that won't be called
+    // directly from Twig.
+    //
+    // By putting only controller components in `react/controllers`, you ensure that
+    // internal components won't be automatically included in your JS built file if
+    // they are not necessary.
+    registerReactControllerComponents(require.context('./react/controllers', true, /\.(j|t)sx?$/));
+
+
+Usage
+-----
+
+UX React works by using a system of **React controller components**: React components that
+are registered using ``registerReactControllerComponents`` and that are meant to be rendered
+from Twig.
+
+When using the ``registerReactControllerComponents`` configuration shown previously, all
+React components located in the directory ``assets/react/controllers`` are registered as
+React controller components.
+
+You can then render any React controller component in Twig using the ``react_component``.
+For example:
+
+.. code-block:: javascript
+
+    // assets/react/controllers/MyComponent.jsx
+    import React from 'react';
+
+    export default function (props) {
+        return <div>Hello {props.fullName}</div>;
+    }
+
+
+.. code-block:: twig
+
+    {# templates/home.html.twig #}
+
+    <div {{ react_component('MyComponent', { 'fullName': app.user.fullName }) }}></div>
+
+Backward Compatibility promise
+------------------------------
+
+This bundle aims at following the same Backward Compatibility promise as
+the Symfony framework:
+https://symfony.com/doc/current/contributing/code/bc.html
+
+However it is currently considered `experimental`_,
+meaning it is not bound to Symfony's BC policy for the moment.
+
+.. _`React`: https://reactjs.org/
+.. _`the Symfony UX initiative`: https://symfony.com/ux
+.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
+.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html

--- a/src/React/Tests/Kernel/AppKernelTrait.php
+++ b/src/React/Tests/Kernel/AppKernelTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\React\Tests\Kernel;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+trait AppKernelTrait
+{
+    public function getCacheDir(): string
+    {
+        return $this->createTmpDir('cache');
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->createTmpDir('logs');
+    }
+
+    private function createTmpDir(string $type): string
+    {
+        $dir = sys_get_temp_dir().'/react_bundle/'.uniqid($type.'_', true);
+
+        if (!file_exists($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        return $dir;
+    }
+}

--- a/src/React/Tests/Kernel/FrameworkAppKernel.php
+++ b/src/React/Tests/Kernel/FrameworkAppKernel.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\React\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\React\ReactBundle;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class FrameworkAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        return [new WebpackEncoreBundle(), new FrameworkBundle(), new ReactBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true]);
+            $container->loadFromExtension('webpack_encore', ['output_path' => '%kernel.project_dir%/public/build']);
+        });
+    }
+}

--- a/src/React/Tests/Kernel/TwigAppKernel.php
+++ b/src/React/Tests/Kernel/TwigAppKernel.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\React\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\React\ReactBundle;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class TwigAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        return [new WebpackEncoreBundle(), new FrameworkBundle(), new TwigBundle(), new ReactBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true]);
+            $container->loadFromExtension('webpack_encore', ['output_path' => '%kernel.project_dir%/public/build']);
+            $container->loadFromExtension('twig', ['default_path' => __DIR__.'/templates', 'strict_variables' => true, 'exception_controller' => null]);
+
+            $container->setAlias('test.twig', 'twig')->setPublic(true);
+            $container->setAlias('test.twig.extension.react', 'twig.extension.react')->setPublic(true);
+        });
+    }
+}

--- a/src/React/Tests/ReactBundleTest.php
+++ b/src/React/Tests/ReactBundleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\React\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\React\Tests\Kernel\FrameworkAppKernel;
+use Symfony\UX\React\Tests\Kernel\TwigAppKernel;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class ReactBundleTest extends TestCase
+{
+    public function provideKernels()
+    {
+        yield 'framework' => [new FrameworkAppKernel('test', true)];
+        yield 'twig' => [new TwigAppKernel('test', true)];
+    }
+
+    /**
+     * @dataProvider provideKernels
+     */
+    public function testBootKernel(Kernel $kernel)
+    {
+        $kernel->boot();
+        $this->assertArrayHasKey('ReactBundle', $kernel->getBundles());
+    }
+}

--- a/src/React/Tests/Twig/ReactComponentExtensionTest.php
+++ b/src/React/Tests/Twig/ReactComponentExtensionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\React\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\React\Tests\Kernel\TwigAppKernel;
+use Symfony\UX\React\Twig\ReactComponentExtension;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @internal
+ */
+class ReactComponentExtensionTest extends TestCase
+{
+    public function testRenderComponent()
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+
+        /** @var ReactComponentExtension $extension */
+        $extension = $kernel->getContainer()->get('test.twig.extension.react');
+
+        $rendered = $extension->renderReactComponent(
+            $kernel->getContainer()->get('test.twig'),
+            'SubDir/MyComponent',
+            ['fullName' => 'Titouan Galopin']
+        );
+
+        $this->assertSame(
+            'data-controller="symfony--ux-react--react" data-symfony--ux-react--react-component-value="SubDir&#x2F;MyComponent" data-symfony--ux-react--react-props-value="&#x7B;&quot;fullName&quot;&#x3A;&quot;Titouan&#x20;Galopin&quot;&#x7D;"',
+            $rendered
+        );
+    }
+}

--- a/src/React/Twig/ReactComponentExtension.php
+++ b/src/React/Twig/ReactComponentExtension.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\React\Twig;
+
+use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * @final
+ * @experimental
+ */
+class ReactComponentExtension extends AbstractExtension
+{
+    private $stimulusExtension;
+
+    public function __construct(StimulusTwigExtension $stimulusExtension)
+    {
+        $this->stimulusExtension = $stimulusExtension;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('react_component', [$this, 'renderReactComponent'], ['needs_environment' => true, 'is_safe' => ['html_attr']]),
+        ];
+    }
+
+    public function renderReactComponent(Environment $env, string $componentName, array $props = []): string
+    {
+        return $this->stimulusExtension->renderStimulusController($env, '@symfony/ux-react/react', [
+            'component' => $componentName,
+            'props' => $props,
+        ]);
+    }
+}

--- a/src/React/composer.json
+++ b/src/React/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "symfony/ux-react",
+    "type": "symfony-bundle",
+    "description": "Integration of React in Symfony",
+    "keywords": [
+        "symfony-ux"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Titouan Galopin",
+            "email": "galopintitouan@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Symfony\\UX\\React\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "require": {
+        "symfony/webpack-encore-bundle": "^1.11"
+    },
+    "require-dev": {
+        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
+        "symfony/phpunit-bridge": "^5.2|^6.0",
+        "symfony/twig-bundle": "^4.4|^5.0|^6.0",
+        "symfony/var-dumper": "^4.4|^5.0|^6.0"
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/React/phpunit.xml.dist
+++ b/src/React/phpunit.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true">
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <ini name="intl.default_locale" value="en" />
+        <ini name="intl.error_level" value="0" />
+        <ini name="memory_limit" value="-1" />
+        <env name="SHELL_VERBOSITY" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./Resources</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
         "noEmit": false,
         "declaration": false,
         "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "jsx": "react"
     },
     "exclude": ["src/**/dist"],
     "include": ["src/**/*"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | -
| License       | MIT

This PR introduces a new component called UX React. This UX component creates a bridge between Symfony and React by allowing Twig developers to render React components, passing data smoothly between the two.

After installing this component, it is possible to use the `react_component` Twig function to render a React component in a specific HTML container:

```js
// assets/react/controllers/MyComponent.jsx
import React from 'react';

export default function (props) {
    return (
        <div>Hello {props.fullName}</div>
    );
}
```

```twig
{# templates/home.html.twig #}

<div {{ react_component('MyComponent', { 'fullName': app.user.fullName }) }}></div>
```

This behavior works by allowing UX React users to register React components in a global key-value store that is then used by a generic Stimulus controller (`Resources/assets/src/render_controller.tsx`) to do that the actual rendering. I propose to introduce a `assets/react/controllers` directory to automatically register all components inside this directory, to ease usage. You can read the README for more details.

This component supports Symfony 4.4+ (super simple bundle, no reason not to be IMO) and React 16+ (released in 2017).