### PR TITLE
Unset TomSelect after destroying the Stimulus Controller

### DIFF
--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -41,6 +41,8 @@ export default class extends Controller {
 
     disconnect() {
         this.tomSelect.destroy();
+        // Fixes https://github.com/symfony/ux/issues/407
+        this.tomSelect = undefined;
     }
 
     #getCommonConfig(): Partial<TomSettings> {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | [407](https://github.com/symfony/ux/issues/407)
| License       | MIT

Sometimes Stimulus re-uses an instance of a controller after it's destroyed and re-created - for example when a Live Twig Component re-renders. Without unsetting the variable, [connect() method thinks TomSelect is already in place, and does nothing](https://github.com/symfony/ux/blob/2.x/src/Autocomplete/assets/src/controller.ts#L21-L25).
