### PR TITLE
[Live][POC] Defining interface for files uploader

### DIFF
--- a/src/LiveComponent/src/UploaderInterface.php
+++ b/src/LiveComponent/src/UploaderInterface.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace Symfony\UX\LiveComponent;
+
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\File\Exception\FileException;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ *
+ * @experimental
+ */
+interface UploaderInterface
+{
+    /**
+     * Create full URL for an existing file preview.
+     *
+     * @param  string  $path
+     * @return string
+     *
+     * @throws NotFoundHttpException
+     */
+    public function createExistingFilePreviewUrl(string $path): string;
+
+    /**
+     * Create a URL to preview temporary file.
+     *
+     * If the file is in publicly accessible place it might return full URL for a preview,
+     * otherwise a URL to an endpoint consuming `previewTemporaryFile` should be returned.
+     *
+     * @param  File  $file
+     * @return string
+     *
+     * @throws NotFoundHttpException
+     */
+    public function createTemporaryFilePreviewUrl(File $file): string;
+
+    /**
+     * Create binary response for a file in temporary place.
+     *
+     * Temporary files might not be directly accessible, so preview method needs to return full binary response.
+     *
+     * @param  File  $file
+     * @return BinaryFileResponse
+     *
+     * @throws FileException
+     * @throws NotFoundHttpException
+     */
+    public function previewTemporaryFile(File $file): BinaryFileResponse;
+
+    /**
+     * Save temporary file to persistent storage space.
+     *
+     * When $constraints are defined it should call `validateFile` before save.
+     * When validation fails it should throw *before* saving file.
+     * It is advised to validate files when moving to temporary storage.
+     * This parameter should only be used when files are stored directly to the persistent storage.
+     *
+     * The format of `$manipulators` is TBD - it might be based on Glide (current/next),
+     * directly intervention image library (current/next - 3.0 looks promising).
+     * Leaving for now as a parameter with format to be determined.
+     * Maybe another interface to unify different possible solutions and allow easier extension?
+     *
+     * When `$manipulators` are provided - all the transformations
+     * should be applied *before* saving to temporary place.
+     *
+     * @param  File                   $temporaryFile
+     * @param  string                 $pathPattern  Path pattern where the file should be stored.
+     *                                              Can contain placeholders for easier usage (e.g. [name], [ulid] or else - TBD)
+     * @param  Constraint|array|null  $constraints
+     * @param  array|null             $manipulators
+     * @return File
+     */
+    public function saveTemporaryFile(
+        File $temporaryFile,
+        string $pathPattern,
+        Constraint|array|null  $constraints = null,
+        ?array $manipulators = null
+    ): File;
+
+    /**
+     * Save file to a temporary place.
+     *
+     * When $constraints are defined it should call `validateFile` before save.
+     * When validation fails it should throw *before* saving file to the temporary place.
+     *
+     * The format of `$manipulators` is TBD - it might be based on Glide (current/next),
+     * directly intervention image library (current/next - 3.0 looks promising).
+     * Leaving for now as a parameter with format to be determined.
+     * Maybe another interface to unify different possible solutions and allow easier extension?
+     *
+     * When `$manipulators` are provided - all the transformations
+     * should be applied *before* saving to temporary place.
+     *
+     * @param  UploadedFile           $uploadedFile
+     * @param  Constraint|array|null  $constraints
+     * @param  array|null             $manipulators TBD - an array of manipulations to be applied before saving.
+     * @return File
+     *
+     * @throws FileException
+     * @throws ValidationFailedException
+     */
+    public function saveUploadedFileToTemp(
+        UploadedFile $uploadedFile,
+        Constraint|array|null $constraints = null,
+        ?array $manipulators = null
+    ): File;
+
+    /**
+     * Validates file and throws exception when it fails.
+     *
+     * It should be called by saveFileToTemp when $constraints parameter is not null,
+     * but public method also exists to allow developers for simplified validation.
+     *
+     * @param  File                     $file
+     * @param  Constraint|Constraint[]  $constraints
+     * @return void
+     *
+     * @throws ValidationFailedException
+     */
+    public function validateFile(File $file, Constraint|array $constraints): void;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | n/a
| License       | MIT

This is an attempt to define interface(s) that would allow fully working file upload system and allow high level of customization. The idea comes from discussion in #395 and is by no means finished. We need to start somewhere :)

I was trying to achieve interface with parameters that can be easily defined with attributes and then utilized by library, so that developers won't need to use uploaders directly in most common cases. The problem with `File` serialization might be one of the more difficult topics to explore.

Regarding initial requirements from the discussion by @tgalopin 

>    the ability to store files in different places (locally, S3, CDN, ...) ;

Definitely doable by implementing service (temporary and final storage can differ).

>    the ability to validate files easily (covered by Validator in this PR, which is great) ;

As easy as possible - by defining set of validator constraints (that can easily come from attributes) and utilizing Validator exception

>    the ability to manipulate files before they are stored (resize images, encode them to JPG, decrease the quality, ... to save space) ;

This one needs some discussion as I have no clear vision here. We could go with another interface or focus on a single library (Glide or directly Intervention maybe?).

>    the ability to invalidate HTTP cache (ie. I want each file to have a unique name so that cache is automatically invalidated on upload, and I want to be able to store this name in my database) ;

I think temporary files names should be unique, but implementation may choose whatever solution suits them.

TODOs / problems
===============
- [ ] No clear vision for file manipulators (probably just image files)
- [ ] There might be an issue with using `File` class and custom storage. For example - with Flysystem extended `File` object needs reference to the `FilesystemOperator`, which makes it not serializable. We might need intermediate object and method to (de-)hydrate it.
- [ ] Is that all we need? :wink: 