### PR TITLE
Only ignore .ts files: include other files (e.g. css files)

### DIFF
--- a/src/Autocomplete/.gitattributes
+++ b/src/Autocomplete/.gitattributes
@@ -3,7 +3,7 @@
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
 /assets/.gitignore export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/jest.config.js export-ignore
 /assets/test export-ignore
 /tests export-ignore

--- a/src/Chartjs/.gitattributes
+++ b/src/Chartjs/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Cropperjs/.gitattributes
+++ b/src/Cropperjs/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Dropzone/.gitattributes
+++ b/src/Dropzone/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/LazyImage/.gitattributes
+++ b/src/LazyImage/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/LiveComponent/.gitattributes
+++ b/src/LiveComponent/.gitattributes
@@ -4,7 +4,7 @@
 /phpunit.xml.dist export-ignore
 /assets/.gitignore export-ignore
 /assets/jest.config.js export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /phpunit.xml.dist export-ignore
 /tests export-ignore

--- a/src/Notify/.gitattributes
+++ b/src/Notify/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/React/.gitattributes
+++ b/src/React/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Swup/.gitattributes
+++ b/src/Swup/.gitattributes
@@ -1,6 +1,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore

--- a/src/Turbo/.gitattributes
+++ b/src/Turbo/.gitattributes
@@ -3,7 +3,7 @@
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
 /phpstan.neon.dist export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Typed/.gitattributes
+++ b/src/Typed/.gitattributes
@@ -1,6 +1,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore

--- a/src/Vue/.gitattributes
+++ b/src/Vue/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src export-ignore
+/assets/src/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #657 Fix #658
| License       | MIT

An oversight in 2.7.0. Sometimes we put the `.css` files inside the `src/` directory. And so, those must be included in the package. The intention was just to avoid including the `.ts` files.

Cheers! 