### PR TITLE
[Website] Simplify some contents in the Swup example

### DIFF
--- a/ux.symfony.com/code_snippets/_SwupController.php
+++ b/ux.symfony.com/code_snippets/_SwupController.php
@@ -11,18 +11,19 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class _SwupController extends AbstractController
 {
-    #[Route('/swup/{page<\d+>}', name: 'app_swup')]
-    public function swup(PackageRepository $packageRepository, int $page = 1): Response
+    #[Route('/packages/{page<\d+>}', name: 'app_swup')]
+    public function packagesIndex(PackageRepository $packageRepository, int $page = 1): Response
     {
-        // pagination links are just an example: swup works with any "a" tags!
-        $pagerfanta = Pagerfanta::createForCurrentPageWithMaxPerPage(
+        // this is a normal Symfony controller and pagination links are just an example:
+        // swup works with any "a" tags, so you don't have to make any changes in your code.
+        $pager = Pagerfanta::createForCurrentPageWithMaxPerPage(
             new ArrayAdapter($packageRepository->findAll()),
             $page,
             4
         );
 
-        return $this->render('ux_packages/swup.html.twig', [
-            'pager' => $pagerfanta,
+        return $this->render('packages/index.html.twig', [
+            'pager' => $pager,
         ]);
     }
 }

--- a/ux.symfony.com/code_snippets/_SwupController.php
+++ b/ux.symfony.com/code_snippets/_SwupController.php
@@ -11,8 +11,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class _SwupController extends AbstractController
 {
-    #[Route('/packages/{page<\d+>}', name: 'app_swup')]
-    public function packagesIndex(PackageRepository $packageRepository, int $page = 1): Response
+    #[Route('/swup/{page<\d+>}', name: 'app_swup')]
+    public function swup(PackageRepository $packageRepository, int $page = 1): Response
     {
         // this is a normal Symfony controller and pagination links are just an example:
         // swup works with any "a" tags, so you don't have to make any changes in your code.

--- a/ux.symfony.com/code_snippets/_swup.html.twig
+++ b/ux.symfony.com/code_snippets/_swup.html.twig
@@ -1,8 +1,6 @@
-{# initialize the swup controller, then render normal links! #}
-<div
-    {{ stimulus_controller('symfony/ux-swup/swup') }}
-    id="swup"
->
+{# you only need to add the call to the Stimilus controller;
+   swup doesn't require any other changes in your template #}
+<div {{ stimulus_controller('symfony/ux-swup/swup') }}>
 
     {% for package in pager %}
         <a href="{{ path(package.route) }}" class="col-12">

--- a/ux.symfony.com/templates/ux_packages/swup.html.twig
+++ b/ux.symfony.com/templates/ux_packages/swup.html.twig
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block code_block_left %}
-    {% component code_block with { filename: 'src/Controller/PackageController.php' } %}
+    {% component code_block with { filename: 'src/Controller/SwupController.php' } %}
         {% block content %}
             {{- source('@code_snippets/_SwupController.php')|cleanup_php_file(removeClass=true) -}}
         {% endblock %}
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block code_block_right %}
-    {% component code_block with { filename: 'templates/packages/index.html.twig' } %}
+    {% component code_block with { filename: 'templates/swup.html.twig' } %}
         {% block content %}
             {{- source('@code_snippets/_swup.html.twig') -}}
         {% endblock %}

--- a/ux.symfony.com/templates/ux_packages/swup.html.twig
+++ b/ux.symfony.com/templates/ux_packages/swup.html.twig
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block code_block_left %}
-    {% component code_block with { filename: 'src/Controller/SwupController.php' } %}
+    {% component code_block with { filename: 'src/Controller/PackageController.php' } %}
         {% block content %}
             {{- source('@code_snippets/_SwupController.php')|cleanup_php_file(removeClass=true) -}}
         {% endblock %}
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block code_block_right %}
-    {% component code_block with { filename: 'templates/swup.html.twig' } %}
+    {% component code_block with { filename: 'templates/packages/index.html.twig' } %}
         {% block content %}
             {{- source('@code_snippets/_swup.html.twig') -}}
         {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | -
| License       | MIT

Looking at the code on https://ux.symfony.com/swup it looks like you need to change things in your controller/templates to make it work. Maybe it's because of the naming of things. In practice, you don't have to change anything.