### PR TITLE
Fix TypeScript compilation issue

### DIFF
--- a/src/Turbo/Resources/assets/src/turbo_controller.ts
+++ b/src/Turbo/Resources/assets/src/turbo_controller.ts
@@ -11,7 +11,7 @@ import { Controller } from '@hotwired/stimulus';
 import * as Turbo from '@hotwired/turbo';
 
 // Expose Turbo to the rest of the app to allow for dynamic Turbo calls
-window.Turbo = Turbo;
+Object.assign(window, { Turbo });
 
 /**
  * Empty Stimulus controller only used for Symfony Flex wiring.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

_webpack.config.js_:
```js
Encore
    ...
    .enableTypeScriptLoader()
    .enableForkedTypeScriptTypesChecking()
```

Error message on `yarn encore production`:
```
Failed to compile with 1 errors

 error  in vendor/symfony/ux-turbo/Resources/assets/src/turbo_controller.ts:14:8                                                                                                    11:22:22

TS2339: Property 'Turbo' does not exist on type 'Window & typeof globalThis'.
    12 |
    13 | // Expose Turbo to the rest of the app to allow for dynamic Turbo calls
  > 14 | window.Turbo = Turbo;
       |        ^^^^^
    15 |
    16 | /**
    17 |  * Empty Stimulus controller only used for Symfony Flex wiring.
```