### PR TITLE
[Live] Fixing bad copy paste internal name

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.8.0
+
+-   [BC BREAK]: The "key" used to load the controller in your `assets/controllers.json`
+    file changed from `typed` to `live`. Update your `assets/controllers.json`
+    file to change this key.
+
 ## 2.7.0
 
 -   Added a new `route` parameter to `AsLiveComponent`, which allows to choose

--- a/src/LiveComponent/assets/package.json
+++ b/src/LiveComponent/assets/package.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "symfony": {
         "controllers": {
-            "typed": {
+            "live": {
                 "main": "dist/live_controller.js",
                 "name": "live",
                 "webpackMode": "eager",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

Definitely from a copy-and-paste error. That key is actually meaningless, since we specify the `name` key to choose a specific name: https://github.com/symfony/ux/blob/2.x/src/LiveComponent/assets/package.json#L12

I need to test, but after merge, when people update to this version, Flex should automatically update their `controllers.json` to remove the wrong key and add this one. Though, annoyingly, I'm sure this may still cause some trouble for some people - you'll likely at least need to restart Encore.

Cheers!
