### PR TITLE
[Autocomplete]: implement group_by option on Entity Autocompleter results

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## 2.8.0
 
+
 -   The autocomplete will now update if any of the `option` elements inside of
     it change, including the empty / placeholder element. Additionally, if the
     `select` or `input` element's `disabled` attribute changes, the autocomplete
     instance will update accordingly. This makes Autocomplete work perfectly inside
     of a LiveComponent.
+
+-   Added support for using [OptionGroups](https://tom-select.js.org/examples/optgroups/).
+
 
 ## 2.7.0
 

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -266,13 +266,14 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
                 .then((response) => response.json())
                 .then((json) => {
                 this.setNextUrl(query, json.next_page);
-                callback(json.results);
+                callback(json.results.options || json.results, json.results.optgroups || []);
             })
-                .catch(() => callback());
+                .catch(() => callback([], []));
         },
         shouldLoad: function (query) {
             return query.length >= minCharacterLength;
         },
+        optgroupField: 'group_by',
         score: function (search) {
             return function (item) {
                 return 1;

--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -28,6 +28,7 @@
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
+        "symfony/property-access": "^5.4|^6.0",
         "symfony/string": "^5.4|^6.0"
     },
     "require-dev": {

--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -513,6 +513,20 @@ a :ref:`custom autocompleter <custom-autocompleter>`:
             ]
         }
 
+    for using `Tom Select Option Group`_ the format is as follows
+
+    .. code-block:: json
+
+        {
+            "results": {
+                "options": [
+                    { "value": "1", "text": "Pizza", "group_by": ["food"] },
+                    { "value": "2", "text": "Banana", "group_by": ["food"] }
+                ],
+                "optgroups": [{ "value": "food", "label": "food" }]
+            }
+        }
+
     Once you have this, generate the URL to your controller and
     pass it to the ``url`` value of the ``stimulus_controller()`` Twig
     function, or to the ``autocomplete_url`` option of your form field.
