### PR TITLE
[Live] Lower the normalizer priority of `DoctrineObjectNormalizer` and fix embeddables

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/Compiler/OptionalDependencyPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/OptionalDependencyPass.php
@@ -22,7 +22,7 @@ final class OptionalDependencyPass implements CompilerPassInterface
         if ($container->hasDefinition('doctrine')) {
             $container->register('ux.live_component.doctrine_object_normalizer', DoctrineObjectNormalizer::class)
                 ->setArguments([new IteratorArgument([new Reference('doctrine')])]) // todo add other object managers (mongo)
-                ->addTag('serializer.normalizer', ['priority' => 100])
+                ->addTag('serializer.normalizer', ['priority' => -100])
             ;
         }
     }

--- a/src/LiveComponent/tests/Fixtures/Component/WithObjects.php
+++ b/src/LiveComponent/tests/Fixtures/Component/WithObjects.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Embeddable2;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Money;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Temperature;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Embeddable1;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity1;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity2;
+
+#[AsLiveComponent('with_objects')]
+final class WithObjects
+{
+    use DefaultActionTrait;
+
+    #[LiveProp]
+    public Money $money;
+
+    #[LiveProp]
+    public Temperature $temperature;
+
+    #[LiveProp]
+    public Entity1 $entity1;
+
+    #[LiveProp]
+    public Entity2 $entity2;
+
+    #[LiveProp]
+    public Embeddable1 $embeddable1;
+
+    #[LiveProp]
+    public Embeddable2 $embeddable2;
+}

--- a/src/LiveComponent/tests/Fixtures/Dto/Embeddable2.php
+++ b/src/LiveComponent/tests/Fixtures/Dto/Embeddable2.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Dto;
+
+final class Embeddable2
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Dto/Money.php
+++ b/src/LiveComponent/tests/Fixtures/Dto/Money.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Dto;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Money
+{
+    public function __construct(public int $amount, public string $currency)
+    {
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Dto/Temperature.php
+++ b/src/LiveComponent/tests/Fixtures/Dto/Temperature.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Dto;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Temperature
+{
+    public function __construct(public int $degrees, public string $uom)
+    {
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Entity/Embeddable1.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/Embeddable1.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable
+ */
+final class Embeddable1
+{
+    /**
+     * @ORM\Column
+     */
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Entity/Entity2.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/Entity2.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Embeddable2;
+
+/**
+ * @ORM\Entity
+ */
+class Entity2
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @ORM\Embedded(Embeddable1::class)
+     */
+    public Embeddable1 $embedded1;
+
+    /**
+     * @ORM\Embedded(Embeddable2::class)
+     */
+    public Embeddable2 $embedded2;
+}

--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\UX\LiveComponent\LiveComponentBundle;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Serializer\Entity2Normalizer;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Serializer\MoneyNormalizer;
 use Symfony\UX\TwigComponent\TwigComponentBundle;
 use Twig\Environment;
 
@@ -73,12 +75,19 @@ final class Kernel extends BaseKernel
                 'auto_generate_proxy_classes' => true,
                 'auto_mapping' => true,
                 'mappings' => [
-                    'Test' => [
+                    'Default' => [
                         'is_bundle' => false,
                         'type' => 'annotation',
                         'dir' => '%kernel.project_dir%/tests/Fixtures/Entity',
                         'prefix' => 'Symfony\UX\LiveComponent\Tests\Fixtures\Entity',
-                        'alias' => 'Test',
+                        'alias' => 'Default',
+                    ],
+                    'XML' => [
+                        'is_bundle' => false,
+                        'type' => 'xml',
+                        'dir' => '%kernel.project_dir%/tests/Fixtures/config/doctrine',
+                        'prefix' => 'Symfony\UX\LiveComponent\Tests\Fixtures\Dto',
+                        'alias' => 'XML',
                     ],
                 ],
             ],
@@ -90,6 +99,8 @@ final class Kernel extends BaseKernel
                 ->autoconfigure()
             // disable logging errors to the console
             ->set('logger', NullLogger::class)
+            ->set(MoneyNormalizer::class)->autoconfigure()->autowire()
+            ->set(Entity2Normalizer::class)->autoconfigure()->autowire()
             ->load(__NAMESPACE__.'\\Component\\', __DIR__.'/Component')
         ;
     }

--- a/src/LiveComponent/tests/Fixtures/Serializer/Entity2Normalizer.php
+++ b/src/LiveComponent/tests/Fixtures/Serializer/Entity2Normalizer.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Serializer;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity2;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Entity2Normalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function __construct(private ManagerRegistry $doctrine)
+    {
+    }
+
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
+    {
+        [, $id] = \explode(':', $data);
+
+        return $this->doctrine->getRepository(Entity2::class)->find($id);
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, string $format = null)
+    {
+        return Entity2::class === $type;
+    }
+
+    public function normalize(mixed $object, string $format = null, array $context = [])
+    {
+        return 'entity2:'.$object->id;
+    }
+
+    public function supportsNormalization(mixed $data, string $format = null)
+    {
+        return $data instanceof Entity2;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Serializer/MoneyNormalizer.php
+++ b/src/LiveComponent/tests/Fixtures/Serializer/MoneyNormalizer.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Serializer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Money;
+
+final class MoneyNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
+    {
+        return new Money(...\explode('|', $data));
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, string $format = null)
+    {
+        return Money::class === $type;
+    }
+
+    public function normalize(mixed $object, string $format = null, array $context = [])
+    {
+        return \implode('|', [$object->amount, $object->currency]);
+    }
+
+    public function supportsNormalization(mixed $data, string $format = null)
+    {
+        return $data instanceof Money;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/config/doctrine/Embeddable2.orm.xml
+++ b/src/LiveComponent/tests/Fixtures/config/doctrine/Embeddable2.orm.xml
@@ -1,0 +1,5 @@
+<doctrine-mapping>
+    <embeddable name="Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Embeddable2">
+        <field name="name" type="string" />
+    </embeddable>
+</doctrine-mapping>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #452
| License       | MIT

Changed from 100 to -100, we want a user's entity normalizers to run before. We also want `DoctrineObjectNormalizer` to run before the default object normalizer.

Tests added to cover the following ways object properties on a component are normalized:
- entity with no custom normalizer (uses `DoctrineObjectNormalizer`)
- entity with custom normalizer
- dto with custom normalizer
- dto with no custom normalizer (uses the default object normalizer)
- entity with embeddable (mapped using annotations)
- entity with embeddable (mapped using xml)
- dto with embeddable (mapped using annotations)
- dto with embeddable (mapped using xml)
