### PR TITLE
[Typed] Using -- instead of / in name

### DIFF
--- a/src/Typed/Resources/assets/package.json
+++ b/src/Typed/Resources/assets/package.json
@@ -7,7 +7,7 @@
         "controllers": {
             "typed": {
                 "main": "dist/controller.js",
-                "name": "symfony/ux-typed",
+                "name": "symfony--ux-typed",
                 "webpackMode": "eager",
                 "fetch": "eager",
                 "enabled": true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | none
| License       | MIT

The "/" is not normalized to -- when you define it explicitly. So we need to use -- here. This was an oversight when I set the name. @symfony/stimulus-bridge could also be changed to normalize this. But let's fix it here now.