### PR TITLE
[Autocomplete] Distinct autocomplete field from normal field in templates

### DIFF
--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -39,9 +39,11 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
         ];
     }
 
-    public function finishView(FormView $view, FormInterface $form, array $options)
+    public function finishView(FormView $view, FormInterface $form, array $options): void
     {
         if (!$options['autocomplete']) {
+            $view->vars['uses_autocomplete'] = false;
+
             return;
         }
 
@@ -83,10 +85,11 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             $attr['data-'.$controllerName.'-'.$name.'-value'] = $value;
         }
 
+        $view->vars['uses_autocomplete'] = true;
         $view->vars['attr'] = $attr;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'autocomplete' => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #581  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

As discussed in the corresponding issue, it should allow to easily distinct autocomplete fields from non autocomplete fields with a variable added to the view.

Before, I used to write this:
```twig
{% block choice_widget %}
    {% set attr = attr|merge({'class': 'my-input-css-class'}) %}

    {# Condition simplified, let's assume the stimulus controller can only be autocomplete for the example #}
    {% if attr['data-controller'] is not defined %}
    <select name="{{ full_name }}" {{ block('widget_attributes') }}>
        {% for choice in choices %}
            <option value="{{ choice.value }}" {% if choice.value == value %}selected{% endif %}>{{ choice.label }}</option>
        {% endfor %}
    </select>
    {% else %}
        {{ parent() }}
    {% endif %}
{% endblock %}
```
With this, it should be able to become as below:
```twig
{% block choice_widget %}
    {% set attr = attr|merge({'class': 'my-input-css-class'}) %}

    {% if not autocomplete %}
    <select name="{{ full_name }}" {{ block('widget_attributes') }}>
        {% for choice in choices %}
            <option value="{{ choice.value }}" {% if choice.value == value %}selected{% endif %}>{{ choice.label }}</option>
        {% endfor %}
    </select>
    {% else %}
        {{ parent() }}
    {% endif %}
{% endblock %}
```