### PR TITLE
[WIP] [Live] Make Ajax calls happen in serial, with "queued" changes

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 2.5.0
+
+-   [BEHAVIOR CHANGE] Previously, Ajax calls could happen in parallel (if
+    you changed a model then triggered an action before the model update Ajax
+    call finished, the action Ajax call would being in parallel). Now, if
+    an Ajax call is currently happening, any future requests will wait until
+    it finishes. Then, all queued changes (potentially multiple model updates
+    or actions) will be sent all at once on the next request.
+
 ## 2.4.0
 
 -   [BC BREAK] Previously, the `id` attribute was used with `morphdom` as the

--- a/src/LiveComponent/assets/src/UnsyncedInputContainer.ts
+++ b/src/LiveComponent/assets/src/UnsyncedInputContainer.ts
@@ -1,6 +1,6 @@
 export default class UnsyncedInputContainer {
     #mappedFields: Map<string, HTMLElement>;
-    #unmappedFields: Array<HTMLElement>= [];
+    #unmappedFields: Array<HTMLElement> = [];
 
     constructor() {
         this.#mappedFields = new Map();
@@ -18,14 +18,6 @@ export default class UnsyncedInputContainer {
 
     all() {
         return [...this.#unmappedFields, ...this.#mappedFields.values()]
-    }
-
-    clone(): UnsyncedInputContainer {
-        const container = new UnsyncedInputContainer();
-        container.#mappedFields = new Map(this.#mappedFields);
-        container.#unmappedFields = [...this.#unmappedFields];
-
-        return container;
     }
 
     allMappedFields(): Map<string, HTMLElement> {

--- a/src/LiveComponent/assets/src/ValueStore.ts
+++ b/src/LiveComponent/assets/src/ValueStore.ts
@@ -4,6 +4,7 @@ import { normalizeModelName } from './string_utils';
 
 export default class {
     controller: LiveController;
+    updatedModels: string[] = [];
 
     constructor(liveController: LiveController) {
         this.controller = liveController;
@@ -33,6 +34,7 @@ export default class {
      */
     set(name: string, value: any): void {
         const normalizedName = normalizeModelName(name);
+        this.updatedModels.push(normalizedName);
 
         this.controller.dataValue = setDeepData(this.controller.dataValue, normalizedName, value);
     }
@@ -48,5 +50,9 @@ export default class {
 
     asJson(): string {
         return JSON.stringify(this.controller.dataValue);
+    }
+
+    all(): any {
+        return this.controller.dataValue;
     }
 }

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -445,7 +445,6 @@ export default class extends Controller implements LiveController {
 
                     url += `/${encodeURIComponent(actions[0].name)}`;
                 } else {
-                    // TODO: support on the server
                     url += '/_batch';
                     requestData.actions = actions;
                 }

--- a/src/LiveComponent/assets/test/controller/csrf.test.ts
+++ b/src/LiveComponent/assets/test/controller/csrf.test.ts
@@ -30,6 +30,7 @@ describe('LiveController CSRF Tests', () => {
 
         test.expectsAjaxCall('post')
             .expectSentData(test.initialData)
+            .expectActionCalled('save')
             .expectHeader('X-CSRF-TOKEN', '123TOKEN')
             .serverWillChangeData((data: any) => {
                 data.isSaved = true;

--- a/src/LiveComponent/src/Controller/BatchActionController.php
+++ b/src/LiveComponent/src/Controller/BatchActionController.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\UX\TwigComponent\MountedComponent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class BatchActionController
+{
+    public function __construct(private HttpKernelInterface $kernel)
+    {
+    }
+
+    public function __invoke(Request $request, MountedComponent $mounted, string $serviceId, array $actions): ?Response
+    {
+        $request->attributes->set('_mounted_component', $mounted);
+
+        foreach ($actions as $action) {
+            $name = $action['name'] ?? throw new BadRequestHttpException('Invalid JSON');
+
+            $subRequest = $request->duplicate(attributes: [
+                '_controller' => [$serviceId, $name],
+                '_component_action_args' => $action['args'] ?? [],
+                '_mounted_component' => $mounted,
+                '_route' => 'live_component',
+            ]);
+
+            $response = $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
+
+            if ($response->isRedirection()) {
+                return $response;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/LiveComponent/src/Controller/BatchActionController.php
+++ b/src/LiveComponent/src/Controller/BatchActionController.php
@@ -28,17 +28,15 @@ final class BatchActionController
     {
     }
 
-    public function __invoke(Request $request, MountedComponent $mounted, string $serviceId, array $actions): ?Response
+    public function __invoke(Request $request, MountedComponent $_mounted_component, string $serviceId, array $actions): ?Response
     {
-        $request->attributes->set('_mounted_component', $mounted);
-
         foreach ($actions as $action) {
             $name = $action['name'] ?? throw new BadRequestHttpException('Invalid JSON');
 
             $subRequest = $request->duplicate(attributes: [
                 '_controller' => [$serviceId, $name],
                 '_component_action_args' => $action['args'] ?? [],
-                '_mounted_component' => $mounted,
+                '_mounted_component' => $_mounted_component,
                 '_route' => 'live_component',
             ]);
 

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\ComponentValidator;
 use Symfony\UX\LiveComponent\ComponentValidatorInterface;
+use Symfony\UX\LiveComponent\Controller\BatchActionController;
 use Symfony\UX\LiveComponent\EventListener\AddLiveAttributesSubscriber;
 use Symfony\UX\LiveComponent\EventListener\LiveComponentSubscriber;
 use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
@@ -67,6 +68,13 @@ final class LiveComponentExtension extends Extension implements PrependExtension
                 new Reference('serializer'),
                 new Reference('property_accessor'),
                 '%kernel.secret%',
+            ])
+        ;
+
+        $container->register('ux.live_component.batch_action_controller', BatchActionController::class)
+            ->setPublic(true)
+            ->setArguments([
+                new Reference('http_kernel'),
             ])
         ;
 

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -161,7 +161,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
 
         /*
          * Either we:
-         *      A) To not have a _mounted_component, so hydrate $component
+         *      A) We do NOT have a _mounted_component, so hydrate $component
          *      B) We DO have a _mounted_component, so no need to hydrate,
          *          but we DO need to make sure it's set as the controller.
          */
@@ -201,7 +201,6 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
     private function parseDataFor(Request $request): array
     {
         if (!$request->attributes->has('_live_request_data')) {
-
             if ($request->query->has('data')) {
                 return [
                     'data' => json_decode($request->query->get('data'), true, 512, \JSON_THROW_ON_ERROR),

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -210,7 +210,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
                 ];
             }
 
-            $requestData = json_decode($request->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+            $requestData = $request->toArray();
 
             $request->attributes->set('_live_request_data', [
                 'data' => $requestData['data'] ?? [],

--- a/src/LiveComponent/tests/Fixtures/Component/WithActions.php
+++ b/src/LiveComponent/tests/Fixtures/Component/WithActions.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('with_actions')]
+final class WithActions
+{
+    use DefaultActionTrait;
+
+    #[LiveProp]
+    public array $items = ['initial'];
+
+    #[LiveAction]
+    public function add(#[LiveArg] string $what, UrlGeneratorInterface $router): void
+    {
+        $this->items[] = $what;
+    }
+
+    #[LiveAction]
+    public function redirect(UrlGeneratorInterface $router): RedirectResponse
+    {
+        return new RedirectResponse($router->generate('homepage'));
+    }
+
+    #[LiveAction]
+    public function exception(): void
+    {
+        throw new \RuntimeException('Exception message');
+    }
+
+    public function nonLive(): void
+    {
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/with_actions.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/with_actions.html.twig
@@ -1,0 +1,5 @@
+<ul{{ attributes }}>
+    {% for item in items %}
+        <li>{{ item }}</li>
+    {% endfor %}
+</ul>

--- a/src/LiveComponent/tests/Functional/Controller/BatchActionControllerTest.php
+++ b/src/LiveComponent/tests/Functional/Controller/BatchActionControllerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Functional\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\LiveComponent\Tests\LiveComponentTestHelper;
+use Zenstruck\Browser\KernelBrowser;
+use Zenstruck\Browser\Response\HtmlResponse;
+use Zenstruck\Browser\Test\HasBrowser;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class BatchActionControllerTest extends KernelTestCase
+{
+    use HasBrowser;
+    use LiveComponentTestHelper;
+
+    public function testCanBatchActions(): void
+    {
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
+
+        $this->browser()
+            ->throwExceptions()
+            ->get('/_components/with_actions', ['json' => ['data' => $dehydrated]])
+            ->assertSuccessful()
+            ->assertSee('initial')
+            ->use(function (HtmlResponse $response, KernelBrowser $browser) {
+                $browser->post('/_components/with_actions/add', [
+                    'json' => [
+                        'data' => json_decode($response->crawler()->filter('ul')->first()->attr('data-live-data-value')),
+                        'args' => ['what' => 'first'],
+                    ],
+                    'headers' => ['X-CSRF-TOKEN' => $response->crawler()->filter('ul')->first()->attr('data-live-csrf-value')],
+                ]);
+            })
+            ->assertSee('initial')
+            ->assertSee('first')
+            ->use(function (HtmlResponse $response, KernelBrowser $browser) {
+                $browser->post('/_components/with_actions/_batch', [
+                    'json' => [
+                        'data' => json_decode($response->crawler()->filter('ul')->first()->attr('data-live-data-value')),
+                        'actions' => [
+                            ['name' => 'add', 'args' => ['what' => 'second']],
+                            ['name' => 'add', 'args' => ['what' => 'third']],
+                            ['name' => 'add', 'args' => ['what' => 'fourth']],
+                        ],
+                    ],
+                    'headers' => ['X-CSRF-TOKEN' => $response->crawler()->filter('ul')->first()->attr('data-live-csrf-value')],
+                ]);
+            })
+            ->assertSee('initial')
+            ->assertSee('first')
+            ->assertSee('second')
+            ->assertSee('third')
+            ->assertSee('fourth')
+        ;
+    }
+
+    public function testCsrfTokenIsChecked(): void
+    {
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
+
+        $this->browser()
+            ->post('/_components/with_actions/_batch', ['json' => [
+                'data' => $dehydrated,
+                'actions' => [],
+            ]])
+            ->assertStatus(400)
+        ;
+    }
+
+    public function testRedirect(): void
+    {
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
+
+        $this->browser()
+            ->throwExceptions()
+            ->get('/_components/with_actions', ['json' => ['data' => $dehydrated]])
+            ->assertSuccessful()
+            ->interceptRedirects()
+            ->use(function (HtmlResponse $response, KernelBrowser $browser) {
+                $browser->post('/_components/with_actions/_batch', [
+                    'json' => [
+                        'data' => json_decode($response->crawler()->filter('ul')->first()->attr('data-live-data-value')),
+                        'actions' => [
+                            ['name' => 'add', 'args' => ['what' => 'second']],
+                            ['name' => 'redirect'],
+                            ['name' => 'add', 'args' => ['what' => 'fourth']],
+                        ],
+                    ],
+                    'headers' => ['X-CSRF-TOKEN' => $response->crawler()->filter('ul')->first()->attr('data-live-csrf-value')],
+                ]);
+            })
+            ->assertRedirectedTo('/')
+        ;
+    }
+
+    public function testException(): void
+    {
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
+
+        $this->browser()
+            ->get('/_components/with_actions', ['json' => ['data' => $dehydrated]])
+            ->assertSuccessful()
+            ->use(function (HtmlResponse $response, KernelBrowser $browser) {
+                $browser->post('/_components/with_actions/_batch', [
+                    'json' => [
+                        'data' => json_decode($response->crawler()->filter('ul')->first()->attr('data-live-data-value')),
+                        'actions' => [
+                            ['name' => 'add', 'args' => ['what' => 'second']],
+                            ['name' => 'exception'],
+                            ['name' => 'add', 'args' => ['what' => 'fourth']],
+                        ],
+                    ],
+                    'headers' => ['X-CSRF-TOKEN' => $response->crawler()->filter('ul')->first()->attr('data-live-csrf-value')],
+                ]);
+            })
+            ->assertStatus(500)
+            ->assertContains('Exception message')
+        ;
+    }
+
+    public function testCannotBatchWithNonLiveAction(): void
+    {
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
+
+        $this->browser()
+            ->get('/_components/with_actions', ['json' => ['data' => $dehydrated]])
+            ->assertSuccessful()
+            ->use(function (HtmlResponse $response, KernelBrowser $browser) {
+                $browser->post('/_components/with_actions/_batch', [
+                    'json' => [
+                        'data' => json_decode($response->crawler()->filter('ul')->first()->attr('data-live-data-value')),
+                        'actions' => [
+                            ['name' => 'add', 'args' => ['what' => 'second']],
+                            ['name' => 'nonLive'],
+                            ['name' => 'add', 'args' => ['what' => 'fourth']],
+                        ],
+                    ],
+                    'headers' => ['X-CSRF-TOKEN' => $response->crawler()->filter('ul')->first()->attr('data-live-csrf-value')],
+                ]);
+            })
+            ->assertStatus(404)
+            ->assertContains('The action \"nonLive\" either doesn\'t exist or is not allowed')
+        ;
+    }
+}

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -72,7 +72,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             })
             ->post('/_components/component2/increase', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode($dehydrated),
+                'body' => json_encode(['data' => $dehydrated]),
             ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
@@ -145,7 +145,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Count: 1')
             ->post('/_components/disabled_csrf/increase', [
-                'body' => json_encode($dehydrated),
+                'body' => json_encode(['data' => $dehydrated]),
             ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
@@ -184,7 +184,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             // with no custom header, it redirects like a normal browser
             ->post('/_components/component2/redirect', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode($dehydrated),
+                'body' => json_encode(['data' => $dehydrated]),
             ])
             ->assertRedirectedTo('/')
 
@@ -194,7 +194,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
                     'Accept' => 'application/vnd.live-component+html',
                     'X-CSRF-TOKEN' => $token,
                 ],
-                'body' => json_encode($dehydrated),
+                'body' => json_encode(['data' => $dehydrated]),
             ])
             ->assertStatus(204)
             ->assertHeaderEquals('Location', '/')
@@ -206,10 +206,10 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         $dehydrated = $this->dehydrateComponent($this->mountComponent('component6'));
         $token = null;
 
-        $argsQueryParams = http_build_query(['args' => http_build_query(['arg1' => 'hello', 'arg2' => 666, 'custom' => '33.3'])]);
+        $arguments = ['arg1' => 'hello', 'arg2' => 666, 'custom' => '33.3'];
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/component6?data='.urlencode(json_encode($dehydrated)).'&'.$argsQueryParams)
+            ->get('/_components/component6?data='.urlencode(json_encode($dehydrated)))
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Arg1: not provided')
@@ -219,9 +219,12 @@ final class LiveComponentSubscriberTest extends KernelTestCase
                 // get a valid token to use for actions
                 $token = $response->crawler()->filter('div')->first()->attr('data-live-csrf-value');
             })
-            ->post('/_components/component6/inject?'.$argsQueryParams, [
+            ->post('/_components/component6/inject', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode($dehydrated),
+                'body' => json_encode([
+                    'data' => $dehydrated,
+                    'args' => $arguments,
+                ]),
             ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -50,7 +50,7 @@ class ComponentWithFormTest extends KernelTestCase
 
             // post to action, which will add a new embedded comment
             ->post('/_components/form_with_collection_type/addComment', [
-                'body' => json_encode($dehydrated),
+                'body' => json_encode(['data' => $dehydrated]),
                 'headers' => ['X-CSRF-TOKEN' => $token],
             ])
             ->assertStatus(422)
@@ -85,8 +85,8 @@ class ComponentWithFormTest extends KernelTestCase
             })
 
             // post to action, which will remove the original embedded comment
-            ->post('/_components/form_with_collection_type/removeComment?'.http_build_query(['args' => 'index=0']), [
-                'body' => json_encode($dehydrated),
+            ->post('/_components/form_with_collection_type/removeComment', [
+                'body' => json_encode(['data' => $dehydrated, 'args' => ['index' => '0']]),
                 'headers' => ['X-CSRF-TOKEN' => $token],
             ])
             ->assertStatus(422)
@@ -265,8 +265,8 @@ class ComponentWithFormTest extends KernelTestCase
                 $token = $response->crawler()->filter('div')->first()->attr('data-live-csrf-value');
             })
             // post to action, which will add a new embedded comment
-            ->post('/_components/form_with_live_collection_type/addCollectionItem?'.http_build_query(['args' => 'name=blog_post_form[comments]']), [
-                'body' => json_encode($dehydrated),
+            ->post('/_components/form_with_live_collection_type/addCollectionItem', [
+                'body' => json_encode(['data' => $dehydrated, 'args' => ['name' => 'blog_post_form[comments]']]),
                 'headers' => ['X-CSRF-TOKEN' => $token],
             ])
             ->assertStatus(422)
@@ -301,8 +301,8 @@ class ComponentWithFormTest extends KernelTestCase
             })
 
             // post to action, which will remove the original embedded comment
-            ->post('/_components/form_with_live_collection_type/removeCollectionItem?'.http_build_query(['args' => 'name=blog_post_form[comments]&index=0']), [
-                'body' => json_encode($dehydrated),
+            ->post('/_components/form_with_live_collection_type/removeCollectionItem', [
+                'body' => json_encode(['data' => $dehydrated, 'args' => ['name' => 'blog_post_form[comments]', 'index' => '0']]),
                 'headers' => ['X-CSRF-TOKEN' => $token],
             ])
             ->assertStatus(422)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Tickets       | None
| License       | MIT

Hi!

Consider the following situation:

A) Model update is made: Ajax call starts
B) An action is triggered BEFORE the Ajax call from (A) finishes.

Previously, we would start a 2nd Ajax call for (B) before the Ajax call from (A) finished... meaning two Ajax calls were happening at the same time. There are a few problems with this: (i) Ajax call (B) is missing any potential data changes from Ajax call (A) and (i) complexity of multiple things loading at once, and potentially finishing in a different order.

This PR simplifies things, which matches Livewire's behavior anyways. Now, the action from (B) will WAIT until the Ajax call from (A) finishes and THEN start. In fact, while an Ajax call is being made, all changes (potentially multiple model updates or actions) will be "queued" and then all set at once on the next request.

TODO:

* [X] Update the backend: for POST requests, the "data" was moved under a `data` key in JSON. Previously the entire body was the "data".
* [X] Update the backend: for POST/action requests, action "arguments" were moved from query parameters to an `args` key in the JSON.
* [x] Frontend: add tests for the `batch` action Ajax calls
* [x] Update the backend: a new fake `/batch` action needs to be added that can handle multiple actions at once
* [ ] A new `updatedModels` is sent on the ajax requests. If the signature fails, use this to give a better error message about what readonly properties were just modified. (in fact, this is the only purpose of sending this new field to the backend at this time).
* [X] ~~Pass a `includeUpdatedModels` value to the Stimulus controller ONLY when in `dev` mode.~~ For consistency, we will always pass the `updatedModels` in our Ajax requests, though this is intended to be "internal" and we won't use it other than to throw better errors.
* [X] ~~(Optional) If the backend has an unexpected exception (i.e. 5xx or maybe some 4xx where we mark that this is a problem we should show the developer), then render the entire HTML exception page (in dev mode only) so the user can see the error.~~ Done in #467 

Cheers!