### PR TITLE
[LiveComponent] Add a modifier to validate the form input before triggering the AJAX call

### DIFF
--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -181,6 +181,11 @@ export default class extends Controller implements LiveController {
             let handled = false;
             directive.modifiers.forEach((modifier) => {
                 switch (modifier.name) {
+                    case 'validate':
+                        if (!event.currentTarget.form.reportValidity()) {
+                            handled = true;
+                        }
+                        break;
                     case 'prevent':
                         event.preventDefault();
                         break;
@@ -275,6 +280,11 @@ export default class extends Controller implements LiveController {
 
         modelDirective.modifiers.forEach((modifier) => {
             switch (modifier.name) {
+                case 'validate':
+                    if (!element.reportValidity()) {
+                        shouldRender = false;
+                    }
+                    break;
                 case 'on':
                     if (!modifier.value) {
                         throw new Error(`The "on" modifier in ${modelDirective.getString()} requires a value - e.g. on(change).`);

--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -337,6 +337,22 @@ it won't, yet, make an Ajax call to re-render the component. Whenever
 the next re-render *does* happen, the updated ``max`` value will be
 used.
 
+
+Validating the form before triggering the action
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using HTML5 form validation, you might want to avoid triggering an
+action as long as the form is invalid (for example when a required field is
+empty). To do that, use the ``validate`` modifier:
+
+.. code-block:: diff
+
+    <input
+        data-model="validate|max"
+        required="required"
+        value="{{ max }}"
+    >
+
 .. _name-attribute-model:
 
 Using name="" instead of data-model


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #441
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
