### PR TITLE
Note on localized URLs requiring localized UX route

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -91,6 +91,19 @@ Now install the library with:
 Also make sure you have at least version 3.2 of
 ``@symfony/stimulus-bridge`` in your ``package.json`` file.
 
+In case your project `localizes its URLs`_ by adding the special
+``{_locale}`` parameter to its routes' paths, you need to do the same
+with your UX Live Components route:
+
+.. code-block:: diff
+
+      // config/routes/ux_live_component.yaml
+
+      live_component:
+          resource: '@LiveComponentBundle/config/routes.php'
+        - prefix: /_components
+        + prefix: /{_locale}/_components
+
 That's it! We're ready!
 
 Making your Component "Live"
@@ -2174,6 +2187,7 @@ bound to Symfony's BC policy for the moment.
 .. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`dependent form fields`: https://ux.symfony.com/live-component/demos/dependent-form-fields
 .. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _`localizes its URLs`: https://symfony.com/doc/current/translation/locale.html#translation-locale-url
 .. _`attributes variable`: https://symfony.com/bundles/ux-twig-component/current/index.html#component-attributes
 .. _`CollectionType`: https://symfony.com/doc/current/form/form_collections.html
 .. _`the traditional collection type`: https://symfony.com/doc/current/form/form_themes.html#fragment-naming-for-collections


### PR DESCRIPTION
I ran into a rather subtle problem the other day: my UX Live Component stuff worked beautifully on URL `/de/konto`, but failed on URL `/en/account`, which is the same location/page, but under its "English"-localized URL.

On the `en` URL, triggering anything UX Live related resulted in JavaScript error `Could not clone element`, from https://github.com/symfony/ux/blob/dc6d8312b8663051957c4096af3d1e082cd0796a/src/LiveComponent/assets/src/dom_utils.ts#L211

Inspecting the XMLHttpRequest response, I saw that the response contained the German-translated DOM-fragment, not the English one.

When changing my browser's preferred language to English, it was the other way round: the `en` URL worked as expected, and the `de` URL now failed, with the XMLHttpRequest response now always containing the English-translated DOM-fragment.

Obviously, the UX Live Component backend had no hint on what locale to use when requested, and therefore fell back to choose the locale based on the browser's `Accept-Language` header. This, however, not only returns a DOM-fragment in the wrong language — it also seems to make the DOM-fragment "incompatible" with the main-page DOM, which is why the `cloneNode()` call fails.

Extending the docs with this note should help others avoid this issue.