### PR TITLE
[Autocomplete] Not destroyed on disconnect()

### DIFF
--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -39,6 +39,10 @@ export default class extends Controller {
         this.tomSelect = this.#createAutocomplete();
     }
 
+    disconnect() {
+        this.tomSelect.destroy();
+    }
+
     #getCommonConfig(): Partial<TomSettings> {
         const plugins: any = {}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #366
| License       | MIT

Call the `destroy()` method from TomSelect on `disconnect` event of the Controller. (https://tom-select.js.org/docs/api/)