### PR TITLE
Making all events bubble - affects Chartjs, Cropperjs, Dropzone, LazyImage, Swup

### DIFF
--- a/src/Autocomplete/assets/dist/controller.d.ts
+++ b/src/Autocomplete/assets/dist/controller.d.ts
@@ -28,5 +28,6 @@ export default class extends Controller {
     disconnect(): void;
     get selectElement(): HTMLSelectElement | null;
     get formElement(): HTMLInputElement | HTMLSelectElement;
+    private dispatchEvent;
     get preload(): string | boolean;
 }

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -22,7 +22,7 @@ function __classPrivateFieldGet(receiver, state, kind, f) {
     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
 
-var _default_1_instances, _default_1_getCommonConfig, _default_1_createAutocomplete, _default_1_createAutocompleteWithHtmlContents, _default_1_createAutocompleteWithRemoteData, _default_1_stripTags, _default_1_mergeObjects, _default_1_createTomSelect, _default_1_dispatchEvent;
+var _default_1_instances, _default_1_getCommonConfig, _default_1_createAutocomplete, _default_1_createAutocompleteWithHtmlContents, _default_1_createAutocompleteWithRemoteData, _default_1_stripTags, _default_1_mergeObjects, _default_1_createTomSelect;
 class default_1 extends Controller {
     constructor() {
         super(...arguments);
@@ -63,6 +63,9 @@ class default_1 extends Controller {
             throw new Error('Autocomplete Stimulus controller can only be used on an <input> or <select>.');
         }
         return this.element;
+    }
+    dispatchEvent(name, payload) {
+        this.dispatch(name, { detail: payload, prefix: 'autocomplete' });
     }
     get preload() {
         if (!this.hasPreloadValue) {
@@ -180,12 +183,10 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
 }, _default_1_mergeObjects = function _default_1_mergeObjects(object1, object2) {
     return Object.assign(Object.assign({}, object1), object2);
 }, _default_1_createTomSelect = function _default_1_createTomSelect(options) {
-    __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_dispatchEvent).call(this, 'autocomplete:pre-connect', { options });
+    this.dispatchEvent('pre-connect', { options });
     const tomSelect = new TomSelect(this.formElement, options);
-    __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_dispatchEvent).call(this, 'autocomplete:connect', { tomSelect, options });
+    this.dispatchEvent('connect', { tomSelect, options });
     return tomSelect;
-}, _default_1_dispatchEvent = function _default_1_dispatchEvent(name, payload) {
-    this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
 };
 default_1.values = {
     url: String,

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -213,15 +213,15 @@ export default class extends Controller {
     }
 
     #createTomSelect(options: RecursivePartial<TomSettings>): TomSelect {
-        this.#dispatchEvent('autocomplete:pre-connect', { options });
+        this.dispatchEvent('pre-connect', { options });
         const tomSelect = new TomSelect(this.formElement, options);
-        this.#dispatchEvent('autocomplete:connect', { tomSelect, options });
+        this.dispatchEvent('connect', { tomSelect, options });
 
         return tomSelect;
     }
 
-    #dispatchEvent(name: string, payload: any): void {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    private dispatchEvent(name: string, payload: any): void {
+        this.dispatch(name, { detail: payload, prefix: 'autocomplete' });
     }
 
     get preload() {

--- a/src/Chartjs/assets/dist/controller.d.ts
+++ b/src/Chartjs/assets/dist/controller.d.ts
@@ -5,5 +5,5 @@ export default class extends Controller {
         view: ObjectConstructor;
     };
     connect(): void;
-    _dispatchEvent(name: string, payload: any): void;
+    private dispatchEvent;
 }

--- a/src/Chartjs/assets/dist/controller.js
+++ b/src/Chartjs/assets/dist/controller.js
@@ -10,16 +10,16 @@ class default_1 extends Controller {
         if (Array.isArray(payload.options) && 0 === payload.options.length) {
             payload.options = {};
         }
-        this._dispatchEvent('chartjs:pre-connect', { options: payload.options });
+        this.dispatchEvent('pre-connect', { options: payload.options });
         const canvasContext = this.element.getContext('2d');
         if (!canvasContext) {
             throw new Error('Could not getContext() from Element');
         }
         const chart = new Chart(canvasContext, payload);
-        this._dispatchEvent('chartjs:connect', { chart });
+        this.dispatchEvent('connect', { chart });
     }
