### PR TITLE
Removing outdated data-action from example

### DIFF
--- a/ux.symfony.com/code_snippets/_search_packages.html.twig
+++ b/ux.symfony.com/code_snippets/_search_packages.html.twig
@@ -3,7 +3,6 @@
         type="text"
         data-model="query"
         value="{{ query }}"
-        data-action="live#update"
     >
 
     {% if this.packages|length > 0 %}

--- a/ux.symfony.com/code_snippets/_search_packages.html.twig
+++ b/ux.symfony.com/code_snippets/_search_packages.html.twig
@@ -2,7 +2,6 @@
     <input
         type="text"
         data-model="query"
-        value="{{ query }}"
     >
 
     {% if this.packages|length > 0 %}

--- a/ux.symfony.com/templates/components/search_packages.html.twig
+++ b/ux.symfony.com/templates/components/search_packages.html.twig
@@ -2,7 +2,6 @@
     <input
         type="text"
         data-model="query"
-        value="{{ query }}"
         placeholder="Results update as you type..."
         class="form-control"
     >


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | none
| License       | MIT

The "example" template got out of date with the real one. Neither of these attributes are needed anymore!