### PR TITLE
imp: install PHP-CS-Fixer locally, allowing us to run in locally

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,9 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.0'
-                  tools: php-cs-fixer
+            - uses: ramsey/composer-install@v2
             - name: php-cs-fixer
-              run: php-cs-fixer fix --dry-run --diff
+              run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
 
     coding-style-js:
         runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "symfony/ux",
     "license": "MIT",
     "require-dev": {
-        "symfony/filesystem": "^5.2|^6.0"
+        "symfony/filesystem": "^5.2|^6.0",
+        "php-cs-fixer/shim": "^3.13"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

After opening #616, the CI showed me a lot of style issues in the PHP code: 
<img width="537" alt="image" src="https://user-images.githubusercontent.com/2103975/208297036-3521128f-c2cc-4847-92c3-30a8d1b2a4ce.png">

I don't have PHP CS Fixer globally installed on my machine because that's a bad practice, and I don't want to fix those errors manually (the time is precious).

So, this PR adds PHP CS Fixer locally.