### PR TITLE
fixing name for css import

### DIFF
--- a/src/LiveComponent/assets/package.json
+++ b/src/LiveComponent/assets/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@symfony/live-component",
+    "name": "@symfony/ux-live-component",
     "description": "Live Component: bring server-side re-rendering & model binding to any element.",
     "main": "dist/live_controller.js",
     "module": "dist/live_controller.js",
@@ -14,7 +14,7 @@
                 "fetch": "eager",
                 "enabled": true,
                 "autoimport": {
-                    "@symfony/live-component/styles/live.css": true
+                    "@symfony/ux-live-component/styles/live.css": true
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | none
| License       | MIT

Thanks to Flex, the Node package will match the PHP package's name. Thus, it is `@symfony/ux-live-component`. The `name` key being wrong is meaningless, but inconsistent. But the style import caused things to fail to load.

Cheers!