-    _dispatchEvent(name, payload) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    dispatchEvent(name, payload) {
+        this.dispatch(name, { detail: payload, prefix: 'chartjs' });
     }
 }
 default_1.values = {

--- a/src/Chartjs/assets/src/controller.ts
+++ b/src/Chartjs/assets/src/controller.ts
@@ -29,7 +29,7 @@ export default class extends Controller {
             payload.options = {};
         }
 
-        this._dispatchEvent('chartjs:pre-connect', { options: payload.options });
+        this.dispatchEvent('pre-connect', { options: payload.options });
 
         const canvasContext = this.element.getContext('2d');
         if (!canvasContext) {
@@ -37,10 +37,10 @@ export default class extends Controller {
         }
         const chart = new Chart(canvasContext, payload);
 
-        this._dispatchEvent('chartjs:connect', { chart });
+        this.dispatchEvent('connect', { chart });
     }
 
-    _dispatchEvent(name: string, payload: any) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    private dispatchEvent(name: string, payload: any) {
+        this.dispatch(name, { detail: payload, prefix: 'chartjs' });
     }
 }

--- a/src/Cropperjs/assets/dist/controller.d.ts
+++ b/src/Cropperjs/assets/dist/controller.d.ts
@@ -7,5 +7,5 @@ export default class CropperController extends Controller {
         options: ObjectConstructor;
     };
     connect(): void;
-    _dispatchEvent(name: string, payload: any): void;
+    private dispatchEvent;
 }

--- a/src/Cropperjs/assets/dist/controller.js
+++ b/src/Cropperjs/assets/dist/controller.js
@@ -12,15 +12,15 @@ class CropperController extends Controller {
         }
         parent.appendChild(img);
         const options = this.optionsValue;
-        this._dispatchEvent('cropperjs:pre-connect', { options, img });
+        this.dispatchEvent('pre-connect', { options, img });
         const cropper = new Cropper(img, options);
         img.addEventListener('crop', (event) => {
             this.element.value = JSON.stringify(event.detail);
         });
-        this._dispatchEvent('cropperjs:connect', { cropper, options, img });
+        this.dispatchEvent('connect', { cropper, options, img });
     }
-    _dispatchEvent(name, payload) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    dispatchEvent(name, payload) {
+        this.dispatch(name, { detail: payload, prefix: 'cropperjs' });
     }
 }
 CropperController.values = {

--- a/src/Cropperjs/assets/src/controller.ts
+++ b/src/Cropperjs/assets/src/controller.ts
@@ -36,7 +36,7 @@ export default class CropperController extends Controller {
         parent.appendChild(img);
 
         const options = this.optionsValue;
-        this._dispatchEvent('cropperjs:pre-connect', { options, img });
+        this.dispatchEvent('pre-connect', { options, img });
 
         // Build the cropper
         const cropper = new Cropper(img, options);
@@ -45,10 +45,10 @@ export default class CropperController extends Controller {
             (this.element as HTMLInputElement).value = JSON.stringify((event as CropEvent).detail);
         });
 
-        this._dispatchEvent('cropperjs:connect', { cropper, options, img });
+        this.dispatchEvent('connect', { cropper, options, img });
     }
 
-    _dispatchEvent(name: string, payload: any) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    private dispatchEvent(name: string, payload: any) {
+        this.dispatch(name, { detail: payload, prefix: 'cropperjs' });
     }
 }

--- a/src/Dropzone/assets/dist/controller.d.ts
+++ b/src/Dropzone/assets/dist/controller.d.ts
@@ -11,5 +11,5 @@ export default class extends Controller {
     clear(): void;
     onInputChange(event: any): void;
     _populateImagePreview(file: Blob): void;
-    _dispatchEvent(name: string, payload?: any): void;
+    private dispatchEvent;
 }

