### PR TITLE
[Live] remove calls to `Request::get()`

### DIFF
--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -74,8 +74,8 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
         }
 
         // the default "action" is get, which does nothing
-        $action = $request->get('action', 'get');
-        $componentName = (string) $request->get('component');
+        $action = $request->attributes->get('action', 'get');
+        $componentName = (string) $request->attributes->get('component');
 
         $request->attributes->set('_component_name', $componentName);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | n/a
| License       | MIT

`Request::get()` is marked as `@internal`.
