### PR TITLE
Removing "experimental" from all components (except for Live)

### DIFF
--- a/src/Autocomplete/README.md
+++ b/src/Autocomplete/README.md
@@ -2,9 +2,6 @@
 
 Javascript-powered auto-completion functionality for your Symfony forms!
 
-**EXPERIMENTAL** This component is currently experimental and is
-likely to change, or even change drastically.
-
 **This repository is a READ-ONLY sub-tree split**. See
 https://github.com/symfony/ux to create issues or submit pull requests.
 

--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -9,9 +9,6 @@ into an Ajax-powered autocomplete smart UI control (leveraging `Tom Select`_):
    :align: center
    :width: 300
 
-**EXPERIMENTAL** This component is currently experimental and is likely
-to change, or even change drastically.
-
 Installation
 ------------
 
@@ -176,7 +173,7 @@ includes a CSS file for Tom Select which will give you basic styles.
         "tom-select/dist/css/tom-select.default.css": true
     }
 
-If you're using Bootstrap, you can get Bootstrap-ready styling by 
+If you're using Bootstrap, you can get Bootstrap-ready styling by
 changing this line to ``false``:
 
 .. code-block:: text
@@ -505,12 +502,8 @@ Backward Compatibility promise
 This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework: https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_, meaning it is not bound
