### PR TITLE
[UX Turbo] Added missing use statement in example code 

### DIFF
--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -425,6 +425,7 @@ Let's create our chat::
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Mercure\HubInterface;
+    use Symfony\Component\Mercure\Update;
 
     class ChatController extends AbstractController
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| License       | MIT

Fixed error in 'chat' example code for Symfony UX Turbo page:
- added missing use statement for Mercure\Update entity

