### PR TITLE
[Autocomplete] Setting preload back to "focus" as the default

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -248,7 +248,7 @@ to the options above, you can also pass:
 ``max_results`` (default: 10)
     Allow you to control the max number of results returned by the automatic autocomplete endpoint.
 
-``preload`` (default: ``false``)
+``preload`` (default: ``focus``)
     Set to ``focus`` to call the ``load`` function when control receives focus.
     Set to ``true`` to call the ``load`` upon control initialization (with an empty search).
 

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -98,7 +98,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'no_more_results_text' => 'No more results',
             'min_characters' => 3,
             'max_results' => 10,
-            'preload' => false,
+            'preload' => 'focus',
         ]);
 
         // if autocomplete_url is passed, then HTML options are already supported


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

Hi!

In 2.6.0, #539 accidentally changed the `preload` behavior from `focus` to `false`. The result is that, in 2.5.0, clicking on an autocomplete field will instantly make an Ajax call to load options. But in 2.6.0, clicking on it does nothing, until you type a few characters.

This changes back to the old default, which I like better, and also (maybe more importantly) is the previous behavior.

Cheers!