### PR TITLE
Use shorter controller names for "live" and "Typed"

### DIFF
--- a/src/Autocomplete/src/Resources/doc/index.rst
+++ b/src/Autocomplete/src/Resources/doc/index.rst
@@ -24,12 +24,12 @@ Then install the bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-autocomplete
 
     # Don't forget to install the JavaScript dependencies as well and compile
-    $ yarn install --force
-    $ yarn watch
-
-    # or use npm
     $ npm install --force
     $ npm run watch
+
+    # or use yarn
+    $ yarn install --force
+    $ yarn watch
 
 Usage in a Form (without Ajax)
 ------------------------------

--- a/src/Chartjs/Resources/doc/index.rst
+++ b/src/Chartjs/Resources/doc/index.rst
@@ -17,8 +17,12 @@ Then, install this bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-chartjs
 
     # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
 Also make sure you have at least version 3.0 of `@symfony/stimulus-bridge`_
 in your ``package.json`` file.

--- a/src/Cropperjs/Resources/doc/index.rst
+++ b/src/Cropperjs/Resources/doc/index.rst
@@ -17,8 +17,12 @@ Then, install this bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-cropperjs
 
     # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
 Also make sure you have at least version 3.0 of
 `@symfony/stimulus-bridge`_ in your ``package.json`` file.

--- a/src/Dropzone/Resources/doc/index.rst
+++ b/src/Dropzone/Resources/doc/index.rst
@@ -19,8 +19,12 @@ Then, install this bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-dropzone
 
     # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
 Also make sure you have at least version 3.0 of
 `@symfony/stimulus-bridge`_ in your ``package.json`` file.

--- a/src/LazyImage/Resources/doc/index.rst
+++ b/src/LazyImage/Resources/doc/index.rst
@@ -21,8 +21,12 @@ Then install this bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-lazy-image
 
     # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
 Also make sure you have at least version 3.0 of
 `@symfony/stimulus-bridge`_ in your ``package.json`` file.

--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## 2.2.0
 
--   Allow to disable CSRF per component
+- The bundle now properly exposes a `live` controller, which can be
+  imported via your `assets/controllers.json` file (like any other
+  UX package). Previously, the controller needed to be imported and
+  registered with Stimulus directly (usually in your `assets/bootstrap.js`
+  file). That is no longer needed.
+
+- Allow to disable CSRF per component
 
 ## 2.1.0
 