--- a/src/Dropzone/assets/dist/controller.js
+++ b/src/Dropzone/assets/dist/controller.js
@@ -5,7 +5,7 @@ class default_1 extends Controller {
         this.clear();
         this.previewClearButtonTarget.addEventListener('click', () => this.clear());
         this.inputTarget.addEventListener('change', (event) => this.onInputChange(event));
-        this._dispatchEvent('dropzone:connect');
+        this.dispatchEvent('connect');
     }
     clear() {
         this.inputTarget.value = '';
@@ -15,7 +15,7 @@ class default_1 extends Controller {
         this.previewImageTarget.style.display = 'none';
         this.previewImageTarget.style.backgroundImage = 'none';
         this.previewFilenameTarget.textContent = '';
-        this._dispatchEvent('dropzone:clear');
+        this.dispatchEvent('clear');
     }
     onInputChange(event) {
         const file = event.target.files[0];
@@ -30,7 +30,7 @@ class default_1 extends Controller {
         if (file.type && file.type.indexOf('image') !== -1) {
             this._populateImagePreview(file);
         }
-        this._dispatchEvent('dropzone:change', file);
+        this.dispatchEvent('change', file);
     }
     _populateImagePreview(file) {
         if (typeof FileReader === 'undefined') {
@@ -43,8 +43,8 @@ class default_1 extends Controller {
         });
         reader.readAsDataURL(file);
     }
-    _dispatchEvent(name, payload = {}) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    dispatchEvent(name, payload = {}) {
+        this.dispatch(name, { detail: payload, prefix: 'dropzone' });
     }
 }
 default_1.targets = ['input', 'placeholder', 'preview', 'previewClearButton', 'previewFilename', 'previewImage'];

--- a/src/Dropzone/assets/src/controller.ts
+++ b/src/Dropzone/assets/src/controller.ts
@@ -31,7 +31,7 @@ export default class extends Controller {
         // Listen on input change and display preview
         this.inputTarget.addEventListener('change', (event) => this.onInputChange(event));
 
-        this._dispatchEvent('dropzone:connect');
+        this.dispatchEvent('connect');
     }
 
     clear() {
@@ -43,7 +43,7 @@ export default class extends Controller {
         this.previewImageTarget.style.backgroundImage = 'none';
         this.previewFilenameTarget.textContent = '';
 
-        this._dispatchEvent('dropzone:clear');
+        this.dispatchEvent('clear');
     }
 
     onInputChange(event: any) {
@@ -66,7 +66,7 @@ export default class extends Controller {
             this._populateImagePreview(file);
         }
 
-        this._dispatchEvent('dropzone:change', file);
+        this.dispatchEvent('change', file);
     }
 
     _populateImagePreview(file: Blob) {
@@ -85,7 +85,7 @@ export default class extends Controller {
         reader.readAsDataURL(file);
     }
 
-    _dispatchEvent(name: string, payload: any = {}) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    private dispatchEvent(name: string, payload: any = {}) {
+        this.dispatch(name, { detail: payload, prefix: 'dropzone' });
     }
 }

--- a/src/LazyImage/assets/dist/controller.d.ts
+++ b/src/LazyImage/assets/dist/controller.d.ts
@@ -9,5 +9,5 @@ export default class extends Controller {
     };
     connect(): void;
     _calculateSrcsetString(): string;
-    _dispatchEvent(name: string, payload: any): void;
+    private dispatchEvent;
 }

--- a/src/LazyImage/assets/dist/controller.js
+++ b/src/LazyImage/assets/dist/controller.js
@@ -10,13 +10,13 @@ class default_1 extends Controller {
             if (srcsetString) {
                 element.srcset = srcsetString;
             }
-            this._dispatchEvent('lazy-image:ready', { image: hd });
+            this.dispatchEvent('ready', { image: hd });
         });
         hd.src = this.srcValue;
         if (srcsetString) {
             hd.srcset = srcsetString;
         }
-        this._dispatchEvent('lazy-image:connect', { image: hd });
+        this.dispatchEvent('connect', { image: hd });
     }
     _calculateSrcsetString() {
         if (!this.hasSrcsetValue) {
@@ -27,8 +27,8 @@ class default_1 extends Controller {
         });
         return sets.join(', ').trimEnd();
     }
