### PR TITLE
[Turbo] Fix checking "topics" option in Broadcaster

### DIFF
--- a/src/Turbo/src/Bridge/Mercure/Broadcaster.php
+++ b/src/Turbo/src/Bridge/Mercure/Broadcaster.php
@@ -70,7 +70,7 @@ final class Broadcaster implements BroadcasterInterface
             throw new \InvalidArgumentException(sprintf('Cannot broadcast entity of class "%s" as option "rendered_action" is missing.', $entityClass));
         }
 
-        if (!isset($options['topic']) && !isset($options['id'])) {
+        if (!isset($options['topics']) && !isset($options['id'])) {
             throw new \InvalidArgumentException(sprintf('Cannot broadcast entity of class "%s": either option "topics" or "id" is missing, or the PropertyAccess component is not installed. Try running "composer require property-access".', $entityClass));
         }
 


### PR DESCRIPTION
Mercure Broadcaster class was checking for the "topic" option, which is incorrect. This fixes that by checking for "topics" option instead.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
