### PR TITLE
[Live] Fixed redirect keep custom response headers

### DIFF
--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -281,10 +281,13 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
             return;
         }
 
-        $event->setResponse(new Response(null, 204, [
-            'Location' => $response->headers->get('Location'),
-            self::REDIRECT_HEADER => 1,
-        ]));
+        $responseNoContent = new Response(null, Response::HTTP_NO_CONTENT, [
+            self::REDIRECT_HEADER => '1',
+        ]);
+
+        $responseNoContent->headers->add($response->headers->all());
+
+        $event->setResponse($responseNoContent);
     }
 
     public static function getSubscribedEvents(): array

--- a/src/LiveComponent/tests/Fixtures/Component/Component2.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component2.php
@@ -48,7 +48,7 @@ final class Component2
     #[LiveAction]
     public function redirect(UrlGeneratorInterface $urlGenerator): RedirectResponse
     {
-        return new RedirectResponse($urlGenerator->generate('homepage'));
+        return new RedirectResponse($urlGenerator->generate('homepage'), 302, ['X-Custom-Header' => '1']);
     }
 
     #[PreDehydrate]

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -235,6 +235,8 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ])
             ->assertStatus(204)
             ->assertHeaderEquals('Location', '/')
+            ->assertHeaderContains('X-Live-Redirect', '1')
+            ->assertHeaderEquals('X-Custom-Header', '1')
         ;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->

Sending a redirect from a Live-Component will drop any headers from the origin `RedirectResponse`. This makes is impossible to add custom response header from the controller (e.g. cookies, etc.).