-    _dispatchEvent(name, payload) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    dispatchEvent(name, payload) {
+        this.dispatch(name, { detail: payload, prefix: 'lazy-image' });
     }
 }
 default_1.values = {

--- a/src/LazyImage/assets/src/controller.ts
+++ b/src/LazyImage/assets/src/controller.ts
@@ -32,7 +32,7 @@ export default class extends Controller {
             if (srcsetString) {
                 element.srcset = srcsetString;
             }
-            this._dispatchEvent('lazy-image:ready', { image: hd });
+            this.dispatchEvent('ready', { image: hd });
         });
 
         hd.src = this.srcValue;
@@ -40,7 +40,7 @@ export default class extends Controller {
             hd.srcset = srcsetString;
         }
 
-        this._dispatchEvent('lazy-image:connect', { image: hd });
+        this.dispatchEvent('connect', { image: hd });
     }
 
     _calculateSrcsetString(): string {
@@ -55,7 +55,7 @@ export default class extends Controller {
         return sets.join(', ').trimEnd();
     }
 
-    _dispatchEvent(name: string, payload: any) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    private dispatchEvent(name: string, payload: any) {
+        this.dispatch(name, { detail: payload, prefix: 'lazy-image' });
     }
 }

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -48,5 +48,5 @@ export default class extends Controller<HTMLElement> implements LiveController {
     private updateModelFromElementEvent;
     handleConnectedControllerEvent(event: LiveEvent): void;
     handleDisconnectedChildControllerEvent(event: LiveEvent): void;
-    _dispatchEvent(name: string, detail?: any, canBubble?: boolean, cancelable?: boolean): boolean;
+    private dispatchEvent;
 }

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2238,7 +2238,7 @@ class default_1 extends Controller {
             this.component.element.addEventListener(event, callback);
         });
         ComponentRegistry$1.registerComponent(this.element, this.component);
-        this._dispatchEvent('live:connect');
+        this.dispatchEvent('connect');
     }
     disconnect() {
         this.component.disconnect();
@@ -2246,7 +2246,7 @@ class default_1 extends Controller {
             this.component.element.removeEventListener(event, callback);
         });
         ComponentRegistry$1.unregisterComponent(this.element);
-        this._dispatchEvent('live:disconnect');
+        this.dispatchEvent('disconnect');
     }
     update(event) {
         if (event.type === 'input' || event.type === 'change') {
@@ -2365,14 +2365,10 @@ class default_1 extends Controller {
         }
         this.component.removeChild(childController.component);
     }
-    _dispatchEvent(name, detail = {}, canBubble = true, cancelable = false) {
+    dispatchEvent(name, detail = {}, canBubble = true, cancelable = false) {
         detail.controller = this;
         detail.component = this.proxiedComponent;
-        return this.element.dispatchEvent(new CustomEvent(name, {
-            bubbles: canBubble,
-            cancelable,
-            detail,
-        }));
+        this.dispatch(name, { detail, prefix: 'live', cancelable, bubbles: canBubble });
     }
 }
 default_1.values = {

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -107,7 +107,7 @@ export default class extends Controller<HTMLElement> implements LiveController {
         });
 
         ComponentRegistry.registerComponent(this.element, this.component);
-        this._dispatchEvent('live:connect');
+        this.dispatchEvent('connect');
     }
 
     disconnect() {
@@ -118,7 +118,7 @@ export default class extends Controller<HTMLElement> implements LiveController {
         });
 
         ComponentRegistry.unregisterComponent(this.element);
