### PR TITLE
[Live] Allow to edit component route

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.7.0
 
-- Added a new `route` parameter to `AsLiveComponent`, which allows to choose another route for Ajax calls.
+-   Added a new `route` parameter to `AsLiveComponent`, which allows to choose
+    another route for Ajax calls.
 
 ## 2.6.0
 

--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.7.0
+
+- Added a new `route` parameter to `AsLiveComponent`, which allows to choose another route for Ajax calls.
+
 ## 2.6.0
 
 -   [BC BREAK]: The path to `live_component.xml` changed _and_ the import now

--- a/src/LiveComponent/config/routes.php
+++ b/src/LiveComponent/config/routes.php
@@ -5,7 +5,7 @@ use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 return function (RoutingConfigurator $routes) {
     $routes->add('ux_live_component', '/{_live_component}/{_live_action}')
         ->defaults([
-            'action' => 'get',
+            '_live_action' => 'get',
         ])
     ;
 };

--- a/src/LiveComponent/config/routes.php
+++ b/src/LiveComponent/config/routes.php
@@ -3,7 +3,7 @@
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 return function (RoutingConfigurator $routes) {
-    $routes->add('ux_live_component', '/{component}/{action}')
+    $routes->add('ux_live_component', '/{_live_component}/{_live_action}')
         ->defaults([
             'action' => 'get',
         ])

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2114,6 +2114,39 @@ To handle this, add the ``data-live-ignore`` attribute to the element:
     ``data-live-id`` attribute. During a re-render, if this value changes, all
     of the children of the element will be re-rendered, even those with ``data-live-ignore``.
 
+Define another route for your Component
+---------------------------------------
+
+The default route for live components is ``/components/{_live_component}/{_live_action}``
+If you have multiples firewalls in your app, you may want to specify another route for your component.
+It may be useful if you want to get the current logged in user in your component.
+
+To use another route, you need to declare it :
+
+.. code-block:: yaml
+
+    # config/routes/attributes.yaml
+    live_component_admin:
+        path: /admin/_components/{_live_component}/{_live_action}
+        defaults:
+            _live_action: 'get'
+
+then specify this new route to your component :
+
+.. code-block:: diff
+
+    // src/Components/RandomNumberComponent.php
+
+    use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+    use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+    - #[AsLiveComponent('random_number')]
+    + #[AsLiveComponent('random_number', route: 'live_component_admin')]
+      class RandomNumberComponent
+      {
+          use DefaultActionTrait;
+      }
+
 Backward Compatibility promise
 ------------------------------
 

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -28,6 +28,7 @@ final class AsLiveComponent extends AsTwigComponent
         bool $exposePublicProps = true,
         string $attributesVar = 'attributes',
         public bool $csrf = true,
+        public string $route = 'ux_live_component'
     ) {
         parent::__construct($name, $template, $exposePublicProps, $attributesVar);
     }
@@ -41,6 +42,7 @@ final class AsLiveComponent extends AsTwigComponent
             'default_action' => $this->defaultAction,
             'live' => true,
             'csrf' => $this->csrf,
+            'route' => $this->route,
         ]);
     }
 

--- a/src/LiveComponent/src/Controller/BatchActionController.php
+++ b/src/LiveComponent/src/Controller/BatchActionController.php
@@ -37,7 +37,7 @@ final class BatchActionController
                 '_controller' => [$serviceId, $name],
                 '_component_action_args' => $action['args'] ?? [],
                 '_mounted_component' => $_mounted_component,
-                '_route' => 'ux_live_component',
+                '_live_component' => $serviceId,
             ]);
 
             $response = $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);

