### PR TITLE
Fixed indentation in diff code block and improved sentence structure

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -92,8 +92,8 @@ Also make sure you have at least version 3.2 of
 ``@symfony/stimulus-bridge`` in your ``package.json`` file.
 
 In case your project `localizes its URLs`_ by adding the special
-``{_locale}`` parameter to its routes' paths, you need to do the same
-with your UX Live Components route:
+``{_locale}`` parameter to the paths of its route definitions,
+you need to do the same with the UX Live Components route definition:
 
 .. code-block:: diff
 
@@ -101,8 +101,8 @@ with your UX Live Components route:
 
       live_component:
           resource: '@LiveComponentBundle/config/routes.php'
-        - prefix: /_components
-        + prefix: /{_locale}/_components
+    -     prefix: /_components
+    +     prefix: /{_locale}/_components
 
 That's it! We're ready!
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

I've messed up the indentation of the diff code block in my previous PR https://github.com/symfony/ux/pull/627, thus its not rendered correctly on https://symfony.com/bundles/ux-live-component/current/index.html#installation. Also, the structure of the introduction sentence was a bit unwieldy, at least for my non-native-English-speaker ears, and is now hopefully improved.