### PR TITLE
[UxSite] example tabbed-terminal block

### DIFF
--- a/ux.symfony.com/assets/app.js
+++ b/ux.symfony.com/assets/app.js
@@ -10,6 +10,7 @@ import './bootstrap';
 // imported to initialize global plugins
 import Dropdown from 'bootstrap/js/dist/dropdown';
 import Collapse from 'bootstrap/js/dist/collapse';
+import Tab from 'bootstrap/js/dist/tab';
 
 // initialize symfony/ux-react
 registerReactControllerComponents(require.context('./react/controllers', true, /\.(j|t)sx?$/));

--- a/ux.symfony.com/assets/styles/_navigation.scss
+++ b/ux.symfony.com/assets/styles/_navigation.scss
@@ -1,0 +1,18 @@
+.nav-tabs {
+    border-bottom: 1px solid $n-900;
+}
+
+.nav-tabs .nav-link.active, .nav-tabs .nav-item.show .nav-link {
+    color: #fff;
+    background-color: $n-800;
+    border-color: $n-800;
+}
+
+.nav-link {
+    color: #fff;
+}
+
+.nav-tabs .nav-link:hover, .nav-tabs .nav-link:focus {
+    border-color: $n-800;
+    color: $n-100;
+}

--- a/ux.symfony.com/assets/styles/_terminal.scss
+++ b/ux.symfony.com/assets/styles/_terminal.scss
@@ -8,7 +8,7 @@
 .terminal-code {
     background-color: $n-900;
     border-radius: 12px;
-    padding: 10px 0px 0px 0px;
+    padding: 0px;
     color: #fff;
     font-size: 12px;
 }
@@ -53,6 +53,11 @@
 }
 .terminal-code.terminal-code-no-filename .terminal-body {
     border-radius: 12px;
+}
+/* for tabbed terminal blocks */
+.terminal-code .terminal-code.terminal-code-no-filename .terminal-body {
+    border-top-right-radius: 0;
+    border-top-left-radius: 0;
 }
 .homepage-terminal-swapper pre {
     margin-bottom: 0;

--- a/ux.symfony.com/assets/styles/app.scss
+++ b/ux.symfony.com/assets/styles/app.scss
@@ -2,6 +2,7 @@
 @import '~bootstrap';
 
 @import './container';
+@import './navigation';
 @import './images';
 @import './type';
 @import './terminal';

--- a/ux.symfony.com/templates/components/code_block.html.twig
+++ b/ux.symfony.com/templates/components/code_block.html.twig
@@ -2,7 +2,7 @@
     class: this.classString,
 }) }}>
     {% if showFilename %}
-        <p class="pb-2 ps-4 mb-0">{{ filename }}</p>
+        <p class="py-2 ps-4 mb-0">{{ filename }}</p>
     {% endif %}
     <div class="terminal-body ps-4" style="height: {{ height }}; overflow: auto;">
         <pre class="pt-2">

--- a/ux.symfony.com/templates/liveDemoBase.html.twig
+++ b/ux.symfony.com/templates/liveDemoBase.html.twig
@@ -16,6 +16,7 @@
     {% endfor %}
 
     <div class="container-fluid container-xxl px-5 pt-5">
+        {% block code_block_full %}
         <div class="arrow mb-3 d-none d-md-block"></div>
 
         <div class="row mb-5">
@@ -26,6 +27,7 @@
                 {% block code_block_right %}{% endblock %}
             </div>
         </div>
+        {% endblock %}
 
         <div class="p-4 markdown-container rainbow-gradient mt-5" id="demo" style="position: relative;">
                 <div class="arrow-2 mb-3 d-sm-block" style="position:absolute; top:-55px; right: -25px;"></div>

--- a/ux.symfony.com/templates/live_component_demo/dependent_form_fields.html.twig
+++ b/ux.symfony.com/templates/live_component_demo/dependent_form_fields.html.twig
@@ -1,19 +1,44 @@
 {% extends 'liveDemoBase.html.twig' %}
 
-{% block code_block_left %}
-    {% component code_block with { filename: 'src/Twig/MealPlannerComponent.php', height: '300px' } %}
-        {% block content %}
-            {{- source('@src/Twig/MealPlannerComponent.php')|cleanup_php_file -}}
-        {% endblock %}
-    {% endcomponent %}
-{% endblock %}
-
-{% block code_block_right %}
-    {% component code_block with { filename: 'templates/components/registration_form.html.twig', height: '300px' } %}
-        {% block content %}
-            {{- source('components/meal_planner.html.twig') -}}
-        {% endblock %}
-    {% endcomponent %}
+{% block code_block_full %}
+<div class="row mb-5">
+    <div class="terminal-code">
+        <ul class="nav nav-tabs">
+          <li class="nav-item" role="presentation">
+            <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#demo_component" type="button" role="tab" aria-controls="demo_component" aria-selected="true">src/Twig/MealPlannerComponent.php</a>
+          </li>
+          <li class="nav-item" role="presentation">
+              <button class="nav-link" data-bs-toggle="tab" data-bs-target="#demo_template" type="button" role="tab" aria-controls="demo_template">templates/components/registration_form.html.twig</a>
+          </li>
+          <li class="nav-item" role="presentation">
+              <button class="nav-link" data-bs-toggle="tab" data-bs-target="#demo_form" type="button" role="tab" aria-controls="demo_form">src/Form/MealPlannerForm.php</a>
+          </li>
+        </ul>
+        <div class="tab-content" id="code-tabs">
+            <div class="tab-pane show active" id="demo_component">
+                {% component code_block with { filename: 'src/Twig/MealPlannerComponent.php', showFilename: false, height: '300px' } %}
+                    {% block content %}
+                        {{- source('@src/Twig/MealPlannerComponent.php')|cleanup_php_file -}}
+                    {% endblock %}
+                {% endcomponent %}
+            </div>
+            <div class="tab-pane" id="demo_template">
+                {% component code_block with { filename: 'templates/components/meal_planner.html.twig', showFilename: false, height: '300px' } %}
+                    {% block content %}
+                        {{- source('components/meal_planner.html.twig') -}}
+                    {% endblock %}
+                {% endcomponent %}
+            </div>
+            <div class="tab-pane" id="demo_form">
+                {% component code_block with { filename: 'src/Form/MealPlannerForm.php', showFilename: false, height: '300px' } %}
+                    {% block content %}
+                        {{- source('@src/Form/MealPlannerForm.php')|cleanup_php_file -}}
+                    {% endblock %}
+                {% endcomponent %}
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block demo_content %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

The design allows for some live component demos (that need it) to show more than 2 code blocks.

TODO:

* [x] Make dependent form fields render tab over entire area (not just right side)
* [x] Make contents dynamic again

<img width="1245" alt="Screen Shot 2022-06-30 at 12 46 39 PM" src="https://user-images.githubusercontent.com/777948/176733093-1314e2c1-ddb1-49bf-9b17-d8459dd9baca.png">
