### PR TITLE
Add assets/src-directories to .gitattributes-files for each component

### DIFF
--- a/src/Autocomplete/.gitattributes
+++ b/src/Autocomplete/.gitattributes
@@ -1,7 +1,9 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
+/phpunit.xml.dist export-ignore
 /assets/.gitignore export-ignore
+/assets/src export-ignore
 /assets/jest.config.js export-ignore
 /assets/test export-ignore
 /tests export-ignore

--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK]: The path to `routes.php` changed and you should update your

--- a/src/Chartjs/.gitattributes
+++ b/src/Chartjs/.gitattributes
@@ -2,6 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Chartjs/CHANGELOG.md
+++ b/src/Chartjs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK] The `assets/` directory was moved from `Resources/assets/` to `assets/`. Make

--- a/src/Cropperjs/.gitattributes
+++ b/src/Cropperjs/.gitattributes
@@ -2,6 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Cropperjs/CHANGELOG.md
+++ b/src/Cropperjs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK] The `assets/` directory was moved from `Resources/assets/` to `assets/`. Make

--- a/src/Dropzone/.gitattributes
+++ b/src/Dropzone/.gitattributes
@@ -2,6 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Dropzone/CHANGELOG.md
+++ b/src/Dropzone/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK] The `assets/` directory was moved from `Resources/assets/` to `assets/`. Make

--- a/src/LazyImage/.gitattributes
+++ b/src/LazyImage/.gitattributes
@@ -2,6 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/LazyImage/CHANGELOG.md
+++ b/src/LazyImage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK] The `assets/` directory was moved from `Resources/assets/` to `assets/`. Make

--- a/src/LiveComponent/.gitattributes
+++ b/src/LiveComponent/.gitattributes
@@ -1,8 +1,10 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
+/phpunit.xml.dist export-ignore
 /assets/.gitignore export-ignore
 /assets/jest.config.js export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /phpunit.xml.dist export-ignore
 /tests export-ignore

--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -5,6 +5,8 @@
 -   Added a new `route` parameter to `AsLiveComponent`, which allows to choose
     another route for Ajax calls.
 
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK]: The path to `live_component.xml` changed _and_ the import now

--- a/src/Notify/.gitattributes
+++ b/src/Notify/.gitattributes
@@ -2,6 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Notify/CHANGELOG.md
+++ b/src/Notify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK] The `assets/` directory was moved from `Resources/assets/` to `assets/`. Make

--- a/src/React/.gitattributes
+++ b/src/React/.gitattributes
@@ -2,6 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/React/CHANGELOG.md
+++ b/src/React/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK] The `assets/` directory was moved from `Resources/assets/` to `assets/`. Make

--- a/src/Swup/.gitattributes
+++ b/src/Swup/.gitattributes
@@ -1,5 +1,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore

--- a/src/Swup/CHANGELOG.md
+++ b/src/Swup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK] The `assets/` directory was moved from `Resources/assets/` to `assets/`. Make

--- a/src/Turbo/.gitattributes
+++ b/src/Turbo/.gitattributes
@@ -3,6 +3,7 @@
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
 /phpstan.neon.dist export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Turbo/CHANGELOG.md
+++ b/src/Turbo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.1
 
 -   The `symfony/ux-turbo-mercure` package was abandoned and moved into this package.

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.5
 
 -   [BC BREAK] The `PreRenderEvent` namespace was changed from `Symfony\UX\TwigComponent\EventListener`

--- a/src/Typed/.gitattributes
+++ b/src/Typed/.gitattributes
@@ -1,5 +1,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore

--- a/src/Typed/CHANGELOG.md
+++ b/src/Typed/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK] The `assets/` directory was moved from `Resources/assets/` to `assets/`. Make

--- a/src/Vue/.gitattributes
+++ b/src/Vue/.gitattributes
@@ -2,6 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
+/assets/src export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Vue/CHANGELOG.md
+++ b/src/Vue/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `assets/src` to `.gitattributes` to exclude them from the installation
+
 ## 2.6.0
 
 -   [BC BREAK] The `assets/` directory was moved from `Resources/assets/` to `assets/`. Make


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #597 (mentioned)
| License       | MIT

This change prevents the export of the source files from `assets` when installing a component.
