### PR TITLE
[Autocomplete] Fix setData in AutocompleteField

### DIFF
--- a/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
+++ b/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
@@ -43,7 +43,7 @@ final class AutocompleteEntityTypeSubscriber implements EventSubscriberInterface
         // pass to AutocompleteChoiceTypeExtension
         $options['autocomplete'] = true;
         $options['autocomplete_url'] = $this->autocompleteUrl;
-        unset($options['searchable_fields'], $options['security'], $options['filter_query']);
+        unset($options['searchable_fields'], $options['security'], $options['filter_query'], $options['data_class']);
 
         $form->add('autocomplete', EntityType::class, $options);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #667  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

After debugging the code again, I think this is the best way to bypass the error,
unset `data_class` option from the `autocomplete` field