### PR TITLE
[UXSite] Improve color contrast between form inputs and placeholders

### DIFF
--- a/ux.symfony.com/assets/styles/_type.scss
+++ b/ux.symfony.com/assets/styles/_type.scss
@@ -220,3 +220,7 @@ h4.ubuntu {
     box-shadow: 2px 3px 9px 4px rgb(0 0 0 / 12%);
 }
 
+.form-control::placeholder {
+    color: $n-300;
+    font-weight: lighter;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no 
| License       | MIT

The contrast between input values and/or placeholder texts was a bit light

(exemple: https://ux.symfony.com/live-component/demos/form-collection-type)

Before : 
<img width="1170" alt="before" src="https://user-images.githubusercontent.com/1359581/174460388-7f17e214-ebd7-4354-8f9e-1c07b95c246b.png">

After : 

<img width="764" alt="after" src="https://user-images.githubusercontent.com/1359581/174460391-0c184305-8e29-43d8-9508-d28602a4ee0f.png">

