### PR TITLE
[Typed] Updating note - stimulus-bridge 3.2.1 is needed for custom names

### DIFF
--- a/src/Typed/Resources/doc/index.rst
+++ b/src/Typed/Resources/doc/index.rst
@@ -29,7 +29,7 @@ Then install the bundle using Composer and Symfony Flex:
     $ yarn install --force
     $ yarn watch
 
-Also make sure you have at least version 3.2 of
+Also make sure you have at least version 3.2.1 of
 `@symfony/stimulus-bridge`_ in your ``package.json`` file.
 
 Usage


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | none
| License       | MIT

Version 3.2.1 fixed a bug where the `/` wasn't normalized in the custom controller name.