### PR TITLE
[Twig] Allowing Pre/PostMount hooks to not return anything

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -173,6 +173,11 @@ fresh copy of our component. That HTML will replace the current HTML. In
 other words, you just generated a new random number! That's cool, but
 let's keep going because… things get cooler.
 
+.. tip::
+
+    Need to do some extra data initialization on your component? Create
+    a ``mount()`` method or use the ``PostMount`` hook: `Twig Component mount documentation`_.
+
 LiveProps: Stateful Component Properties
 ----------------------------------------
 
@@ -2123,6 +2128,7 @@ bound to Symfony's BC policy for the moment.
 .. _`Livewire`: https://laravel-livewire.com
 .. _`Phoenix LiveView`: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html
 .. _`Twig Component`: https://symfony.com/bundles/ux-twig-component/current/index.html
+.. _`Twig Component mount documentation`: https://symfony.com/bundles/ux-twig-component/current/index.html#the-mount-method
 .. _`Symfony form`: https://symfony.com/doc/current/forms.html
 .. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`dependent form fields`: https://ux.symfony.com/live-component/demos/dependent-form-fields

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -234,6 +234,121 @@ If an option name matches an argument name in ``mount()``, the option is
 passed as that argument and the component system will *not* try to set
 it directly on a property.
 
+PreMount Hook
+~~~~~~~~~~~~~
+
+If you need to modify/validate data before it's *mounted* on the
+component use a ``PreMount`` hook::
+
+    // src/Components/AlertComponent.php
+
+    use Symfony\UX\TwigComponent\Attribute\PreMount;
+    // ...
+
+    #[AsTwigComponent('alert')]
+    class AlertComponent
+    {
+        public string $message;
+        public string $type = 'success';
+
+        #[PreMount]
+        public function preMount(array $data): array
+        {
+            // validate data
+            $resolver = new OptionsResolver();
+            $resolver->setDefaults(['type' => 'success']);
+            $resolver->setAllowedValues('type', ['success', 'danger']);
+            $resolver->setRequired('message');
+            $resolver->setAllowedTypes('message', 'string');
+
+            return $resolver->resolve($data)
+        }
+
+        // ...
+    }
+
+.. note::
+
+    If your component has multiple ``PreMount`` hooks, and you'd like to control
+    the order in which they're called, use the ``priority`` attribute parameter:
+    ``PreMount(priority: 10)`` (higher called earlier).
+
+PostMount Hook
+~~~~~~~~~~~~~~
+
+.. versionadded:: 2.1
+
+    The ``PostMount`` hook was added in TwigComponents 2.1.
+
+When a component is mounted with the passed data, if an item cannot be
+mounted on the component, an exception is thrown. You can intercept this
+behavior and "catch" this extra data with a ``PostMount`` hook method. This
+method accepts the extra data as an argument and must return an array. If
+the returned array is empty, the exception will be avoided::
+
+    // src/Components/AlertComponent.php
+
+    use Symfony\UX\TwigComponent\Attribute\PostMount;
+    // ...
+
+    #[AsTwigComponent('alert')]
+    class AlertComponent
+    {
+        #[PostMount]
+        public function postMount(): array
+        {
+            if (str_contains($this->message, 'danger')) {
+                $this->type = 'danger';
+            }
+        }
+        // ...
+    }
+
+A ``PostMount`` method can also receive an array ``$data`` argument, which
+will contain any props passed to the component that have *not* yet been processed,
+i.e. because they don't correspond to any property. You can handle and remove those
+here. For example, imagine an extra ``autoChooseType`` prop were passed when
+creating the ``alert`` component::
+
+    {{ component('alert', {
+        message: 'Danger Will Robinson!',
+        autoChooseType: true,
+    }) }}
+
+You can handle this prop via a ``#[PostMount]`` hook::
+
+    // src/Components/AlertComponent.php
+
+    #[AsTwigComponent('alert')]
+    class AlertComponent
+    {
+        public string $message;
+        public string $type = 'success';
+
+        #[PostMount]
+        public function processAutoChooseType(array $data): array
+        {
+            if (array_key_exists('autoChooseType', $data) && $data['autoChooseType']) {
+                if (str_contains($this->message, 'danger')) {
+                    $this->type = 'danger';
+                }
+
+                // remove the autoChooseType prop from the data array
+                unset($data['autoChooseType']);
+            }
+
+            // any remaining data will become attributes on the component
+            return $data;
+        }
+        // ...
+    }
+
+.. note::
+
+    If your component has multiple ``PostMount`` hooks, and you'd like to control
+    the order in which they're called, use the ``priority`` attribute parameter:
+    ``PostMount(priority: 10)`` (higher called earlier).
+
 ExposeInTemplate Attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -312,82 +427,6 @@ required parameters.
 
     When using ``ExposeInTemplate`` on a method the value is fetched eagerly
     before rendering.
