### PR TITLE
Add a new DataTable Component

### DIFF
--- a/src/DataTable/.gitignore
+++ b/src/DataTable/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+.php_cs.cache
+.phpunit.cache/
+composer.lock

--- a/src/DataTable/.symfony.bundle.yaml
+++ b/src/DataTable/.symfony.bundle.yaml
@@ -1,0 +1,3 @@
+branches: ["2.x"]
+maintained_branches: ["2.x"]
+doc_dir: "doc"

--- a/src/DataTable/LICENSE
+++ b/src/DataTable/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020-2021 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -1,0 +1,13 @@
+# Symfony UX DataTable
+
+Symfony UX DataTable is a Symfony bundle integrating the [simple-datatables](https://github.com/fiduswriter/Simple-DataTables)
+library in Symfony applications. It is part of [the Symfony UX initiative](https://symfony.com/ux).
+
+**This repository is a READ-ONLY sub-tree split**. See
+https://github.com/symfony/ux to create issues or submit pull requests.
+
+## Resources
+
+-   [Report issues](https://github.com/symfony/ux/issues) and
+    [send Pull Requests](https://github.com/symfony/ux/pulls)
+    in the [main Symfony UX repository](https://github.com/symfony/ux)

--- a/src/DataTable/assets/dist/controller.d.ts
+++ b/src/DataTable/assets/dist/controller.d.ts
@@ -1,0 +1,22 @@
+import { Controller } from '@hotwired/stimulus';
+interface tableData {
+    headings: string[];
+    data: string[][];
+}
+export default class extends Controller {
+    readonly rowsValue: any;
+    readonly columnsValue: any;
+    readonly optionsValue: any;
+    static values: {
+        rows: ArrayConstructor;
+        columns: ArrayConstructor;
+        options: {
+            string: new (text?: string | undefined, value?: string | undefined, defaultSelected?: boolean | undefined, selected?: boolean | undefined) => HTMLOptionElement;
+        };
+    };
+    connect(): void;
+    _buildTableData(rowsValue: any): tableData;
+    _addCssLink(url: string): void;
+    _dispatchEvent(name: string, payload: any): void;
+}
+export {};

--- a/src/DataTable/assets/dist/controller.js
+++ b/src/DataTable/assets/dist/controller.js
@@ -1,0 +1,60 @@
+import { Controller } from '@hotwired/stimulus';
+import { DataTable } from 'simple-datatables';
+
+class default_1 extends Controller {
+    connect() {
+        var _a, _b;
+        if (!(this.element instanceof HTMLTableElement)) {
+            throw new Error('invalid Element, please provide a HTMLTableElement');
+        }
+        this._dispatchEvent('datatable:pre-connect', {
+            data: this.rowsValue,
+            columns: this.columnsValue,
+            options: this.optionsValue,
+        });
+        new DataTable(this.element, Object.assign({ data: this._buildTableData(this.rowsValue) }, this.optionsValue));
+        if ((_a = this.optionsValue) === null || _a === void 0 ? void 0 : _a.withPluginCss) {
+            this._addCssLink('https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css');
+        }
+        if ((_b = this.optionsValue) === null || _b === void 0 ? void 0 : _b.withCss) {
+            this._addCssLink(this.optionsValue.withCss);
+        }
+        this._dispatchEvent('datatable:post-connect', {
+            data: this.rowsValue,
+            columns: this.columnsValue,
+            options: this.optionsValue,
+        });
+    }
+    _buildTableData(rowsValue) {
+        const tableData = {
+            headings: Object.keys(rowsValue[0]),
+            data: [],
+        };
+        for (let i = 0; i < rowsValue.length; i++) {
+            tableData.data[i] = [];
+            for (const p in rowsValue[i]) {
+                if (Object.prototype.hasOwnProperty.call(rowsValue[i], p)) {
+                    tableData.data[i].push(rowsValue[i][p]);
+                }
+            }
+        }
+        return tableData;
+    }
+    _addCssLink(url) {
+        const link = document.createElement('link');
+        link.type = 'text/css';
+        link.rel = 'stylesheet';
+        link.href = url;
+        document.head.appendChild(link);
+    }
+    _dispatchEvent(name, payload) {
+        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    }
+}
+default_1.values = {
+    rows: Array,
+    columns: Array,
+    options: { string: Option },
+};
+
+export { default_1 as default };

--- a/src/DataTable/assets/jest.config.js
+++ b/src/DataTable/assets/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../jest.config.js');

--- a/src/DataTable/assets/package.json
+++ b/src/DataTable/assets/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@symfony/ux-datatable",
+    "description": "Simple-DataTables integration for Symfony",
+    "license": "MIT",
+    "version": "0.1.2",
+    "symfony": {
+        "controllers": {
+            "table": {
+                "main": "dist/controller.js",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": true
+            }
+        }
+    },
+    "peerDependencies": {
+        "simple-datatables": "^5.0.0",
+        "@hotwired/stimulus": "^3.0.0"
+    },
+    "devDependencies": {
+        "simple-datatables": "^5.0.0",
+        "@hotwired/stimulus": "^3.0.0"
+    }
+}

--- a/src/DataTable/assets/src/controller.ts
+++ b/src/DataTable/assets/src/controller.ts
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { Controller } from '@hotwired/stimulus';
+import { DataTable } from 'simple-datatables';
+
+interface tableData {
+    headings: string[];
+    data: string[][];
+}
+
+export default class extends Controller {
+    declare readonly rowsValue: any;
+    declare readonly columnsValue: any;
+    declare readonly optionsValue: any;
+
+    static values = {
+        rows: Array,
+        columns: Array,
+        options: { string: Option },
+    };
+
+    connect() {
+        if (!(this.element instanceof HTMLTableElement)) {
+            throw new Error('invalid Element, please provide a HTMLTableElement');
+        }
+
+        this._dispatchEvent('datatable:pre-connect', {
+            data: this.rowsValue,
+            columns: this.columnsValue,
+            options: this.optionsValue,
+        });
+
+        new DataTable(this.element, {
+            data: this._buildTableData(this.rowsValue),
+            ...this.optionsValue,
+        });
+
+        if (this.optionsValue?.withPluginCss) {
+            this._addCssLink('https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css');
+        }
+
+        if (this.optionsValue?.withCss) {
+            this._addCssLink(this.optionsValue.withCss);
+        }
+
+        this._dispatchEvent('datatable:post-connect', {
+            data: this.rowsValue,
+            columns: this.columnsValue,
+            options: this.optionsValue,
+        });
+    }
+
+    _buildTableData(rowsValue: any): tableData {
+        const tableData: tableData = {
+            headings: Object.keys(rowsValue[0]),
+            data: [],
+        };
+
+        for (let i = 0; i < rowsValue.length; i++) {
+            tableData.data[i] = [];
+
+            for (const p in rowsValue[i]) {
+                if (Object.prototype.hasOwnProperty.call(rowsValue[i], p)) {
+                    tableData.data[i].push(rowsValue[i][p]);
+                }
+            }
+        }
+
+        return tableData;
+    }
+
+    _addCssLink(url: string) {
+        const link = document.createElement('link');
+        link.type = 'text/css';
+        link.rel = 'stylesheet';
+        link.href = url;
+        document.head.appendChild(link);
+    }
+
+    _dispatchEvent(name: string, payload: any) {
+        this.element.dispatchEvent(new CustomEvent(name, { detail: payload }));
+    }
+}

--- a/src/DataTable/assets/test/controller.test.ts
+++ b/src/DataTable/assets/test/controller.test.ts
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
+import { Application, Controller } from '@hotwired/stimulus';
+import DataTable from '../src/controller';
+import { getByTestId, waitFor } from '@testing-library/dom';
+
+class CheckController extends Controller {
+    connect() {
+        this.element.addEventListener('datatable:pre-connect', () => {
+            this.element.classList.add('pre-connected');
+        });
+
+        this.element.addEventListener('datatable:post-connect', () => {
+            this.element.classList.add('connected');
+        });
+    }
+}
+
+const startStimulus = () => {
+    const application = Application.start();
+    application.register('check', CheckController);
+    application.register('table', DataTable);
+
+    return application;
+};
+
+describe('DataTableController', () => {
+    let application: Application;
+
+    afterEach(() => {
+        clearDOM();
+        application.stop();
+    });
+
+    it('connect controller', async () => {
+        const container = mountDOM(`
+            <table
+                data-testid="tableTest"
+                data-controller='table check'
+                data-table-rows-value='&#x5B;&#x7B;&quot;id&quot;&#x3A;1,&quot;pseudo&quot;&#x3A;&quot;Bob&quot;,&quot;age&quot;&#x3A;23,&quot;gender&quot;&#x3A;&quot;M&quot;&#x7D;,&#x7B;&quot;id&quot;&#x3A;2,&quot;pseudo&quot;&#x3A;&quot;Kitty&quot;,&quot;age&quot;&#x3A;36,&quot;gender&quot;&#x3A;&quot;F&quot;&#x7D;,&#x7B;&quot;id&quot;&#x3A;3,&quot;pseudo&quot;&#x3A;&quot;Spongy&quot;,&quot;age&quot;&#x3A;34,&quot;gender&quot;&#x3A;&quot;M&quot;&#x7D;,&#x7B;&quot;id&quot;&#x3A;4,&quot;pseudo&quot;&#x3A;&quot;Slurp&quot;,&quot;age&quot;&#x3A;20,&quot;gender&quot;&#x3A;&quot;F&quot;&#x7D;,&#x7B;&quot;id&quot;&#x3A;5,&quot;pseudo&quot;&#x3A;&quot;Zoom&quot;,&quot;age&quot;&#x3A;29,&quot;gender&quot;&#x3A;&quot;M&quot;&#x7D;&#x5D;'
+                data-table-columns-value='&#x5B;&#x7B;&quot;title&quot;&#x3A;&quot;ID&quot;,&quot;field&quot;&#x3A;&quot;id&quot;&#x7D;,&#x7B;&quot;title&quot;&#x3A;&quot;Pseudo&quot;,&quot;field&quot;&#x3A;&quot;pseudo&quot;&#x7D;,&#x7B;&quot;title&quot;&#x3A;&quot;Age&quot;,&quot;field&quot;&#x3A;&quot;age&quot;&#x7D;,&#x7B;&quot;title&quot;&#x3A;&quot;Gender&quot;,&quot;field&quot;&#x3A;&quot;gender&quot;&#x7D;&#x5D;'
+                data-table-options-value='&#x7B;&quot;pagination&quot;&#x3A;&quot;true&quot;,&quot;search&quot;&#x3A;&quot;true&quot;&#x7D;'
+            ></table>
+        `);
+
+        expect(getByTestId(container, 'tableTest')).not.toHaveClass('table');
+
+        application = startStimulus();
+
+        await waitFor(() => {
+            expect(getByTestId(container, 'tableTest')).toHaveClass('pre-connected');
+            expect(getByTestId(container, 'tableTest')).toHaveClass('connected');
+        });
+    });
+});

--- a/src/DataTable/composer.json
+++ b/src/DataTable/composer.json
@@ -1,0 +1,54 @@
+{
+    "name": "symfony/ux-datatable",
+    "type": "symfony-bundle",
+    "description": "Simple-DataTables integration for Symfony",
+    "keywords": [
+        "symfony-ux"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Matheo Daninos",
+            "email": "matheo.daninos@gmail.com"
+        },
+        {
+            "name": "Thierry Raoux",
+            "email": "thi.raoux@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Symfony\\UX\\DataTable\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\UX\\DataTable\\Tests\\": "tests/"
+        }
+    },
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/config": "^4.4.17|^5.0|^6.0",
+        "symfony/dependency-injection": "^4.4.17|^5.0|^6.0",
+        "symfony/http-kernel": "^4.4.17|^5.0|^6.0"
+    },
+    "require-dev": {
+        "symfony/framework-bundle": "4.4.17|^5.0|^6.0",
+        "symfony/phpunit-bridge": "^5.2|^6.0",
+        "symfony/twig-bundle": "^4.4.17|^5.0|^6.0",
+        "symfony/var-dumper": "^4.4.17|^5.0|^6.0",
+        "symfony/webpack-encore-bundle": "^1.11"
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/DataTable/doc/index.rst
+++ b/src/DataTable/doc/index.rst
@@ -1,0 +1,115 @@
+Symfony UX BootstrapTable
+===================
+
+Symfony UX DataTable is a Symfony bundle integrating the
+`Simple-DataTables`_ library in Symfony applications.
+It is part of `the Symfony UX initiative`_.
+
+Installation
+------------
+
+Before you start, make sure you have `Symfony UX configured in your app`_.
+
+Then, install this bundle using Composer and Symfony Flex:
+
+.. code-block:: terminal
+
+    $ composer require symfony/ux-datatable
+
+    # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install --force
+    $ npm run watch
+
+    # or use yarn
+    $ yarn install --force
+    $ yarn watch
+
+Also make sure you have at least version 3.0 of `@symfony/stimulus-bridge`_
+in your ``package.json`` file.
+
+Usage
+-----
+
+To use Symfony UX DataTable, inject the ``TableBuilderInterface`` service
+and create a table ::
+
+Minimalistic example::
+
+        $table = $tableBuilder
+                ->addData([
+                        ['id' => 1, 'pseudo' => 'Bob'],
+                        ['id' => 2, 'pseudo' => 'Kitty'],
+                    ])
+                    ->addOptions([
+                        'paging' => false,
+                        'searchable' => false,
+                    ])
+                ->createTable();
+
+A more complete example from a controller::
+
+    #[Route('/usersList', name: 'app_users_list')]
+    public function index(TableBuilderInterface $tableBuilder, UserRepository $userRepository): Response
+    {
+        $manifestPath = $this->getParameter('kernel.project_dir').'/public/build/manifest.json';
+        $package = new Package(new JsonManifestVersionStrategy($manifestPath));
+
+        $users = $userRepository->getUsersWithPostsAndCommentsCount();
+        $table = $tableBuilder
+                    ->addData($users)
+                    ->addOptions([
+                        'paging' => true,
+                        'perPage' => 10,
+                        'searchable' => true,
+                        // Optionally import Simple-DataTables CSS file from CDN
+                        'withPluginCss' => true,
+                        // Optionally add custom CSS file, here through webpack entry and manifest.json
+                        'withCss' => $package->getUrl('build/datatable.css'),
+                        // Customize labels (@see https://github.com/fiduswriter/Simple-DataTables/wiki/labels)
+                        'labels' => [
+                            'placeholder' => 'Find a customer...',
+                            'perPage' => 'Show {select} customers per page',
+                        ],
+                        // Customize layout (@see https://github.com/fiduswriter/Simple-DataTables/wiki/layout)
+                        'layout' => [
+                            'top' => '{search}{select}',
+                            'bottom' => '{info}{pager}',
+                        ],
+                        // Customize columns (@see
+                        'columns' => [
+                            ['select' => 3, 'sort' => 'desc'],
+                        ],
+                        // Useful accessibility options
+                        'rowNavigation' => true,
+                        'tabIndex' => 1,
+                        // ... and more
+                    ])
+                    ->createTable();
+
+        return $this->render('datatable/index.html.twig', [
+            'table' => $table,
+        ]);
+    }
+
+You can pass most of the options supported by the `Simple-DataTables`_ library.
+Check out the `Simple-DataTables documentation`_  to discover them all.
+
+Once created in PHP, a table can be displayed using Twig if installed
+(requires `Symfony Webpack Encore`_):
+
+.. code-block:: twig
+
+    {{ render_table(table) }}
+
+Backward Compatibility promise
+------------------------------
+
+This bundle aims at following the same Backward Compatibility promise as
+the Symfony framework: https://symfony.com/doc/current/contributing/code/bc.html.
+
+.. _`Simple-DataTables`: https://github.com/fiduswriter/Simple-DataTables
+.. _`the Symfony UX initiative`: https://symfony.com/ux
+.. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
+.. _`Simple-DataTables documentation`: https://github.com/fiduswriter/Simple-DataTables/wiki/
+.. _`Symfony Webpack Encore`: https://symfony.com/doc/current/frontend/encore/installation.html
+.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html

--- a/src/DataTable/phpunit.xml.dist
+++ b/src/DataTable/phpunit.xml.dist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true">
+  <coverage>
+    <include>
+      <directory>./src</directory>
+    </include>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <ini name="intl.default_locale" value="en"/>
+    <ini name="intl.error_level" value="0"/>
+    <ini name="memory_limit" value="-1"/>
+    <env name="SHELL_VERBOSITY" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/DataTable/src/Builder/TableBuilder.php
+++ b/src/DataTable/src/Builder/TableBuilder.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\DataTable\Builder;
+
+use Symfony\UX\DataTable\Model\Table;
+
+/**
+ * @author Mathéo Daninos <matheo.daninos@gmail.com>
+ */
+class TableBuilder implements TableBuilderInterface
+{
+    public $data = [];
+    public $columns = [];
+    public $options = [];
+
+    public function createTable(): Table
+    {
+        return new Table($this->data, $this->columns, $this->options);
+    }
+
+    public function addData(array $data): TableBuilderInterface
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function addColumns(array $columns): TableBuilderInterface
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
+
+    public function addOptions(array $options): TableBuilderInterface
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+}

--- a/src/DataTable/src/Builder/TableBuilderInterface.php
+++ b/src/DataTable/src/Builder/TableBuilderInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\DataTable\Builder;
+
+use Symfony\UX\DataTable\Model\Table;
+
+/**
+ * @author Mathéo Daninos <mathéo.daninos@gmail.com>
+ */
+interface TableBuilderInterface
+{
+    public function createTable(): Table;
+
+    public function addData(array $data): self;
+
+    public function addColumns(array $columns): self;
+
+    public function addOptions(array $options): self;
+}

--- a/src/DataTable/src/DataTableBundle.php
+++ b/src/DataTable/src/DataTableBundle.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\DataTable;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Mathéo Daninos <matheo.daninos@gmail.com>
+ */
+class DataTableBundle extends Bundle
+{
+    public function getPath(): string
+    {
+        return \dirname(__DIR__);
+    }
+}

--- a/src/DataTable/src/DependencyInjection/DataTableExtension.php
+++ b/src/DataTable/src/DependencyInjection/DataTableExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\DataTable\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\UX\DataTable\Builder\TableBuilder;
+use Symfony\UX\DataTable\Builder\TableBuilderInterface;
+use Symfony\UX\DataTable\Twig\DataTableExtension as TwigExtension;
+use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
+use Twig\Environment;
+
+/**
+ * @author Mathéo Daninos <mathéo.daninos@gmail.com>
+ */
+class DataTableExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $container
+            ->setDefinition('datatable.builder', new Definition(TableBuilder::class))
+            ->setPublic(false)
+        ;
+
+        $container
+            ->setAlias(TableBuilderInterface::class, 'datatable.builder')
+            ->setPublic(false)
+        ;
+
+        if (class_exists(Environment::class) && class_exists(StimulusTwigExtension::class)) {
+            $container
+                ->setDefinition('datatable.twig_extension', new Definition(TwigExtension::class))
+                ->addArgument(new Reference('webpack_encore.twig_stimulus_extension'))
+                ->addTag('twig.extension')
+                ->setPublic(false)
+            ;
+        }
+    }
+}

--- a/src/DataTable/src/Model/Table.php
+++ b/src/DataTable/src/Model/Table.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\DataTable\Model;
+
+/**
+ * @author Mathéo Daninos <matheo.daninos@gmail.com>
+ *
+ * @final
+ */
+class Table
+{
+    private $data = [];
+    private $columns = [];
+    private $options = [];
+
+    public function __construct($data = [], $columns = [], $options = [])
+    {
+        $this->data = $data;
+        $this->columns = $columns;
+        $this->options = $options;
+    }
+
+    public function setData(array $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function setColumns(array $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getColumns(): array
+    {
+        return $this->columns;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function renderView(): array
+    {
+        return [
+            'rows' => $this->data,
+            'columns' => $this->columns,
+            'options' => $this->options,
+        ];
+    }
+}

--- a/src/DataTable/src/Twig/DataTableExtension.php
+++ b/src/DataTable/src/Twig/DataTableExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\DataTable\Twig;
+
+use Symfony\UX\DataTable\Model\Table;
+use Symfony\WebpackEncoreBundle\Dto\StimulusControllersDto;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @author Mathéo Daninos <mathéo.daninos@gmail.com>
+ */
+class DataTableExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('render_table', [$this, 'renderTable'], ['needs_environment' => true, 'is_safe' => ['html']]),
+        ];
+    }
+
+    public function renderTable(Environment $environment, Table $table): string
+    {
+        $dto = new StimulusControllersDto($environment);
+        $dto->addController('symfony/ux-datatable/table', $table->renderView());
+
+        return '<table '.$dto.'></table>';
+    }
+}

--- a/src/DataTable/tests/Kernel/TwigAppKernel.php
+++ b/src/DataTable/tests/Kernel/TwigAppKernel.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\DataTable\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\DataTable\DataTableBundle;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
+/**
+ * @author Mathéo Daninos <mathéo.daninos@gmail.com>
+ */
+class TwigAppKernel extends Kernel
+{
+    public function registerBundles(): iterable
+    {
+        return [new FrameworkBundle(), new TwigBundle(), new WebpackEncoreBundle(), new DataTableBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true]);
+            $container->loadFromExtension('twig', ['default_path' => __DIR__.'/templates', 'strict_variables' => true, 'exception_controller' => null]);
+            $container->loadFromExtension('webpack_encore', ['output_path' => '%kernel.project_dir%/public/build']);
+
+            $container->setAlias('test.datatable.builder', 'datatable.builder')->setPublic(true);
+            $container->setAlias('test.datatable.twig_extension', 'datatable.twig_extension')->setPublic(true);
+        });
+    }
+}