-to Symfony's BC policy for the moment.
-
 .. _`Tom Select`: https://tom-select.js.org/
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
 .. _`Tom Select Options`: https://tom-select.js.org/docs/#general-configuration
 .. _`controller.ts`: https://github.com/symfony/ux/blob/2.x/src/Autocomplete/assets/src/controller.ts
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Tom Select Render Templates`: https://tom-select.js.org/docs/#render-templates

--- a/src/Autocomplete/src/AutocompleteBundle.php
+++ b/src/Autocomplete/src/AutocompleteBundle.php
@@ -17,8 +17,6 @@ use Symfony\UX\Autocomplete\DependencyInjection\AutocompleteFormTypePass;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 final class AutocompleteBundle extends Bundle
 {

--- a/src/Autocomplete/src/AutocompleteResultsExecutor.php
+++ b/src/Autocomplete/src/AutocompleteResultsExecutor.php
@@ -18,8 +18,6 @@ use Symfony\UX\Autocomplete\Doctrine\DoctrineRegistryWrapper;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 final class AutocompleteResultsExecutor
 {

--- a/src/Autocomplete/src/AutocompleterRegistry.php
+++ b/src/Autocomplete/src/AutocompleterRegistry.php
@@ -15,8 +15,6 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 final class AutocompleterRegistry
 {

--- a/src/Autocomplete/src/Controller/EntityAutocompleteController.php
+++ b/src/Autocomplete/src/Controller/EntityAutocompleteController.php
@@ -21,8 +21,6 @@ use Symfony\UX\Autocomplete\AutocompleterRegistry;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 final class EntityAutocompleteController
 {

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
@@ -34,8 +34,6 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 final class AutocompleteExtension extends Extension implements PrependExtensionInterface
 {

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteFormTypePass.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteFormTypePass.php
@@ -21,8 +21,6 @@ use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 class AutocompleteFormTypePass implements CompilerPassInterface
 {

--- a/src/Autocomplete/src/Doctrine/DoctrineRegistryWrapper.php
+++ b/src/Autocomplete/src/Doctrine/DoctrineRegistryWrapper.php
@@ -19,8 +19,6 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
  * Small wrapper around ManagerRegistry to help if Doctrine is missing.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 class DoctrineRegistryWrapper
 {

--- a/src/Autocomplete/src/Doctrine/EntityMetadata.php
+++ b/src/Autocomplete/src/Doctrine/EntityMetadata.php
@@ -15,8 +15,6 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 class EntityMetadata
 {

--- a/src/Autocomplete/src/Doctrine/EntityMetadataFactory.php
+++ b/src/Autocomplete/src/Doctrine/EntityMetadataFactory.php
@@ -16,8 +16,6 @@ use Doctrine\Persistence\ObjectManager;
 
 /**
  * Adapted from EasyCorp/EasyAdminBundle EntityFactory.
- *
- * @experimental
  */
 class EntityMetadataFactory
 {

--- a/src/Autocomplete/src/Doctrine/EntitySearchUtil.php
+++ b/src/Autocomplete/src/Doctrine/EntitySearchUtil.php
@@ -17,8 +17,6 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * Adapted from EasyCorp/EasyAdminBundle.
- *
- * @experimental
  */
 class EntitySearchUtil
 {

--- a/src/Autocomplete/src/Doctrine/SearchEscaper.php
+++ b/src/Autocomplete/src/Doctrine/SearchEscaper.php
@@ -15,8 +15,6 @@ use Doctrine\ORM\Query\Lexer;
 
 /**
  * Adapted from EasyCorp/EasyAdminBundle Escaper.
- *
- * @experimental
  */
 class SearchEscaper
 {

--- a/src/Autocomplete/src/Form/AsEntityAutocompleteField.php
+++ b/src/Autocomplete/src/Form/AsEntityAutocompleteField.php
@@ -17,8 +17,6 @@ use Symfony\Component\String\UnicodeString;
  * All form types that want to expose autocomplete functionality should have this.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class AsEntityAutocompleteField

--- a/src/Autocomplete/src/Maker/MakeAutocompleteField.php
+++ b/src/Autocomplete/src/Maker/MakeAutocompleteField.php
@@ -32,8 +32,6 @@ use Symfony\UX\Autocomplete\Form\ParentEntityAutocompleteType;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 class MakeAutocompleteField extends AbstractMaker
 {

--- a/src/Chartjs/doc/index.rst
+++ b/src/Chartjs/doc/index.rst
@@ -152,13 +152,9 @@ Backward Compatibility promise
 This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework: https://symfony.com/doc/current/contributing/code/bc.html.
 
-However it is currently considered `experimental`, meaning it is not
-bound to Symfony's BC policy for the moment.
-
 .. _`Chart.js`: https://www.chartjs.org
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
 .. _`Chart.js documentation`: https://www.chartjs.org/docs/latest/
 .. _`Symfony Webpack Encore`: https://symfony.com/doc/current/frontend/encore/installation.html
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html

--- a/src/Chartjs/src/Builder/ChartBuilder.php
+++ b/src/Chartjs/src/Builder/ChartBuilder.php
@@ -17,8 +17,6 @@ use Symfony\UX\Chartjs\Model\Chart;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class ChartBuilder implements ChartBuilderInterface
 {

--- a/src/Chartjs/src/Builder/ChartBuilderInterface.php
+++ b/src/Chartjs/src/Builder/ChartBuilderInterface.php
@@ -15,8 +15,6 @@ use Symfony\UX\Chartjs\Model\Chart;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 interface ChartBuilderInterface
 {

--- a/src/Chartjs/src/ChartjsBundle.php
+++ b/src/Chartjs/src/ChartjsBundle.php
@@ -17,8 +17,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class ChartjsBundle extends Bundle
 {

--- a/src/Chartjs/src/Model/Chart.php
+++ b/src/Chartjs/src/Model/Chart.php
@@ -15,8 +15,6 @@ namespace Symfony\UX\Chartjs\Model;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class Chart
 {

--- a/src/Chartjs/src/Twig/ChartExtension.php
+++ b/src/Chartjs/src/Twig/ChartExtension.php
@@ -22,8 +22,6 @@ use Twig\TwigFunction;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class ChartExtension extends AbstractExtension
 {

--- a/src/Cropperjs/doc/index.rst
+++ b/src/Cropperjs/doc/index.rst
@@ -148,12 +148,8 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_,
-meaning it is not bound to Symfony’s BC policy for the moment.
-
 .. _`Cropper.js`: https://fengyuanchen.github.io/cropperjs/
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
 .. _`the Cropper.js options`: https://github.com/fengyuanchen/cropperjs/blob/main/README.md#options
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html

--- a/src/Cropperjs/src/CropperjsBundle.php
+++ b/src/Cropperjs/src/CropperjsBundle.php
@@ -17,8 +17,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class CropperjsBundle extends Bundle
 {

--- a/src/Cropperjs/src/Factory/Cropper.php
+++ b/src/Cropperjs/src/Factory/Cropper.php
@@ -18,8 +18,6 @@ use Symfony\UX\Cropperjs\Model\Crop;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class Cropper implements CropperInterface
 {

--- a/src/Cropperjs/src/Factory/CropperInterface.php
+++ b/src/Cropperjs/src/Factory/CropperInterface.php
@@ -15,8 +15,6 @@ use Symfony\UX\Cropperjs\Model\Crop;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 interface CropperInterface
 {

--- a/src/Cropperjs/src/Form/CropperType.php
+++ b/src/Cropperjs/src/Form/CropperType.php
@@ -23,8 +23,6 @@ use Symfony\UX\Cropperjs\Model\Crop;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class CropperType extends AbstractType
 {

--- a/src/Cropperjs/src/Model/Crop.php
+++ b/src/Cropperjs/src/Model/Crop.php
@@ -20,8 +20,6 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class Crop
 {

--- a/src/Dropzone/doc/index.rst
+++ b/src/Dropzone/doc/index.rst
@@ -153,10 +153,6 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_, meaning it is not
-bound to Symfony’s BC policy for the moment.
-
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html

--- a/src/Dropzone/src/DropzoneBundle.php
+++ b/src/Dropzone/src/DropzoneBundle.php
@@ -17,8 +17,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class DropzoneBundle extends Bundle
 {

--- a/src/Dropzone/src/Form/DropzoneType.php
+++ b/src/Dropzone/src/Form/DropzoneType.php
@@ -19,8 +19,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class DropzoneType extends AbstractType
 {

--- a/src/LazyImage/doc/index.rst
+++ b/src/LazyImage/doc/index.rst
@@ -169,12 +169,8 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_,
-meaning it is not bound to Symfony’s BC policy for the moment.
-
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
 .. _`BlurHash implementation`: https://blurha.sh
 .. _`WebpackEncoreBundle v1.10`: https://github.com/symfony/webpack-encore-bundle
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html

--- a/src/LazyImage/src/BlurHash/BlurHash.php
+++ b/src/LazyImage/src/BlurHash/BlurHash.php
@@ -18,8 +18,6 @@ use kornrunner\Blurhash\Blurhash as BlurhashEncoder;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class BlurHash implements BlurHashInterface
 {

--- a/src/LazyImage/src/BlurHash/BlurHashInterface.php
+++ b/src/LazyImage/src/BlurHash/BlurHashInterface.php
@@ -13,8 +13,6 @@ namespace Symfony\UX\LazyImage\BlurHash;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @experimental
  */
 interface BlurHashInterface
 {

--- a/src/LazyImage/src/LazyImageBundle.php
+++ b/src/LazyImage/src/LazyImageBundle.php
@@ -17,8 +17,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class LazyImageBundle extends Bundle
 {

--- a/src/LazyImage/src/Twig/BlurHashExtension.php
+++ b/src/LazyImage/src/Twig/BlurHashExtension.php
@@ -19,8 +19,6 @@ use Twig\TwigFunction;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class BlurHashExtension extends AbstractExtension
 {

--- a/src/Notify/doc/index.rst
+++ b/src/Notify/doc/index.rst
@@ -152,12 +152,8 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_, meaning it is not
-bound to Symfony’s BC policy for the moment.
-
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
 .. _`Mercure`: https://mercure.rocks
 .. _`running Mercure server`: https://symfony.com/doc/current/mercure.html#running-a-mercure-hub

--- a/src/Notify/src/NotifyBundle.php
+++ b/src/Notify/src/NotifyBundle.php
@@ -17,8 +17,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class NotifyBundle extends Bundle
 {

--- a/src/Notify/src/Twig/NotifyExtension.php
+++ b/src/Notify/src/Twig/NotifyExtension.php
@@ -16,8 +16,6 @@ use Twig\TwigFunction;
 
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
- *
- * @experimental
  */
 final class NotifyExtension extends AbstractExtension
 {

--- a/src/Notify/src/Twig/NotifyRuntime.php
+++ b/src/Notify/src/Twig/NotifyRuntime.php
@@ -19,8 +19,6 @@ use Twig\Extension\RuntimeExtensionInterface;
 
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
- *
- * @experimental
  */
 final class NotifyRuntime implements RuntimeExtensionInterface
 {

--- a/src/React/doc/index.rst
+++ b/src/React/doc/index.rst
@@ -85,10 +85,6 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_,
-meaning it is not bound to Symfony's BC policy for the moment.
-
 .. _`React`: https://reactjs.org/
 .. _`the Symfony UX initiative`: https://symfony.com/ux
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html

--- a/src/React/src/ReactBundle.php
+++ b/src/React/src/ReactBundle.php
@@ -17,8 +17,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class ReactBundle extends Bundle
 {

--- a/src/React/src/Twig/ReactComponentExtension.php
+++ b/src/React/src/Twig/ReactComponentExtension.php
@@ -20,8 +20,6 @@ use Twig\TwigFunction;
  * @author Titouan Galopin <galopintitouan@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class ReactComponentExtension extends AbstractExtension
 {

--- a/src/Swup/doc/index.rst
+++ b/src/Swup/doc/index.rst
@@ -197,13 +197,9 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_,
-meaning it is not bound to Symfony's BC policy for the moment.
-
 .. _`Swup`: https://swup.js.org/
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
 .. _`WebpackEncoreBundle v1.10`: https://github.com/symfony/webpack-encore-bundle
 .. _`Swup Options`: https://swup.js.org/options
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html

--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -789,9 +789,6 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However, it is currently considered `experimental`_,
-meaning it is not bound to Symfony's BC policy for the moment.
-
 Credits
 -------
 
@@ -820,7 +817,6 @@ Symfony UX Turbo has been created by `Kévin Dunglas`_. It has been inspired by
 .. _`autoconfigure option`: https://symfony.com/doc/current/service_container.html#the-autoconfigure-option
 .. _`private updates`: https://symfony.com/doc/current/mercure.html#authorization
 .. _`async dispatching with Symfony Messenger`: https://symfony.com/doc/current/mercure.html#async-dispatching
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Kévin Dunglas`: https://dunglas.fr
 .. _`hotwired/turbo-rails`: https://github.com/hotwired/turbo-rails
 .. _`sroze/live-twig`: https://github.com/sroze/live-twig

