### PR TITLE
[Autocomplete] Add pagination

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -138,6 +138,15 @@ jobs:
               working-directory: src/LiveComponent
               run: php vendor/bin/simple-phpunit
 
+            - name: Autocomplete Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                working-directory: src/Autocomplete
+                dependency-versions: lowest
+            - name: Autocomplete Tests
+              working-directory: src/Autocomplete
+              run: php vendor/bin/simple-phpunit
+
     tests-php-high-deps:
         runs-on: ubuntu-latest
         steps:
@@ -201,6 +210,14 @@ jobs:
                   working-directory: src/React
             - name: React Tests
               working-directory: src/React
+              run: php vendor/bin/simple-phpunit
+
+            - name: Autocomplete Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                working-directory: src/Autocomplete
+            - name: Autocomplete Tests
+              working-directory: src/Autocomplete
               run: php vendor/bin/simple-phpunit
 
     tests-php81-high-deps:

--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.5.0
+
+-   Automatic pagination support added: if the query would return more results
+    than your limit, when the user scrolls to the bottom of the options, it will
+    make a second Ajax call to load more.
+
 ## 2.4.0
 
 -   Support added for setting the required minimum search query length (defaults to 3) (#492) - @daFish

--- a/src/Autocomplete/assets/test/controller.test.ts
+++ b/src/Autocomplete/assets/test/controller.test.ts
@@ -15,6 +15,20 @@ import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
 import AutocompleteController from '../src/controller';
 import fetchMock from 'fetch-mock-jest';
 import userEvent from '@testing-library/user-event';
+import TomSelect from 'tom-select';
+
+const getTomSelectInstance = (container: HTMLElement): TomSelect => {
+    const element = container.querySelector('[data-controller*="autocomplete"]');
+
+    if (!element) {
+        throw new Error('Cannot find data-controller="autocomplete" element');
+    }
+    if ('tomSelect' in element) {
+        return element.tomSelect;
+    }
+
+    throw new Error('Cannot find tomSelect instance');
+}
 
 // Controller used to check the actual controller was properly booted
 class CheckController extends Controller {
@@ -69,7 +83,7 @@ describe('AutocompleteController', () => {
             expect(getByTestId(container, 'main-element')).toHaveClass('connected');
         });
 
-        const tomSelect = getByTestId(container, 'main-element').tomSelect;
+        const tomSelect = getTomSelectInstance(container);
         expect(tomSelect.input).toBe(getByTestId(container, 'main-element'));
     });
 
@@ -119,7 +133,7 @@ describe('AutocompleteController', () => {
             }),
         );
 
-        const tomSelect = getByTestId(container, 'main-element').tomSelect;
+        const tomSelect = getTomSelectInstance(container);
         const controlInput = tomSelect.control_input;
 
         // wait for the initial Ajax request to finish
@@ -156,7 +170,7 @@ describe('AutocompleteController', () => {
             expect(getByTestId(container, 'main-element')).toHaveClass('connected');
         });
 
-        const tomSelect = getByTestId(container, 'main-element').tomSelect;
+        const tomSelect = getTomSelectInstance(container);
         const controlInput = tomSelect.control_input;
 
         controlInput.value = 'fo';
@@ -238,7 +252,7 @@ describe('AutocompleteController', () => {
             }),
         );
 
-        const tomSelect = getByTestId(container, 'main-element').tomSelect;
+        const tomSelect = getTomSelectInstance(container);
         const controlInput = tomSelect.control_input;
 
         // wait for the initial Ajax request to finish

--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -31,8 +31,8 @@
         "symfony/string": "^5.4|^6.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^2.0",
-        "doctrine/orm": "^2.7",
+        "doctrine/doctrine-bundle": "^2.4",
+        "doctrine/orm": "^2.9",
         "mtdowling/jmespath.php": "2.6.x-dev",
         "symfony/form": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
@@ -45,6 +45,9 @@
         "symfony/uid": "^5.4|^6.0",
         "zenstruck/browser": "^1.1",
         "zenstruck/foundry": "^1.19"
+    },
+    "conflict": {
+        "doctrine/orm": "2.9.0 || 2.9.1"
     },
     "config": {
         "sort-packages": true

--- a/src/Autocomplete/src/AutocompleteResults.php
+++ b/src/Autocomplete/src/AutocompleteResults.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Autocomplete;
+
+final class AutocompleteResults
+{
+    /**
+     * @param list<array{label: string, value: mixed}> $results
+     */
+    public function __construct(
+        public array $results,
+        public bool $hasNextPage,
+    ) {
+    }
+}

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
@@ -106,6 +106,7 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
             ->setArguments([
                 new Reference('ux.autocomplete.autocompleter_registry'),
                 new Reference('ux.autocomplete.results_executor'),
+                new Reference('router'),
             ])
             ->addTag('controller.service_arguments')
         ;

--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -89,6 +89,7 @@ final class Kernel extends BaseKernel
                         'is_bundle' => false,
                         'dir' => '%kernel.project_dir%/tests/Fixtures/Entity',
                         'prefix' => 'Symfony\UX\Autocomplete\Tests\Fixtures\Entity',
+                        'type' => 'attribute',
                         'alias' => 'Test',
                     ],
                 ],
