### PR TITLE
[Live] Adding a response:error hook

### DIFF
--- a/src/LiveComponent/assets/test/controller/error.test.ts
+++ b/src/LiveComponent/assets/test/controller/error.test.ts
@@ -11,6 +11,11 @@
 
 import { createTest, initComponent, shutdownTests } from '../tools';
 import { getByText, waitFor } from '@testing-library/dom';
+import BackendResponse from '../../src/BackendResponse';
+
+const getErrorElement = (): Element|null => {
+    return document.getElementById('live-component-error');
+};
 
 describe('LiveController Error Handling', () => {
     afterEach(() => {
@@ -39,7 +44,7 @@ describe('LiveController Error Handling', () => {
         await waitFor(() => expect(document.getElementById('live-component-error')).not.toBeNull());
         // the component did not change or re-render
         expect(test.element).toHaveTextContent('Original component text');
-        const errorContainer = document.getElementById('live-component-error');
+        const errorContainer = getErrorElement();
         if (!errorContainer) {
             throw new Error('containing missing');
         }
@@ -68,5 +73,33 @@ describe('LiveController Error Handling', () => {
         await waitFor(() => expect(document.getElementById('live-component-error')).not.toBeNull());
         // the component did not change or re-render
         expect(test.element).toHaveTextContent('Original component text');
+    });
+
+    it('triggers response:error hook', async () => {
+        const test = await createTest({ }, (data: any) => `
+            <div ${initComponent(data)}>
+                component text
+            </div>
+        `);
+
+        test.expectsAjaxCall('post')
+            .expectSentData(test.initialData)
+            .serverWillReturnCustomResponse(200, `
+                <html><head><title>Hi!</title></head><body><h1>I'm a whole page, not a component!</h1></body></html>
+            `)
+            .expectActionCalled('save')
+            .init();
+
+        let isHookCalled = false;
+        test.component.on('response:error', (backendResponse: BackendResponse, controls) => {
+            isHookCalled = true;
+            controls.displayError = false;
+        });
+
+        await test.component.action('save');
+
+        await waitFor(() => expect(isHookCalled).toBe(true));
+        const errorContainer = getErrorElement();
+        expect(errorContainer).toBeNull();
     });
 });

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -471,6 +471,7 @@ The following hooks are available (along with the arguments that are passed):
 * ``disconnect`` args ``(component: Component)``
 * ``render:started`` args ``(html: string, response: BackendResponse, controls: { shouldRender: boolean })``
 * ``render:finished`` args ``(component: Component)``
+* ``response:error`` args ``(backendResponse: BackendResponse, controls: { displayError: boolean })``
 * ``loading.state:started`` args ``(element: HTMLElement, request: BackendRequest)``
 * ``loading.state:finished`` args ``(element: HTMLElement)``
 * ``model:set`` args ``(model: string, value: any, component: Component)``


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #488
| License       | MIT

Pretty simple - as requested in #488. Someone using this hook could set `controls.displayError = false` to prevent live components from rendering the error in a modal.

Cheers!
