### PR TITLE
[Live] Action and Model-based data-loading behavior

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -26,6 +26,12 @@
     <input data-model="firstName">
     ```
 
+-   Added the ability to add `data-loading` behavior, which is only activated
+    when a specific **action** is triggered - e.g. `<span data-loading="action(save)|show">Loading</span>`.
+
+-   Added the ability to add `data-loading` behavior, which is only activated
+    when a specific **model** has been updated - e.g. `<span data-loading="model(firstName)|show">Loading</span>`.
+
 ## 2.4.0
 
 -   [BC BREAK] Previously, the `id` attribute was used with `morphdom` as the

--- a/src/LiveComponent/assets/src/ValueStore.ts
+++ b/src/LiveComponent/assets/src/ValueStore.ts
@@ -34,7 +34,9 @@ export default class {
      */
     set(name: string, value: any): void {
         const normalizedName = normalizeModelName(name);
-        this.updatedModels.push(normalizedName);
+        if (!this.updatedModels.includes(normalizedName)) {
+            this.updatedModels.push(normalizedName);
+        }
 
         this.controller.dataValue = setDeepData(this.controller.dataValue, normalizedName, value);
     }
@@ -54,5 +56,12 @@ export default class {
 
     all(): any {
         return this.controller.dataValue;
+    }
+
+    /**
+     * Are any of the passed models currently "updated"?
+     */
+    areAnyModelsUpdated(targetedModels: string[]): boolean {
+        return (this.updatedModels.filter(modelName => targetedModels.includes(modelName))).length > 0;
     }
 }

--- a/src/LiveComponent/assets/src/directives_parser.ts
+++ b/src/LiveComponent/assets/src/directives_parser.ts
@@ -1,7 +1,7 @@
 /**
  * A modifier for a directive
  */
-interface DirectiveModifier {
+export interface DirectiveModifier {
     /**
      * The name of the modifier (e.g. delay)
      */

--- a/src/LiveComponent/assets/test/controller/loading.test.ts
+++ b/src/LiveComponent/assets/test/controller/loading.test.ts
@@ -1,0 +1,207 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import {createTest, initComponent, shutdownTest} from '../tools';
+import {getByTestId, getByText, waitFor} from '@testing-library/dom';
+import userEvent from "@testing-library/user-event";
+
+describe('LiveController data-loading Tests', () => {
+    afterEach(() => {
+        shutdownTest();
+    })
+
+    it('executes basic loading functionality on an element', async () => {
+        const test = await createTest({food: 'pizza'}, (data: any) => `
+            <div ${initComponent(data)}>
+                <span>I like: ${data.food}</span> 
+                <span data-loading="show" data-testid="loading-element">Loading...</span>
+                <button data-action="live#$render">Re-Render</button>
+            </div>
+        `);
+
+        test.expectsAjaxCall('get')
+            .expectSentData(test.initialData)
+            .serverWillChangeData((data: any) => {
+                // to help detect when rendering is done
+                data.food = 'popcorn';
+            })
+            // delay so we can check loading
+            .delayResponse(50)
+            .init();
+
+        // wait for element to hide itself on start up
+        await waitFor(() => expect(getByTestId(test.element, 'loading-element')).not.toBeVisible());
+
+        getByText(test.element, 'Re-Render').click();
+        // element should instantly be visible
+        expect(getByTestId(test.element, 'loading-element')).toBeVisible();
+
+        // wait for loading to finish
+        await waitFor(() => expect(test.element).toHaveTextContent('I like: popcorn'));
+        // loading element should now be hidden
+        expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
+    });
+
+    it('takes into account the "action" modifier', async () => {
+        const test = await createTest({}, (data: any) => `
+            <div ${initComponent(data)}> 
+                <span data-loading="action(save)|show" data-testid="loading-element">Loading...</span>
+
+                <button data-action="live#action" data-action-name="save">Save</button>
+                <button data-action="live#action" data-action-name="otherAction">Other Action</button>
+                <button data-action="live#$render">Re-Render</button>
+            </div>
+        `);
+
+        test.expectsAjaxCall('get')
+            .expectSentData(test.initialData)
+            // delay so we can check loading
+            .delayResponse(50)
+            .init();
+
+        getByText(test.element, 'Re-Render').click();
+        // it should not be loading yet
+        expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
+        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+
+        test.expectsAjaxCall('post')
+            .expectSentData(test.initialData)
+            .expectActionCalled('otherAction')
+            // delay so we can check loading
+            .delayResponse(50)
+            .init();
+        getByText(test.element, 'Other Action').click();
+        // it should not be loading yet
+        expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
+        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+
+        test.expectsAjaxCall('post')
+            .expectSentData(test.initialData)
+            .expectActionCalled('save')
+            // delay so we can check loading
+            .delayResponse(50)
+            .init();
+        getByText(test.element, 'Save').click();
+        // it SHOULD be loading now
+        expect(getByTestId(test.element, 'loading-element')).toBeVisible();
+        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        // now it should be hidden again
+        expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
+    });
+
+    it('takes into account the "model" modifier', async () => {
+        const test = await createTest({ comments: '', user: { email: '' }}, (data: any) => `
+            <div ${initComponent(data)}> 
+                <textarea data-model="comments"></textarea>
+                <span data-loading="model(comments)|show" data-testid="comments-loading">Comments change loading...</span>
+
+                <textarea data-model="user.email"></textarea>
+                <span data-loading="model(user.email)|show" data-testid="email-loading">Checking if email is taken...</span>
+            </div>
+        `);
+
+        test.expectsAjaxCall('get')
+            .expectSentData({ comments: 'Changing the comments!', user: { email: '' } })
+            // delay so we can check loading
+            .delayResponse(50)
+            .init();
+
+        userEvent.type(test.queryByDataModel('comments'), 'Changing the comments!')
+        // it should not be loading yet due to debouncing
+        expect(getByTestId(test.element, 'comments-loading')).not.toBeVisible();
+        // wait for ajax call to start
+        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        // NOW it should be loading
+        expect(getByTestId(test.element, 'comments-loading')).toBeVisible();
+        // but email-loading is not loading
+        expect(getByTestId(test.element, 'email-loading')).not.toBeVisible();
+        // wait for Ajax call to finish
+        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        // loading is no longer visible
+        expect(getByTestId(test.element, 'comments-loading')).not.toBeVisible();
+
+        // now try the user.email "child property" field
+        test.expectsAjaxCall('get')
+            .expectSentData({ comments: 'Changing the comments!', user: { email: 'ryan@symfonycasts.com' } })
+            // delay so we can check loading
+            .delayResponse(50)
+            .init();
+
+        userEvent.type(test.queryByDataModel('user.email'), 'ryan@symfonycasts.com');
+        // it should not be loading yet due to debouncing
+        expect(getByTestId(test.element, 'email-loading')).not.toBeVisible();
+        // wait for ajax call to start
+        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        // NOW it should be loading
+        expect(getByTestId(test.element, 'email-loading')).toBeVisible();
+        // but comments-loading is not loading
+        expect(getByTestId(test.element, 'comments-loading')).not.toBeVisible();
+        // wait for Ajax call to finish
+        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        // loading is no longer visible
+        expect(getByTestId(test.element, 'email-loading')).not.toBeVisible();
+    });
+
+    it('can handle multiple actions on the same request', async () => {
+        const test = await createTest({}, (data: any) => `
+            <div ${initComponent(data)}> 
+                <span data-loading="action(otherAction)|show" data-testid="loading-element">Loading...</span>
+
+                <button data-action="live#action" data-action-name="debounce(50)|save">Save</button>
+                <button data-action="live#action" data-action-name="otherAction">Other Action</button>
+            </div>
+        `);
+
+        // 1 ajax request with both actions
+        test.expectsAjaxCall('post')
+            .expectSentData(test.initialData)
+            .expectActionCalled('save')
+            .expectActionCalled('otherAction')
+            // delay so we can check loading
+            .delayResponse(50)
+            .init();
+
+        getByText(test.element, 'Save').click();
+        getByText(test.element, 'Other Action').click();
+        // it SHOULD be loading now
+        expect(getByTestId(test.element, 'loading-element')).toBeVisible();
+        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        // now it should be hidden again
+        expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
+    });
+
+    it('does not trigger loading if request finishes first', async () => {
+        const test = await createTest({}, (data: any) => `
+           <div ${initComponent(data)}> 
+               <span data-loading="action(save)|delay(50)|show" data-testid="loading-element">Loading...</span>
+
+               <button data-action="live#action" data-action-name="save">Save</button>
+           </div>
+       `);
+
+        test.expectsAjaxCall('post')
+            .expectSentData(test.initialData)
+            .expectActionCalled('save')
+            // delay, but not as long as the loading delay
+            .delayResponse(30)
+            .init();
+
+        getByText(test.element, 'Save').click();
+        // it should NOT be loading: loading is delayed
+        expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
+        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+
+        // request took 30ms, action loading is delayed for 50
+        // wait 30 more (30+30=60) and verify the element did not switch into loading
+        await (new Promise(resolve => setTimeout(resolve, 30)));
+        expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
+    });
+});

--- a/src/LiveComponent/assets/test/tools.ts
+++ b/src/LiveComponent/assets/test/tools.ts
@@ -112,11 +112,11 @@ class FunctionalTest {
 class MockedAjaxCall {
     method: string;
     test: FunctionalTest;
-    expectedSentData?: any;
-    expectedActions: Array<{ name: string, args: any }> = [];
-    expectedHeaders: any = {};
-    changeDataCallback?: (data: any) => void;
-    template?: (data: any) => string
+    private expectedSentData?: any;
+    private expectedActions: Array<{ name: string, args: any }> = [];
+    private expectedHeaders: any = {};
+    private changeDataCallback?: (data: any) => void;
+    private template?: (data: any) => string
     options: any = {};
     fetchMock?: typeof fetchMock;
     routeName?: string;

--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -480,6 +480,44 @@ changes until loading has taken longer than a certain amount of time:
     <!-- Show after 500ms of loading -->
     <div data-loading="delay(500)|show">Loading</div>
 
+Targeting Loading for a Specific Action
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.5
+
+    The ``action()`` modifier was introduced in Live Components 2.5.
+
+To only toggle the loading behavior when a specific action is triggered,
+use the ``action()`` modifier with the name of the action - e.g. ``saveForm()``:
+
+.. code-block:: twig
+
+    <!-- show only when the "saveForm" action is triggering -->
+    <span data-loading="action(saveForm)|show">Loading</span>
+    <!-- multiple modifiers -->
+    <div data-loading="action(saveForm)|delay|addClass(opacity-50)">...</div>
+
+Targeting Loading When a Specific Model Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.5
+
+    The ``model()`` modifier was introduced in Live Components 2.5.
+
+You can also toggle the loading behavior only if a specific model value
+was just changed using the ``model()`` modifier:
+
+.. code-block:: twig
+
+    <input data-model="email" type="email">
+
+    <span data-loading="model(email)|show">
+        Checking if email is available...
+    </span>
+
+    <!-- multiple modifiers & child properties -->
+    <span data-loading="model(user.email)|delay|addClass(opacity-50)">...</span>
+
 .. _actions:
 
 Actions

--- a/ux.symfony.com/assets/bootstrap.js
+++ b/ux.symfony.com/assets/bootstrap.js
@@ -1,5 +1,6 @@
 import { startStimulusApp } from '@symfony/stimulus-bridge';
 import Clipboard from 'stimulus-clipboard'
+import LiveController from '../live_assets/dist/live_controller';
 
 // Registers Stimulus controllers from controllers.json and in the controllers/ directory
 export const app = startStimulusApp(require.context(
@@ -12,5 +13,5 @@ app.debug = process.env.NODE_ENV === 'development';
 
 app.register('clipboard', Clipboard);
 // register any custom, 3rd party controllers here
-// app.register('some_controller_name', SomeImportedController);
+app.register('live', LiveController);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes
| Tickets       | Fix #462 and Feature E
| License       | MIT

NOTE: BUILT ON TOP OF #466. 

Been wanting this for awhile :): only trigger loading behavior on an element for a specific action.

```
<span data-loading="action(saveForm)|show">Loading</span>
```

Or only when a specific model has been updated:

```
<span data-loading="model(email)|show">Loading</span>
```

TODO:

* [x] Let's also add "model" loading to this PR as well