### PR TITLE
Add information about the query search string when creating custom co…

### DIFF
--- a/src/Autocomplete/src/Resources/doc/index.rst
+++ b/src/Autocomplete/src/Resources/doc/index.rst
@@ -483,7 +483,7 @@ a :ref:`custom autocompleter <custom-autocompleter>`:
     Once you have this, generate the URL to your controller and
     pass it to the ``url`` value of the ``stimulus_controller()`` Twig
     function, or to the ``autocomplete_url`` option of your form field.
-    The search term entered by the user is passed a query parameter:
+    The search term entered by the user is passed as a query parameter called ``query``.
     ``query``
 
 Beyond ``url``, the Stimulus controller has various other values,

--- a/src/Autocomplete/src/Resources/doc/index.rst
+++ b/src/Autocomplete/src/Resources/doc/index.rst
@@ -484,7 +484,6 @@ a :ref:`custom autocompleter <custom-autocompleter>`:
     pass it to the ``url`` value of the ``stimulus_controller()`` Twig
     function, or to the ``autocomplete_url`` option of your form field.
     The search term entered by the user is passed as a query parameter called ``query``.
-    ``query``
 
 Beyond ``url``, the Stimulus controller has various other values,
 including ``tomSelectOptions``. See the `controller.ts`_ file for

--- a/src/Autocomplete/src/Resources/doc/index.rst
+++ b/src/Autocomplete/src/Resources/doc/index.rst
@@ -483,6 +483,8 @@ a :ref:`custom autocompleter <custom-autocompleter>`:
     Once you have this, generate the URL to your controller and
     pass it to the ``url`` value of the ``stimulus_controller()`` Twig
     function, or to the ``autocomplete_url`` option of your form field.
+    The search term entered by the user is passed a query parameter:
+    ``query``
 
 Beyond ``url``, the Stimulus controller has various other values,
 including ``tomSelectOptions``. See the `controller.ts`_ file for


### PR DESCRIPTION
…ntrollers

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

I was looking how to know what the user was looking (what the user typed). Easy to find with a debug bar, but I think it should be part of the documentation.