### PR TITLE
[LiveComponent][TwigComponent] Define requirement to the twig bundle for UX Component and UX Live Components

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -29,7 +29,9 @@
         "php": ">=8.0",
         "symfony/property-access": "^5.4|^6.0",
         "symfony/serializer": "^5.4|^6.0",
-        "symfony/ux-twig-component": "^2.5"
+        "symfony/twig-bundle": "^5.4|^6.0",
+        "symfony/ux-twig-component": "^2.5",
+        "twig/twig": "^2.0|^3.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.0",
@@ -40,7 +42,6 @@
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^6.0",
         "symfony/security-csrf": "^5.4|^6.0",
-        "symfony/twig-bundle": "^5.4|^6.0",
         "symfony/validator": "^5.4|^6.0",
         "zenstruck/browser": "^1.2.0",
         "zenstruck/foundry": "^1.10"

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -30,12 +30,12 @@
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/property-access": "^5.4|^6.0",
+        "symfony/twig-bundle": "^5.4|^6.0",
         "twig/twig": "^2.0|^3.0"
     },
     "require-dev": {
         "symfony/framework-bundle": "^5.4|^6.0",
-        "symfony/phpunit-bridge": "^6.0",
-        "symfony/twig-bundle": "^5.4|^6.0"
+        "symfony/phpunit-bridge": "^6.0"
     },
     "conflict": {
         "symfony/config": "<5.4.0"

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -16,7 +16,6 @@ use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
@@ -38,10 +37,6 @@ final class TwigComponentExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
-        if (!isset($container->getParameter('kernel.bundles')['TwigBundle'])) {
-            throw new LogicException('The TwigBundle is not registered in your application. Try running "composer require symfony/twig-bundle".');
-        }
-
         $container->registerAttributeForAutoconfiguration(
             AsTwigComponent::class,
             static function (ChildDefinition $definition, AsTwigComponent $attribute) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Define requirement to the twig bundle for UX Component and UX Live Components. Currently installing ux component and live component fails. Both have a direct requirement to the `TwigBundle` as both require a service named `twig`.

Without defining this requirement the installation of the package will fail when not already have twig-bundle installed: https://github.com/schranz-php-recipes/symfony-recipes-php/actions/runs/3567748595/jobs/5995813798

Related PR: #313
