### PR TITLE
[UxSite] Fixing missing slash on image path

### DIFF
--- a/ux.symfony.com/src/Model/LiveDemo.php
+++ b/ux.symfony.com/src/Model/LiveDemo.php
@@ -34,6 +34,6 @@ class LiveDemo
 
     public function getScreenshotFilename(): string
     {
-        return 'build/images/live_demo/'.$this->identifier.'.png';
+        return '/build/images/live_demo/'.$this->identifier.'.png';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | Fix #381
| License       | MIT

It's a bit odd that it worked at all, but this fixes the problem. The code is still a pretty "cheap" way (i.e. hardcoded) to get the path, but it should work fine for now.

Cheers!