### PR TITLE
Include required changes to bootstrap.js in ux-live-component docs

### DIFF
--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -90,8 +90,26 @@ Now install the library with:
     $ yarn install --force
     $ yarn watch
 
-Also make sure you have at least version 3.2 of
+Make sure you have at least version 3.2 of
 ``@symfony/stimulus-bridge`` in your ``package.json`` file.
+
+Finally, modify ``assets/bootstrap.js`` to include the ``LiveController``:
+
+.. code-block:: diff
+
+      import { startStimulusApp } from '@symfony/stimulus-bridge';
+    + import LiveController from '@symfony/ux-live-component';
+    + import '@symfony/ux-live-component/styles/live.css';
+
+      // Registers Stimulus controllers from controllers.json and in the controllers/ directory
+      export const app = startStimulusApp(require.context(
+          '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
+          true,
+          /\.[jt]sx?$/
+      ));
+
+      // register any custom, 3rd party controllers here
+    + app.register('live', LiveController);
 
 That's it! We're ready!
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

When installing ux-live-components, it did not automatically modify bootstrap.js, so installation instructions were incomplete in my experience (near-fresh Symfony 6.2 installation with stimulus working). I compared with the demo, and they had this crucial piece of JavaScript in `assets/bootstrap.js` that was required to actually make the components "live". There's no mention of this in the documentation at all. Even if some automatic process didn't happen on my machine, it's still worth mentioning in the installation instructions since the file technically belongs to the user.
