### PR TITLE
[Autocomplete] add option to specify minimum characters for autocomplete

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 2.4.0
+
+-   Support added for setting the required minimum search query length (defaults to 3) (#492) - @daFish

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -39,7 +39,7 @@ class default_1 extends Controller {
     }
     connect() {
         if (this.urlValue) {
-            this.tomSelect = __classPrivateFieldGet(this, _instances, "m", _createAutocompleteWithRemoteData).call(this, this.urlValue);
+            this.tomSelect = __classPrivateFieldGet(this, _instances, "m", _createAutocompleteWithRemoteData).call(this, this.urlValue, this.minCharactersValue);
             return;
         }
         if (this.optionsAsHtmlValue) {
@@ -121,7 +121,7 @@ _instances = new WeakSet(), _getCommonConfig = function _getCommonConfig() {
         },
     });
     return __classPrivateFieldGet(this, _instances, "m", _createTomSelect).call(this, config);
-}, _createAutocompleteWithRemoteData = function _createAutocompleteWithRemoteData(autocompleteEndpointUrl) {
+}, _createAutocompleteWithRemoteData = function _createAutocompleteWithRemoteData(autocompleteEndpointUrl, minCharacterLength) {
     const config = __classPrivateFieldGet(this, _instances, "m", _mergeObjects).call(this, __classPrivateFieldGet(this, _instances, "m", _getCommonConfig).call(this), {
         firstUrl: (query) => {
             const separator = autocompleteEndpointUrl.includes('?') ? '&' : '?';
@@ -133,6 +133,10 @@ _instances = new WeakSet(), _getCommonConfig = function _getCommonConfig() {
                 .then(response => response.json())
                 .then(json => { this.setNextUrl(query, json.next_page); callback(json.results); })
                 .catch(() => callback());
+        },
+        shouldLoad: function (query) {
+            const minLength = minCharacterLength || 3;
+            return query.length >= minLength;
         },
         score: function (search) {
             return function (item) {
@@ -173,6 +177,7 @@ default_1.values = {
     optionsAsHtml: Boolean,
     noResultsFoundText: String,
     noMoreResultsText: String,
+    minCharacters: Number,
     tomSelectOptions: Object,
 };
 

--- a/src/Autocomplete/assets/test/controller.test.ts
+++ b/src/Autocomplete/assets/test/controller.test.ts
@@ -138,6 +138,35 @@ describe('AutocompleteController', () => {
         });
     });
 
+    it('limits updates when min-characters', async () => {
+        const container = mountDOM(`
+            <label for="the-select">Items</label>
+            <select
+                id="the-select"
+                data-testid="main-element"
+                data-controller="check autocomplete"
+                data-autocomplete-url-value="/path/to/autocomplete"
+                data-autocomplete-min-characters-value="3"
+            ></select>
+        `);
+
+        application = startStimulus();
+
+        await waitFor(() => {
+            expect(getByTestId(container, 'main-element')).toHaveClass('connected');
+        });
+
+        const tomSelect = getByTestId(container, 'main-element').tomSelect;
+        const controlInput = tomSelect.control_input;
+
+        controlInput.value = 'fo';
+        controlInput.dispatchEvent(new Event('input'));
+
+        await waitFor(() => {
+            expect(container.querySelectorAll('.option[data-selectable]')).toHaveLength(0);
+        });
+    });
+
     it('adds live-component support', async () => {
         const container = mountDOM(`
             <div>

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -71,6 +71,10 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             $values['max-results'] = $options['max_results'];
         }
 
+        if ($options['min_characters']) {
+            $values['min-characters'] = $options['min_characters'];
+        }
+
         $values['no-results-found-text'] = $this->trans($options['no_results_found_text']);
         $values['no-more-results-text'] = $this->trans($options['no_more_results_text']);
 
@@ -91,6 +95,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'allow_options_create' => false,
             'no_results_found_text' => 'No results found',
             'no_more_results_text' => 'No more results',
+            'min_characters' => 3,
             'max_results' => 10,
         ]);
 

--- a/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
@@ -42,6 +42,7 @@ class CategoryAutocompleteType extends AbstractType
                 'data-controller' => 'custom-autocomplete',
             ],
             'max_results' => 5,
+            'min_characters' => 2,
         ]);
     }
 

--- a/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
+++ b/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
@@ -31,6 +31,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
             ->get('/test-form')
             ->assertElementAttributeContains('#product_category_autocomplete', 'data-controller', 'custom-autocomplete symfony--ux-autocomplete--autocomplete')
             ->assertElementAttributeContains('#product_category_autocomplete', 'data-symfony--ux-autocomplete--autocomplete-url-value', '/test/autocomplete/category_autocomplete_type')
+            ->assertElementAttributeContains('#product_category_autocomplete', 'data-symfony--ux-autocomplete--autocomplete-min-characters-value', '2')
 
             ->assertElementAttributeContains('#product_portionSize', 'data-controller', 'symfony--ux-autocomplete--autocomplete')
             ->assertElementAttributeContains('#product_tags', 'data-controller', 'symfony--ux-autocomplete--autocomplete')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #432 
| License       | MIT

This change adds a new option `min_characters` for specifying the value of entered characters before the autocomplete is triggerd. This avoids calls with an empty query.

Todos:
- [x] add tests

@weaverryan I also added a `CHANGELOG.md` because this file wasn't present. 