### PR TITLE
Add all possible CSS files to the autoimport

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   Fix issue where `max_results` was not passed as a Stimulus value (#538)
+-   Add all possible stylesheets for tom-select to the autoimport to choose from
 
 ## 2.5.0
 

--- a/src/Autocomplete/assets/package.json
+++ b/src/Autocomplete/assets/package.json
@@ -13,7 +13,9 @@
                 "fetch": "eager",
                 "enabled": true,
                 "autoimport": {
-                    "tom-select/dist/css/tom-select.default.css": true
+                    "tom-select/dist/css/tom-select.default.css": true,
+                    "tom-select/dist/css/tom-select.bootstrap4.css": false,
+                    "tom-select/dist/css/tom-select.bootstrap5.css": false
                 }
             }
         }


### PR DESCRIPTION
Came up during a workshop, that it might make sense to include all possible stylesheets in the autoimport. Default is true, all others false but can then be easily switched

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| License       | MIT