### PR TITLE
Increasing LiveComponentSubscriber ExceptionEvent priority to avoid excess logging

### DIFF
--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -297,7 +297,8 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
             ControllerEvent::class => 'onKernelController',
             ViewEvent::class => 'onKernelView',
             ResponseEvent::class => 'onKernelResponse',
-            ExceptionEvent::class => 'onKernelException',
+            // priority so that the exception is processed before it can be logged as an error
+            ExceptionEvent::class => ['onKernelException', 20],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

Hi!

If you use the `ComponentWithFormTrait`, when validation fails, a `UnprocessableEntityHttpException` is thrown. This is caught by the `ExceptionEvent` listener on `LiveComponentSubscriber`, which renders the component. It's a very normal, excepted flow.

However, currently, the `LiveComponentSubscriber` may run after the core `ErrorListener` as both have a priority of 0. By making our subscriber run first, it avoids unnecessary logging of UnprocessableEntityHttpException by that listener.

Caught in the wild on the Symfonycasts code 🎥 

Cheers!