### PR TITLE
Fix failing CI

### DIFF
--- a/src/Chartjs/Builder/ChartBuilder.php
+++ b/src/Chartjs/Builder/ChartBuilder.php
@@ -17,6 +17,7 @@ use Symfony\UX\Chartjs\Model\Chart;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class ChartBuilder implements ChartBuilderInterface

--- a/src/Chartjs/ChartjsBundle.php
+++ b/src/Chartjs/ChartjsBundle.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class ChartjsBundle extends Bundle

--- a/src/Chartjs/Model/Chart.php
+++ b/src/Chartjs/Model/Chart.php
@@ -15,6 +15,7 @@ namespace Symfony\UX\Chartjs\Model;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class Chart

--- a/src/Chartjs/Twig/ChartExtension.php
+++ b/src/Chartjs/Twig/ChartExtension.php
@@ -22,6 +22,7 @@ use Twig\TwigFunction;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class ChartExtension extends AbstractExtension

--- a/src/Cropperjs/CropperjsBundle.php
+++ b/src/Cropperjs/CropperjsBundle.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class CropperjsBundle extends Bundle

--- a/src/Cropperjs/Factory/Cropper.php
+++ b/src/Cropperjs/Factory/Cropper.php
@@ -18,6 +18,7 @@ use Symfony\UX\Cropperjs\Model\Crop;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class Cropper implements CropperInterface

--- a/src/Cropperjs/Form/CropperType.php
+++ b/src/Cropperjs/Form/CropperType.php
@@ -23,6 +23,7 @@ use Symfony\UX\Cropperjs\Model\Crop;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class CropperType extends AbstractType

--- a/src/Cropperjs/Model/Crop.php
+++ b/src/Cropperjs/Model/Crop.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class Crop

--- a/src/Dropzone/DropzoneBundle.php
+++ b/src/Dropzone/DropzoneBundle.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class DropzoneBundle extends Bundle

--- a/src/Dropzone/Form/DropzoneType.php
+++ b/src/Dropzone/Form/DropzoneType.php
@@ -19,6 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class DropzoneType extends AbstractType

--- a/src/LazyImage/BlurHash/BlurHash.php
+++ b/src/LazyImage/BlurHash/BlurHash.php
@@ -18,6 +18,7 @@ use kornrunner\Blurhash\Blurhash as BlurhashEncoder;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class BlurHash implements BlurHashInterface

--- a/src/LazyImage/LazyImageBundle.php
+++ b/src/LazyImage/LazyImageBundle.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class LazyImageBundle extends Bundle

--- a/src/LazyImage/Twig/BlurHashExtension.php
+++ b/src/LazyImage/Twig/BlurHashExtension.php
@@ -19,6 +19,7 @@ use Twig\TwigFunction;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class BlurHashExtension extends AbstractExtension

--- a/src/LiveComponent/src/ValidatableComponentTrait.php
+++ b/src/LiveComponent/src/ValidatableComponentTrait.php
@@ -134,6 +134,7 @@ trait ValidatableComponentTrait
 
     /**
      * @internal
+     *
      * @required
      */
     public function setComponentValidator(ComponentValidatorInterface $componentValidator): void

--- a/src/Notify/NotifyBundle.php
+++ b/src/Notify/NotifyBundle.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class NotifyBundle extends Bundle

--- a/src/React/ReactBundle.php
+++ b/src/React/ReactBundle.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class ReactBundle extends Bundle

--- a/src/React/Twig/ReactComponentExtension.php
+++ b/src/React/Twig/ReactComponentExtension.php
@@ -20,6 +20,7 @@ use Twig\TwigFunction;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class ReactComponentExtension extends AbstractExtension

--- a/src/Turbo/Tests/app/Entity/Artist.php
+++ b/src/Turbo/Tests/app/Entity/Artist.php
@@ -16,6 +16,7 @@ use Symfony\UX\Turbo\Attribute\Broadcast;
 
 /**
  * @ORM\Entity
+ *
  * @Broadcast
  *
  * @author Rick Kuipers <rick@levelup-it.com>

--- a/src/Turbo/Tests/app/Entity/Book.php
+++ b/src/Turbo/Tests/app/Entity/Book.php
@@ -16,6 +16,7 @@ use Symfony\UX\Turbo\Attribute\Broadcast;
 
 /**
  * @ORM\Entity
+ *
  * @Broadcast
  *
  * @author Kévin Dunglas <kevin@dunglas.fr>

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -15,6 +15,7 @@ namespace Symfony\UX\TwigComponent;
  * @author Kevin Bond <kevinbond@gmail.com>
  *
  * @experimental
+ *
  * @immutable
  */
 final class ComponentAttributes

--- a/src/Vue/Twig/VueComponentExtension.php
+++ b/src/Vue/Twig/VueComponentExtension.php
@@ -21,6 +21,7 @@ use Twig\TwigFunction;
  * @author Thibault RICHARD <thibault.richard62@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class VueComponentExtension extends AbstractExtension

--- a/src/Vue/VueBundle.php
+++ b/src/Vue/VueBundle.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Thibault RICHARD <thibault.richard62@gmail.com>
  *
  * @final
+ *
  * @experimental
  */
 class VueBundle extends Bundle


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

- Latest version of php-cs-fixer adds a fixer that separates php docs. Do we want to keep the defaults or customize the config?
- js-dist-current [is failing](https://github.com/symfony/ux/runs/8251702511?check_suite_focus=true#step:6:1268). Not sure what's required to fix.