-
-PreMount Hook
-~~~~~~~~~~~~~
-
-If you need to modify/validate data before it's *mounted* on the
-component use a ``PreMount`` hook::
-
-    // src/Components/AlertComponent.php
-
-    use Symfony\UX\TwigComponent\Attribute\PreMount;
-    // ...
-
-    #[AsTwigComponent('alert')]
-    class AlertComponent
-    {
-        public string $message;
-        public string $type = 'success';
-
-        #[PreMount]
-        public function preMount(array $data): array
-        {
-            // validate data
-            $resolver = new OptionsResolver();
-            $resolver->setDefaults(['type' => 'success']);
-            $resolver->setAllowedValues('type', ['success', 'danger']);
-            $resolver->setRequired('message');
-            $resolver->setAllowedTypes('message', 'string');
-
-            return $resolver->resolve($data)
-        }
-
-        // ...
-    }
-
-.. note::
-
-    If your component has multiple ``PreMount`` hooks, and you'd like to control
-    the order in which they're called, use the ``priority`` attribute parameter:
-    ``PreMount(priority: 10)`` (higher called earlier).
-
-PostMount Hook
-~~~~~~~~~~~~~~
-
-.. versionadded:: 2.1
-
-    The ``PostMount`` hook was added in TwigComponents 2.1.
-
-When a component is mounted with the passed data, if an item cannot be
-mounted on the component, an exception is thrown. You can intercept this
-behavior and "catch" this extra data with a ``PostMount`` hook method. This
-method accepts the extra data as an argument and must return an array. If
-the returned array is empty, the exception will be avoided::
-
-    // src/Components/AlertComponent.php
-
-    use Symfony\UX\TwigComponent\Attribute\PostMount;
-    // ...
-
-    #[AsTwigComponent('alert')]
-    class AlertComponent
-    {
-        #[PostMount]
-        public function postMount(array $data): array
-        {
-            // do something with the "extra" data
-
-            return $data;
-        }
-        // ...
-    }
-
-.. note::
-
-    If your component has multiple ``PostMount`` hooks, and you'd like to control
-    the order in which they're called, use the ``priority`` attribute parameter:
-    ``PostMount(priority: 10)`` (higher called earlier).
 
 Fetching Services
 -----------------

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -145,7 +145,11 @@ final class ComponentFactory
         $data = $event->getData();
 
         foreach (AsTwigComponent::preMountMethods($component) as $method) {
-            $data = $component->{$method->name}($data);
+            $newData = $component->{$method->name}($data);
+
+            if (null !== $newData) {
+                $data = $newData;
+            }
         }
 
         return $data;
@@ -158,7 +162,11 @@ final class ComponentFactory
         $data = $event->getData();
 
         foreach (AsTwigComponent::postMountMethods($component) as $method) {
-            $data = $component->{$method->name}($data);
+            $newData = $component->{$method->name}($data);
+
+            if (null !== $newData) {
+                $data = $newData;
+            }
         }
 
         return $data;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | None
| License       | MIT

Hi!

Spotted when creating a new demo for ux.symfony.com: I wanted to use a `#[PostMount]` hook so that I could initialize some properties if they weren't already initialized. And so, I didn't need the `$data` argument nor did I need to return anything. So, effectively, the return value of a `Pre/PostMount` hook is now `array|null`.

Not sure if this is easily testable - I didn't see anything in `ComponentFactoryTest` relate to pre/post mount hooks.

Also reorganizing the docs and tweaking the PostMount example
