### PR TITLE
[Autocomplete] Correct Method Name for FQCN

### DIFF
--- a/src/Autocomplete/src/Doctrine/EntityMetadata.php
+++ b/src/Autocomplete/src/Doctrine/EntityMetadata.php
@@ -53,7 +53,7 @@ class EntityMetadata
             return $this->metadata->associationMappings[$propertyName];
         }
 
-        throw new \InvalidArgumentException(sprintf('The "%s" field does not exist in the "%s" entity.', $propertyName, $this->getFqcn()));
+        throw new \InvalidArgumentException(sprintf('The "%s" field does not exist in the "%s" entity.', $propertyName, $this->metadata->getName()));
     }
 
     public function getPropertyDataType(string $propertyName): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | N/A
| License       | MIT

The current method does not seem to exist, but this one will return the FQCN of the metadata being wrapped, which seems to be what it intends to do.

This bug triggers when a specified search property does not exist, and an exception is thrown when creating the exception message.

There are no tests for this code atm, and the `ClassMetadata` service has properties accessed which do not exist on the interface which makes mocking or adding a dummy problematic. Static analysis would also have trouble here I think.

I'm happy to spend time adding these tests, but unsure if this is the right fix right now, perhaps I missed something.