### PR TITLE
[Website] Making the Mercure key longer to satisfy JWT key requirements

### DIFF
--- a/ux.symfony.com/.env
+++ b/ux.symfony.com/.env
@@ -25,7 +25,7 @@ MERCURE_URL=https://ux.symfony.com/.well-known/mercure
 # The public URL of the Mercure hub, used by the browser to connect
 MERCURE_PUBLIC_URL=https://ux.symfony.com/.well-known/mercure
 # The secret used to sign the JWTs
-MERCURE_JWT_SECRET="!ChangeMe!"
+MERCURE_JWT_SECRET="!ChangeMe!+MAKE_THE_KEY_LONG_ENOUGH"
 ###< symfony/mercure-bundle ###
 
 ###> doctrine/doctrine-bundle ###

--- a/ux.symfony.com/docker-compose.yml
+++ b/ux.symfony.com/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     restart: unless-stopped
     environment:
       SERVER_NAME: ':80'
-      MERCURE_PUBLISHER_JWT_KEY: '!ChangeMe!'
-      MERCURE_SUBSCRIBER_JWT_KEY: '!ChangeMe!'
+      MERCURE_PUBLISHER_JWT_KEY: '!ChangeMe!+MAKE_THE_KEY_LONG_ENOUGH'
+      MERCURE_SUBSCRIBER_JWT_KEY: '!ChangeMe!+MAKE_THE_KEY_LONG_ENOUGH'
       # Set the URL of your Symfony project (without trailing slash!) as value of the cors_origins directive
       MERCURE_EXTRA_DIRECTIVES: |
         cors_origins https://127.0.0.1:9044


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no (only to the website)
| New feature?  | no
| Tickets       | fixes #442 
| License       | MIT

New key validation in 4.2.0 of lcobucci/jwt - https://github.com/lcobucci/jwt/releases/tag/4.2.0 causes errors because our keys were too short. Fair enough :). The production site is already fixed, as the key is stored as a platform.sh variable (and I made the key longer there). This is just for local development.

Cheers!
