### PR TITLE
[Autocomplete] max_results option is not passed to parent entity

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Fix issue where `max_results` was not passed as a Stimulus value (#538)
+
 ## 2.5.0
 
 -   Automatic pagination support added: if the query would return more results

--- a/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
+++ b/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
@@ -43,7 +43,7 @@ final class AutocompleteEntityTypeSubscriber implements EventSubscriberInterface
         // pass to AutocompleteChoiceTypeExtension
         $options['autocomplete'] = true;
         $options['autocomplete_url'] = $this->autocompleteUrl;
-        unset($options['searchable_fields'], $options['security'], $options['filter_query'], $options['max_results']);
+        unset($options['searchable_fields'], $options['security'], $options['filter_query']);
 
         $form->add('autocomplete', EntityType::class, $options);
     }

--- a/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
@@ -41,7 +41,7 @@ class CategoryAutocompleteType extends AbstractType
             'attr' => [
                 'data-controller' => 'custom-autocomplete',
             ],
-            'max_results' => 5,
+            'max_results' => 25,
             'min_characters' => 2,
         ]);
     }

--- a/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
+++ b/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
@@ -33,6 +33,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
             ->assertElementAttributeContains('#product_category_autocomplete', 'data-controller', 'custom-autocomplete symfony--ux-autocomplete--autocomplete')
             ->assertElementAttributeContains('#product_category_autocomplete', 'data-symfony--ux-autocomplete--autocomplete-url-value', '/test/autocomplete/category_autocomplete_type')
             ->assertElementAttributeContains('#product_category_autocomplete', 'data-symfony--ux-autocomplete--autocomplete-min-characters-value', '2')
+            ->assertElementAttributeContains('#product_category_autocomplete', 'data-symfony--ux-autocomplete--autocomplete-max-results-value', '25')
 
             ->assertElementAttributeContains('#product_portionSize', 'data-controller', 'symfony--ux-autocomplete--autocomplete')
             ->assertElementAttributeContains('#product_tags', 'data-controller', 'symfony--ux-autocomplete--autocomplete')

--- a/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
+++ b/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
@@ -86,7 +86,7 @@ class FieldAutocompleterTest extends KernelTestCase
             ->throwExceptions()
             ->get('/test/autocomplete/category_autocomplete_type?query=foo')
             ->assertSuccessful()
-            ->assertJsonMatches('length(results)', 5)
+            ->assertJsonMatches('length(results)', 25)
         ;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | none <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

There seems to be an oversight from #478 when it comes to passing the option from types that use `#[AsEntityAutocompleteField]`.

This fix removes the unsetting of `$options['max_results']` from the `AutocompleteEntityTypeSubscriber` to allow passing the information. I also extended the tests to cover this case.
