### PR TITLE
[Autocomplete] Allow full control over the search query

### DIFF
--- a/src/Autocomplete/src/AutocompleteResultsExecutor.php
+++ b/src/Autocomplete/src/AutocompleteResultsExecutor.php
@@ -14,7 +14,6 @@ namespace Symfony\UX\Autocomplete;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\UX\Autocomplete\Doctrine\DoctrineRegistryWrapper;
-use Symfony\UX\Autocomplete\Doctrine\EntitySearchUtil;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
@@ -24,7 +23,6 @@ use Symfony\UX\Autocomplete\Doctrine\EntitySearchUtil;
 final class AutocompleteResultsExecutor
 {
     public function __construct(
-        private EntitySearchUtil $entitySearchUtil,
         private DoctrineRegistryWrapper $managerRegistry,
         private ?Security $security = null
     ) {
@@ -36,9 +34,10 @@ final class AutocompleteResultsExecutor
             throw new AccessDeniedException('Access denied from autocompleter class.');
         }
 
-        $queryBuilder = $autocompleter->getQueryBuilder($this->managerRegistry->getRepository($autocompleter->getEntityClass()));
-        $searchableProperties = $autocompleter->getSearchableFields();
-        $this->entitySearchUtil->addSearchClause($queryBuilder, $query, $autocompleter->getEntityClass(), $searchableProperties);
+        $queryBuilder = $autocompleter->createFilteredQueryBuilder(
+            $this->managerRegistry->getRepository($autocompleter->getEntityClass()),
+            $query
+        );
 
         // if no max is set, set one
         if (!$queryBuilder->getMaxResults()) {

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
@@ -81,7 +81,6 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
         $container
             ->register('ux.autocomplete.results_executor', AutocompleteResultsExecutor::class)
             ->setArguments([
-                new Reference('ux.autocomplete.entity_search_util'),
                 new Reference('ux.autocomplete.doctrine_registry_wrapper'),
                 new Reference('security.helper', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
@@ -143,6 +142,7 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
                 new Reference('form.factory'),
                 new Reference('ux.autocomplete.entity_metadata_factory'),
                 new Reference('property_accessor'),
+                new Reference('ux.autocomplete.entity_search_util'),
             ]);
     }
 }

--- a/src/Autocomplete/src/EntityAutocompleterInterface.php
+++ b/src/Autocomplete/src/EntityAutocompleterInterface.php
@@ -26,9 +26,9 @@ interface EntityAutocompleterInterface
     public function getEntityClass(): string;
 
     /**
-     * A query builder that would return all potential results.
+     * Create a query builder that filters for the given "query".
      */
-    public function getQueryBuilder(EntityRepository $repository): QueryBuilder;
+    public function createFilteredQueryBuilder(EntityRepository $repository, string $query): QueryBuilder;
 
     /**
      * Returns the "choice_label" used to display this entity.
@@ -39,13 +39,6 @@ interface EntityAutocompleterInterface
      * Returns the "value" attribute for this entity, usually the id.
      */
     public function getValue(object $entity): mixed;
-
-    /**
-     * Return an array of the fields to search.
-     *
-     * If null is returned, all fields are searched.
-     */
-    public function getSearchableFields(): ?array;
 
     /**
      * Return true if access should be granted to the autocomplete results for the current user.

--- a/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
+++ b/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
@@ -39,7 +39,7 @@ final class AutocompleteEntityTypeSubscriber implements EventSubscriberInterface
         // pass to AutocompleteChoiceTypeExtension
         $options['autocomplete'] = true;
         $options['autocomplete_url'] = $this->autocompleteUrl;
-        unset($options['searchable_fields'], $options['security']);
+        unset($options['searchable_fields'], $options['security'], $options['filter_query']);
 
         $form->add('autocomplete', EntityType::class, $options);
     }

--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -127,6 +128,7 @@ final class Kernel extends BaseKernel
 
         $services->set(CustomProductAutocompleter::class)
             ->public()
+            ->arg(1, new Reference('ux.autocomplete.entity_search_util'))
             ->tag(AutocompleteFormTypePass::ENTITY_AUTOCOMPLETER_TAG, [
                 'alias' => 'custom_product'
             ]);

--- a/src/Autocomplete/tests/Unit/AutocompleteResultsExecutorTest.php
+++ b/src/Autocomplete/tests/Unit/AutocompleteResultsExecutorTest.php
@@ -19,17 +19,12 @@ use Symfony\Bundle\SecurityBundle\Security\Security;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\UX\Autocomplete\AutocompleteResultsExecutor;
 use Symfony\UX\Autocomplete\Doctrine\DoctrineRegistryWrapper;
-use Symfony\UX\Autocomplete\Doctrine\EntitySearchUtil;
 use Symfony\UX\Autocomplete\EntityAutocompleterInterface;
 
 class AutocompleteResultsExecutorTest extends TestCase
 {
     public function testItExecutesTheResults()
     {
-        $entitySearchUtil = $this->createMock(EntitySearchUtil::class);
-        $entitySearchUtil->expects($this->once())
-            ->method('addSearchClause');
-
         $doctrineRegistry = $this->createMock(DoctrineRegistryWrapper::class);
         $doctrineRegistry->expects($this->any())
             ->method('getRepository')
@@ -38,7 +33,7 @@ class AutocompleteResultsExecutorTest extends TestCase
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $autocompleter = $this->createMock(EntityAutocompleterInterface::class);
         $autocompleter->expects($this->once())
-            ->method('getQueryBuilder')
+            ->method('createFilteredQueryBuilder')
             ->willReturn($queryBuilder);
         $autocompleter->expects($this->exactly(2))
             ->method('getValue')
@@ -66,7 +61,7 @@ class AutocompleteResultsExecutorTest extends TestCase
             ->method('getQuery')
             ->willReturn($mockQuery);
 
-        $executor = new AutocompleteResultsExecutor($entitySearchUtil, $doctrineRegistry);
+        $executor = new AutocompleteResultsExecutor($doctrineRegistry);
         $this->assertEquals([
             ['value' => 1, 'text' => 'Result 1'],
             ['value' => 2, 'text' => 'Result 2'],
@@ -75,7 +70,6 @@ class AutocompleteResultsExecutorTest extends TestCase
 
     public function testItExecutesSecurity()
     {
-        $entitySearchUtil = $this->createMock(EntitySearchUtil::class);
         $doctrineRegistry = $this->createMock(DoctrineRegistryWrapper::class);
 
         $autocompleter = $this->createMock(EntityAutocompleterInterface::class);
@@ -84,7 +78,6 @@ class AutocompleteResultsExecutorTest extends TestCase
             ->willReturn(false);
 
         $executor = new AutocompleteResultsExecutor(
-            $entitySearchUtil,
             $doctrineRegistry,
             $this->createMock(Security::class)
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Closes #333 
| License       | MIT

Hi!

@bendavies pointed out that it will sometimes be useful to control the entire query for the autocomplete component - e.g. to take advantage of full text search in pgsql, instead of relying on fuzzy LIKE queries.

This PR adds that ability via a new `filter_query` form option.

Usage in the docs.

Cheers!