### PR TITLE
[Turbo] Fix TypeScript compilation issue... again

### DIFF
--- a/src/Turbo/Resources/assets/dist/turbo_controller.js
+++ b/src/Turbo/Resources/assets/dist/turbo_controller.js
@@ -1,7 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
-import * as Turbo from '@hotwired/turbo';
+import '@hotwired/turbo';
 
-window.Turbo = Turbo;
 class turbo_controller extends Controller {
 }
 

--- a/src/Turbo/Resources/assets/package.json
+++ b/src/Turbo/Resources/assets/package.json
@@ -19,7 +19,7 @@
         "@hotwired/stimulus": "^3.0.0"
     },
     "devDependencies": {
-        "@hotwired/turbo": "^7.0.1",
+        "@hotwired/turbo": "^7.1.0",
         "@hotwired/stimulus": "^3.0.0"
     }
 }

--- a/src/Turbo/Resources/assets/src/turbo_controller.ts
+++ b/src/Turbo/Resources/assets/src/turbo_controller.ts
@@ -8,10 +8,7 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import * as Turbo from '@hotwired/turbo';
-
-// Expose Turbo to the rest of the app to allow for dynamic Turbo calls
-window.Turbo = Turbo;
+import '@hotwired/turbo';
 
 /**
  * Empty Stimulus controller only used for Symfony Flex wiring.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

_webpack.config.js_:
```js
Encore
    ...
    .enableTypeScriptLoader()
    .enableForkedTypeScriptTypesChecking()
```

Error message on `yarn encore production`:
```
Failed to compile with 1 errors

 error  in vendor/symfony/ux-turbo/Resources/assets/src/turbo_controller.ts:14:8                                                                                                    11:22:22

TS2339: Property 'Turbo' does not exist on type 'Window & typeof globalThis'.
    12 |
    13 | // Expose Turbo to the rest of the app to allow for dynamic Turbo calls
  > 14 | window.Turbo = Turbo;
       |        ^^^^^
    15 |
    16 | /**
    17 |  * Empty Stimulus controller only used for Symfony Flex wiring.
```

Previously, #331 proposed a different solution, but it was rejected due to the changes already being prepared in hotwired/turbo#280. At the moment, the changes in the second package have been made, as a result of which it is possible to change lines that cause a compilation error.