### PR TITLE
[Live] Rendering any errors in a simple modal

### DIFF
--- a/src/LiveComponent/assets/test/controller/error.test.ts
+++ b/src/LiveComponent/assets/test/controller/error.test.ts
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { createTest, initComponent, shutdownTest } from '../tools';
+import { getByText, waitFor } from '@testing-library/dom';
+
+describe('LiveController Error Handling', () => {
+    afterEach(() => {
+        shutdownTest();
+    })
+
+    it('displays an error modal on 500 errors', async () => {
+        const test = await createTest({ }, (data: any) => `
+            <div ${initComponent(data)}>
+                Original component text
+                <button data-action="live#action" data-action-name="save">Save</button>
+            </div>
+        `);
+
+        // ONLY a post is sent, not a re-render GET
+        test.expectsAjaxCall('post')
+            .expectSentData(test.initialData)
+            .serverWillReturnCustomResponse(500, `
+                <html><head><title>Error!</title></head><body><h1>An error occurred</h1></body></html>
+            `)
+            .expectActionCalled('save')
+            .init();
+
+        getByText(test.element, 'Save').click();
+
+        await waitFor(() => expect(document.getElementById('live-component-error')).not.toBeNull());
+        // the component did not change or re-render
+        expect(test.element).toHaveTextContent('Original component text');
+        const errorContainer = document.getElementById('live-component-error');
+        if (!errorContainer) {
+            throw new Error('containing missing');
+        }
+        expect(errorContainer.querySelector('iframe')).not.toBeNull();
+    });
+
+    it('displays a modal on any non-component response', async () => {
+        const test = await createTest({ }, (data: any) => `
+            <div ${initComponent(data)}>
+                Original component text
+                <button data-action="live#action" data-action-name="save">Save</button>
+            </div>
+        `);
+
+        // ONLY a post is sent, not a re-render GET
+        test.expectsAjaxCall('post')
+            .expectSentData(test.initialData)
+            .serverWillReturnCustomResponse(200, `
+                <html><head><title>Hi!</title></head><body><h1>I'm a whole page, not a component!</h1></body></html>
+            `)
+            .expectActionCalled('save')
+            .init();
+
+        getByText(test.element, 'Save').click();
+
+        await waitFor(() => expect(document.getElementById('live-component-error')).not.toBeNull());
+        // the component did not change or re-render
+        expect(test.element).toHaveTextContent('Original component text');
+    });
+});

--- a/src/LiveComponent/assets/test/tools.ts
+++ b/src/LiveComponent/assets/test/tools.ts
@@ -120,6 +120,8 @@ class MockedAjaxCall {
     options: any = {};
     fetchMock?: typeof fetchMock;
     routeName?: string;
+    customResponseStatusCode?: number;
+    customResponseHTML?: string;
 
     constructor(method: string, test: FunctionalTest) {
         this.method = method.toUpperCase();
@@ -180,9 +182,24 @@ class MockedAjaxCall {
         // use custom template, or the main one
         const template = this.template ? this.template : this.test.template;
 
+        let response;
+        if (this.customResponseStatusCode) {
+            response = {
+                body: this.customResponseHTML,
+                status: this.customResponseStatusCode
+            }
+        } else {
+            response = {
+                body: template(finalServerData),
+                headers: {
+                    'Content-Type': 'application/vnd.live-component+html'
+                }
+            }
+        }
+
         this.fetchMock = fetchMock.mock(
             this.getMockMatcher(),
-            template(finalServerData),
+            response,
             this.options
         );
     }
@@ -197,6 +214,14 @@ class MockedAjaxCall {
     expectHeader(headerName: string, value: string): MockedAjaxCall {
         this.checkInitialization('expectHeader');
         this.expectedHeaders[headerName] = value;
+
+        return this;
+    }
+
+    serverWillReturnCustomResponse(statusCode: number, responseHTML: string): MockedAjaxCall {
+        this.checkInitialization('serverWillReturnAnError');
+        this.customResponseStatusCode = statusCode;
+        this.customResponseHTML = responseHTML;
 
         return this;
     }

--- a/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
+++ b/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\LiveComponent\EventListener;
 
 use Psr\Container\ContainerInterface;

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -232,7 +232,9 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
             $component->{$method->name}();
         }
 
-        return new Response($this->container->get(ComponentRenderer::class)->render($mounted));
+        return new Response($this->container->get(ComponentRenderer::class)->render($mounted), 200, [
+            'Content-Type' => self::HTML_CONTENT_TYPE,
+        ]);
     }
 
     private function isLiveComponentRequest(Request $request): bool

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -235,7 +235,7 @@ final class LiveComponentHydrator
         }
 
         if (!hash_equals($this->computeChecksum($data, $readonlyProperties), $data[self::CHECKSUM_KEY])) {
-            throw new UnprocessableEntityHttpException('Invalid checksum!');
+            throw new UnprocessableEntityHttpException('Invalid checksum. This usually means that you tried to change a property that is not writable: true.');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | #102 Bugs G
| License       | MIT

Beautiful error handling! Inspired by Livewire:

<img width="1280" alt="Screen Shot 2022-09-19 at 4 10 35 PM" src="https://user-images.githubusercontent.com/121003/191117592-7a203e6c-0a18-4eb1-aa89-4e07698f5227.png">

You can even `dd()` from your code and that will render in the modal:

<img width="1275" alt="Screen Shot 2022-09-19 at 5 10 29 PM" src="https://user-images.githubusercontent.com/121003/191117596-5bcdb75d-42c1-4fae-8af5-2007127c2fac.png">

If an Ajax call returns anything OTHER than a rendered component (i.e. there was SOME sort of error), it's rendered in a modal. This is mostly for development errors. The modal will show on production also (and would show, for example, the 500 production page), but that should not happen in normal situations.

Cheers!