### PR TITLE
[ChartJS] Fix failing build with ChartJS >= 3.9.0

### DIFF
--- a/src/Chartjs/Resources/assets/dist/controller.js
+++ b/src/Chartjs/Resources/assets/dist/controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
-import { Chart } from 'chart.js';
+import { Chart, registerables } from 'chart.js';
 
+Chart.register(...registerables);
 class default_1 extends Controller {
     connect() {
         if (!(this.element instanceof HTMLCanvasElement)) {

--- a/src/Chartjs/Resources/assets/dist/controller.js
+++ b/src/Chartjs/Resources/assets/dist/controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
-import Chart from 'chart.js/auto';
+import { Chart } from 'chart.js';
 
 class default_1 extends Controller {
     connect() {

--- a/src/Chartjs/Resources/assets/src/controller.ts
+++ b/src/Chartjs/Resources/assets/src/controller.ts
@@ -10,7 +10,7 @@
 'use strict';
 
 import { Controller } from '@hotwired/stimulus';
-import Chart from 'chart.js/auto';
+import { Chart } from 'chart.js';
 
 export default class extends Controller {
     readonly viewValue: any;

--- a/src/Chartjs/Resources/assets/src/controller.ts
+++ b/src/Chartjs/Resources/assets/src/controller.ts
@@ -10,7 +10,8 @@
 'use strict';
 
 import { Controller } from '@hotwired/stimulus';
-import { Chart } from 'chart.js';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
 
 export default class extends Controller {
     readonly viewValue: any;

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1084,8 +1084,8 @@ function getModelDirectiveFromInput(element, throwOnMissing = true) {
     }
     if (element.getAttribute('name')) {
         const formElement = element.closest('form');
-        if (formElement && formElement.dataset.model) {
-            const directives = parseDirectives(formElement.dataset.model);
+        if (formElement && ('model' in formElement.dataset)) {
+            const directives = parseDirectives(formElement.dataset.model || '*');
             const directive = directives[0];
             if (directive.args.length > 0 || directive.named.length > 0) {
                 throw new Error(`The data-model="${formElement.dataset.model}" format is invalid: it does not support passing arguments to the model.`);
@@ -1222,9 +1222,7 @@ class default_1 extends Controller {
         if (!(this.element instanceof HTMLElement)) {
             throw new Error('Invalid Element Type');
         }
-        if (this.element.dataset.poll !== undefined) {
-            this._initiatePolling(this.element.dataset.poll);
-        }
+        this._initiatePolling();
         window.addEventListener('beforeunload', this.markAsWindowUnloaded);
         this._startAttributesMutationObserver();
         this.element.addEventListener('live:update-model', this.handleUpdateModelEvent);
@@ -1234,9 +1232,7 @@ class default_1 extends Controller {
         this._dispatchEvent('live:connect', { controller: this });
     }
     disconnect() {
-        this.pollingIntervals.forEach((interval) => {
-            clearInterval(interval);
-        });
+        this._stopAllPolling();
         window.removeEventListener('beforeunload', this.markAsWindowUnloaded);
         this.element.removeEventListener('live:update-model', this.handleUpdateModelEvent);
         this.element.removeEventListener('input', this.handleInputEvent);
@@ -1665,7 +1661,12 @@ class default_1 extends Controller {
         }
         this._updateModelFromElement(target, 'change');
     }
-    _initiatePolling(rawPollConfig) {
+    _initiatePolling() {
+        this._stopAllPolling();
+        if (this.element.dataset.poll === undefined) {
+            return;
+        }
+        const rawPollConfig = this.element.dataset.poll;
         const directives = parseDirectives(rawPollConfig || '$render');
         directives.forEach((directive) => {
             let duration = 2000;
@@ -1790,9 +1791,12 @@ class default_1 extends Controller {
         const element = this.element;
         this.mutationObserver = new MutationObserver((mutations) => {
             mutations.forEach((mutation) => {
-                if (mutation.type === 'attributes' && !element.dataset.originalData) {
-                    this.originalDataJSON = this.valueStore.asJson();
-                    this._exposeOriginalData();
+                if (mutation.type === 'attributes') {
+                    if (!element.dataset.originalData) {
+                        this.originalDataJSON = this.valueStore.asJson();
+                        this._exposeOriginalData();
+                    }
+                    this._initiatePolling();
                 }
             });
         });
@@ -1802,6 +1806,11 @@ class default_1 extends Controller {
     }
     getDefaultDebounce() {
         return this.hasDebounceValue ? this.debounceValue : DEFAULT_DEBOUNCE;
+    }
+    _stopAllPolling() {
+        this.pollingIntervals.forEach((interval) => {
+            clearInterval(interval);
+        });
     }
 }
 default_1.values = {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->

Fix the failing builds like https://github.com/symfony/ux/runs/7813370449?check_suite_focus

If running with ChartJS < 3.9.0, the build passes, not sure where it comes from but changing the way we import fixes it.

When I builded locally, it changed some other files which I included here. Those changes seem mostly like syntax changes.