### PR TITLE
[Doc] Live Component: Fixed a typo in the documentation

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -236,7 +236,7 @@ For example, could we allow the user to *change* the ``$max``
 property and then re-render the component when they do? Definitely! And
 *that* is where live components really shine.
 
-Add an inputs to the template:
+Add an input to the template:
 
 .. code-block:: twig
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR fixes a simple typo: "..add an input**s** to the template:" to "...add an input to the template:">
