### PR TITLE
[Doc] Live Component: Fixed typo in documentation

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1183,7 +1183,7 @@ Using Actions to Change your Form: CollectionType
 
 Symfony's `CollectionType`_ can be used to embed a collection of
 embedded forms including allowing the user to dynamically add or remove
-them. Live components can accomplish make this all possible while
+them. Live components make this all possible while
 writing zero JavaScript.
 
 For example, imagine a "Blog Post" form with an embedded "Comment" forms


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR fixes a simple typo in the docs for UX Live Component.