### PR TITLE
[Live] Adding ComponentRegistry as an easy way to fetch a Live Component

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -22,11 +22,11 @@ function __classPrivateFieldGet(receiver, state, kind, f) {
     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
 
-var _instances, _getCommonConfig, _createAutocomplete, _createAutocompleteWithHtmlContents, _createAutocompleteWithRemoteData, _stripTags, _mergeObjects, _createTomSelect, _dispatchEvent;
+var _default_1_instances, _default_1_getCommonConfig, _default_1_createAutocomplete, _default_1_createAutocompleteWithHtmlContents, _default_1_createAutocompleteWithRemoteData, _default_1_stripTags, _default_1_mergeObjects, _default_1_createTomSelect, _default_1_dispatchEvent;
 class default_1 extends Controller {
     constructor() {
         super(...arguments);
-        _instances.add(this);
+        _default_1_instances.add(this);
     }
     initialize() {
         this.element.setAttribute('data-live-ignore', '');
@@ -39,14 +39,14 @@ class default_1 extends Controller {
     }
     connect() {
         if (this.urlValue) {
-            this.tomSelect = __classPrivateFieldGet(this, _instances, "m", _createAutocompleteWithRemoteData).call(this, this.urlValue, this.minCharactersValue);
+            this.tomSelect = __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createAutocompleteWithRemoteData).call(this, this.urlValue, this.minCharactersValue);
             return;
         }
         if (this.optionsAsHtmlValue) {
-            this.tomSelect = __classPrivateFieldGet(this, _instances, "m", _createAutocompleteWithHtmlContents).call(this);
+            this.tomSelect = __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createAutocompleteWithHtmlContents).call(this);
             return;
         }
-        this.tomSelect = __classPrivateFieldGet(this, _instances, "m", _createAutocomplete).call(this);
+        this.tomSelect = __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createAutocomplete).call(this);
     }
     disconnect() {
         this.tomSelect.revertSettings.innerHTML = this.element.innerHTML;
@@ -77,7 +77,7 @@ class default_1 extends Controller {
         return this.preloadValue;
     }
 }
-_instances = new WeakSet(), _getCommonConfig = function _getCommonConfig() {
+_default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _default_1_getCommonConfig() {
     const plugins = {};
     const isMultiple = !this.selectElement || this.selectElement.multiple;
     if (!this.formElement.disabled && !isMultiple) {
@@ -109,19 +109,19 @@ _instances = new WeakSet(), _getCommonConfig = function _getCommonConfig() {
     if (!this.selectElement && !this.urlValue) {
         config.shouldLoad = () => false;
     }
-    return __classPrivateFieldGet(this, _instances, "m", _mergeObjects).call(this, config, this.tomSelectOptionsValue);
-}, _createAutocomplete = function _createAutocomplete() {
-    const config = __classPrivateFieldGet(this, _instances, "m", _mergeObjects).call(this, __classPrivateFieldGet(this, _instances, "m", _getCommonConfig).call(this), {
+    return __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_mergeObjects).call(this, config, this.tomSelectOptionsValue);
+}, _default_1_createAutocomplete = function _default_1_createAutocomplete() {
+    const config = __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_mergeObjects).call(this, __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_getCommonConfig).call(this), {
         maxOptions: this.selectElement ? this.selectElement.options.length : 50,
     });
-    return __classPrivateFieldGet(this, _instances, "m", _createTomSelect).call(this, config);
-}, _createAutocompleteWithHtmlContents = function _createAutocompleteWithHtmlContents() {
-    const config = __classPrivateFieldGet(this, _instances, "m", _mergeObjects).call(this, __classPrivateFieldGet(this, _instances, "m", _getCommonConfig).call(this), {
+    return __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createTomSelect).call(this, config);
+}, _default_1_createAutocompleteWithHtmlContents = function _default_1_createAutocompleteWithHtmlContents() {
+    const config = __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_mergeObjects).call(this, __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_getCommonConfig).call(this), {
         maxOptions: this.selectElement ? this.selectElement.options.length : 50,
         score: (search) => {
             const scoringFunction = this.tomSelect.getScoreFunction(search);
             return (item) => {
-                return scoringFunction(Object.assign(Object.assign({}, item), { text: __classPrivateFieldGet(this, _instances, "m", _stripTags).call(this, item.text) }));
+                return scoringFunction(Object.assign(Object.assign({}, item), { text: __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_stripTags).call(this, item.text) }));
             };
         },
         render: {
@@ -133,9 +133,9 @@ _instances = new WeakSet(), _getCommonConfig = function _getCommonConfig() {
             },
         },
     });
-    return __classPrivateFieldGet(this, _instances, "m", _createTomSelect).call(this, config);
-}, _createAutocompleteWithRemoteData = function _createAutocompleteWithRemoteData(autocompleteEndpointUrl, minCharacterLength) {
-    const config = __classPrivateFieldGet(this, _instances, "m", _mergeObjects).call(this, __classPrivateFieldGet(this, _instances, "m", _getCommonConfig).call(this), {
+    return __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createTomSelect).call(this, config);
+}, _default_1_createAutocompleteWithRemoteData = function _default_1_createAutocompleteWithRemoteData(autocompleteEndpointUrl, minCharacterLength) {
+    const config = __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_mergeObjects).call(this, __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_getCommonConfig).call(this), {
         firstUrl: (query) => {
             const separator = autocompleteEndpointUrl.includes('?') ? '&' : '?';
             return `${autocompleteEndpointUrl}${separator}query=${encodeURIComponent(query)}`;
@@ -174,17 +174,17 @@ _instances = new WeakSet(), _getCommonConfig = function _getCommonConfig() {
         },
         preload: this.preload,
     });
-    return __classPrivateFieldGet(this, _instances, "m", _createTomSelect).call(this, config);
-}, _stripTags = function _stripTags(string) {
+    return __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createTomSelect).call(this, config);
+}, _default_1_stripTags = function _default_1_stripTags(string) {
     return string.replace(/(<([^>]+)>)/gi, '');
-}, _mergeObjects = function _mergeObjects(object1, object2) {
+}, _default_1_mergeObjects = function _default_1_mergeObjects(object1, object2) {
     return Object.assign(Object.assign({}, object1), object2);
-}, _createTomSelect = function _createTomSelect(options) {
-    __classPrivateFieldGet(this, _instances, "m", _dispatchEvent).call(this, 'autocomplete:pre-connect', { options });
+}, _default_1_createTomSelect = function _default_1_createTomSelect(options) {
+    __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_dispatchEvent).call(this, 'autocomplete:pre-connect', { options });
     const tomSelect = new TomSelect(this.formElement, options);
