### PR TITLE
Removing unnecessary double slashes in docs

### DIFF
--- a/src/Autocomplete/src/Resources/doc/index.rst
+++ b/src/Autocomplete/src/Resources/doc/index.rst
@@ -370,7 +370,7 @@ endpoint and then :ref:`initialize the Stimulus controller manually <manual-stim
 This only works for Doctrine entities: see `Manually using the Stimulus Controller`_
 if you're autocompleting something other than an entity.
 
-To expose the endpoint, create a class that implements ``Symfony\\UX\\Autocomplete\\EntityAutocompleterInterface``::
+To expose the endpoint, create a class that implements ``Symfony\UX\Autocomplete\EntityAutocompleterInterface``::
 
     namespace App\Autocompleter;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

Double slashes are not needed inside normal ticks - an oversight on my part.