### PR TITLE
[LiveComponent] Avoiding model re-renders during an action

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2.3.1
+
+-   [BEHAVIOR CHANGE] If an action Ajax call is still processing and a
+    model update occurs, the component will _no_ longer re-render. The
+    model will be updated internally, but not re-rendered (so, any
+    model updates would effectively have the `|norender` modifier). See #419.
+
 ## 2.3.0
 
 -   [BC BREAK] The `data-action="live#update"` attribute must now be


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fixes issue reported on Slack by @FrancoisPog
| License       | MIT

This is so that we can guarantee that an action's response WILL always be used. Previously, an action's response would be ignored if a model-update re-render was triggered while the action's Ajax call was completing.

Cheers!