### PR TITLE
[ChartJs] chart.js v4 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -235,13 +235,39 @@ jobs:
               working-directory: src/Notify
               run: php vendor/bin/simple-phpunit
 
-    tests-js:
+    tests-js-low-deps:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@master
+
+            -   name: Get yarn cache directory path
+                id: yarn-cache-dir-path
+                run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+            -   uses: actions/cache@v2
+                id: yarn-cache
+                with:
+                    path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                    key: ${{ runner.os }}-low-yarn-${{ hashFiles('**/package.json') }}
+                    restore-keys: |
+                        ${{ runner.os }}-low-yarn-
+
+            -   name: Force Lowest Dependencies
+                run: node ./src/Chartjs/assets/scripts/force-lowest-dependencies.js
+
+            -   run: yarn
+
+            -   run: yarn test
+
+    tests-js-high-deps:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
+
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
             - uses: actions/cache@v2
               id: yarn-cache
               with:
@@ -249,5 +275,7 @@ jobs:
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
                   restore-keys: |
                       ${{ runner.os }}-yarn-
+
             - run: yarn
+
             - run: yarn test

--- a/src/Chartjs/CHANGELOG.md
+++ b/src/Chartjs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   Add `assets/src` to `.gitattributes` to exclude them from the installation
+-   Support added for Chart.js version 4
 
 ## 2.6.0
 

--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -7,11 +7,19 @@
     "types": "dist/controller.d.ts",
     "symfony": {
         "controllers": {
-            "chart": {
-                "main": "dist/controller.js",
+            "chart_v3": {
+                "main": "dist/chart_v3_controller.js",
+                "name": "symfony--ux-chartjs--chart",
                 "webpackMode": "eager",
                 "fetch": "eager",
                 "enabled": true
+            },
+            "chart_v4": {
+                "main": "dist/chart_v4_controller.js",
+                "name": "symfony--ux-chartjs--chart",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": false
             }
         }
     },

--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -30,7 +30,7 @@
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
         "@types/chart.js": "^2.9.34",
-        "chart.js": "^4.0",
+        "chart.js": "^3.4.1 <3.9 || ^4.0",
         "jest-canvas-mock": "^2.3.0",
         "resize-observer-polyfill": "^1.5.1"
     }

--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -17,7 +17,7 @@
     },
     "peerDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "chart.js": "^3.4.1 || ^4.0"
+        "chart.js": "^3.4.1 <3.9 || ^4.0"
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",

--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -22,7 +22,7 @@
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
         "@types/chart.js": "^2.9.34",
-        "chart.js": "^3.4.1 <3.9",
+        "chart.js": "^4.0",
         "jest-canvas-mock": "^2.3.0",
         "resize-observer-polyfill": "^1.5.1"
     }

--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -17,7 +17,7 @@
     },
     "peerDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "chart.js": "^3.4.1"
+        "chart.js": "^3.4.1 || ^4.0"
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",