--- a/src/LiveComponent/assets/package.json
+++ b/src/LiveComponent/assets/package.json
@@ -1,10 +1,24 @@
 {
-    "name": "@symfony/live-stimulus",
+    "name": "@symfony/live-component",
     "description": "Live Component: bring server-side re-rendering & model binding to any element.",
     "main": "dist/live_controller.js",
     "module": "dist/live_controller.js",
-    "version": "0.0.1",
+    "version": "1.0.0",
     "license": "MIT",
+    "symfony": {
+        "controllers": {
+            "typed": {
+                "main": "dist/live_controller.js",
+                "name": "live",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": true,
+                "autoimport": {
+                    "@symfony/live-component/styles/live.css": true
+                }
+            }
+        }
+    },
     "dependencies": {
         "morphdom": "^2.6.1"
     },

--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -82,35 +82,16 @@ Now install the library with:
 
     $ composer require symfony/ux-live-component
 
-This comes with an embedded JavaScript Stimulus controller. Unlike other
-Symfony UX packages, this needs to be enabled manually in your
-``assets/bootstrap.js`` file:
+    # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
 
-.. code-block:: javascript
-
-    // assets/bootstrap.js
-    import LiveController from '@symfony/ux-live-component';
-    import '@symfony/ux-live-component/styles/live.css';
-    // ...
-
-    app.register('live', LiveController);
-
-Finally, reinstall your Node dependencies and restart Encore:
-
-.. code-block:: terminal
-
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
-Oh, and just one more step! Import a routing file from the bundle:
-
-.. code-block:: yaml
-
-    # config/routes.yaml
-    live_component:
-        resource: '@LiveComponentBundle/Resources/config/routing/live_component.xml'
-        # uncomment to add localization to your components
-        #prefix: '/{_locale}'
+Also make sure you have at least version 3.2 of
+``@symfony/stimulus-bridge`` in your ``package.json`` file.
 
 That's it! We're ready!
 

--- a/src/Notify/Resources/doc/index.rst
+++ b/src/Notify/Resources/doc/index.rst
@@ -16,8 +16,12 @@ Then, install this bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-notify
 
     # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
 Also make sure you have at least version 3.0 of
 `@symfony/stimulus-bridge`_ in your ``package.json`` file.

--- a/src/React/Resources/doc/index.rst
+++ b/src/React/Resources/doc/index.rst
@@ -22,8 +22,12 @@ Then install the bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-react
 
     # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
 You also need to add the following lines at the end to your ``assets/app.js`` file:
 

--- a/src/Swup/Resources/doc/index.rst
+++ b/src/Swup/Resources/doc/index.rst
@@ -21,8 +21,12 @@ Then install the bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-swup
 
     # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
 Also make sure you have at least version 3.0 of
 `@symfony/stimulus-bridge`_ in your ``package.json`` file.

--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -27,8 +27,12 @@ Install this bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-turbo
 
     # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
 Usage
 -----
@@ -301,7 +305,7 @@ Forms
 ^^^^^
 
 .. versionadded:: 2.1
-  
+
     Prior to 2.1, ``TurboStreamResponse::STREAM_FORMAT`` was used instead of ``TurboBundle::STREAM_FORMAT``.
     Also, one had to return a new ``TurboStreamResponse()`` object as the third argument to ``$this->render()``.
 

--- a/src/Typed/Resources/assets/package.json
+++ b/src/Typed/Resources/assets/package.json
@@ -7,6 +7,7 @@
         "controllers": {
             "typed": {
                 "main": "dist/controller.js",
+                "name": "symfony/ux-typed",
                 "webpackMode": "eager",
                 "fetch": "eager",
                 "enabled": true

--- a/src/Typed/Resources/doc/index.rst
+++ b/src/Typed/Resources/doc/index.rst
@@ -29,7 +29,7 @@ Then install the bundle using Composer and Symfony Flex:
     $ yarn install --force
     $ yarn watch
 
-Also make sure you have at least version 3.0 of
+Also make sure you have at least version 3.2 of
 `@symfony/stimulus-bridge`_ in your ``package.json`` file.
 
 Usage
@@ -45,7 +45,7 @@ The main usage of Symfony UX Typed is to use its Stimulus controller to initiali
 
     <div>
         I created this UX component because
-        <span {{ stimulus_controller('symfony/ux-typed/typed', {
+        <span {{ stimulus_controller('symfony/ux-typed', {
             strings: ['I ❤ Symfony UX', 'Symfony UX is great', 'Symfony UX is easy']
         }) }}></span>
     </div>
@@ -59,7 +59,7 @@ Parameters are exactly the same as for the `typed library`_
 
     <div>
         I created this UX component because
-        <span {{ stimulus_controller('symfony/ux-typed/typed', {
+        <span {{ stimulus_controller('symfony/ux-typed', {
             strings: ['I ❤ Symfony UX', 'Symfony UX is great', 'Symfony UX is easy'],
             smartBackspace: true,
             startDelay: 100,
@@ -133,7 +133,7 @@ Then in your template, add your controller to the HTML attribute:
         </head>
         <body {{ stimulus_controller({
             mytyped: {},
-            'symfony/ux-typed/typed': {}
+            'symfony/ux-typed': {}
         }) }}>
             {# ... #}
         </body>

--- a/src/Typed/Resources/doc/index.rst
+++ b/src/Typed/Resources/doc/index.rst
@@ -22,8 +22,12 @@ Then install the bundle using Composer and Symfony Flex:
     $ composer require symfony/ux-typed
 
     # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
     $ yarn install --force
-    $ yarn encore dev
+    $ yarn watch
 
 Also make sure you have at least version 3.0 of
 `@symfony/stimulus-bridge`_ in your ``package.json`` file.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | None
| License       | MIT

2 major changes:

A) The unreleased ux-typed package controller's name was shorted from `symfony/ux-typed/typed` to `symfony/ux-typed`. 

B) The LiveComponent controller was properly registered and named `live`. Also, docs were updated to prep for a recipe.

I also normalized the install instructions for npm vs yarn, putting npm first because people will definitely have this installed.

Cheers!
