### PR TITLE
Fix redirection with nginx and http2

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1517,7 +1517,8 @@ class Component {
             const backendResponse = new BackendResponse(response);
             thisPromiseResolve(backendResponse);
             const html = await backendResponse.getBody();
-            if (backendResponse.response.headers.get('Content-Type') !== 'application/vnd.live-component+html') {
+            const headers = backendResponse.response.headers;
+            if (headers.get('Content-Type') !== 'application/vnd.live-component+html' && !headers.get('X-Live-Redirect')) {
                 this.renderError(html);
                 return response;
             }

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -302,7 +302,8 @@ export default class Component {
             thisPromiseResolve(backendResponse);
             const html = await backendResponse.getBody();
             // if the response does not contain a component, render as an error
-            if (backendResponse.response.headers.get('Content-Type') !== 'application/vnd.live-component+html') {
+            const headers = backendResponse.response.headers;
+            if (headers.get('Content-Type') !== 'application/vnd.live-component+html' && !headers.get('X-Live-Redirect')) {
                 this.renderError(html);
 
                 return response;

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -47,6 +47,7 @@ use Symfony\UX\TwigComponent\MountedComponent;
 class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscriberInterface
 {
     private const HTML_CONTENT_TYPE = 'application/vnd.live-component+html';
+    private const REDIRECT_HEADER = 'X-Live-Redirect';
 
     public function __construct(private ContainerInterface $container)
     {
@@ -282,7 +283,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
 
         $event->setResponse(new Response(null, 204, [
             'Location' => $response->headers->get('Location'),
-            'Content-Type' => self::HTML_CONTENT_TYPE,
+            self::REDIRECT_HEADER => 1,
         ]));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Tickets       | Fix https://github.com/symfony/ux/issues/543
| License       | MIT


> Let’s drop the header during the redirect (which is when we have an empty body) and, instead, add a 2nd header - something custom like X-Live-Redirect. Then, in the javascript, only throw the error of the content-type is wrong/missing AND that special header is missing.
> 
> I’d welcome a PR of you’re open to it :)
