### PR TITLE
refactor(Autocomplete Doc): adding tip to modify the results number returned by a query on automatic endpoint

### DIFF
--- a/src/Autocomplete/src/AutocompleteResultsExecutor.php
+++ b/src/Autocomplete/src/AutocompleteResultsExecutor.php
@@ -39,11 +39,6 @@ final class AutocompleteResultsExecutor
             $query
         );
 
-        // if no max is set, set one
-        if (!$queryBuilder->getMaxResults()) {
-            $queryBuilder->setMaxResults(10);
-        }
-
         $entities = $queryBuilder->getQuery()->execute();
 
         $results = [];

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -67,6 +67,10 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             $values['tom-select-options'] = json_encode($options['tom_select_options']);
         }
 
+        if ($options['max_results']) {
+            $values['max-results'] = $options['max_results'];
+        }
+
         $values['no-results-found-text'] = $this->trans($options['no_results_found_text']);
         $values['no-more-results-text'] = $this->trans($options['no_more_results_text']);
 
@@ -87,6 +91,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'allow_options_create' => false,
             'no_results_found_text' => 'No results found',
             'no_more_results_text' => 'No more results',
+            'max_results' => 10,
         ]);
 
         // if autocomplete_url is passed, then HTML options are already supported

--- a/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
+++ b/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
@@ -39,7 +39,7 @@ final class AutocompleteEntityTypeSubscriber implements EventSubscriberInterface
         // pass to AutocompleteChoiceTypeExtension
         $options['autocomplete'] = true;
         $options['autocomplete_url'] = $this->autocompleteUrl;
-        unset($options['searchable_fields'], $options['security'], $options['filter_query']);
+        unset($options['searchable_fields'], $options['security'], $options['filter_query'], $options['max_results']);
 
         $form->add('autocomplete', EntityType::class, $options);
     }

--- a/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
+++ b/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
@@ -76,10 +76,13 @@ final class ParentEntityAutocompleteType extends AbstractType implements DataMap
             // set to the string role that's required to view the autocomplete results
             // or a callable: function(Symfony\Component\Security\Core\Security $security): bool
             'security' => false,
+            // set the max results number that a query on automatic endpoint return.
+            'max_results' => 10,
         ]);
 
         $resolver->setRequired(['class']);
         $resolver->setAllowedTypes('security', ['boolean', 'string', 'callable']);
+        $resolver->setAllowedTypes('max_results', ['int', 'null']);
         $resolver->setAllowedTypes('filter_query', ['callable', 'null']);
         $resolver->setNormalizer('searchable_fields', function (Options $options, ?array $searchableFields) {
             if (null !== $searchableFields && null !== $options['filter_query']) {

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -54,6 +54,9 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
             return $queryBuilder;
         }
 
+        // Applying max result limit or not
+        $queryBuilder->setMaxResults($this->getMaxResults());
+
         $this->entitySearchUtil->addSearchClause(
             $queryBuilder,
             $query,
@@ -129,6 +132,11 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
     private function getFilterQuery(): ?callable
     {
         return $this->getForm()->getConfig()->getOption('filter_query');
+    }
+
+    private function getMaxResults(): ?int
+    {
+        return $this->getForm()->getConfig()->getOption('max_results');
     }
 
     private function getEntityMetadata(): EntityMetadata

--- a/src/Autocomplete/src/Resources/doc/index.rst
+++ b/src/Autocomplete/src/Resources/doc/index.rst
@@ -258,7 +258,37 @@ to the options above, you can also pass:
             $qb->andWhere('entity.name LIKE :filter OR entity.description LIKE :filter')
                 ->setParameter('filter', '%'.$query.'%');
         }
+..tip::
 
+    By default, the query results number is limited to ten results.
+    In the case where you use the ``filter_query`` attribute, you can define the expected number results
+    by calling the setMaxResults() method of the query builder::
+
+        'filter_query' => function(QueryBuilder $qb, string $query, EntityRepository $repository) {
+            if (!$query) {
+                return;
+            }
+
+            $qb->andWhere('entity.name LIKE :filter OR entity.description LIKE :filter')
+                ->setParameter('filter', '%'.$query.'%')
+                ->setMaxResults(100);
+        }
+    In the case where you use the ``searchable_fields`` attribute, you can define a ``query_builder`` to
+    call the setMaxResults() method of the query builder::
+
+        $resolver->setDefaults([
+            'class' => Food::class,
+            'placeholder' => 'What should we eat?',
+
+            // choose which fields to use in the search
+            // if not passed, *all* fields are used
+            'searchable_fields' => ['name'],
+            'query_builder' => function(EntityRepository $repository)
+            {
+                return $repository->createQueryBuilder('food')
+                    ->setMaxResults(100);
+            },
+        ]);
 Using with a TextType Field
 ---------------------------
 

--- a/src/Autocomplete/src/Resources/doc/index.rst
+++ b/src/Autocomplete/src/Resources/doc/index.rst
@@ -258,37 +258,9 @@ to the options above, you can also pass:
             $qb->andWhere('entity.name LIKE :filter OR entity.description LIKE :filter')
                 ->setParameter('filter', '%'.$query.'%');
         }
-..tip::
-
-    By default, the query results number is limited to ten results.
-    In the case where you use the ``filter_query`` attribute, you can define the expected number results
-    by calling the setMaxResults() method of the query builder::
-
-        'filter_query' => function(QueryBuilder $qb, string $query, EntityRepository $repository) {
-            if (!$query) {
-                return;
-            }
-
-            $qb->andWhere('entity.name LIKE :filter OR entity.description LIKE :filter')
-                ->setParameter('filter', '%'.$query.'%')
-                ->setMaxResults(100);
-        }
-    In the case where you use the ``searchable_fields`` attribute, you can define a ``query_builder`` to
-    call the setMaxResults() method of the query builder::
-
-        $resolver->setDefaults([
-            'class' => Food::class,
-            'placeholder' => 'What should we eat?',
-
-            // choose which fields to use in the search
-            // if not passed, *all* fields are used
-            'searchable_fields' => ['name'],
-            'query_builder' => function(EntityRepository $repository)
-            {
-                return $repository->createQueryBuilder('food')
-                    ->setMaxResults(100);
-            },
-        ]);
+``max_results`` (default: 10)
+    Allow you to control the reults number returned by a query on automatic endpoint.
+    Set it to ``null`` if you don't want to limit results. 
 Using with a TextType Field
 ---------------------------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT


Adding tip to to the doc to explain how can it be possible to modify the max results number when using autocomplete UX. 

