### PR TITLE
[Autocomplete] implement max_results option

### DIFF
--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -67,6 +67,10 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             $values['tom-select-options'] = json_encode($options['tom_select_options']);
         }
 
+        if ($options['max_results']) {
+            $values['max-results'] = $options['max_results'];
+        }
+
         $values['no-results-found-text'] = $this->trans($options['no_results_found_text']);
         $values['no-more-results-text'] = $this->trans($options['no_more_results_text']);
 
@@ -87,6 +91,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'allow_options_create' => false,
             'no_results_found_text' => 'No results found',
             'no_more_results_text' => 'No more results',
+            'max_results' => 10,
         ]);
 
         // if autocomplete_url is passed, then HTML options are already supported

--- a/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
+++ b/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
@@ -39,7 +39,7 @@ final class AutocompleteEntityTypeSubscriber implements EventSubscriberInterface
         // pass to AutocompleteChoiceTypeExtension
         $options['autocomplete'] = true;
         $options['autocomplete_url'] = $this->autocompleteUrl;
-        unset($options['searchable_fields'], $options['security'], $options['filter_query']);
+        unset($options['searchable_fields'], $options['security'], $options['filter_query'], $options['max_results']);
 
         $form->add('autocomplete', EntityType::class, $options);
     }

--- a/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
+++ b/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
@@ -76,10 +76,13 @@ final class ParentEntityAutocompleteType extends AbstractType implements DataMap
             // set to the string role that's required to view the autocomplete results
             // or a callable: function(Symfony\Component\Security\Core\Security $security): bool
             'security' => false,
+            // set the max results number that a query on automatic endpoint return.
+            'max_results' => 10,
         ]);
 
         $resolver->setRequired(['class']);
         $resolver->setAllowedTypes('security', ['boolean', 'string', 'callable']);
+        $resolver->setAllowedTypes('max_results', ['int', 'null']);
         $resolver->setAllowedTypes('filter_query', ['callable', 'null']);
         $resolver->setNormalizer('searchable_fields', function (Options $options, ?array $searchableFields) {
             if (null !== $searchableFields && null !== $options['filter_query']) {

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -54,6 +54,9 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
             return $queryBuilder;
         }
 
+        // Applying max result limit or not
+        $queryBuilder->setMaxResults($this->getMaxResults());
+
         $this->entitySearchUtil->addSearchClause(
             $queryBuilder,
             $query,
@@ -129,6 +132,11 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
     private function getFilterQuery(): ?callable
     {
         return $this->getForm()->getConfig()->getOption('filter_query');
+    }
+
+    private function getMaxResults(): ?int
+    {
+        return $this->getForm()->getConfig()->getOption('max_results');
     }
 
     private function getEntityMetadata(): EntityMetadata

--- a/src/Autocomplete/src/Resources/doc/index.rst
+++ b/src/Autocomplete/src/Resources/doc/index.rst
@@ -258,6 +258,8 @@ to the options above, you can also pass:
             $qb->andWhere('entity.name LIKE :filter OR entity.description LIKE :filter')
                 ->setParameter('filter', '%'.$query.'%');
         }
+``max_results`` (default: 10)
+    Allow you to control the max number of results returned by the automatic autocomplete endpoint.
 
 Using with a TextType Field
 ---------------------------

--- a/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
@@ -41,6 +41,7 @@ class CategoryAutocompleteType extends AbstractType
             'attr' => [
                 'data-controller' => 'custom-autocomplete',
             ],
+            'max_results' => 5,
         ]);
     }
 

--- a/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
+++ b/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
@@ -78,4 +78,16 @@ class FieldAutocompleterTest extends KernelTestCase
             ->assertJsonMatches('length(results)', 3)
         ;
     }
+
+    public function testItCheckMaxResultsOption() : void
+    {
+        CategoryFactory::createMany(30, ['name' => 'foo']);
+
+        $this->browser()
+            ->throwExceptions()
+            ->get('/test/autocomplete/category_autocomplete_type?query=foo')
+            ->assertSuccessful()
+            ->assertJsonMatches('length(results)', 5)
+        ;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       |N/A
| License       | MIT

Added max_results option in formType options to control the results number returned by a query on automatic endpoint. 
