### PR TITLE
[Turbo] Make the Broadcast attribute repeatable

### DIFF
--- a/src/Turbo/Attribute/Broadcast.php
+++ b/src/Turbo/Attribute/Broadcast.php
@@ -23,7 +23,7 @@ use Symfony\UX\Turbo\Bridge\Mercure\Broadcaster;
  *
  * @experimental
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Broadcast
 {
     public const ACTION_CREATE = 'create';

--- a/src/Turbo/CHANGELOG.md
+++ b/src/Turbo/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.2
 
--   The topics defined in the Broadcast attribute now support expression language when prefixed with `@=`.
+-   The topics defined in the `Broadcast` attribute now support expression language when prefixed with `@=`.
+-   The `Broadcast` attribute can now be repeated, this is convenient to render several Turbo Streams Twig templates for the same change
 
 ## 2.1
 

--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -620,6 +620,11 @@ The ``Broadcast`` attribute comes with a set of handy options:
    is derived from the FQCN of the entity and from its id
 -  ``template`` (``string``): Twig template to render (see above)
 
+The ``Broadcast`` attribute can be repeated. This is convenient to
+to render several templates associated with their own topics for the
+same change (e.g. the same data is rendered in different way in the
+list and in the detail pages).
+
 Options are transport-specific. When using Mercure, some extra options
 are supported:
 
@@ -638,7 +643,8 @@ Example::
 
     use Symfony\UX\Turbo\Attribute\Broadcast;
 
-    #[Broadcast(topics: ['@="books_by_author_" ~ entity.author?.id', 'books'], template: 'foo.stream.html.twig', private: true)]
+    #[Broadcast(topics: ['@="book_detail" ~ entity.id', 'books'], template: 'book_detail.stream.html.twig', private: true)]
+    #[Broadcast(topics: ['@="book_list" ~ entity.id', 'books'], template: 'book_list.stream.html.twig', private: true)]
     class Book
     {
         // ...

--- a/src/Turbo/Tests/app/Entity/Song.php
+++ b/src/Turbo/Tests/app/Entity/Song.php
@@ -40,7 +40,7 @@ class Song
     public $title = '';
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Artist", inversedBy="songs")
+     * @ORM\ManyToOne(targetEntity=Artist::class, inversedBy="songs")
      *
      * @var Artist|null
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT

Allow the `Broadcast` attribute to be used many times.
This is convenient to update different pages (ex: the list and the detail page) containing the same data but rendered differently.

Ex:

```php
#[Broadcast(topics: '@="product-detail-" ~ entity.id', template: 'product-detail.stream.html.twig']
#[Broadcast(topics: '@="product-list-" ~ entity.id', template: 'product-list.stream.html.twig']
class Product
{
    public string $id;
}
```

