### PR TITLE
Changing the docs on how you customize the autocomplete css

### DIFF
--- a/src/Autocomplete/src/Resources/doc/index.rst
+++ b/src/Autocomplete/src/Resources/doc/index.rst
@@ -175,14 +175,21 @@ includes a CSS file for Tom Select.
     }
 
 This should give you basic styles for Tom Select. If you're using
-Bootstrap, you can get Bootstrap-ready styling by changing this
-line to:
+Bootstrap, you can get Bootstrap-ready styling by (A) changing this
+line to ``false``:
 
 .. code-block:: text
 
     "autoimport": {
-        "tom-select/dist/css/tom-select.bootstrap5.css": true
+        "tom-select/dist/css/tom-select.default.css": false
     }
+
+And then (B) importing the Bootstrap-css file:
+
+.. code-bock:: css
+
+    /* assets/styles/app.css
+    @import 'tom-select/dist/css/tom-select.bootstrap5.css';
 
 To further customize things, you can override the classes with your own custom
 CSS and even control how individual parts of Tom Select render. See `Tom Select Render Templates`_.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | none
| License       | MIT

The issue is that Flex really likes you to keep the same keys under `autoimport`, and will replace with the original keys. So, we keep the original keys, set to false, then import the new one manually.

I don't necessarily love this Flex behavior, but this updates the docs to reflect reality.

Cheers!