### PR TITLE
[LiveComponent] Fix rendering HTML containing SVG

### DIFF
--- a/src/LiveComponent/assets/src/morphdom.ts
+++ b/src/LiveComponent/assets/src/morphdom.ts
@@ -59,7 +59,7 @@ export function executeMorphdom(
             }
 
             // https://github.com/patrick-steele-idem/morphdom#can-i-make-morphdom-blaze-through-the-dom-tree-even-faster-yes
-            if (fromEl.isEqualNode(toEl)) {
+            if (fromEl instanceof HTMLElement && toEl instanceof HTMLElement && fromEl.isEqualNode(toEl)) {
                 // the nodes are equal, but the "value" on some might differ
                 // lets try to quickly compare a bit more deeply
                 const normalizedFromEl = cloneHTMLElement(fromEl);

--- a/src/LiveComponent/assets/test/controller/render.test.ts
+++ b/src/LiveComponent/assets/test/controller/render.test.ts
@@ -365,4 +365,28 @@ describe('LiveController rendering Tests', () => {
 
         await waitFor(() => expect(test.element).toHaveTextContent('123'));
     });
+
+    it('can update html containing svg', async () => {
+        const test = await createTest({ text: 'Hello' }, (data: any) => `
+            <div ${initComponent(data)}>
+                ${data.text}
+                <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+                    <text x="150" y="125" font-size="60" text-anchor="middle" fill="red">SVG</text>
+                </svg>
+                <button data-action="live#$render">Reload</button>
+            </div>
+        `);
+
+        test.expectsAjaxCall('get')
+            .expectSentData(test.initialData)
+            .serverWillChangeData((data: any) => {
+                // change the data on the server so the template renders differently
+                data.text = '123';
+            })
+            .init();
+
+        getByText(test.element, 'Reload').click();
+
+        await waitFor(() => expect(test.element).toHaveTextContent('123'));
+    });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | -
| License       | MIT


This fixes the following error, when rendering a modified element which contains SVG

```
Error: Could not clone element
    at cloneHTMLElement (src/LiveComponent/assets/src/dom_utils.ts:215:11)
    at onBeforeElUpdated (src/LiveComponent/assets/src/morphdom.ts:67:66)
    at morphEl (node_modules/morphdom/dist/morphdom.js:492:21)
    at morphChildren (node_modules/morphdom/dist/morphdom.js:605:33)
    at morphEl (node_modules/morphdom/dist/morphdom.js:507:15)
    at morphdom (node_modules/morphdom/dist/morphdom.js:722:13)
    at executeMorphdom (src/LiveComponent/assets/src/morphdom.ts:34:25)
    at Component.processRerender (src/LiveComponent/assets/src/Component/index.ts:334:35)
    at src/LiveComponent/assets/src/Component/index.ts:283:12
```