@@ -96,6 +97,7 @@ final class Kernel extends BaseKernel
         ]);
 
         $c->extension('security', [
+            'enable_authenticator_manager' => true,
             'password_hashers' => [
                 PasswordAuthenticatedUserInterface::class => 'plaintext'
             ],

--- a/src/Autocomplete/tests/Integration/WiringTest.php
+++ b/src/Autocomplete/tests/Integration/WiringTest.php
@@ -44,6 +44,33 @@ class WiringTest extends KernelTestCase
         /** @var AutocompleteResultsExecutor $executor */
         $executor = $kernel->getContainer()->get('public.results_executor');
         $autocompleter = $kernel->getContainer()->get(CustomProductAutocompleter::class);
-        $this->assertCount(3, $executor->fetchResults($autocompleter, ''));
+        $data = $executor->fetchResults($autocompleter, '', 1);
+        $this->assertCount(3, $data->results);
+        $this->assertFalse($data->hasNextPage);
+    }
+
+    public function testWiringWithManyResults(): void
+    {
+        $kernel = new Kernel('test', true);
+        $kernel->disableForms();
+        $kernel->boot();
+
+        ProductFactory::createMany(22);
+
+        /** @var AutocompleteResultsExecutor $executor */
+        $executor = $kernel->getContainer()->get('public.results_executor');
+        $autocompleter = $kernel->getContainer()->get(CustomProductAutocompleter::class);
+        $data = $executor->fetchResults($autocompleter, '', 1);
+        $this->assertCount(10, $data->results);
+        $this->assertTrue($data->hasNextPage);
+        $data = $executor->fetchResults($autocompleter, '', 2);
+        $this->assertCount(10, $data->results);
+        $this->assertTrue($data->hasNextPage);
+        $data = $executor->fetchResults($autocompleter, '', 3);
+        $this->assertCount(2, $data->results);
+        $this->assertFalse($data->hasNextPage);
+        $data = $executor->fetchResults($autocompleter, '', 4);
+        $this->assertCount(0, $data->results);
+        $this->assertFalse($data->hasNextPage);
     }
 }

--- a/src/Autocomplete/tests/Unit/AutocompleteResultsExecutorTest.php
+++ b/src/Autocomplete/tests/Unit/AutocompleteResultsExecutorTest.php
@@ -11,63 +11,15 @@
 
 namespace Symfony\UX\Autocomplete\Tests\Unit;
 
-use Doctrine\ORM\AbstractQuery;
-use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Security\Security;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Security;
 use Symfony\UX\Autocomplete\AutocompleteResultsExecutor;
 use Symfony\UX\Autocomplete\Doctrine\DoctrineRegistryWrapper;
 use Symfony\UX\Autocomplete\EntityAutocompleterInterface;
 
 class AutocompleteResultsExecutorTest extends TestCase
 {
-    public function testItExecutesTheResults()
-    {
-        $doctrineRegistry = $this->createMock(DoctrineRegistryWrapper::class);
-        $doctrineRegistry->expects($this->any())
-            ->method('getRepository')
-            ->willReturn($this->createMock(EntityRepository::class));
-
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $autocompleter = $this->createMock(EntityAutocompleterInterface::class);
-        $autocompleter->expects($this->once())
-            ->method('createFilteredQueryBuilder')
-            ->willReturn($queryBuilder);
-        $autocompleter->expects($this->exactly(2))
-            ->method('getValue')
-            ->willReturnCallback(function (object $object) {
-                return $object->id;
-            });
-        $autocompleter->expects($this->exactly(2))
-            ->method('getLabel')
-            ->willReturnCallback(function (object $object) {
-                return $object->name;
-            });
-
-        $result1 = new \stdClass();
-        $result1->id = 1;
-        $result1->name = 'Result 1';
-        $result2 = new \stdClass();
-        $result2->id = 2;
-        $result2->name = 'Result 2';
-
-        $mockQuery = $this->createMock(AbstractQuery::class);
-        $mockQuery->expects($this->once())
-            ->method('execute')
-            ->willReturn([$result1, $result2]);
-        $queryBuilder->expects($this->once())
-            ->method('getQuery')
-            ->willReturn($mockQuery);
-
-        $executor = new AutocompleteResultsExecutor($doctrineRegistry);
-        $this->assertEquals([
-            ['value' => 1, 'text' => 'Result 1'],
-            ['value' => 2, 'text' => 'Result 2'],
-        ], $executor->fetchResults($autocompleter, 'foo'));
-    }
-
     public function testItExecutesSecurity()
     {
         $doctrineRegistry = $this->createMock(DoctrineRegistryWrapper::class);
@@ -83,6 +35,6 @@ class AutocompleteResultsExecutorTest extends TestCase
         );
 
         $this->expectException(AccessDeniedException::class);
-        $executor->fetchResults($autocompleter, 'foo');
+        $executor->fetchResults($autocompleter, 'foo', 1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #399
| License       | MIT

Adds pagination as discussed in #399.

- `AutocompleteResultsExecutorTest::testItExecutesTheResults` is broken now because mocked `AbstractQuery` doesn't have `setMaxResults` and `setFirstResult` methods and also because we use now Doctrine Paginator it's basically no point to unit test this.
- > (we could do this by cloning the current Request object, calling $request->query->set('page', $nextPage), then calling $request->getRequestUri()

  this was not possible so because request uri is already prepared at that point so calling `$request->query->set('page')` was not changing the uri for this reason I've used `UrlGenerator` with `_route`, `_route_params` and `$request->query->all()` and merged `

- Added some tests in `WiringTest` but not sure if this is the right place.
- Wanted to do the functional test which tries to scroll the options dropdown, but I don't know if this possible, because didn't find a way :)