### PR TITLE
[UxSite] fixing minor markup problems with the ux site

### DIFF
--- a/ux.symfony.com/assets/styles/_container.scss
+++ b/ux.symfony.com/assets/styles/_container.scss
@@ -151,16 +151,16 @@
 .file-tree ul {
   position: relative;
 }
-.file-tree ul :not(summary) {
+.file-tree ul :not(span) {
   margin-left: 20px;
 }
-.file-tree ul summary {
+.file-tree ul span {
   display: inline;
 }
 .file-tree .tooltip-inner {
     max-width: 350px;
 }
-.file-tree.nodots ul :not(summary) {
+.file-tree.nodots ul :not(span) {
   margin-left: 12px;
 }
 .file-tree ul::before,
@@ -176,7 +176,7 @@
 }
 
 .file-tree.nodots ul::before,
-.file-tree.nodots ul>:not(summary)::before {
+.file-tree.nodots ul>:not(span)::before {
   background-image: none;
 }
 .file-tree ul::before {

--- a/ux.symfony.com/templates/_main_nav.html.twig
+++ b/ux.symfony.com/templates/_main_nav.html.twig
@@ -28,7 +28,7 @@
                     <a class="dropdown-item" href="{{ path(package.route) }}">
                         <div class="d-flex">
                             <div class="nav-component-img d-flex justify-content-center align-items-center me-2" style="background: {{ package.gradient }}">
-                                <img width="10px" height="10px" src="{{ asset('build/images/'~package.imageFilename) }}" alt="Image for the {{ package.humanName }} UX package">
+                                <img width="10" height="10" src="{{ asset('build/images/'~package.imageFilename) }}" alt="Image for the {{ package.humanName }} UX package">
                             </div>
                             {{ package.humanName }}
                         </div>

--- a/ux.symfony.com/templates/main/_componentsList.html.twig
+++ b/ux.symfony.com/templates/main/_componentsList.html.twig
@@ -5,14 +5,14 @@
                 <div class="row p-4" style="min-height: 165px;">
                     <div class="col-12 col-md-2">
                         <div class="component-img d-flex justify-content-center align-items-center me-md-2" style="background: {{ package.gradient }}">
-                            <img width="36px" height="36px" src="{{ asset('build/images/'~package.imageFilename) }}" alt="Image for the {{ package.humanName }} UX package">
+                            <img width="36" height="36" src="{{ asset('build/images/'~package.imageFilename) }}" alt="Image for the {{ package.humanName }} UX package">
                         </div>
                     </div>
                     <div class="col-12 col-md-10">
                         <div class="mt-3 mt-md-0 ms-md-3">
                             <h3 class="d-inline">{{ package.humanName }}</h3>
                             <i class="fa-solid fa-arrow-right-long component-arrow ms-2" style="font-size: 20px;"></i>
-                            <p>{{ package.description|markdown_to_html }}</p>
+                            {{ package.description|markdown_to_html }}
                         </div>
                     </div>
                 </div>

--- a/ux.symfony.com/templates/main/_fileTreeLevel.html.twig
+++ b/ux.symfony.com/templates/main/_fileTreeLevel.html.twig
@@ -7,10 +7,10 @@
 {% for fileInfo in files %}
     {% if fileInfo.isDirectory %}
         <li class="file-tree-main">
-            <summary {{- _self.summaryAttributes(fileInfo.description) -}}>
+            <span {{- _self.summaryAttributes(fileInfo.description) -}}>
                 <i class="fas fa-folder-open pe-2"></i>
                 {{ fileInfo.filename }}
-            </summary>
+            </span>
 
             <ul class="list-unstyled">
                 {{ include('main/_fileTreeLevel.html.twig', {
@@ -20,9 +20,9 @@
         </li>
     {% else %}
         <li class="file-tree-main">
-            <summary {{- _self.summaryAttributes(fileInfo.description) -}}>
+            <span {{- _self.summaryAttributes(fileInfo.description) -}}>
                 <i class="fas fa-folder pe-2"></i>{{ fileInfo.filename }}
-            </summary>
+            </span>
         </li>
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

Fixing minor markup issues with the UX homepage. There is a "quirk" with how the page scrolls after clicking a component link on the homepage (for most it doesn't scroll to the top) that may be caused by the extra `<p>` tags (the markdown parser adds a 2nd set of p tags, so they were nested, and nobody likes p tags inside p tags).

Cheers!