### PR TITLE
Autocomplete choice label

### DIFF
--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -4,6 +4,7 @@ namespace Symfony\UX\Autocomplete\Form;
 
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLabel;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -77,6 +78,10 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
 
         if (\is_string($choiceLabel) || $choiceLabel instanceof PropertyPathInterface) {
             return $this->propertyAccessor->getValue($entity, $choiceLabel);
+        }
+
+        if ($choiceLabel instanceof ChoiceLabel) {
+            $choiceLabel = $choiceLabel->getOption();
         }
 
         // 0 hardcoded as the "index", should not be relevant

--- a/src/Autocomplete/tests/Fixtures/Entity/Category.php
+++ b/src/Autocomplete/tests/Fixtures/Entity/Category.php
@@ -72,4 +72,9 @@ class Category
 
         return $this;
     }
+
+    public function __toString(): string
+    {
+        return $this->getName();
+    }
 }

--- a/src/Autocomplete/tests/Fixtures/Form/CategoryNoChoiceLabelAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/CategoryNoChoiceLabelAutocompleteType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\UX\Autocomplete\Tests\Fixtures\Form;
+
+use Doctrine\ORM\EntityRepository;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Category;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Security;
+use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
+use Symfony\UX\Autocomplete\Form\ParentEntityAutocompleteType;
+
+#[AsEntityAutocompleteField]
+class CategoryNoChoiceLabelAutocompleteType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'class' => Category::class,
+            'placeholder' => 'What should we eat?',
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ParentEntityAutocompleteType::class;
+    }
+}

--- a/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
+++ b/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
@@ -18,7 +18,6 @@ use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
-// tests CategoryAutocompleteType
 class FieldAutocompleterTest extends KernelTestCase
 {
     use Factories;
@@ -86,6 +85,18 @@ class FieldAutocompleterTest extends KernelTestCase
         $this->browser()
             ->throwExceptions()
             ->get('/test/autocomplete/category_autocomplete_type?query=foo')
+            ->assertSuccessful()
+            ->assertJsonMatches('length(results)', 5)
+        ;
+    }
+
+    public function testItWorksWithoutAChoiceLabel(): void
+    {
+        CategoryFactory::createMany(5, ['name' => 'foo']);
+
+        $this->browser()
+            ->throwExceptions()
+            ->get('/test/autocomplete/category_no_choice_label_autocomplete_type?query=foo')
             ->assertSuccessful()
             ->assertJsonMatches('length(results)', 5)
         ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | none
| License       | MIT

If your autocomplete field does not specify `choice_label`, this creates a choice label situation that we apparently weren't handling yet:

<img width="973" alt="Screen Shot 2022-11-03 at 10 16 58 AM" src="https://user-images.githubusercontent.com/121003/199744820-10196553-21dc-4a01-a134-9133aa8cea4f.png">

Fixed with test.