### PR TITLE
[Live] Doc'ing how to set values via Js, select sync bug & auto-setting data-model values

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -9,6 +9,23 @@
     it finishes. Then, all queued changes (potentially multiple model updates
     or actions) will be sent all at once on the next request.
 
+-   [BEHAVIOR CHANGE] Fields with `data-model` will now have their `value` set
+    automatically when the component initially loads and re-renders. For example,
+    previously you needed to manually set the value in your component template:
+
+    ```twig
+    <!-- BEFORE -->
+    <input data-model="firstName" value="{{ firstName }}">
+    ```
+
+    This is no longer necessary: Live Components will now set the value on load,
+    which allows you to simply have the following in your template:
+
+    ```twig
+    <!-- AFTER -->
+    <input data-model="firstName">
+    ```
+
 ## 2.4.0
 
 -   [BC BREAK] Previously, the `id` attribute was used with `morphdom` as the

--- a/src/LiveComponent/assets/src/UnsyncedInputContainer.ts
+++ b/src/LiveComponent/assets/src/UnsyncedInputContainer.ts
@@ -1,3 +1,11 @@
+/**
+ * Tracks field & models whose values are "unsynced".
+ *
+ * Unsynced means that the value has been updated inside of
+ * a field (e.g. an input), but that this new value hasn't
+ * yet been set onto the actual model data. It is "unsynced"
+ * from the underlying model data.
+ */
 export default class UnsyncedInputContainer {
     #mappedFields: Map<string, HTMLElement>;
     #unmappedFields: Array<HTMLElement> = [];
@@ -20,11 +28,11 @@ export default class UnsyncedInputContainer {
         return [...this.#unmappedFields, ...this.#mappedFields.values()]
     }
 
-    allMappedFields(): Map<string, HTMLElement> {
-        return this.#mappedFields;
+    markModelAsSynced(modelName: string): void {
+        this.#mappedFields.delete(modelName);
     }
 
-    remove(modelName: string) {
-        this.#mappedFields.delete(modelName);
+    getModifiedModels(): string[] {
+        return Array.from(this.#mappedFields.keys());
     }
 }

--- a/src/LiveComponent/assets/test/UnsyncedInputContainer.test.ts
+++ b/src/LiveComponent/assets/test/UnsyncedInputContainer.test.ts
@@ -12,7 +12,7 @@ describe('UnsyncedInputContainer', () => {
         expect(container.all()).toEqual([element1, element2]);
     });
 
-    it('removes items added to it', () => {
+    it('markModelAsSynced removes items added to it', () => {
         const container = new UnsyncedInputContainer();
         const element1 = htmlToElement('<span>element1</span');
         const element2 = htmlToElement('<span>element2</span');
@@ -21,8 +21,21 @@ describe('UnsyncedInputContainer', () => {
         container.add(element2, 'some_model2');
         container.add(element3, 'some_model3');
 
-        container.remove('some_model2');
+        container.markModelAsSynced('some_model2');
 
         expect(container.all()).toEqual([element1, element3]);
+    });
+
+    it('returns modified models via getModifiedModels()', () => {
+        const container = new UnsyncedInputContainer();
+        const element1 = htmlToElement('<span>element1</span');
+        const element2 = htmlToElement('<span>element2</span');
+        const element3 = htmlToElement('<span>element3</span');
+        container.add(element1);
+        container.add(element2, 'some_model2');
+        container.add(element3, 'some_model3');
+
+        container.markModelAsSynced('some_model2');
+        expect(container.getModifiedModels()).toEqual(['some_model3'])
     });
 });

--- a/src/LiveComponent/src/Resources/doc/index.rst
+++ b/src/LiveComponent/src/Resources/doc/index.rst
@@ -237,15 +237,17 @@ Add an inputs to the template:
 
     {# templates/components/random_number.html.twig #}
     <div {{ attributes }}>
-        <input
-            type="number"
-            value="{{ max }}"
-            data-model="max"
-        >
+        <input type="number" data-model="max">
 
         Generating a number between 9 and {{ max }}
         <strong>{{ this.randomNumber }}</strong>
     </div>
+
+.. versionadded:: 2.5
+
+    Before version 2.5, you needed to also set ``value="{{ max }}"``
+    on the ``<input>``. That is now set automatically for all
+    "data-model" fields.
 
 The key is the ``data-model`` attribute. Thanks
 to that, when the user types, the ``$max`` property on
@@ -296,10 +298,7 @@ delay via the ``debounce`` modifier:
 
 .. code-block:: twig
 
-        <input
-            data-model="debounce(100)|max"
-            value="{{ max }}"
-        >
+        <input data-model="debounce(100)|max">
 
 Lazy Updating on "change" of a Field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -311,10 +310,7 @@ happens, use the ``on(change)`` modifier:
 
 .. code-block:: twig
 
-    <input
-        data-model="on(change)|max"
-        value="{{ max }}"
-    >
+    <input data-model="on(change)|max">
 
 .. _deferring-a-re-render-until-later:
 
@@ -327,10 +323,7 @@ clicked). To do that, use ``norender`` modifier:
 
 .. code-block:: diff
 
-    <input
-        data-model="norender|max"
-        value="{{ max }}"
-    >
+    <input data-model="norender|max">
 
 Now, as you type, the ``max`` "model" will be updated in JavaScript, but
 it won't, yet, make an Ajax call to re-render the component. Whenever
@@ -390,6 +383,33 @@ In this example, clicking the button will change a ``mode``
 live property on your component to the value ``edit``. The
 ``data-action="live#update"`` is Stimulus code that triggers
 the update.
+
+Updating a Field via Custom JavaScript
+--------------------------------------
+
+Sometimes you might want to change the value of a field via your own
+custom JavaScript. Suppose you have the following field inside your component:
+
+.. code-block:: twig
+
+    <input
+        id="favorite-food"
+        data-model="favoriteFood"
+    >
+
+To set the value of this field via custom JavaScript (e.g. a Stimulus controller),
+be sure to *also* trigger a ``change`` event so that live components is notified
+of the change:
+
+.. code-block:: javascript
+
+    const input = document.getElementById('favorite-food');
+    input.value = 'sushi';
+
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // if you have data-model="on(change)|favoriteFood", use the "change" event
+    element.dispatchEvent(new Event('change', { bubbles: true }));
 
 Loading States
 --------------
@@ -1421,12 +1441,9 @@ filter from the ``twig/markdown-extra`` library):
 .. code-block:: twig
 
     <div {{ attributes }}>
-        <input
-            value="{{ post.title }}"
-            data-model="post.title"
-        >
+        <input data-model="post.title">
 
-       <textarea data-model="post.content">{{post.content}}</textarea>
+       <textarea data-model="post.content"></textarea>
 
         <div data-loading="addClass(low-opacity)">
             <h3>{{ post.title }}</h3>
@@ -1543,7 +1560,7 @@ method:
     <textarea
         data-model="post.content"
         class="{{ this.getError('post.content') ? 'has-error' : '' }}"
-    >{{ post.content }}</textarea>
+    ></textarea>
 
     {% if this.getError('agreeToTerms') %}
         <div class="error">
@@ -1553,9 +1570,9 @@ method:
     <input type="checkbox" data-model="agreeToTerms" class="{{ this.getError('agreeToTerms') ? 'has-error' : '' }}"/>
 
     <button
-            type="submit"
-            data-action="live#action"
-            data-action-name="prevent|save"
+        type="submit"
+        data-action="live#action"
+        data-action-name="prevent|save"
     >Save</button>
 
 Once a component has been validated, the component will "remember" that
@@ -1578,7 +1595,6 @@ To validate only on "change", use the ``on(change)`` modifier:
     <input
         type="email"
         data-model="on(change)|user.email"
-        value="{{ user.email }}"
         class="{{ this.getError('post.content') ? 'has-error' : '' }}"
     >
 
@@ -1833,7 +1849,7 @@ In the ``EditPostComponent`` template, you render the
         <textarea
             name="{{ name }}"
             data-model="value"
-        >{{ value }}</textarea>
+        ></textarea>
 
         <div class="markdown-preview">
             {{ value|markdown_to_html }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fixes #469 Fixes #473
| License       | MIT

This does 3 unrelated things to close #469 and #473

**NOTE: BUILT ON TOP OF https://github.com/symfony/ux/pull/466.**

A) [X] Documents how to change a "model" field via JavaScript
B) [X] Fixes a problem where a `select` element is rendered without an `empty` option, and so the component data isn't aware of the pre-selected option.
C) [X] Automatically set the `value` of a `data-model` field - #473. 

Cheers!
