### PR TITLE
[Autocomplete] implement `preload` option

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -64,6 +64,13 @@ class default_1 extends Controller {
         }
         return this.element;
     }
+    get preload() {
+        if (this.preloadValue == 'false')
+            return false;
+        if (this.preloadValue == 'true')
+            return true;
+        return this.preloadValue;
+    }
 }
 _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _default_1_getCommonConfig() {
     const plugins = {};
@@ -158,7 +165,7 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
                 return `<div class="no-results">${this.noResultsFoundTextValue}</div>`;
             },
         },
-        preload: 'focus',
+        preload: this.preload,
     });
     return __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createTomSelect).call(this, config);
 }, _default_1_stripTags = function _default_1_stripTags(string) {
@@ -180,6 +187,7 @@ default_1.values = {
     noMoreResultsText: String,
     minCharacters: Number,
     tomSelectOptions: Object,
+    preload: String,
 };
 
 export { default_1 as default };

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -10,6 +10,7 @@ export default class extends Controller {
         noMoreResultsText: String,
         minCharacters: Number,
         tomSelectOptions: Object,
+        preload: String,
     };
 
     readonly urlValue: string;
@@ -18,6 +19,7 @@ export default class extends Controller {
     readonly noResultsFoundTextValue: string;
     readonly minCharactersValue: number;
     readonly tomSelectOptionsValue: object;
+    readonly preloadValue: string;
     tomSelect: TomSelect;
 
     initialize() {
@@ -174,7 +176,7 @@ export default class extends Controller {
                     return `<div class="no-results">${this.noResultsFoundTextValue}</div>`;
                 },
             },
-            preload: 'focus',
+            preload: this.preload,
         });
 
         return this.#createTomSelect(config);
@@ -220,5 +222,17 @@ export default class extends Controller {
 
     #dispatchEvent(name: string, payload: any): void {
         this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    }
+
+    get preload() {
+        if (this.preloadValue == 'false') {
+            return false;
+        }
+
+        if (this.preloadValue == 'true') {
+            return true;
+        }
+
+        return this.preloadValue;
     }
 }

--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -260,6 +260,10 @@ to the options above, you can also pass:
 ``max_results`` (default: 10)
     Allow you to control the max number of results returned by the automatic autocomplete endpoint.
 
+``preload`` (default: ``false``)
+    Set to ``focus`` to call the ``load`` function when control receives focus.
+    Set to ``true`` to call the ``load`` upon control initialization (with an empty search).
+
 Using with a TextType Field
 ---------------------------
 

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -77,6 +77,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
 
         $values['no-results-found-text'] = $this->trans($options['no_results_found_text']);
         $values['no-more-results-text'] = $this->trans($options['no_more_results_text']);
+        $values['preload'] = $options['preload'];
 
         foreach ($values as $name => $value) {
             $attr['data-'.$controllerName.'-'.$name.'-value'] = $value;
@@ -97,11 +98,20 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'no_more_results_text' => 'No more results',
             'min_characters' => 3,
             'max_results' => 10,
+            'preload' => false,
         ]);
 
         // if autocomplete_url is passed, then HTML options are already supported
         $resolver->setNormalizer('options_as_html', function (Options $options, $value) {
             return null === $options['autocomplete_url'] ? $value : false;
+        });
+
+        $resolver->setNormalizer('preload', function (Options $options, $value) {
+            if (\is_bool($value)) {
+                $value = $value ? 'true' : 'false';
+            }
+
+            return $value;
         });
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | N/A
| License       | MIT


Added [preload](https://tom-select.js.org/docs/#preload) option to control the preload.
Default value is `false`