### PR TITLE
Add Vue app to the vue:mount event

### DIFF
--- a/src/Vue/Resources/assets/src/render_controller.ts
+++ b/src/Vue/Resources/assets/src/render_controller.ts
@@ -35,6 +35,13 @@ export default class extends Controller {
         if (this.element.__vue_app__ !== undefined) {
             this.element.__vue_app__.unmount();
         }
+        
+        this._dispatchEvent('vue:before-mount', {
+            componentName: this.componentValue,
+            component: component,
+            props: this.props,
+            app: this.app,
+        });
 
         this.app.mount(this.element);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | N/A
| License       | MIT

Add the Vue app to the `vue:mount` event, so that users can have access to it when hooking into the event in order to use [Vue Plugins](https://vuejs.org/guide/reusability/plugins.html#introduction) with components. Without access to the app instance, it's not possible to use plugins.