--- a/src/DataTable/tests/Twig/DataTableExtensionTest.php
+++ b/src/DataTable/tests/Twig/DataTableExtensionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\DataTable\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\DataTable\Builder\TableBuilderInterface;
+use Symfony\UX\DataTable\Tests\Kernel\TwigAppKernel;
+use Twig\Environment;
+
+/**
+ * @author Mathéo Daninos <mathéo.daninos@gmail.com>
+ */
+class DataTableExtensionTest extends TestCase
+{
+    public function testRenderTable(): void
+    {
+        $kernel = new TwigAppKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        /** @var TableBuilderInterface $builder */
+        $builder = $container->get('test.datatable.builder');
+
+        $table = $builder
+            ->addData([
+                ['id' => 1, 'pseudo' => 'Bob'],
+                ['id' => 2, 'pseudo' => 'Kitty'],
+            ])
+            ->addOptions([
+                'paging' => false,
+                'searchable' => false,
+            ])
+            ->createTable()
+        ;
+
+        $rendered = $container
+            ->get('test.datatable.twig_extension')
+            ->renderTable(
+                $container->get(Environment::class),
+                $table
+            )
+        ;
+
+        $this->assertSame(
+            '<table data-controller="symfony--ux-datatable--table" data-symfony--ux-datatable--table-rows-value="&#x5B;&#x7B;&quot;id&quot;&#x3A;1,&quot;pseudo&quot;&#x3A;&quot;Bob&quot;&#x7D;,&#x7B;&quot;id&quot;&#x3A;2,&quot;pseudo&quot;&#x3A;&quot;Kitty&quot;&#x7D;&#x5D;" data-symfony--ux-datatable--table-columns-value="&#x5B;&#x5D;" data-symfony--ux-datatable--table-options-value="&#x7B;&quot;paging&quot;&#x3A;false,&quot;searchable&quot;&#x3A;false&#x7D;"></table>',
+            $rendered);
+    }
+}


