### PR TITLE
[LiveComponent] Fixing bug with <form data-model not set to any value

### DIFF
--- a/src/LiveComponent/assets/src/dom_utils.ts
+++ b/src/LiveComponent/assets/src/dom_utils.ts
@@ -75,8 +75,8 @@ export function getModelDirectiveFromInput(element: HTMLElement, throwOnMissing 
         const formElement = element.closest('form');
         // require a <form data-model="*"> around elements in order to
         // activate automatic "data binding" via the "name" attribute
-        if (formElement && formElement.dataset.model) {
-            const directives = parseDirectives(formElement.dataset.model);
+        if (formElement && ('model' in formElement.dataset)) {
+            const directives = parseDirectives(formElement.dataset.model || '*');
             const directive = directives[0];
 
             if (directive.args.length > 0 || directive.named.length > 0) {

--- a/src/LiveComponent/assets/test/controller/model.test.ts
+++ b/src/LiveComponent/assets/test/controller/model.test.ts
@@ -179,7 +179,7 @@ describe('LiveController data-model Tests', () => {
     it('falls back to using the name attribute when no data-model is present and <form data-model> is ancestor', async () => {
         const test = await createTest({ color: '' }, (data: any) => `
             <div ${initComponent(data)}>
-                <form data-model="*">
+                <form data-model>
                     <input
                         name="color"
                         value="${data.color}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

An oversight from #378: you should be allowed to simply say `<form data-model>` without setting `data-model` to any value.

Cheers!