### PR TITLE
[Live] Throw if a live component wrapped in other element

### DIFF
--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -370,6 +370,10 @@ export default class Component {
         let newElement;
         try {
             newElement = htmlToElement(html);
+
+            if (!newElement.matches('[data-controller~=live]')) {
+                throw new Error('A live component template must contain a single root controller element.');
+            }
         } catch (error) {
             console.error('There was a problem with the component HTML returned:');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | #612
| License       | MIT

As how it works at the moment, it is intended for a live component to have a single root
as a live controller element. Maybe this can be checked earlier on server side, but that's not that easy.