--- a/src/Turbo/src/Attribute/Broadcast.php
+++ b/src/Turbo/src/Attribute/Broadcast.php
@@ -21,8 +21,6 @@ use Symfony\UX\Turbo\Bridge\Mercure\Broadcaster;
  * @Target({"CLASS"})
  *
  * @author Kévin Dunglas <kevin@dunglas.fr>
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Broadcast

--- a/src/Turbo/src/Bridge/Mercure/src/Broadcaster.php
+++ b/src/Turbo/src/Bridge/Mercure/src/Broadcaster.php
@@ -31,8 +31,6 @@ use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
  *  * sse_retry (int) retry field of the SSE
  *
  * @author Kévin Dunglas <kevin@dunglas.fr>
- *
- * @experimental
  */
 final class Broadcaster implements BroadcasterInterface
 {

--- a/src/Turbo/src/Broadcaster/BroadcasterInterface.php
+++ b/src/Turbo/src/Broadcaster/BroadcasterInterface.php
@@ -15,8 +15,6 @@ namespace Symfony\UX\Turbo\Broadcaster;
  * Broadcasts an update of an entity.
  *
  * @author Kévin Dunglas <kevin@dunglas.fr>
- *
- * @experimental
  */
 interface BroadcasterInterface
 {

--- a/src/Turbo/src/DependencyInjection/Configuration.php
+++ b/src/Turbo/src/DependencyInjection/Configuration.php
@@ -20,8 +20,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * Turbo configuration structure.
  *
  * @author Kévin Dunglas <kevin@dunglas.fr>
- *
- * @experimental
  */
 final class Configuration implements ConfigurationInterface
 {

--- a/src/Turbo/src/DependencyInjection/TurboExtension.php
+++ b/src/Turbo/src/DependencyInjection/TurboExtension.php
@@ -25,8 +25,6 @@ use Symfony\UX\Turbo\Twig\TurboStreamListenRendererInterface;
 
 /**
  * @author Kévin Dunglas <kevin@dunglas.fr>
- *
- * @experimental
  */
 final class TurboExtension extends Extension
 {

--- a/src/Turbo/src/Doctrine/BroadcastListener.php
+++ b/src/Turbo/src/Doctrine/BroadcastListener.php
@@ -24,8 +24,6 @@ use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
  * Detects changes made from Doctrine entities and broadcasts updates to the broadcasters.
  *
  * @author Kévin Dunglas <kevin@dunglas.fr>
- *
- * @experimental
  */
 final class BroadcastListener implements ResetInterface
 {

--- a/src/Turbo/src/TurboBundle.php
+++ b/src/Turbo/src/TurboBundle.php
@@ -19,8 +19,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Kévin Dunglas <kevin@dunglas.fr>
- *
- * @experimental
  */
 final class TurboBundle extends Bundle
 {

--- a/src/Turbo/src/Twig/TwigExtension.php
+++ b/src/Turbo/src/Twig/TwigExtension.php
@@ -18,8 +18,6 @@ use Twig\TwigFunction;
 
 /**
  * @author Kévin Dunglas <kevin@dunglas.fr>
- *
- * @experimental
  */
 final class TwigExtension extends AbstractExtension
 {

--- a/src/TwigComponent/README.md
+++ b/src/TwigComponent/README.md
@@ -1,8 +1,5 @@
 # Twig Components
 
-**EXPERIMENTAL** This component is currently experimental and is
-likely to change, or even change drastically.
-
 Twig components give you the power to bind an object to a template, making
 it easier to render and re-use small template "units" - like an "alert",
 markup for a modal, or a category sidebar. A very simple example

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1,9 +1,6 @@
 Twig Components
 ===============
 
-**EXPERIMENTAL** This component is currently experimental and is likely
-to change, or even change drastically.
-
 Twig components give you the power to bind an object to a template,
 making it easier to render and re-use small template "units" - like an
 "alert", markup for a modal, or a category sidebar:
@@ -791,12 +788,8 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_,
-meaning it is not bound to Symfony's BC policy for the moment.
-
 .. _`Live Components`: https://symfony.com/bundles/ux-live-component/current/index.html
 .. _`live component`: https://symfony.com/bundles/ux-live-component/current/index.html
 .. _`Vue`: https://v3.vuejs.org/guide/computed.html
 .. _`Live Nested Components`: https://symfony.com/bundles/ux-live-component/current/index.html#nested-components
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`embed tag`: https://twig.symfony.com/doc/3.x/tags/embed.html

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -13,8 +13,6 @@ namespace Symfony\UX\TwigComponent\Attribute;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class AsTwigComponent

--- a/src/TwigComponent/src/Attribute/ExposeInTemplate.php
+++ b/src/TwigComponent/src/Attribute/ExposeInTemplate.php
@@ -17,8 +17,6 @@ namespace Symfony\UX\TwigComponent\Attribute;
  * properties must be "accessible" (have a getter).
  *
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD)]
 final class ExposeInTemplate

--- a/src/TwigComponent/src/Attribute/PostMount.php
+++ b/src/TwigComponent/src/Attribute/PostMount.php
@@ -13,8 +13,6 @@ namespace Symfony\UX\TwigComponent\Attribute;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class PostMount

--- a/src/TwigComponent/src/Attribute/PreMount.php
+++ b/src/TwigComponent/src/Attribute/PreMount.php
@@ -13,8 +13,6 @@ namespace Symfony\UX\TwigComponent\Attribute;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class PreMount

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -13,8 +13,7 @@ namespace Symfony\UX\TwigComponent;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
+
  *
  * @immutable
  */

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -20,8 +20,7 @@ use Symfony\UX\TwigComponent\Event\PreMountEvent;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/ComponentMetadata.php
+++ b/src/TwigComponent/src/ComponentMetadata.php
@@ -13,8 +13,6 @@ namespace Symfony\UX\TwigComponent;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 final class ComponentMetadata
 {

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -22,8 +22,7 @@ use Twig\Extension\EscaperExtension;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/ComponentRendererInterface.php
+++ b/src/TwigComponent/src/ComponentRendererInterface.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\UX\TwigComponent;
 
-/**
- * @experimental
- */
 interface ComponentRendererInterface
 {
     /**

--- a/src/TwigComponent/src/ComponentStack.php
+++ b/src/TwigComponent/src/ComponentStack.php
@@ -13,8 +13,7 @@ namespace Symfony\UX\TwigComponent;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/ComputedPropertiesProxy.php
+++ b/src/TwigComponent/src/ComputedPropertiesProxy.php
@@ -13,8 +13,6 @@ namespace Symfony\UX\TwigComponent;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 final class ComputedPropertiesProxy
 {

--- a/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
+++ b/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
@@ -17,8 +17,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -30,8 +30,7 @@ use Symfony\UX\TwigComponent\Twig\ComponentExtension;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/Event/PostMountEvent.php
+++ b/src/TwigComponent/src/Event/PostMountEvent.php
@@ -15,8 +15,6 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 final class PostMountEvent extends Event
 {

--- a/src/TwigComponent/src/Event/PostRenderEvent.php
+++ b/src/TwigComponent/src/Event/PostRenderEvent.php
@@ -14,9 +14,6 @@ namespace Symfony\UX\TwigComponent\Event;
 use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\UX\TwigComponent\MountedComponent;
 
-/**
- * @experimental
- */
 final class PostRenderEvent extends Event
 {
     /**

--- a/src/TwigComponent/src/Event/PreCreateForRenderEvent.php
+++ b/src/TwigComponent/src/Event/PreCreateForRenderEvent.php
@@ -17,8 +17,6 @@ use Symfony\Contracts\EventDispatcher\Event;
  * Dispatched at the start of the component rendering process.
  *
  * This event occurs before the component is created & mounted.
- *
- * @experimental
  */
 final class PreCreateForRenderEvent extends Event
 {

--- a/src/TwigComponent/src/Event/PreMountEvent.php
+++ b/src/TwigComponent/src/Event/PreMountEvent.php
@@ -15,8 +15,6 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 final class PreMountEvent extends Event
 {

--- a/src/TwigComponent/src/Event/PreRenderEvent.php
+++ b/src/TwigComponent/src/Event/PreRenderEvent.php
@@ -17,8 +17,6 @@ use Symfony\UX\TwigComponent\MountedComponent;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 final class PreRenderEvent extends Event
 {

--- a/src/TwigComponent/src/EventListener/DataModelPropsSubscriber.php
+++ b/src/TwigComponent/src/EventListener/DataModelPropsSubscriber.php
@@ -24,8 +24,7 @@ use Symfony\UX\TwigComponent\Util\ModelBindingParser;
  * to be passed in set to the parent component's "content" prop.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/MountedComponent.php
+++ b/src/TwigComponent/src/MountedComponent.php
@@ -13,8 +13,7 @@ namespace Symfony\UX\TwigComponent;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -20,8 +20,7 @@ use Twig\TwigFunction;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -9,8 +9,7 @@ use Twig\Node\Expression\AbstractExpression;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/Twig/ComponentTokenParser.php
+++ b/src/TwigComponent/src/Twig/ComponentTokenParser.php
@@ -14,8 +14,7 @@ use Twig\TokenParser\AbstractTokenParser;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/TwigComponent/src/TwigComponentBundle.php
+++ b/src/TwigComponent/src/TwigComponentBundle.php
@@ -17,8 +17,6 @@ use Symfony\UX\TwigComponent\DependencyInjection\Compiler\TwigComponentPass;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 final class TwigComponentBundle extends Bundle
 {

--- a/src/TwigComponent/src/Util/ModelBindingParser.php
+++ b/src/TwigComponent/src/Util/ModelBindingParser.php
@@ -15,8 +15,7 @@ namespace Symfony\UX\TwigComponent\Util;
  * Parses the "data-model" format.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
+
  *
  * @internal
  */

--- a/src/Typed/doc/index.rst
+++ b/src/Typed/doc/index.rst
@@ -151,12 +151,8 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_,
-meaning it is not bound to Symfony's BC policy for the moment.
-
 .. _`Typed`: https://github.com/mattboldt/typed.js/blob/master/README.md
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
 .. _`typed library`: https://github.com/mattboldt/typed.js/blob/master/README.md
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html

--- a/src/Vue/doc/index.rst
+++ b/src/Vue/doc/index.rst
@@ -155,7 +155,7 @@ which should render the same template and Vue component:
     {
         // render the template
     }
-    
+
 This controller will catch any URL that starts with `/survey`. This prefix can then be
 used for all the Vue routes:
 
@@ -179,11 +179,7 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_,
-meaning it is not bound to Symfony's BC policy for the moment.
-
 .. _`Vue.js`: https://vuejs.org/
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _ `the related section of the documentation`: https://symfony.com/doc/current/frontend/encore/vuejs.html
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html

--- a/src/Vue/src/Twig/VueComponentExtension.php
+++ b/src/Vue/src/Twig/VueComponentExtension.php
@@ -21,8 +21,6 @@ use Twig\TwigFunction;
  * @author Thibault RICHARD <thibault.richard62@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class VueComponentExtension extends AbstractExtension
 {

--- a/src/Vue/src/VueBundle.php
+++ b/src/Vue/src/VueBundle.php
@@ -18,8 +18,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @author Thibault RICHARD <thibault.richard62@gmail.com>
  *
  * @final
- *
- * @experimental
  */
 class VueBundle extends Bundle
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | None
| License       | MIT

Hi!

As promised last week at SymfonyCon, it's time to remove the experimental status from the UX components! 🔥

This means we will protect backward compatibility as we do in the core. The great news is that, for the vast majority of the components, we haven't made breaking changes during the last 1+ year anyways!

The one exception is LiveComponents which still needs more work before stabilizing.

Cheers!