### PR TITLE
[Live] coerce falsey strings to scalar types

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Component/ScalarTypes.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ScalarTypes.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('scalar_types')]
+final class ScalarTypes
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)]
+    public int $int = 1;
+
+    #[LiveProp(writable: true)]
+    public float $float = 1.0;
+
+    #[LiveProp(writable: true)]
+    public bool $bool = true;
+
+    #[LiveProp(writable: true)]
+    public ?int $nullableInt = 1;
+
+    #[LiveProp(writable: true)]
+    public ?float $nullableFloat = 1.0;
+
+    #[LiveProp(writable: true)]
+    public ?bool $nullableBool = true;
+}

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -382,4 +382,41 @@ final class LiveComponentHydratorTest extends KernelTestCase
         $this->assertSame('foo', $component->embeddable1->name);
         $this->assertSame('qux', $component->embeddable2->name);
     }
+
+    /**
+     * @dataProvider falseyValueProvider
+     */
+    public function testCoerceFalseyValuesForScalarTypes($prop, $value, $expected): void
+    {
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('scalar_types'))->all();
+
+        $dehydrated[$prop] = $value;
+
+        $hydrated = $this->hydrateComponent($this->getComponent('scalar_types'), $dehydrated, 'scalar_types')
+            ->getComponent()
+        ;
+
+        $this->assertSame($expected, $hydrated->$prop);
+    }
+
+    public static function falseyValueProvider(): iterable
+    {
+        yield ['int', '', 0];
+        yield ['int', '   ', 0];
+        yield ['int', 'apple', 0];
+        yield ['float', '', 0.0];
+        yield ['float', '   ', 0.0];
+        yield ['float', 'apple', 0.0];
+        yield ['bool', '', false];
+        yield ['bool', '   ', false];
+
+        yield ['nullableInt', '', null];
+        yield ['nullableInt', '   ', null];
+        yield ['nullableInt', 'apple', 0];
+        yield ['nullableFloat', '', null];
+        yield ['nullableFloat', '   ', null];
+        yield ['nullableFloat', 'apple', 0.0];
+        yield ['nullableBool', '', null];
+        yield ['nullableBool', '   ', null];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #526
| License       | MIT

I chose to allow _weird_ values to be cast to the proper type instead of throwing an exception (ie `0 === (int) 'apple'`).