-    __classPrivateFieldGet(this, _instances, "m", _dispatchEvent).call(this, 'autocomplete:connect', { tomSelect, options });
+    __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_dispatchEvent).call(this, 'autocomplete:connect', { tomSelect, options });
     return tomSelect;
-}, _dispatchEvent = function _dispatchEvent(name, payload) {
+}, _default_1_dispatchEvent = function _default_1_dispatchEvent(name, payload) {
     this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
 };
 default_1.values = {

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 import Component from './Component';
 export { Component };
+export declare const getComponent: (element: HTMLElement) => Promise<Component>;
 export interface LiveEvent extends CustomEvent {
     detail: {
         controller: LiveController;

--- a/src/LiveComponent/assets/src/ComponentRegistry.ts
+++ b/src/LiveComponent/assets/src/ComponentRegistry.ts
@@ -1,0 +1,35 @@
+import Component from './Component';
+import { getElementAsTagText } from './dom_utils';
+
+const ComponentRegistry = class {
+    private components = new WeakMap<HTMLElement, Component>();
+
+    public registerComponent(element: HTMLElement, definition: Component) {
+        this.components.set(element, definition);
+    }
+
+    public unregisterComponent(element: HTMLElement) {
+        this.components.delete(element);
+    }
+
+    public getComponent(element: HTMLElement): Promise<Component> {
+        return new Promise((resolve, reject) => {
+            let count = 0;
+            const maxCount = 10;
+            const interval = setInterval(() => {
+                const component = this.components.get(element);
+                if (component) {
+                    resolve(component);
+                }
+                count++;
+
+                if (count > maxCount) {
+                    clearInterval(interval);
+                    reject(new Error(`Component not found for element ${getElementAsTagText(element)}`));
+                }
+            }, 5);
+        });
+    }
+};
+
+export default new ComponentRegistry();

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -17,8 +17,10 @@ import PollingPlugin from './Component/plugins/PollingPlugin';
 import SetValueOntoModelFieldsPlugin from './Component/plugins/SetValueOntoModelFieldsPlugin';
 import { PluginInterface } from './Component/plugins/PluginInterface';
 import getModelBinding from './Directive/get_model_binding';
+import ComponentRegistry from './ComponentRegistry';
 
 export { Component };
+export const getComponent = (element: HTMLElement): Promise<Component> => ComponentRegistry.getComponent(element);
 
 export interface LiveEvent extends CustomEvent {
     detail: {
@@ -104,6 +106,7 @@ export default class extends Controller<HTMLElement> implements LiveController {
             this.component.element.addEventListener(event, callback);
         });
 
+        ComponentRegistry.registerComponent(this.element, this.component);
         this._dispatchEvent('live:connect');
     }
 
@@ -114,6 +117,7 @@ export default class extends Controller<HTMLElement> implements LiveController {
             this.component.element.removeEventListener(event, callback);
         });
 
+        ComponentRegistry.unregisterComponent(this.element);
         this._dispatchEvent('live:disconnect');
     }
 

--- a/src/LiveComponent/assets/test/ComponentRegistry.test.ts
+++ b/src/LiveComponent/assets/test/ComponentRegistry.test.ts
@@ -1,0 +1,53 @@
+import Component from '../src/Component';
+import ComponentRegistry from '../src/ComponentRegistry';
+import BackendRequest from '../src/BackendRequest';
+import { BackendInterface } from '../src/Backend';
+import { Response } from 'node-fetch';
+import { StandardElementDriver } from '../src/Component/ElementDriver';
+
+const createComponent = (element: HTMLElement): Component => {
+    const backend: BackendInterface = {
+        makeRequest(): BackendRequest {
+            return new BackendRequest(
+                // @ts-ignore Response doesn't quite match the underlying interface
+                new Promise((resolve) => resolve(new Response(''))),
+                [],
+                []
+            )
+        }
+    }
+
+    return new Component(
+        element,
+        {},
+        {},
+        null,
+        null,
+        backend,
+        new StandardElementDriver(),
+    );
+};
+
+describe('ComponentRegistry', () => {
+    it('can add and retrieve components', async () => {
+        const element1 = document.createElement('div');
+        const component1 = createComponent(element1);
+        const element2 = document.createElement('div');
+        const component2 = createComponent(element2);
+
+        ComponentRegistry.registerComponent(element1, component1);
+        ComponentRegistry.registerComponent(element2, component2);
+
+        const promise1 = ComponentRegistry.getComponent(element1);
+        const promise2 = ComponentRegistry.getComponent(element2);
+        await expect(promise1).resolves.toBe(component1);
+        await expect(promise2).resolves.toBe(component2);
+    });
+
+    it('fails if component is not found soon', async () => {
+        const element1 = document.createElement('div');
+        const promise = ComponentRegistry.getComponent(element1);
+        expect.assertions(1);
+        await expect(promise).rejects.toEqual(new Error('Component not found for element <div></div>'));
+    });
+});

--- a/src/LiveComponent/assets/test/controller/basic.test.ts
+++ b/src/LiveComponent/assets/test/controller/basic.test.ts
@@ -12,6 +12,7 @@
 import {createTest, initComponent, shutdownTests, startStimulus} from '../tools';
 import { htmlToElement } from '../../src/dom_utils';
 import Component from '../../src/Component';
+import { getComponent } from '../../src/live_controller';
 
 describe('LiveController Basic Tests', () => {
     afterEach(() => {
@@ -41,5 +42,6 @@ describe('LiveController Basic Tests', () => {
         expect(test.component.defaultDebounce).toEqual(115);
         expect(test.component.id).toEqual('the-id');
         expect(test.component.fingerprint).toEqual('the-fingerprint');
+        await expect(getComponent(test.element)).resolves.toBe(test.component);
     });
 });

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -416,14 +416,11 @@ controller and put it around (or attached to) your root component element:
 
     // assets/controllers/some-custom-controller.js
     // ...
+    import { getComponent } from '@symfony/ux-live-component';
 
     export default class extends Controller {
-        connect() {
-            // when the live component inside of this controller is initialized,
-            // this method will be called and you can access the Component object
-            this.element.addEventListener('live:connect', (event) => {
-                this.component = event.detail.component;
-            });
+        async initialize() {
+            this.component = await getComponent(this.element);
         }
 
         // some Stimulus action triggered, for example, on user click
@@ -441,11 +438,13 @@ controller and put it around (or attached to) your root component element:
     }
 
 You can also access the ``Component`` object via a special property
-on the root component element:
+on the root component element, though ``getComponent()`` is the
+recommended way, as it will work even if the component is not yet
+initialized:
 
 .. code-block:: javascript
 
-    const component = document.getElementById('id-on-your-element').__component;
+    const component = document.getElementById('id-of-your-element').__component;
     component.mode = 'editing';
 
 Finally, you can also set the value of a model field directly. However,
@@ -470,15 +469,14 @@ component system from Stimulus:
 
     // assets/controllers/some-custom-controller.js
     // ...
+    import { getComponent } from '@symfony/ux-live-component';
 
     export default class extends Controller {
-        connect() {
-            this.element.addEventListener('live:connect', (event) => {
-                this.component = event.detail.component;
+        async initialize() {
+            this.component = await getComponent(this.element);
 
-                this.component.on('render:finished', (component) => {
-                    // do something after the component re-renders
-                });
+            this.component.on('render:finished', (component) => {
+                // do something after the component re-renders
             });
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #612
| License       | MIT

Hi!

My solution for #612. It seems... to work perfectly well and it's dead-simple:

```js
const element = // find some Element that is your live controller rot

ComponentRegistry.get(element).then((component) => {
    // use the Component
    component.render()
});

// or use await
const component = await ComponentRegistry.get(element)l
component.render();
```

Cheers!