### PR TITLE
[LiveComponent] Fix live component rendering when loaded from bfcache

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1238,17 +1238,13 @@ class default_1 extends Controller {
         this.isRerenderRequested = false;
         this.requestDebounceTimeout = null;
         this.pollingIntervals = [];
-        this.isWindowUnloaded = false;
+        this.isConnected = false;
         this.originalDataJSON = '{}';
         this.mutationObserver = null;
         this.childComponentControllers = [];
         this.pendingActionTriggerModelElement = null;
-        this.markAsWindowUnloaded = () => {
-            this.isWindowUnloaded = true;
-        };
     }
     initialize() {
-        this.markAsWindowUnloaded = this.markAsWindowUnloaded.bind(this);
         this.handleUpdateModelEvent = this.handleUpdateModelEvent.bind(this);
         this.handleInputEvent = this.handleInputEvent.bind(this);
         this.handleChangeEvent = this.handleChangeEvent.bind(this);
@@ -1261,12 +1257,12 @@ class default_1 extends Controller {
         this.synchronizeValueOfModelFields();
     }
     connect() {
+        this.isConnected = true;
         this._onLoadingFinish();
         if (!(this.element instanceof HTMLElement)) {
             throw new Error('Invalid Element Type');
         }
         this._initiatePolling();
-        window.addEventListener('beforeunload', this.markAsWindowUnloaded);
         this._startAttributesMutationObserver();
         this.element.addEventListener('live:update-model', this.handleUpdateModelEvent);
         this.element.addEventListener('input', this.handleInputEvent);
@@ -1277,7 +1273,6 @@ class default_1 extends Controller {
     disconnect() {
         this._stopAllPolling();
         __classPrivateFieldGet(this, _instances, "m", _clearRequestDebounceTimeout).call(this);
-        window.removeEventListener('beforeunload', this.markAsWindowUnloaded);
         this.element.removeEventListener('live:update-model', this.handleUpdateModelEvent);
         this.element.removeEventListener('input', this.handleInputEvent);
         this.element.removeEventListener('change', this.handleChangeEvent);
@@ -1287,6 +1282,7 @@ class default_1 extends Controller {
         if (this.mutationObserver) {
             this.mutationObserver.disconnect();
         }
+        this.isConnected = false;
     }
     update(event) {
         if (event.type === 'input' || event.type === 'change') {
@@ -1944,7 +1940,7 @@ _instances = new WeakSet(), _startPendingRequest = function _startPendingRequest
         __classPrivateFieldGet(this, _instances, "m", _startPendingRequest).call(this);
     });
 }, _processRerender = function _processRerender(html, response) {
-    if (this.isWindowUnloaded) {
+    if (!this.isConnected) {
         return;
     }
     if (response.headers.get('Location')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | #510 
| License       | MIT

I have a live component with a form. On a fresh initial page load it works normally, but when I submit the form (not with ajax) and the controller redirects to another page and I come back using the browsers back button the live forms stops working. It does not re-render because of this check

https://github.com/symfony/ux/blob/73c656950c640b9a7f9aa9871356f0a24de61df7/src/LiveComponent/assets/src/live_controller.ts#L487-L490

If I comment it out, or I enable Turbo, it works. I think this is because bfcache of the browser. If I change the `beforeunload` listener to `unload` it works too, but that disables the cache.

Why we need this check? Can we leave it out? If we really need it we can use `pagehide` and `pageshow` instead. See https://webkit.org/blog/516/webkit-page-cache-ii-the-unload-event/

How to reproduce with the demo site:

- disable turbo `<html data-turbo="false">`
- open chrome incognito
- go to https://localhost:8000/
- click on "Live Components" card
- write something in the search input
- navigate back-and-forth
- try to update the search input
