### PR TITLE
[Live] Fix bug where child components would sometimes fail this step

### DIFF
--- a/src/LiveComponent/assets/src/morphdom.ts
+++ b/src/LiveComponent/assets/src/morphdom.ts
@@ -23,7 +23,7 @@ export function executeMorphdom(
             // we need to "correct" the tag name for the child to match the "from"
             // so that we always get a "diff", not a remove/add
             const newTag = cloneElementWithNewTagName(childComponentToElement, childComponent.element.tagName);
-            rootToElement.replaceChild(newTag, childComponentToElement);
+            childComponentToElement.replaceWith(newTag);
         }
     });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #537instead -->
| License       | MIT

The error would be:

Failed to execute 'replaceChild' on 'Node': The node to be replaced is not a child of this node.

I'm not sure what caused that (it seemed to be related to using a non-div root child component element), but replaceWith() works great.

Also updated the outdated js built file.
