### PR TITLE
[Autocomplete] Only add the clear_button plugin to TomSelect if the form element is not required

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -219,7 +219,7 @@ class default_1 extends Controller {
 _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _default_1_getCommonConfig() {
     const plugins = {};
     const isMultiple = !this.selectElement || this.selectElement.multiple;
-    if (!this.formElement.disabled && !isMultiple) {
+    if (!this.formElement.required && !this.formElement.disabled && !isMultiple) {
         plugins.clear_button = { title: '' };
     }
     if (isMultiple) {

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -120,7 +120,7 @@ export default class extends Controller {
 
         // multiple values excepted if this is NOT A select (i.e. input) or a multiple select
         const isMultiple = !this.selectElement || this.selectElement.multiple;
-        if (!this.formElement.disabled && !isMultiple) {
+        if (!this.formElement.required && !this.formElement.disabled && !isMultiple) {
             plugins.clear_button = { title: '' };
         }
 

--- a/src/Autocomplete/tests/Fixtures/Form/ProductType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/ProductType.php
@@ -46,6 +46,16 @@ class ProductType extends AbstractType
                 'autocomplete' => true,
                 'mapped' => false,
             ])
+            ->add('colour', ChoiceType::class, [
+                'choices' => [
+                    'red' => 'red',
+                    'blue' => 'blue',
+                    'green' => 'green',
+                ],
+                'autocomplete' => true,
+                'mapped' => false,
+                'required' => false,
+            ])
             ->add('tags', TextType::class, [
                 'mapped' => false,
                 'autocomplete' => true,

--- a/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
+++ b/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
@@ -34,10 +34,21 @@ class AutocompleteFormRenderingTest extends KernelTestCase
             ->assertElementAttributeContains('#product_category', 'data-symfony--ux-autocomplete--autocomplete-url-value', '/test/autocomplete/category_autocomplete_type?extra_options=')
             ->assertElementAttributeContains('#product_category', 'data-symfony--ux-autocomplete--autocomplete-min-characters-value', '2')
             ->assertElementAttributeContains('#product_category', 'data-symfony--ux-autocomplete--autocomplete-max-results-value', '25')
+            ->assertElementAttributeContains('#product_category', 'required', 'required')
+
+            ->assertElementAttributeContains('#product_ingredients', 'required', 'required')
 
             ->assertElementAttributeContains('#product_portionSize', 'data-controller', 'symfony--ux-autocomplete--autocomplete')
+            ->assertElementAttributeContains('#product_portionSize', 'required', 'required')
+
+            ->assertElementAttributeContains('#product_colour', 'data-controller', 'symfony--ux-autocomplete--autocomplete')
+            // not implemented in zenstruck/browser
+            // ->elementAttributeNotExists('#product_colour', 'required')
+            ->assertNotSeeElement('#product_colour[required]')
+
             ->assertElementAttributeContains('#product_tags', 'data-controller', 'symfony--ux-autocomplete--autocomplete')
             ->assertElementAttributeContains('#product_tags', 'data-symfony--ux-autocomplete--autocomplete-tom-select-options-value', 'createOnBlur')
+            ->assertElementAttributeContains('#product_tags', 'required', 'required')
         ;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fixes #402
| License       | MIT

Only add the `clear_button` plugin to TomSelect if the form element is not required