@@ -557,3 +571,4 @@ the Symfony framework: https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Tom Select Options`: https://tom-select.js.org/docs/#general-configuration
 .. _`controller.ts`: https://github.com/symfony/ux/blob/2.x/src/Autocomplete/assets/src/controller.ts
 .. _`Tom Select Render Templates`: https://tom-select.js.org/docs/#render-templates
+.. _`Tom Select Option Group`: https://tom-select.js.org/examples/optgroups/

--- a/src/Autocomplete/src/AutocompleteResults.php
+++ b/src/Autocomplete/src/AutocompleteResults.php
@@ -19,6 +19,7 @@ final class AutocompleteResults
     public function __construct(
         public array $results,
         public bool $hasNextPage,
+        public array $optgroups = [],
     ) {
     }
 }

--- a/src/Autocomplete/src/AutocompleteResultsExecutor.php
+++ b/src/Autocomplete/src/AutocompleteResultsExecutor.php
@@ -12,6 +12,11 @@
 namespace Symfony\UX\Autocomplete;
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\PropertyAccess\PropertyPathInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\UX\Autocomplete\Doctrine\DoctrineRegistryWrapper;
@@ -21,10 +26,22 @@ use Symfony\UX\Autocomplete\Doctrine\DoctrineRegistryWrapper;
  */
 final class AutocompleteResultsExecutor
 {
+    private PropertyAccessorInterface $propertyAccessor;
+    private ?Security $security;
+
     public function __construct(
         private DoctrineRegistryWrapper $managerRegistry,
-        private ?Security $security = null
+        $propertyAccessor,
+        /* Security $security = null */
     ) {
+        if ($propertyAccessor instanceof Security) {
+            trigger_deprecation('symfony/ux-autocomplete', '2.8.0', 'Passing a "%s" instance as the second argument of "%s()" is deprecated, pass a "%s" instance instead.', Security::class, __METHOD__, PropertyAccessorInterface::class);
+            $this->security = $propertyAccessor;
+            $this->propertyAccessor = new PropertyAccessor();
+        } else {
+            $this->propertyAccessor = $propertyAccessor;
+            $this->security = \func_num_args() >= 3 ? func_get_arg(2) : null;
+        }
     }
 
     public function fetchResults(EntityAutocompleterInterface $autocompleter, string $query, int $page): AutocompleteResults
@@ -50,15 +67,61 @@ final class AutocompleteResultsExecutor
         $paginator = new Paginator($queryBuilder);
 
         $nbPages = (int) ceil($paginator->count() / $queryBuilder->getMaxResults());
+        $hasNextPage = $page < $nbPages;
 
         $results = [];
+
+        if (null === $groupBy = $autocompleter->getGroupBy()) {
+            foreach ($paginator as $entity) {
+                $results[] = [
+                    'value' => $autocompleter->getValue($entity),
+                    'text' => $autocompleter->getLabel($entity),
+                ];
+            }
+
+            return new AutocompleteResults($results, $hasNextPage);
+        }
+
+        if (\is_string($groupBy)) {
+            $groupBy = new PropertyPath($groupBy);
+        }
+
+        if ($groupBy instanceof PropertyPathInterface) {
+            $accessor = $this->propertyAccessor;
+            $groupBy = function ($choice) use ($accessor, $groupBy) {
+                try {
+                    return $accessor->getValue($choice, $groupBy);
+                } catch (UnexpectedTypeException) {
+                    return null;
+                }
+            };
+        }
+
+        if (!\is_callable($groupBy)) {
+            throw new \InvalidArgumentException(sprintf('Option "group_by" must be callable, "%s" given.', get_debug_type($groupBy)));
+        }
+
+        $optgroupLabels = [];
+
         foreach ($paginator as $entity) {
-            $results[] = [
+            $result = [
                 'value' => $autocompleter->getValue($entity),
                 'text' => $autocompleter->getLabel($entity),
             ];
+
+            $groupLabels = $groupBy($entity, $result['value'], $result['text']);
+
+            if (null !== $groupLabels) {
+                $groupLabels = \is_array($groupLabels) ? array_map('strval', $groupLabels) : [(string) $groupLabels];
+                $result['group_by'] = $groupLabels;
+                $optgroupLabels = array_merge($optgroupLabels, $groupLabels);
+            }
+
+            $results[] = $result;
         }
 
-        return new AutocompleteResults($results, $page < $nbPages);
+        $optgroups = array_map(fn (string $label) => ['value' => $label, 'label' => $label], array_unique($optgroupLabels));
+
+        return new AutocompleteResults($results, $hasNextPage, $optgroups);
     }
 }

--- a/src/Autocomplete/src/Controller/EntityAutocompleteController.php
+++ b/src/Autocomplete/src/Controller/EntityAutocompleteController.php
@@ -50,7 +50,7 @@ final class EntityAutocompleteController
         }
 
         return new JsonResponse([
-            'results' => $data->results,
+            'results' => ($data->optgroups) ? ['options' => $data->results, 'optgroups' => $data->optgroups] : $data->results,
             'next_page' => $nextPage,
         ]);
     }

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
@@ -81,6 +81,7 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
             ->register('ux.autocomplete.results_executor', AutocompleteResultsExecutor::class)
             ->setArguments([
                 new Reference('ux.autocomplete.doctrine_registry_wrapper'),
+                new Reference('property_accessor'),
                 new Reference('security.helper', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
         ;

--- a/src/Autocomplete/src/EntityAutocompleterInterface.php
+++ b/src/Autocomplete/src/EntityAutocompleterInterface.php
@@ -46,4 +46,9 @@ interface EntityAutocompleterInterface
      * Note: if SecurityBundle is not installed, this will not be called.
      */
     public function isGranted(Security $security): bool;
+
+    /**
+     * Return group_by option.
+     */
+    public function getGroupBy(): mixed;
 }

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -112,6 +112,11 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
         throw new \InvalidArgumentException('Invalid passed to the "security" option: it must be the boolean true, a string role or a callable.');
     }
 
+    public function getGroupBy(): mixed
+    {
+        return $this->getFormOption('group_by');
+    }
+
     private function getFormOption(string $name): mixed
     {
         $form = $this->getForm();

--- a/src/Autocomplete/tests/Fixtures/Autocompleter/CustomGroupByProductAutocompleter.php
+++ b/src/Autocomplete/tests/Fixtures/Autocompleter/CustomGroupByProductAutocompleter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Security;
+use Symfony\UX\Autocomplete\Doctrine\EntitySearchUtil;
+use Symfony\UX\Autocomplete\EntityAutocompleterInterface;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Product;
+
+class CustomGroupByProductAutocompleter extends CustomProductAutocompleter
+{
+    public function getGroupBy(): mixed
+    {
+        return 'category.name';
+    }
+}

--- a/src/Autocomplete/tests/Fixtures/Autocompleter/CustomProductAutocompleter.php
+++ b/src/Autocomplete/tests/Fixtures/Autocompleter/CustomProductAutocompleter.php
@@ -58,4 +58,9 @@ class CustomProductAutocompleter implements EntityAutocompleterInterface
 
         return true;
     }
+
+    public function getGroupBy(): mixed
+    {
+        return null;
+    }
 }

--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -28,6 +28,7 @@ use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\UX\Autocomplete\AutocompleteBundle;
 use Symfony\UX\Autocomplete\DependencyInjection\AutocompleteFormTypePass;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Form\ProductType;
 use Twig\Environment;
@@ -143,6 +144,13 @@ final class Kernel extends BaseKernel
             ->arg(1, new Reference('ux.autocomplete.entity_search_util'))
             ->tag(AutocompleteFormTypePass::ENTITY_AUTOCOMPLETER_TAG, [
                 'alias' => 'custom_product'
+            ]);
+
+        $services->set(CustomGroupByProductAutocompleter::class)
+            ->public()
+            ->arg(1, new Reference('ux.autocomplete.entity_search_util'))
+            ->tag(AutocompleteFormTypePass::ENTITY_AUTOCOMPLETER_TAG, [
+                'alias' => 'custom_group_by_product'
             ]);
 
         $services->alias('public.results_executor', 'ux.autocomplete.results_executor')

--- a/src/Autocomplete/tests/Integration/WiringTest.php
+++ b/src/Autocomplete/tests/Integration/WiringTest.php
@@ -14,7 +14,9 @@ namespace Symfony\UX\Autocomplete\Tests\Integration;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\UX\Autocomplete\AutocompleteResultsExecutor;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomProductAutocompleter;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Factory\CategoryFactory;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Factory\ProductFactory;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Kernel;
 use Zenstruck\Foundry\Test\Factories;
@@ -72,5 +74,25 @@ class WiringTest extends KernelTestCase
         $data = $executor->fetchResults($autocompleter, '', 4);
         $this->assertCount(0, $data->results);
         $this->assertFalse($data->hasNextPage);
+    }
+
+    public function testWiringWithoutFormAndGroupByOption(): void
+    {
+        $kernel = new Kernel('test', true);
+        $kernel->disableForms();
+        $kernel->boot();
+
+        $category1 = CategoryFactory::createOne(['name' => 'foods']);
+        $category2 = CategoryFactory::createOne(['name' => 'toys']);
+        ProductFactory::createOne(['name' => 'pizza', 'category' => $category1]);
+        ProductFactory::createOne(['name' => 'toy food', 'category' => $category2]);
+        ProductFactory::createOne(['name' => 'puzzle', 'category' => $category2]);
+
+        /** @var AutocompleteResultsExecutor $executor */
+        $executor = $kernel->getContainer()->get('public.results_executor');
+        $autocompleter = $kernel->getContainer()->get(CustomGroupByProductAutocompleter::class);
+        $data = $executor->fetchResults($autocompleter, '', 1);
+        $this->assertCount(3, $data->results);
+        $this->assertCount(2, $data->optgroups);
     }
 }

--- a/src/Autocomplete/tests/Unit/AutocompleteResultsExecutorTest.php
+++ b/src/Autocomplete/tests/Unit/AutocompleteResultsExecutorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\Autocomplete\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\UX\Autocomplete\AutocompleteResultsExecutor;
@@ -31,6 +32,7 @@ class AutocompleteResultsExecutorTest extends TestCase
 
         $executor = new AutocompleteResultsExecutor(
             $doctrineRegistry,
+            $this->createMock(PropertyAccessorInterface::class),
             $this->createMock(Security::class)
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | ?
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #477 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->

Add possibility to group results (with `group_by` option) on ajax autocomplete result