--- a/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
+++ b/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
@@ -92,7 +92,7 @@ final class AddLiveAttributesSubscriber implements EventSubscriberInterface, Ser
     private function getLiveAttributes(MountedComponent $mounted, ComponentMetadata $metadata): ComponentAttributes
     {
         $name = $mounted->getName();
-        $url = $this->container->get(UrlGeneratorInterface::class)->generate($metadata->get('route'), ['component' => $name]);
+        $url = $this->container->get(UrlGeneratorInterface::class)->generate($metadata->get('route'), ['_live_component' => $name]);
         /** @var DehydratedComponent $dehydratedComponent */
         $dehydratedComponent = $this->container->get(LiveComponentHydrator::class)->dehydrate($mounted);
         /** @var TwigAttributeHelper $helper */

--- a/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
+++ b/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
@@ -92,7 +92,7 @@ final class AddLiveAttributesSubscriber implements EventSubscriberInterface, Ser
     private function getLiveAttributes(MountedComponent $mounted, ComponentMetadata $metadata): ComponentAttributes
     {
         $name = $mounted->getName();
-        $url = $this->container->get(UrlGeneratorInterface::class)->generate('ux_live_component', ['component' => $name]);
+        $url = $this->container->get(UrlGeneratorInterface::class)->generate($metadata->get('route'), ['component' => $name]);
         /** @var DehydratedComponent $dehydratedComponent */
         $dehydratedComponent = $this->container->get(LiveComponentHydrator::class)->dehydrate($mounted);
         /** @var TwigAttributeHelper $helper */

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -313,7 +313,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
 
     private function isLiveComponentRequest(Request $request): bool
     {
-        return 'ux_live_component' === $request->attributes->get('_route');
+        return str_starts_with($request->attributes->get('_route'), 'ux_live_component');
     }
 
     private function hydrateComponent(object $component, string $componentName, Request $request): MountedComponent

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -76,8 +76,8 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
         }
 
         // the default "action" is get, which does nothing
-        $action = $request->attributes->get('action', 'get');
-        $componentName = (string) $request->attributes->get('component');
+        $action = $request->attributes->get('_live_action', 'get');
+        $componentName = (string) $request->attributes->get('_live_component');
 
         $request->attributes->set('_component_name', $componentName);
 
@@ -313,7 +313,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
 
     private function isLiveComponentRequest(Request $request): bool
     {
-        return str_starts_with($request->attributes->get('_route'), 'ux_live_component');
+        return $request->attributes->has('_live_component');
     }
 
     private function hydrateComponent(object $component, string $componentName, Request $request): MountedComponent

--- a/src/LiveComponent/src/Twig/LiveComponentRuntime.php
+++ b/src/LiveComponent/src/Twig/LiveComponentRuntime.php
@@ -37,6 +37,8 @@ final class LiveComponentRuntime
         $dehydratedComponent = $this->hydrator->dehydrate($mounted);
         $params = ['_live_component' => $name] + $dehydratedComponent->all();
 
-        return $this->urlGenerator->generate('ux_live_component', $params);
+        $metadata = $this->factory->metadataFor($mounted->getName());
+
+        return $this->urlGenerator->generate($metadata->get('route'), $params);
     }
 }

--- a/src/LiveComponent/src/Twig/LiveComponentRuntime.php
+++ b/src/LiveComponent/src/Twig/LiveComponentRuntime.php
@@ -35,7 +35,7 @@ final class LiveComponentRuntime
     {
         $mounted = $this->factory->create($name, $props);
         $dehydratedComponent = $this->hydrator->dehydrate($mounted);
-        $params = ['component' => $name] + $dehydratedComponent->all();
+        $params = ['_live_component' => $name] + $dehydratedComponent->all();
 
         return $this->urlGenerator->generate('ux_live_component', $params);
     }

--- a/src/LiveComponent/tests/Fixtures/Component/AlternateRoute.php
+++ b/src/LiveComponent/tests/Fixtures/Component/AlternateRoute.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsLiveComponent('alternate_route', route: 'alternate_live_route')]
+final class AlternateRoute
+{
+    use DefaultActionTrait;
+
+    #[LiveProp]
+    public int $count = 0;
+
+    #[LiveAction]
+    public function increase(): void
+    {
+        ++$this->count;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -122,5 +122,6 @@ final class Kernel extends BaseKernel
 
         $routes->add('template', '/render-template/{template}')->controller('kernel::renderTemplate');
         $routes->add('homepage', '/')->controller('kernel::index');
+        $routes->add('alternate_live_route', '/alt/{_live_component}/{_live_action}')->defaults(['_live_action' => 'get']);
     }
 }

--- a/src/LiveComponent/tests/Fixtures/templates/component_url.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/component_url.html.twig
@@ -1,1 +1,2 @@
 {{ component_url('component1', { prop1: null, prop2: date }) }}
+{{ component_url('alternate_route') }}

--- a/src/LiveComponent/tests/Fixtures/templates/components/alternate_route.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/alternate_route.html.twig
@@ -1,0 +1,3 @@
+<div{{ attributes }}>
+    From alternate route. (count: {{ count }})
+</div>

--- a/src/LiveComponent/tests/Integration/Twig/LiveComponentExtensionTest.php
+++ b/src/LiveComponent/tests/Integration/Twig/LiveComponentExtensionTest.php
@@ -26,5 +26,6 @@ final class LiveComponentExtensionTest extends KernelTestCase
 
         $this->assertStringContainsString('/_components/component1?prop2=2022-10-06T00:00:00', $rendered);
         $this->assertStringContainsString('_checksum=', $rendered);
+        $this->assertStringContainsString('/alt/alternate_route?', $rendered);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #514
| License       | MIT

Added a new `route` parameter to `AsLiveComponent`, which allows to choose another route for Ajax calls.