-        this._dispatchEvent('live:disconnect');
+        this.dispatchEvent('disconnect');
     }
 
     /**
@@ -348,16 +348,10 @@ export default class extends Controller<HTMLElement> implements LiveController {
         this.component.removeChild(childController.component);
     }
 
-    _dispatchEvent(name: string, detail: any = {}, canBubble = true, cancelable = false) {
+    private dispatchEvent(name: string, detail: any = {}, canBubble = true, cancelable = false) {
         detail.controller = this;
         detail.component = this.proxiedComponent;
 
-        return this.element.dispatchEvent(
-            new CustomEvent(name, {
-                bubbles: canBubble,
-                cancelable,
-                detail,
-            })
-        );
+        this.dispatch(name, { detail, prefix: 'live', cancelable, bubbles: canBubble });
     }
 }

--- a/src/Notify/assets/dist/controller.d.ts
+++ b/src/Notify/assets/dist/controller.d.ts
@@ -9,5 +9,5 @@ export default class extends Controller {
     connect(): void;
     disconnect(): void;
     _notify(content: string | undefined): void;
-    _dispatchEvent(name: string, payload: any): void;
+    private dispatchEvent;
 }

--- a/src/Notify/assets/dist/controller.js
+++ b/src/Notify/assets/dist/controller.js
@@ -27,7 +27,7 @@ class default_1 extends Controller {
         this.eventSources.forEach((eventSource) => {
             eventSource.addEventListener('message', (event) => this._notify(JSON.parse(event.data).summary));
         });
-        this._dispatchEvent('notify:connect', { eventSources: this.eventSources });
+        this.dispatchEvent('connect', { eventSources: this.eventSources });
     }
     disconnect() {
         this.eventSources.forEach((eventSource) => {
@@ -51,8 +51,8 @@ class default_1 extends Controller {
             });
         }
     }
-    _dispatchEvent(name, payload) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    dispatchEvent(name, payload) {
+        this.dispatch(name, { detail: payload, prefix: 'notify' });
     }
 }
 default_1.values = {

--- a/src/Notify/assets/src/controller.ts
+++ b/src/Notify/assets/src/controller.ts
@@ -49,7 +49,7 @@ export default class extends Controller {
             eventSource.addEventListener('message', (event) => this._notify(JSON.parse(event.data).summary));
         });
 
-        this._dispatchEvent('notify:connect', { eventSources: this.eventSources });
+        this.dispatchEvent('connect', { eventSources: this.eventSources });
     }
 
     disconnect() {
@@ -79,7 +79,7 @@ export default class extends Controller {
         }
     }
 
-    _dispatchEvent(name: string, payload: any) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    private dispatchEvent(name: string, payload: any) {
+        this.dispatch(name, { detail: payload, prefix: 'notify' });
     }
 }

--- a/src/React/assets/dist/render_controller.d.ts
+++ b/src/React/assets/dist/render_controller.d.ts
@@ -10,5 +10,5 @@ export default class extends Controller {
     connect(): void;
     disconnect(): void;
     _renderReactElement(reactElement: ReactElement): void;
-    _dispatchEvent(name: string, payload: any): void;
+    private dispatchEvent;
 }

--- a/src/React/assets/dist/render_controller.js
+++ b/src/React/assets/dist/render_controller.js
@@ -23,13 +23,13 @@ if (process.env.NODE_ENV === 'production') {
 class default_1 extends Controller {
     connect() {
         const props = this.propsValue ? this.propsValue : null;
-        this._dispatchEvent('react:connect', { component: this.componentValue, props: props });
+        this.dispatchEvent('connect', { component: this.componentValue, props: props });
         if (!this.componentValue) {
             throw new Error('No component specified.');
         }
         const component = window.resolveReactComponent(this.componentValue);
         this._renderReactElement(React.createElement(component, props, null));
-        this._dispatchEvent('react:mount', {
+        this.dispatchEvent('mount', {
             componentName: this.componentValue,
             component: component,
             props: props,
@@ -37,7 +37,7 @@ class default_1 extends Controller {
     }
     disconnect() {
         this.element.root.unmount();
-        this._dispatchEvent('react:unmount', {
+        this.dispatchEvent('unmount', {
             component: this.componentValue,
             props: this.propsValue ? this.propsValue : null,
         });
@@ -49,8 +49,8 @@ class default_1 extends Controller {
         }
         element.root.render(reactElement);
     }
-    _dispatchEvent(name, payload) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    dispatchEvent(name, payload) {
+        this.dispatch(name, { detail: payload, prefix: 'react' });
     }
 }
 default_1.values = {

--- a/src/React/assets/src/render_controller.ts
+++ b/src/React/assets/src/render_controller.ts
@@ -25,7 +25,7 @@ export default class extends Controller {
     connect() {
         const props = this.propsValue ? this.propsValue : null;
 
-        this._dispatchEvent('react:connect', { component: this.componentValue, props: props });
+        this.dispatchEvent('connect', { component: this.componentValue, props: props });
 
         if (!this.componentValue) {
             throw new Error('No component specified.');
@@ -34,7 +34,7 @@ export default class extends Controller {
         const component = window.resolveReactComponent(this.componentValue);
         this._renderReactElement(React.createElement(component, props, null));
 
-        this._dispatchEvent('react:mount', {
+        this.dispatchEvent('mount', {
             componentName: this.componentValue,
             component: component,
             props: props,
@@ -43,7 +43,7 @@ export default class extends Controller {
 
     disconnect() {
         (this.element as any).root.unmount();
-        this._dispatchEvent('react:unmount', {
+        this.dispatchEvent('unmount', {
             component: this.componentValue,
             props: this.propsValue ? this.propsValue : null,
         });
@@ -60,7 +60,7 @@ export default class extends Controller {
         element.root.render(reactElement);
     }
 
-    _dispatchEvent(name: string, payload: any) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    private dispatchEvent(name: string, payload: any) {
+        this.dispatch(name, { detail: payload, prefix: 'react' });
     }
 }

--- a/src/Swup/assets/dist/controller.d.ts
+++ b/src/Swup/assets/dist/controller.d.ts
@@ -24,5 +24,5 @@ export default class extends Controller {
         mainElement: StringConstructor;
     };
     connect(): void;
-    _dispatchEvent(name: string, payload: any): void;
+    private dispatchEvent;
 }

--- a/src/Swup/assets/dist/controller.js
+++ b/src/Swup/assets/dist/controller.js
@@ -40,12 +40,12 @@ class default_1 extends Controller {
         if (this.debugValue) {
             options.plugins.push(new SwupDebugPlugin());
         }
-        this._dispatchEvent('swup:pre-connect', { options });
+        this.dispatchEvent('pre-connect', { options });
         const swup = new Swup(options);
-        this._dispatchEvent('swup:connect', { swup, options });
+        this.dispatchEvent('connect', { swup, options });
     }
-    _dispatchEvent(name, payload) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    dispatchEvent(name, payload) {
+        this.dispatch(name, { detail: payload, prefix: 'swup' });
     }
 }
 default_1.values = {

--- a/src/Swup/assets/src/controller.ts
+++ b/src/Swup/assets/src/controller.ts
@@ -82,14 +82,14 @@ export default class extends Controller {
             options.plugins.push(new SwupDebugPlugin());
         }
 
-        this._dispatchEvent('swup:pre-connect', { options });
+        this.dispatchEvent('pre-connect', { options });
 
         const swup = new Swup(options);
 
-        this._dispatchEvent('swup:connect', { swup, options });
+        this.dispatchEvent('connect', { swup, options });
     }
 
-    _dispatchEvent(name: string, payload: any) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    private dispatchEvent(name: string, payload: any) {
+        this.dispatch(name, { detail: payload, prefix: 'swup' });
     }
 }

--- a/src/Typed/assets/dist/controller.d.ts
+++ b/src/Typed/assets/dist/controller.d.ts
@@ -69,5 +69,5 @@ export default class extends Controller {
     readonly bindInputFocusEventsValue?: boolean;
     readonly contentTypeValue: string;
     connect(): void;
-    _dispatchEvent(name: string, payload: any): void;
+    private dispatchEvent;
 }

--- a/src/Typed/assets/dist/controller.js
+++ b/src/Typed/assets/dist/controller.js
@@ -23,12 +23,12 @@ class default_1 extends Controller {
             bindInputFocusEvents: this.bindInputFocusEventsValue,
             contentType: this.contentTypeValue,
         };
-        this._dispatchEvent('typed:pre-connect', { options });
+        this.dispatchEvent('pre-connect', { options });
         const typed = new Typed(this.element, options);
-        this._dispatchEvent('typed:connect', { typed, options });
+        this.dispatchEvent('connect', { typed, options });
     }
-    _dispatchEvent(name, payload) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    dispatchEvent(name, payload) {
+        this.dispatch(name, { detail: payload, prefix: 'typed' });
     }
 }
 default_1.values = {

--- a/src/Typed/assets/src/controller.ts
+++ b/src/Typed/assets/src/controller.ts
@@ -75,12 +75,12 @@ export default class extends Controller {
             contentType: this.contentTypeValue,
         };
 
-        this._dispatchEvent('typed:pre-connect', { options });
+        this.dispatchEvent('pre-connect', { options });
         const typed = new Typed(this.element, options);
-        this._dispatchEvent('typed:connect', { typed, options });
+        this.dispatchEvent('connect', { typed, options });
     }
 
-    _dispatchEvent(name: string, payload: any) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    private dispatchEvent(name: string, payload: any) {
+        this.dispatch(name, { detail: payload, prefix: 'typed' });
     }
 }

--- a/src/Vue/assets/dist/render_controller.d.ts
+++ b/src/Vue/assets/dist/render_controller.d.ts
@@ -13,5 +13,5 @@ export default class extends Controller<Element & {
     };
     connect(): void;
     disconnect(): void;
-    _dispatchEvent(name: string, payload: any): void;
+    private dispatchEvent;
 }

--- a/src/Vue/assets/dist/render_controller.js
+++ b/src/Vue/assets/dist/render_controller.js
@@ -5,20 +5,20 @@ class default_1 extends Controller {
     connect() {
         var _a;
         this.props = (_a = this.propsValue) !== null && _a !== void 0 ? _a : null;
-        this._dispatchEvent('vue:connect', { componentName: this.componentValue, props: this.props });
+        this.dispatchEvent('connect', { componentName: this.componentValue, props: this.props });
         const component = window.resolveVueComponent(this.componentValue);
         this.app = createApp(component, this.props);
         if (this.element.__vue_app__ !== undefined) {
             this.element.__vue_app__.unmount();
         }
-        this._dispatchEvent('vue:before-mount', {
+        this.dispatchEvent('before-mount', {
             componentName: this.componentValue,
             component: component,
             props: this.props,
             app: this.app,
         });
         this.app.mount(this.element);
-        this._dispatchEvent('vue:mount', {
+        this.dispatchEvent('mount', {
             componentName: this.componentValue,
             component: component,
             props: this.props,
@@ -26,13 +26,13 @@ class default_1 extends Controller {
     }
     disconnect() {
         this.app.unmount();
-        this._dispatchEvent('vue:unmount', {
+        this.dispatchEvent('unmount', {
             componentName: this.componentValue,
             props: this.props,
         });
     }
-    _dispatchEvent(name, payload) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    dispatchEvent(name, payload) {
+        this.dispatch(name, { detail: payload, prefix: 'vue' });
     }
 }
 default_1.values = {

--- a/src/Vue/assets/src/render_controller.ts
+++ b/src/Vue/assets/src/render_controller.ts
@@ -26,7 +26,7 @@ export default class extends Controller<Element & { __vue_app__?: App<Element> }
     connect() {
         this.props = this.propsValue ?? null;
 
-        this._dispatchEvent('vue:connect', { componentName: this.componentValue, props: this.props });
+        this.dispatchEvent('connect', { componentName: this.componentValue, props: this.props });
 
         const component = window.resolveVueComponent(this.componentValue);
 
@@ -36,7 +36,7 @@ export default class extends Controller<Element & { __vue_app__?: App<Element> }
             this.element.__vue_app__.unmount();
         }
 
-        this._dispatchEvent('vue:before-mount', {
+        this.dispatchEvent('before-mount', {
             componentName: this.componentValue,
             component: component,
             props: this.props,
@@ -45,7 +45,7 @@ export default class extends Controller<Element & { __vue_app__?: App<Element> }
 
         this.app.mount(this.element);
 
-        this._dispatchEvent('vue:mount', {
+        this.dispatchEvent('mount', {
             componentName: this.componentValue,
             component: component,
             props: this.props,
@@ -55,13 +55,13 @@ export default class extends Controller<Element & { __vue_app__?: App<Element> }
     disconnect() {
         this.app.unmount();
 
-        this._dispatchEvent('vue:unmount', {
+        this.dispatchEvent('unmount', {
             componentName: this.componentValue,
             props: this.props,
         });
     }
 
-    _dispatchEvent(name: string, payload: any) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    private dispatchEvent(name: string, payload: any) {
+        this.dispatch(name, { detail: payload, prefix: 'vue' });
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #30
| License       | MIT

Long-overdue fix for #30. This is a small behavior change, but I consider it a bug fix. The only way that you could be affected by this change in practice is if you have one of the UX components listed *inside* of itself - e.g. a chart inside a chart, so now the existing listener on the outer chart is fired twice. But I don't think that makes any practical sense for any of these components.

Cheers!
