### PR TITLE
Fixing make:autocomplete-field query alias

### DIFF
--- a/src/Autocomplete/src/Resources/skeletons/AutocompleteField.tpl.php
+++ b/src/Autocomplete/src/Resources/skeletons/AutocompleteField.tpl.php
@@ -25,7 +25,7 @@ class <?php echo $class_name; ?> extends AbstractType
 
 <?php if ($variables->repositoryClassDetails) { ?>
             'query_builder' => function(<?php echo $variables->repositoryClassDetails->getShortName(); ?> $<?php echo Str::asLowerCamelCase($variables->repositoryClassDetails->getShortName()); ?>) {
-                return $<?php echo Str::asLowerCamelCase($variables->repositoryClassDetails->getShortName()); ?>->createQueryBuilder('<?php echo Str::asLowerCamelCase($variables->repositoryClassDetails->getShortName()); ?>');
+                return $<?php echo Str::asLowerCamelCase($variables->repositoryClassDetails->getShortName()); ?>->createQueryBuilder('<?php echo Str::asLowerCamelCase($variables->entityClassDetails->getShortName()); ?>');
             },
 <?php } ?>
             //'security' => 'ROLE_SOMETHING',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | none
| License       | MIT

Change:

```diff
-return $foodRepository->createQueryBuilder('foodRepository');
+return $foodRepository->createQueryBuilder('food');
```
