### PR TITLE
[Live] Forcing JSON to be an object instead of an empty array

### DIFF
--- a/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
+++ b/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
@@ -20,6 +20,7 @@ use Symfony\UX\LiveComponent\DehydratedComponent;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Twig\DeterministicTwigIdCalculator;
 use Symfony\UX\LiveComponent\Util\FingerprintCalculator;
+use Symfony\UX\LiveComponent\Util\JsonUtil;
 use Symfony\UX\LiveComponent\Util\TwigAttributeHelper;
 use Symfony\UX\TwigComponent\ComponentAttributes;
 use Symfony\UX\TwigComponent\ComponentMetadata;
@@ -100,8 +101,8 @@ final class AddLiveAttributesSubscriber implements EventSubscriberInterface, Ser
         $attributes = [
             'data-controller' => 'live',
             'data-live-url-value' => $helper->escapeAttribute($url),
-            'data-live-data-value' => $helper->escapeAttribute(json_encode($dehydratedComponent->getData(), \JSON_THROW_ON_ERROR)),
-            'data-live-props-value' => $helper->escapeAttribute(json_encode($dehydratedComponent->getProps(), \JSON_THROW_ON_ERROR)),
+            'data-live-data-value' => $helper->escapeAttribute(JsonUtil::encodeObject($dehydratedComponent->getData())),
+            'data-live-props-value' => $helper->escapeAttribute(JsonUtil::encodeObject($dehydratedComponent->getProps())),
         ];
 
         if ($this->container->has(CsrfTokenManagerInterface::class) && $metadata->get('csrf')) {

--- a/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
+++ b/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
@@ -15,6 +15,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Twig\DeterministicTwigIdCalculator;
 use Symfony\UX\LiveComponent\Util\FingerprintCalculator;
+use Symfony\UX\LiveComponent\Util\JsonUtil;
 use Symfony\UX\LiveComponent\Util\TwigAttributeHelper;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentStack;
@@ -99,7 +100,7 @@ class InterceptChildComponentRenderSubscriber implements EventSubscriberInterfac
             '<div data-live-id="%s" data-live-fingerprint-value="%s" data-live-props-value="%s"></div>',
             $this->twigAttributeHelper->escapeAttribute($deterministicId),
             $this->twigAttributeHelper->escapeAttribute($newPropsFingerprint),
-            $this->twigAttributeHelper->escapeAttribute(json_encode($dehydratedComponent->getProps(), \JSON_THROW_ON_ERROR))
+            $this->twigAttributeHelper->escapeAttribute(JsonUtil::encodeObject($dehydratedComponent->getProps()))
         );
         $event->setRenderedString($rendered);
     }

--- a/src/LiveComponent/src/Util/JsonUtil.php
+++ b/src/LiveComponent/src/Util/JsonUtil.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Util;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @experimental
+ *
+ * @internal
+ */
+final class JsonUtil
+{
+    public static function encodeObject($data): string
+    {
+        if (0 === \count($data)) {
+            return '{}';
+        }
+
+        return json_encode($data, \JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -85,8 +85,8 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
 
         $lis = $ul->children('li');
         // deterministic id: should not change, and counter should increase
-        $this->assertSame('live-2816377500-0', $lis->first()->attr('data-live-id'));
-        $this->assertSame('live-2816377500-2', $lis->last()->attr('data-live-id'));
+        $this->assertSame('live-3649730296-0', $lis->first()->attr('data-live-id'));
+        $this->assertSame('live-3649730296-2', $lis->last()->attr('data-live-id'));
 
         // fingerprints
         // first and last both have the same input - thus fingerprint


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| Tickets       | None
| License       | MIT

If data or props are an empty array, the JSON would be `[]`, causing Stimulus to throw an exception as this is not an object (and the `data` value is meant to be an object).

Cheers!