### PR TITLE
[LiveComponent] Add missing default action in docs

### DIFF
--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -779,6 +779,14 @@ make it easy to deal with forms::
     class PostFormComponent extends AbstractController
     {
         use ComponentWithFormTrait;
+        
+        /**
+         * Default action. Should not return anything.
+         * Use it to add annotations or attributes to the component (#[Security] and #[Cache])
+         */
+        public function __invoke(): void
+        {
+        }
 
         /**
          * The initial data used to create the form.


### PR DESCRIPTION
Add missing default action in docs about FormCollection example. Without you got an error after copy pasting the example; resulting in bad DX.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

Other option is to use the DefaultActionTrait but I think it is better to hint developers about the fact that you need to set `#[Security]`-attributes.
