### PR TITLE
[Twig] Add prepend to component attributes

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 -   Add `assets/src` to `.gitattributes` to exclude them from the installation
+-   Add `ComponentAttributes::append` and `ComponentAttributes::prepend` to eg. prepend a stimulus
+    controller in templates like `<div {{ attributes.prepend(stimulus_controller('my-controller')) }}>`
 
 ## 2.5
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -592,13 +592,20 @@ Set an attribute's value to ``null`` to exclude the value when rendering:
 
 .. versionadded: 2.7
 
-    The ``add()`` method was introduced in TwigComponents 2.7.
+    The ``appendController()`` and ``prependController()`` methods were introduced in TwigComponents 2.7.
 
-To add a custom Stimulus controller to your root component element:
+To append or prepend a custom Stimulus controller to your root component element:
 
 .. code-block:: twig
 
-    <div {{ attributes.add(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
+    <div {{ attributes.appendController(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
+    <div {{ attributes.prependController(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
+
+.. note::
+
+    As Stimulus controllers' lifecycle methods called in the order as they appear
+    in the DOM. If the order of these calls matters for your use case, you should
+    call the appropriate method. For LiveControllers you usually need prepend.
 
 .. note::
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -590,16 +590,16 @@ Set an attribute's value to ``null`` to exclude the value when rendering:
     {# renders as: #}
     <input type="text" value="" autofocus/>
 
-.. versionadded: 2.7
+.. versionadded:: 2.7
 
-    The ``appendController()`` and ``prependController()`` methods were introduced in TwigComponents 2.7.
+    The ``append()`` and ``prepend()`` methods were introduced in TwigComponents 2.7.
 
 To append or prepend a custom Stimulus controller to your root component element:
 
 .. code-block:: twig
 
-    <div {{ attributes.appendController(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
-    <div {{ attributes.prependController(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
+    <div {{ attributes.append(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
+    <div {{ attributes.prepend(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
 
 .. note::
 

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -96,30 +96,41 @@ final class ComponentAttributes
         return $clone;
     }
 
-    public function appendController(AbstractStimulusDto $stimulusDto): self
+    /**
+     * @param array<string, string>|AbstractStimulusDto $attributes
+     */
+    public function append(array|AbstractStimulusDto $attributes): self
     {
-        return $this->mergeAttribute('data-controller', $stimulusDto);
+        return $this->mergeAttribute($attributes);
     }
 
-    public function prependController(AbstractStimulusDto $stimulusDto): self
+    /**
+     * @param array<string, string>|AbstractStimulusDto $attributes
+     */
+    public function prepend(array|AbstractStimulusDto $attributes): self
     {
-        return $this->mergeAttribute('data-controller', $stimulusDto, true);
+        return $this->mergeAttribute($attributes, true);
     }
 
-    private function mergeAttribute(string $name, AbstractStimulusDto $stimulusDto, bool $prepend = false): self
+    /**
+     * @param array<string, string>|AbstractStimulusDto $other
+     */
+    private function mergeAttribute(array|AbstractStimulusDto $other, bool $prepend = false): self
     {
-        $controllersAttributes = $stimulusDto->toArray();
-        $attributes = $this->attributes;
+        $otherAttributes = $other instanceof AbstractStimulusDto ? $other->toArray() : $other;
+        $selfAttributes = $this->attributes;
 
-        $attributes[$name] = implode(' ', array_merge(
-            explode(' ', $prepend ? $controllersAttributes[$name] ?? '' : $attributes[$name] ?? ''),
-            explode(' ', $prepend ? $attributes[$name] ?? '' : $controllersAttributes[$name] ?? ''),
-        ));
-        unset($controllersAttributes[$name]);
+        $attributes = array_merge($selfAttributes, $otherAttributes);
+        foreach ($selfAttributes as $name => $attr) {
+            $attributes[$name] =
+                trim(
+                    ($prepend ? $otherAttributes[$name] ?? '' : $attr)
+                    .' '.
+                    ($prepend ? $attr : $otherAttributes[$name] ?? ''),
+                    ' '
+                );
+        }
 
-        $clone = new self($attributes);
-
-        // add the remaining attributes for values/classes
-        return $clone->defaults($controllersAttributes);
+        return new self($attributes);
     }
 }

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -98,14 +98,24 @@ final class ComponentAttributes
 
     public function add(AbstractStimulusDto $stimulusDto): self
     {
+        return $this->mergeAttribute('data-controller', $stimulusDto);
+    }
+
+    public function prepend(AbstractStimulusDto $stimulusDto): self
+    {
+        return $this->mergeAttribute('data-controller', $stimulusDto, true);
+    }
+
+    private function mergeAttribute(string $name, AbstractStimulusDto $stimulusDto, bool $prepend = false): self
+    {
         $controllersAttributes = $stimulusDto->toArray();
         $attributes = $this->attributes;
 
-        $attributes['data-controller'] = implode(' ', array_merge(
-            explode(' ', $attributes['data-controller']),
-            explode(' ', $controllersAttributes['data-controller'] ?? [])
+        $attributes[$name] = implode(' ', array_merge(
+            explode(' ', $prepend ? $controllersAttributes[$name] ?? '' : $attributes[$name] ?? ''),
+            explode(' ', $prepend ? $attributes[$name] ?? '' : $controllersAttributes[$name] ?? ''),
         ));
-        unset($controllersAttributes['data-controller']);
+        unset($controllersAttributes[$name]);
 
         $clone = new self($attributes);
 

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -96,12 +96,12 @@ final class ComponentAttributes
         return $clone;
     }
 
-    public function add(AbstractStimulusDto $stimulusDto): self
+    public function appendController(AbstractStimulusDto $stimulusDto): self
     {
         return $this->mergeAttribute('data-controller', $stimulusDto);
     }
 
-    public function prepend(AbstractStimulusDto $stimulusDto): self
+    public function prependController(AbstractStimulusDto $stimulusDto): self
     {
         return $this->mergeAttribute('data-controller', $stimulusDto, true);
     }

--- a/src/TwigComponent/tests/Fixtures/Kernel.php
+++ b/src/TwigComponent/tests/Fixtures/Kernel.php
@@ -40,6 +40,7 @@ final class Kernel extends BaseKernel
             'test' => true,
             'router' => ['utf8' => true],
             'secrets' => false,
+            'http_method_override' => false,
         ]);
         $c->extension('twig', [
             'default_path' => '%kernel.project_dir%/tests/Fixtures/templates',

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -78,13 +78,29 @@ final class ComponentAttributesTest extends TestCase
                 'data-foo-name-value' => 'ryan',
             ]);
 
-        $attributes = $attributes->appendController($controllerDto);
+        $attributes = $attributes->append($controllerDto);
 
         $this->assertEquals([
             'class' => 'foo',
             'data-controller' => 'live foo bar',
             'data-live-data-value' => '{}',
             'data-foo-name-value' => 'ryan',
+        ], $attributes->all());
+    }
+
+    public function testCanAppendArrayOfAttributes(): void
+    {
+        $attributes = new ComponentAttributes([
+            'class' => 'foo',
+            'data-keep' => 'keep-it',
+        ]);
+
+        $attributes = $attributes->append(['data-add' => 'add-it', 'class' => 'bar']);
+
+        $this->assertEquals([
+            'class' => 'foo bar',
+            'data-keep' => 'keep-it',
+            'data-add' => 'add-it',
         ], $attributes->all());
     }
 
@@ -104,13 +120,29 @@ final class ComponentAttributesTest extends TestCase
                 'data-foo-name-value' => 'ryan',
             ]);
 
-        $attributes = $attributes->prependController($controllerDto);
+        $attributes = $attributes->prepend($controllerDto);
 
         $this->assertEquals([
             'class' => 'foo',
             'data-controller' => 'foo bar live',
             'data-live-data-value' => '{}',
             'data-foo-name-value' => 'ryan',
+        ], $attributes->all());
+    }
+
+    public function testCanPrependArrayOfAttributes(): void
+    {
+        $attributes = new ComponentAttributes([
+            'class' => 'foo',
+            'data-keep' => 'keep-it',
+        ]);
+
+        $attributes = $attributes->prepend(['data-add' => 'add-it', 'class' => 'bar']);
+
+        $this->assertEquals([
+            'class' => 'bar foo',
+            'data-keep' => 'keep-it',
+            'data-add' => 'add-it',
         ], $attributes->all());
     }
 }

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -62,7 +62,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(['class' => 'foo'], $attributes->without('style')->all());
     }
 
-    public function testCanAddStimulusController(): void
+    public function testCanAppendStimulusController(): void
     {
         $attributes = new ComponentAttributes([
             'class' => 'foo',
@@ -78,7 +78,7 @@ final class ComponentAttributesTest extends TestCase
                 'data-foo-name-value' => 'ryan',
             ]);
 
-        $attributes = $attributes->add($controllerDto);
+        $attributes = $attributes->appendController($controllerDto);
 
         $this->assertEquals([
             'class' => 'foo',
@@ -104,7 +104,7 @@ final class ComponentAttributesTest extends TestCase
                 'data-foo-name-value' => 'ryan',
             ]);
 
-        $attributes = $attributes->prepend($controllerDto);
+        $attributes = $attributes->prependController($controllerDto);
 
         $this->assertEquals([
             'class' => 'foo',

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -87,4 +87,30 @@ final class ComponentAttributesTest extends TestCase
             'data-foo-name-value' => 'ryan',
         ], $attributes->all());
     }
+
+    public function testCanPrependStimulusController(): void
+    {
+        $attributes = new ComponentAttributes([
+            'class' => 'foo',
+            'data-controller' => 'live',
+            'data-live-data-value' => '{}',
+        ]);
+
+        $controllerDto = $this->createMock(AbstractStimulusDto::class);
+        $controllerDto->expects(self::once())
+            ->method('toArray')
+            ->willReturn([
+                'data-controller' => 'foo bar',
+                'data-foo-name-value' => 'ryan',
+            ]);
+
+        $attributes = $attributes->prepend($controllerDto);
+
+        $this->assertEquals([
+            'class' => 'foo',
+            'data-controller' => 'foo bar live',
+            'data-live-data-value' => '{}',
+            'data-foo-name-value' => 'ryan',
+        ], $attributes->all());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | #612
| License       | MIT

As Stimulus controllers' lifecycle methods called in the order as they appear
in the DOM. If the order of these calls matters for our use case we need a way
to add a controller before others. We can of course wrap the whole thing in a div
and put our controller there, but sometimes that is not convenient (like using flexbox) and for live controllers we can not do it actually.

**TODO**:

- [x] docs
