### PR TITLE
Allow to use react_component without props

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 import TomSelect from 'tom-select';
 
-/*! *****************************************************************************
+/******************************************************************************
 Copyright (c) Microsoft Corporation.
 
 Permission to use, copy, modify, and/or distribute this software for any
@@ -41,6 +41,9 @@ class default_1 extends Controller {
             return;
         }
         this.tomSelect = __classPrivateFieldGet(this, _instances, "m", _createAutocomplete).call(this);
+    }
+    disconnect() {
+        this.tomSelect.destroy();
     }
     get selectElement() {
         if (!(this.element instanceof HTMLSelectElement)) {

--- a/src/React/Resources/assets/dist/render_controller.js
+++ b/src/React/Resources/assets/dist/render_controller.js
@@ -7,6 +7,7 @@ var createRoot;
 var m = require$$0;
 if (process.env.NODE_ENV === 'production') {
   createRoot = m.createRoot;
+  m.hydrateRoot;
 } else {
   var i = m.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
   createRoot = function(c, o) {
@@ -21,23 +22,29 @@ if (process.env.NODE_ENV === 'production') {
 
 class default_1 extends Controller {
     connect() {
-        this._dispatchEvent('react:connect', { component: this.componentValue, props: this.propsValue });
+        const props = this.propsValue ? this.propsValue : null;
+        this._dispatchEvent('react:connect', { component: this.componentValue, props: props });
         const component = window.resolveReactComponent(this.componentValue);
-        this._renderReactElement(React.createElement(component, this.propsValue, null));
+        this._renderReactElement(React.createElement(component, props, null));
         this._dispatchEvent('react:mount', {
             componentName: this.componentValue,
             component: component,
-            props: this.propsValue,
+            props: props,
         });
     }
     disconnect() {
         this.element.root.unmount();
-        this._dispatchEvent('react:unmount', { component: this.componentValue, props: this.propsValue });
+        this._dispatchEvent('react:unmount', {
+            component: this.componentValue,
+            props: this.propsValue ? this.propsValue : null,
+        });
     }
     _renderReactElement(reactElement) {
-        const root = createRoot(this.element);
-        root.render(reactElement);
-        this.element.root = root;
+        const element = this.element;
+        if (!element.root) {
+            element.root = createRoot(this.element);
+        }
+        element.root.render(reactElement);
     }
     _dispatchEvent(name, payload) {
         this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));

--- a/src/React/Resources/assets/test/render_controller.test.tsx
+++ b/src/React/Resources/assets/test/render_controller.test.tsx
@@ -34,8 +34,8 @@ const startStimulus = () => {
     application.register('react', ReactController);
 };
 
-function ReactComponent(props: { fullName: string }) {
-    return <div>Hello {props.fullName}</div>;
+function ReactComponent(props: { fullName?: string }) {
+    return <div>Hello {props.fullName ? props.fullName : 'without props'}</div>;
 }
 
 (window as any).resolveReactComponent = () => {
@@ -43,22 +43,14 @@ function ReactComponent(props: { fullName: string }) {
 };
 
 describe('ReactController', () => {
-    let container: any;
-
-    beforeEach(() => {
-        container = mountDOM(`
+    it('connect with props', async () => {
+        const container = mountDOM(`
           <div data-testid="component"
               data-controller="check react"
               data-react-component-value="ReactComponent"
               data-react-props-value="{&quot;fullName&quot;: &quot;Titouan Galopin&quot;}" />
         `);
-    });
 
-    afterEach(() => {
-        clearDOM();
-    });
-
-    it('connect', async () => {
         const component = getByTestId(container, 'component');
         expect(component).not.toHaveClass('connected');
         expect(component).not.toHaveClass('mounted');
@@ -67,5 +59,26 @@ describe('ReactController', () => {
         await waitFor(() => expect(component).toHaveClass('connected'));
         await waitFor(() => expect(component).toHaveClass('mounted'));
         await waitFor(() => expect(component.innerHTML).toEqual('<div>Hello Titouan Galopin</div>'));
+
+        clearDOM();
+    });
+
+    it('connect without props', async () => {
+        const container = mountDOM(`
+          <div data-testid="component" id="container-2"
+              data-controller="check react"
+              data-react-component-value="ReactComponent" />
+        `);
+
+        const component = getByTestId(container, 'component');
+        expect(component).not.toHaveClass('connected');
+        expect(component).not.toHaveClass('mounted');
+
+        startStimulus();
+        await waitFor(() => expect(component).toHaveClass('connected'));
+        await waitFor(() => expect(component).toHaveClass('mounted'));
+        await waitFor(() => expect(component.innerHTML).toEqual('<div>Hello without props</div>'));
+
+        clearDOM();
     });
 });

--- a/src/React/Tests/Twig/ReactComponentExtensionTest.php
+++ b/src/React/Tests/Twig/ReactComponentExtensionTest.php
@@ -41,4 +41,20 @@ class ReactComponentExtensionTest extends TestCase
             $rendered
         );
     }
+
+    public function testRenderComponentWithoutProps()
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+
+        /** @var ReactComponentExtension $extension */
+        $extension = $kernel->getContainer()->get('test.twig.extension.react');
+
+        $rendered = $extension->renderReactComponent($kernel->getContainer()->get('test.twig'), 'SubDir/MyComponent');
+
+        $this->assertSame(
+            'data-controller="symfony--ux-react--react" data-symfony--ux-react--react-component-value="SubDir&#x2F;MyComponent"',
+            $rendered
+        );
+    }
 }

--- a/src/React/Twig/ReactComponentExtension.php
+++ b/src/React/Twig/ReactComponentExtension.php
@@ -40,9 +40,11 @@ class ReactComponentExtension extends AbstractExtension
 
     public function renderReactComponent(Environment $env, string $componentName, array $props = []): string
     {
-        return $this->stimulusExtension->renderStimulusController($env, '@symfony/ux-react/react', [
-            'component' => $componentName,
-            'props' => $props,
-        ]);
+        $params = ['component' => $componentName];
+        if ($props) {
+            $params['props'] = $props;
+        }
+
+        return $this->stimulusExtension->renderStimulusController($env, '@symfony/ux-react/react', $params);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix https://github.com/symfony/ux/issues/364
| License       | MIT

Allow to use react_component without props:

```twig
<div {{ react_component('MyComponent') }}></div>
```