### PR TITLE
[Autocomplete] fix ar translation Typo

### DIFF
--- a/src/Autocomplete/translations/AutocompleteBundle.ar.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.ar.php
@@ -2,5 +2,5 @@
 
 return [
     'No results found' => 'لم يتم العثور على أي نتائج',
-    'No more results' => 'لا يوجد نتائج أٌخرى',
+    'No more results' => 'لا توجد نتائج أٌخرى',
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Change `يوجد` by `توجد` in Autocomplete translation
