### PR TITLE
[Autocomplete] Fix extending Tom Select when using custom Ajax class

### DIFF
--- a/src/Autocomplete/src/Resources/views/autocomplete_form_theme.html.twig
+++ b/src/Autocomplete/src/Resources/views/autocomplete_form_theme.html.twig
@@ -1,6 +1,6 @@
 {# EasyAdminAutocomplete form type #}
 {% block ux_entity_autocomplete_widget %}
-    {{ form_widget(form.autocomplete, { attr: attr|merge({ required: required }) }) }}
+    {{ form_widget(form.autocomplete, { attr: form.autocomplete.vars.attr|merge({ required: required }) }) }}
 {% endblock ux_entity_autocomplete_widget %}
 
 {% block ux_entity_autocomplete_label %}

--- a/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
@@ -38,6 +38,9 @@ class CategoryAutocompleteType extends AbstractType
                 return true;
             },
             'placeholder' => 'What should we eat?',
+            'attr' => [
+                'data-controller' => 'custom-autocomplete',
+            ],
         ]);
     }
 

--- a/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
+++ b/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
@@ -29,7 +29,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
         $this->browser()
             ->throwExceptions()
             ->get('/test-form')
-            ->assertElementAttributeContains('#product_category_autocomplete', 'data-controller', 'symfony--ux-autocomplete--autocomplete')
+            ->assertElementAttributeContains('#product_category_autocomplete', 'data-controller', 'custom-autocomplete symfony--ux-autocomplete--autocomplete')
             ->assertElementAttributeContains('#product_category_autocomplete', 'data-symfony--ux-autocomplete--autocomplete-url-value', '/test/autocomplete/category_autocomplete_type')
 
             ->assertElementAttributeContains('#product_portionSize', 'data-controller', 'symfony--ux-autocomplete--autocomplete')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #...
| License       | MIT

I have tried to follow the [documentation](https://symfony.com/bundles/ux-autocomplete/current/index.html#extending-tom-select) to extend Tom Select using a custom Stimulus controller. It worked when updating the field configuration but did not when using a custom Ajax class. In this case the core Autocomplete Stimulus controller was missing in the rendered data-controller-Tag. Changing the autocomplete form theme to use the attributes from the autocomplete field seems to fix this!