### PR TITLE
[LiveComponent] Removal of old method_exists

### DIFF
--- a/src/Chartjs/CHANGELOG.md
+++ b/src/Chartjs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.7.0
 
--   The `chart:connect` JavaScript event now bubbles up.
+-   The `chartjs:connect` JavaScript event now bubbles up.
 
 -   Add `assets/src` to `.gitattributes` to exclude source TypeScript files from
     installing.

--- a/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
+++ b/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
@@ -48,8 +48,7 @@ final class AddLiveAttributesSubscriber implements EventSubscriberInterface, Ser
             return;
         }
 
-        if (method_exists($event, 'isEmbedded') && $event->isEmbedded()) {
-            // TODO: remove method_exists once min ux-twig-component version has this method
+        if ($event->isEmbedded()) {
             throw new \LogicException('Embedded components cannot be live.');
         }
 

--- a/src/Turbo/src/Bridge/Mercure/Broadcaster.php
+++ b/src/Turbo/src/Bridge/Mercure/Broadcaster.php
@@ -97,6 +97,10 @@ final class Broadcaster implements BroadcasterInterface
         $options['topics'] = $topics;
 
         if (0 === \count($options['topics'])) {
+            if (!isset($options['id'])) {
+                throw new \InvalidArgumentException(sprintf('Cannot broadcast entity of class "%s": the option "topics" is empty and "id" is missing.', $entityClass));
+            }
+
             $options['topics'] = (array) sprintf(self::TOPIC_PATTERN, rawurlencode($entityClass), rawurlencode(implode('-', (array) $options['id'])));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

`method_exists()` was needed for 2.2 feature, before 2.2 twig components was released. LiveComponents now required 2.5 of TwigComponents.

Also, unrelated typo in CHANGELOG.