### PR TITLE
[Live] Fixing wrong heading type on docs

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -684,7 +684,7 @@ The ``prevent`` modifier would prevent the form from submitting
 you click really fast 5 times, only one Ajax request will be made!
 
 Actions & Services
-^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~
 
 One really neat thing about component actions is that they are *real*
 Symfony controllers. Internally, they are processed identically to a
@@ -713,7 +713,7 @@ This means that, for example, you can use action autowiring::
     }
 
 Actions & Arguments
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.1
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

We use `~~` for the sub-headers, which turn into `h3`. So using something else - like `^^` turns these into `h4`.