### PR TITLE
[Autocomplete] typo in the Maker's template path

### DIFF
--- a/src/Autocomplete/src/Maker/MakeAutocompleteField.php
+++ b/src/Autocomplete/src/Maker/MakeAutocompleteField.php
@@ -131,7 +131,7 @@ EOF)
         );
         $generator->generateClass(
             $classDetails->getFullName(),
-            __DIR__.'./skeletons/AutocompleteField.tpl.php',
+            __DIR__.'/skeletons/AutocompleteField.tpl.php',
             [
                 'variables' => $variables,
             ]


### PR DESCRIPTION
```
suabahasa ❯ php bin/console make:autocomplete-field

 The class name of the entity you want to autocomplete:
 > Pelaku

 Choose a name for your entity field class (e.g. PelakuAutocompleteField) [PelakuAutocompleteField]:
 >


In Generator.php line 176:

  Cannot find template "C:\workspace\git\saspol\vendor\symfony\ux-autocomplete\src\Maker./skeletons/AutocompleteField
  .tpl.php"


make:autocomplete-field
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
