### PR TITLE
[LiveComponent] Add missing ComponentWithFormTrait in docs

### DIFF
--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -774,10 +774,12 @@ make it easy to deal with forms::
     use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
     use Symfony\UX\LiveComponent\Attribute\LiveProp;
     use Symfony\UX\LiveComponent\ComponentWithFormTrait;
+    use Symfony\UX\LiveComponent\DefaultActionTrait;
 
     #[AsLiveComponent('post_form')]
     class PostFormComponent extends AbstractController
     {
+        use DefaultActionTrait;
         use ComponentWithFormTrait;
 
         /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

The Live Form is missing a trait that's needed for it to work.