### PR TITLE
[Documentation] Add unit testing section

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -485,6 +485,31 @@ Beyond ``url``, the Stimulus controller has various other values,
 including ``tomSelectOptions``. See the `controller.ts`_ file for
 the full list.
 
+Unit testing
+------------
+
+When writing unit tests for your form, using the ``TypeTestCase`` class, you should consider registering the needed type extension ``Symfony\UX\Autocomplete\Form\AutocompleteChoiceTypeExtension`` like so::
+
+    // tests/Form/Type/TestedTypeTest.php
+    namespace App\Tests\Form\Type;
+    
+    use Symfony\Component\Form\Test\TypeTestCase;
+    use Symfony\UX\Autocomplete\Form\AutocompleteChoiceTypeExtension;
+    
+    class TestedTypeTest extends TypeTestCase
+    {
+        protected function getTypeExtensions(): array
+        {
+            return [
+                new AutocompleteChoiceTypeExtension(),
+            ];
+        }
+    
+        // ... your tests
+    }
+
+
+
 Backward Compatibility promise
 ------------------------------
 

--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -488,7 +488,8 @@ the full list.
 Unit testing
 ------------
 
-When writing unit tests for your form, using the ``TypeTestCase`` class, you should consider registering the needed type extension ``Symfony\UX\Autocomplete\Form\AutocompleteChoiceTypeExtension`` like so::
+When writing unit tests for your form, using the ``TypeTestCase`` class, you
+consider registering the needed type extension ``AutocompleteChoiceTypeExtension`` like so::
 
     // tests/Form/Type/TestedTypeTest.php
     namespace App\Tests\Form\Type;
@@ -507,8 +508,6 @@ When writing unit tests for your form, using the ``TypeTestCase`` class, you sho
     
         // ... your tests
     }
-
-
 
 Backward Compatibility promise
 ------------------------------


### PR DESCRIPTION
Changing a native `ChoiceType` to an autocomplete field, using [Symfony-UX/autocomplete](https://symfony.com/bundles/ux-autocomplete/current/index.html), might cause unit tests for forms to fail.

It needs to register the right TypeExtensions to make it work correctly.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| License       | MIT