### PR DESCRIPTION
This is a rework of [PR #605](https://github.com/symfony/ux/pull/605), replacing dependencies to Bootstrap & JQuery by a lightweight library, [Simple-DataTables](https://github.com/fiduswriter/Simple-DataTables).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #230 
| License       | MIT

I discussed the topic with @WebMamba from whom a large part of this code comes, and he was interested in exploring this way also. All credits to him :100: .

### Usage

To use Symfony UX DataTable, inject the ``TableBuilderInterface`` in your service and build a table.

**Minimalistic example :**

``` php
$table = $tableBuilder
        ->addData([
                ['id' => 1, 'pseudo' => 'Bob'],
                ['id' => 2, 'pseudo' => 'Kitty'],
            ])
            ->addOptions([
                'paging' => false,
                'searchable' => false,
            ])
        ->createTable();
```

**A more complete one :**
```php
#[Route('/usersList', name: 'app_users_list')]
public function index(TableBuilderInterface $tableBuilder, UserRepository $userRepository): Response
{
    $manifestPath = $this->getParameter('kernel.project_dir').'/public/build/manifest.json';
    $package = new Package(new JsonManifestVersionStrategy($manifestPath));

    $users = $userRepository->getUsersWithPostsAndCommentsCount();
    
    $table = $tableBuilder
                ->addData($users)
                ->addOptions([
                    'paging' => true,
                    'perPage' => 10,
                    'searchable' => true,
                    // Optionally import Simple-DataTables CSS file from CDN
                    'withPluginCss' => true,
                    // Optionally add custom CSS file, here through webpack entry and manifest.json
                    'withCss' => $package->getUrl('build/datatable.css'),
                    // Customize labels (@see https://github.com/fiduswriter/Simple-DataTables/wiki/labels)
                    'labels' => [
                        'placeholder' => 'Find a customer...',
                        'perPage' => 'Show {select} customers per page',
                    ],
                    // Customize layout (@see https://github.com/fiduswriter/Simple-DataTables/wiki/layout)
                    'layout' => [
                        'top' => '{search}{select}',
                        'bottom' => '{info}{pager}',
                    ],
                    // Customize columns (@see
                    'columns' => [
                        ['select' => 3, 'sort' => 'desc'],
                    ],
                    // Useful accessibility options
                    'rowNavigation' => true,
                    'tabIndex' => 1,
                    // ... and more
                ])
                ->createTable();

    return $this->render('datatable/index.html.twig', [
        'table' => $table,
    ]);
}
```
You can pass most of the options supported by the [Simple-DataTables](https://github.com/fiduswriter/Simple-DataTables). Check out the Simple-DataTables [documentation](https://github.com/fiduswriter/Simple-DataTables/wiki/)  to discover them all.

The table can be displayed using Twig if installed :

```twig
    {{ render_table(table) }}
```

### Demo
![alt text](https://github.com/KojoEnch/ux/raw/datatable/src/DataTable/doc/datatable-demo.gif)