### PR TITLE
make ComponentRenderer autowirable and remove internal tag

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.5
+
+-   Add new autowireable `ComponentRendererInterface`
+
 ## 2.2
 
 -   Allow to pass stringable object as non mapped component attribute.

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -25,7 +25,7 @@ use Twig\Extension\EscaperExtension;
  *
  * @internal
  */
-final class ComponentRenderer
+final class ComponentRenderer implements ComponentRendererInterface
 {
     private bool $safeClassesRegistered = false;
 

--- a/src/TwigComponent/src/ComponentRendererInterface.php
+++ b/src/TwigComponent/src/ComponentRendererInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent;
+
+/**
+ * @experimental
+ */
+interface ComponentRendererInterface
+{
+    /**
+     * Create and render a twig component.
+     */
+    public function createAndRender(string $name, array $props = []): string;
+}

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentRenderer;
+use Symfony\UX\TwigComponent\ComponentRendererInterface;
 use Symfony\UX\TwigComponent\DependencyInjection\Compiler\TwigComponentPass;
 use Symfony\UX\TwigComponent\Twig\ComponentExtension;
 
@@ -63,6 +64,8 @@ final class TwigComponentExtension extends Extension
                 new Reference('property_accessor'),
             ])
         ;
+
+        $container->setAlias(ComponentRendererInterface::class, 'ux.twig_component.component_renderer');
 
         $container->register('ux.twig_component.twig.component_extension', ComponentExtension::class)
             ->addTag('twig.extension')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #438 
| License       | MIT

As discussed in the issue this PR makes the ComponentRenderer autowirable and remove the internal tag. 😁