### PR TITLE
[Live] Fixed bug with "unsynced" inputs and <form data-model>

### DIFF
--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -164,8 +164,12 @@ export default class Component {
         return promise;
     }
 
+    /**
+     * Returns an array of models the user has modified, but whose model has not
+     * yet been updated.
+     */
     getUnsyncedModels(): string[] {
-        return this.unsyncedInputsTracker.getModifiedModels();
+        return this.unsyncedInputsTracker.getUnsyncedModels();
     }
 
     addChild(child: Component, modelBindings: ModelBinding[] = []): void {
@@ -276,6 +280,10 @@ export default class Component {
         const thisPromiseResolve = this.nextRequestPromiseResolve;
         // then create a fresh Promise, so any future .then() apply to it
         this.resetPromise();
+
+        // any fields that were modified will now be sent on this request:
+        // they are now "in sync" (with some exceptions noted inside)
+        this.unsyncedInputsTracker.resetUnsyncedFields();
 
         this.backendRequest = this.backend.makeRequest(
             this.valueStore.all(),

--- a/src/LiveComponent/assets/src/morphdom.ts
+++ b/src/LiveComponent/assets/src/morphdom.ts
@@ -12,7 +12,7 @@ import Component from './Component';
 export function executeMorphdom(
     rootFromElement: HTMLElement,
     rootToElement: HTMLElement,
-    modifiedElements: Array<HTMLElement>,
+    modifiedFieldElements: Array<HTMLElement>,
     getElementValue: (element: HTMLElement) => any,
     childComponents: Component[],
     findChildComponent: (id: string, element: HTMLElement) => HTMLElement|null,
@@ -57,7 +57,7 @@ export function executeMorphdom(
 
             // if this field's value has been modified since this HTML was
             // requested, set the toEl's value to match the fromEl
-            if (modifiedElements.includes(fromEl)) {
+            if (modifiedFieldElements.includes(fromEl)) {
                 setValueOnElement(toEl, getElementValue(fromEl))
             }
 

--- a/src/LiveComponent/assets/test/UnsyncedInputContainer.test.ts
+++ b/src/LiveComponent/assets/test/UnsyncedInputContainer.test.ts
@@ -9,10 +9,10 @@ describe('UnsyncedInputContainer', () => {
         container.add(element1);
         container.add(element2, 'some_model');
 
-        expect(container.all()).toEqual([element1, element2]);
+        expect(container.allUnsyncedInputs()).toEqual([element1, element2]);
     });
 
-    it('markModelAsSynced removes items added to it', () => {
+    it('markModelAsSynced removes unsynced models but not fields', () => {
         const container = new UnsyncedInputContainer();
         const element1 = htmlToElement('<span>element1</span');
         const element2 = htmlToElement('<span>element2</span');
@@ -23,7 +23,7 @@ describe('UnsyncedInputContainer', () => {
 
         container.markModelAsSynced('some_model2');
 
-        expect(container.all()).toEqual([element1, element3]);
+        expect(container.allUnsyncedInputs()).toEqual([element1, element2, element3]);
     });
 
     it('returns modified models via getModifiedModels()', () => {
@@ -36,6 +36,21 @@ describe('UnsyncedInputContainer', () => {
         container.add(element3, 'some_model3');
 
         container.markModelAsSynced('some_model2');
-        expect(container.getModifiedModels()).toEqual(['some_model3'])
+        expect(container.getUnsyncedModelNames()).toEqual(['some_model3'])
+    });
+
+    it('resetUnsyncedFields removes all model fields except those unsynced', () => {
+        const container = new UnsyncedInputContainer();
+        const element1 = htmlToElement('<span>element1</span');
+        const element2 = htmlToElement('<span>element2</span');
+        const element3 = htmlToElement('<span>element3</span');
+        container.add(element1);
+        container.add(element2, 'some_model2');
+        container.add(element3, 'some_model3');
+
+        container.markModelAsSynced('some_model2');
+
+        container.resetUnsyncedFields();
+        expect(container.allUnsyncedInputs()).toEqual([element1, element3]);
     });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       |  none
| License       | MIT

This fixes an unreleased bug. In a somewhat edge-case use with forms, as you typed into the fields, the values you were typing would get run-over/replaced by the old values from the server - i.e. some of what you are typing gets deleted as you type. That ends up being 0️⃣ fun!

The technical details:

> If a field is modified during an Ajax request, previously, for model fields, after re-rendering, the modified values from the ValueStore were set back onto those fields via SetValueOntoModelFieldsPlugin. Effectively, morphdom would use the new value from the server (which is not correct) momentarily, and then we would reset it back to the modified value.

> However, that didn't work for fields inside of a <form data-model> that use the name attribute, as the "auto-set model field values" functionality purposely doesn't apply to those.

> So, the system was made smarter. It now keeps track of *all* field elements that have been modified (i.e. are unsynced). Then, only when those values are actually *sent* to the server on an Ajax request, those are removed as unsynced elements. This means that morphdom will now see all unsynced fields during re-rendering and will prefer the browser values over the server values.

Cheers!