--- a/src/Chartjs/assets/scripts/force-lowest-dependencies.js
+++ b/src/Chartjs/assets/scripts/force-lowest-dependencies.js
@@ -1,0 +1,144 @@
+/*
+ * This file is part of the Symfony Webpack Encore package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const childProcess = require('child_process');
+
+const packageFilePath = 'src/Chartjs/assets/package.json';
+const chartJsLowVersion = '3.4.1';
+
+/**
+ * @param {string} dependency
+ * @param {string} range
+ * @return {Promise}
+ */
+function getLowestVersion(dependency, range) {
+    return new Promise((resolve, reject) => {
+        if (range.startsWith('file:')) {
+            resolve([dependency, range]);
+        }
+
+        childProcess.exec(
+            `npm view "${dependency}@${range}" version`,
+            { encoding: 'utf-8' },
+            (error, stdout) => {
+                if (error) {
+                    reject(`Could not retrieve versions list for "${dependency}@${range}"`);
+                    return;
+                }
+
+                const versions = stdout
+                    .split('\n')
+                    .filter(line => line);
+
+                if (versions.length === 0) {
+                    reject(`Could not find a lowest version for "${dependency}@${range}"`);
+                    return;
+                }
+
+                const parts = versions[0].split(' ');
+
+                // If there is only one version available that version
+                // is directly printed as the output of npm view.
+                if (parts.length === 1) {
+                    resolve([dependency, parts[0]]);
+                    return;
+                }
+
+                // If multiple versions are available then it outputs
+                // multiple lines matching the following format:
+                // <package>@<version> '<version>'
+                if (parts.length === 2) {
+                    resolve([dependency, parts[1].replace(/'/g, '')]);
+                    return;
+                }
+
+                reject(`Unexpected response for "${dependency}@${range}": ${versions[0]}`);
+            }
+        );
+    });
+}
+
+fs.readFile(packageFilePath, (error, data) => {
+    if (error) {
+        throw error;
+    }
+
+    const packageInfo = JSON.parse(data);
+
+    const dependencyPromises = [];
+    if (packageInfo.dependencies) {
+        for (const dependency in packageInfo.dependencies) {
+            dependencyPromises.push(getLowestVersion(
+                dependency,
+                packageInfo.dependencies[dependency]
+            ));
+        }
+    }
+
+    const devDependencyPromises = [];
+    if (packageInfo.devDependencies) {
+        for (const devDependency in packageInfo.devDependencies) {
+            devDependencyPromises.push(getLowestVersion(
+                devDependency,
+                packageInfo.devDependencies[devDependency]
+            ));
+        }
+    }
+
+    const dependenciesUpdate = Promise.all(dependencyPromises).then(versions => {
+        versions.forEach(version => {
+            packageInfo.dependencies[version[0]] = version[1];
+        });
+    });
+
+    const devDependenciesUpdate = Promise.all(devDependencyPromises).then(versions => {
+        versions.forEach(version => {
+            packageInfo.devDependencies[version[0]] = version[1];
+        });
+    });
+
+    // Once all the lowest versions have been resolved, update the
+    // package.json file accordingly.
+    Promise
+        .all([dependenciesUpdate, devDependenciesUpdate])
+        .then(() => new Promise((resolve, reject) => {
+            fs.writeFile(packageFilePath, JSON.stringify(packageInfo, null, 2), (error) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+
+                resolve();
+            });
+        }))
+        .then(() => {
+            console.log('Manually forcing chart.js to lowest version');
+            packageInfo.devDependencies['chart.js'] = chartJsLowVersion;
+        })
+        .then(() => {
+            console.log('Updated package.json file with lowest dependency versions: ');
+
+            console.log('Dependencies:');
+            for (const dependency in packageInfo.dependencies) {
+                console.log(`  - ${dependency}: ${packageInfo.dependencies[dependency]}`);
+            }
+
+            console.log('Dev dependencies:');
+            for (const dependency in packageInfo.devDependencies) {
+                console.log(`  - ${dependency}: ${packageInfo.devDependencies[dependency]}`);
+            }
+        })
+        .catch(error => {
+            console.error(error);
+            process.exit(1); // eslint-disable-line
+        });
+});

--- a/src/Chartjs/assets/src/abstract_controller.ts
+++ b/src/Chartjs/assets/src/abstract_controller.ts
@@ -10,9 +10,8 @@
 'use strict';
 
 import { Controller } from '@hotwired/stimulus';
-import Chart from 'chart.js/auto';
 
-export default class extends Controller {
+export default abstract class AbstractChartController extends Controller {
     declare readonly viewValue: any;
 
     static values = {
@@ -35,7 +34,7 @@ export default class extends Controller {
         if (!canvasContext) {
             throw new Error('Could not getContext() from Element');
         }
-        const chart = new Chart(canvasContext, payload);
+        const chart = this.createChart(canvasContext, payload);
 
         this._dispatchEvent('chartjs:connect', { chart });
     }
@@ -43,4 +42,9 @@ export default class extends Controller {
     _dispatchEvent(name: string, payload: any) {
         this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
     }
+
+    /**
+     * To support v3 and v4 of chart.js this help function is added, could be refactored when support for v3 is dropped
+     */
+    abstract createChart(canvasContext: any, payload: any): any;
 }

--- a/src/Chartjs/assets/src/chart_v3_controller.ts
+++ b/src/Chartjs/assets/src/chart_v3_controller.ts
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import AbstractChartController from './abstract_controller';
+import Chart from 'chart.js/auto';
+import { ChartConfiguration, ChartItem } from 'chart.js';
+
+export default class extends AbstractChartController {
+    createChart(canvasContext: ChartItem, payload: ChartConfiguration): any {
+        return new Chart(canvasContext, payload);
+    }
+}

--- a/src/Chartjs/assets/src/chart_v4_controller.ts
+++ b/src/Chartjs/assets/src/chart_v4_controller.ts
@@ -10,7 +10,7 @@
 'use strict';
 
 import AbstractChartController from './abstract_controller';
-import Chart from 'chart.js/auto';
+import Chart from 'chart.js/auto/auto.cjs';
 import { ChartConfiguration, ChartItem } from 'chart.js';
 
 export default class extends AbstractChartController {

--- a/src/Chartjs/assets/src/chart_v4_controller.ts
+++ b/src/Chartjs/assets/src/chart_v4_controller.ts
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import AbstractChartController from './abstract_controller';
+import Chart from 'chart.js/auto';
+import { ChartConfiguration, ChartItem } from 'chart.js';
+
+export default class extends AbstractChartController {
+    createChart(canvasContext: ChartItem, payload: ChartConfiguration): any {
+        return new Chart(canvasContext, payload);
+    }
+}

--- a/src/Chartjs/assets/test/chart_check_controller.ts
+++ b/src/Chartjs/assets/test/chart_check_controller.ts
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Controller } from '@hotwired/stimulus'
+
+// Controller used to check the actual controller was properly booted
+export class CheckController extends Controller {
+    connect() {
+        this.element.addEventListener('chartjs:pre-connect', () => {
+            this.element.classList.add('pre-connected');
+        });
+
+        this.element.addEventListener('chartjs:connect', (event) => {
+            this.element.classList.add('connected');
+            this.element.chart = event.detail.chart;
+        });
+    }
+}

--- a/src/Chartjs/assets/test/chart_v3_controller.test.ts
+++ b/src/Chartjs/assets/test/chart_v3_controller.test.ts
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Application } from '@hotwired/stimulus';
+import { CheckController } from './chart_check_controller';
+import { getByTestId, waitFor } from '@testing-library/dom';
+import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
+import ChartjsController from '../src/chart_v3_controller';
+
+const startStimulus = () => {
+    const application = Application.start();
+    application.register('check', CheckController);
+    application.register('chartjs', ChartjsController);
+
+    return application;
+};
+
+describe('ChartjsController', () => {
+    let application;
+
+    afterEach(() => {
+        clearDOM();
+        application.stop();
+    });
+
+    it('connect without options', async () => {
+        const container = mountDOM(`
+            <canvas
+                data-testid="canvas"
+                data-controller="check chartjs"
+                data-chartjs-view-value="&#x7B;&quot;type&quot;&#x3A;&quot;line&quot;,&quot;data&quot;&#x3A;&#x7B;&quot;labels&quot;&#x3A;&#x5B;&quot;January&quot;,&quot;February&quot;,&quot;March&quot;,&quot;April&quot;,&quot;May&quot;,&quot;June&quot;,&quot;July&quot;&#x5D;,&quot;datasets&quot;&#x3A;&#x5B;&#x7B;&quot;label&quot;&#x3A;&quot;My&#x20;First&#x20;dataset&quot;,&quot;backgroundColor&quot;&#x3A;&quot;rgb&#x28;255,&#x20;99,&#x20;132&#x29;&quot;,&quot;borderColor&quot;&#x3A;&quot;rgb&#x28;255,&#x20;99,&#x20;132&#x29;&quot;,&quot;data&quot;&#x3A;&#x5B;0,10,5,2,20,30,45&#x5D;&#x7D;&#x5D;&#x7D;,&quot;options&quot;&#x3A;&#x5B;&#x5D;&#x7D;"
+            ></canvas>
+        `);
+
+        expect(getByTestId(container, 'canvas')).not.toHaveClass('pre-connected');
+        expect(getByTestId(container, 'canvas')).not.toHaveClass('connected');
+
+        application = startStimulus();
+
+        await waitFor(() => {
+            expect(getByTestId(container, 'canvas')).toHaveClass('pre-connected');
+            expect(getByTestId(container, 'canvas')).toHaveClass('connected');
+        });
+
+        const chart = getByTestId(container, 'canvas').chart;
+        expect(chart.options.showLines).toBeUndefined();
+    });
+
+    it('connect with options', async () => {
+        const container = mountDOM(`
+            <canvas
+                data-testid="canvas"
+                data-controller="check chartjs"
+                data-chartjs-view-value="&#x7B;&quot;type&quot;&#x3A;&quot;line&quot;,&quot;data&quot;&#x3A;&#x7B;&quot;labels&quot;&#x3A;&#x5B;&quot;January&quot;,&quot;February&quot;,&quot;March&quot;,&quot;April&quot;,&quot;May&quot;,&quot;June&quot;,&quot;July&quot;&#x5D;,&quot;datasets&quot;&#x3A;&#x5B;&#x7B;&quot;label&quot;&#x3A;&quot;My&#x20;First&#x20;dataset&quot;,&quot;backgroundColor&quot;&#x3A;&quot;rgb&#x28;255,&#x20;99,&#x20;132&#x29;&quot;,&quot;borderColor&quot;&#x3A;&quot;rgb&#x28;255,&#x20;99,&#x20;132&#x29;&quot;,&quot;data&quot;&#x3A;&#x5B;0,10,5,2,20,30,45&#x5D;&#x7D;&#x5D;&#x7D;,&quot;options&quot;&#x3A;&#x7B;&quot;showLines&quot;&#x3A;false&#x7D;&#x7D;"
+            ></canvas>
+        `);
+
+        expect(getByTestId(container, 'canvas')).not.toHaveClass('pre-connected');
+        expect(getByTestId(container, 'canvas')).not.toHaveClass('connected');
+
+        application = startStimulus();
+        await waitFor(() => {
+            expect(getByTestId(container, 'canvas')).toHaveClass('pre-connected');
+            expect(getByTestId(container, 'canvas')).toHaveClass('connected');
+        });
+
+        const chart = getByTestId(container, 'canvas').chart;
+        expect(chart.options.showLines).toBe(false);
+    });
+});

--- a/src/Chartjs/assets/test/chart_v4_controller.test.ts
+++ b/src/Chartjs/assets/test/chart_v4_controller.test.ts
@@ -9,24 +9,11 @@
 
 'use strict';
 
-import { Application, Controller } from '@hotwired/stimulus';
+import { Application } from '@hotwired/stimulus';
+import { CheckController } from './chart_check_controller';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
-import ChartjsController from '../src/controller';
-
-// Controller used to check the actual controller was properly booted
-class CheckController extends Controller {
-    connect() {
-        this.element.addEventListener('chartjs:pre-connect', () => {
-            this.element.classList.add('pre-connected');
-        });
-
-        this.element.addEventListener('chartjs:connect', (event) => {
-            this.element.classList.add('connected');
-            this.element.chart = event.detail.chart;
-        });
-    }
-}
+import ChartjsController from '../src/chart_v4_controller';
 
 const startStimulus = () => {
     const application = Application.start();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #607
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->

**Current status:**
- Separate controllers per version (`3` and `4`)
  - We could also add specific support for the `3.9` version, see #427
- Added separate test controllers per version
- Added support for running `low`/`high` dependency tests via GH workflow

**Todo**
- [x] Fix importing `chart.js` in the `chart_v4_controller.ts` and fix the test-suite
- [ ] Test specific low/high dependency dir/paths 
  - on `low-deps` (`chart.js:^3.4.1`); only test `chart_v3_controller.test.ts` and on `high-deps` (`chart.js:^4.0`); only test `chart_v4_controller.test.ts`. Otherwise v3 deps will error on v4 controller and vice versa.
- [ ] Files in `dist` directory should also be updated? Or is that part of the Webpack loader magic :)
- [ ] Cleanup/reuse (DRY) code in the test controllers?