### PR TITLE
Also ignore ts files in subdirectories in gitattributes

### DIFF
--- a/src/Autocomplete/.gitattributes
+++ b/src/Autocomplete/.gitattributes
@@ -3,7 +3,7 @@
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
 /assets/.gitignore export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/jest.config.js export-ignore
 /assets/test export-ignore
 /tests export-ignore

--- a/src/Chartjs/.gitattributes
+++ b/src/Chartjs/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Cropperjs/.gitattributes
+++ b/src/Cropperjs/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Dropzone/.gitattributes
+++ b/src/Dropzone/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/LazyImage/.gitattributes
+++ b/src/LazyImage/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/LiveComponent/.gitattributes
+++ b/src/LiveComponent/.gitattributes
@@ -4,7 +4,7 @@
 /phpunit.xml.dist export-ignore
 /assets/.gitignore export-ignore
 /assets/jest.config.js export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /phpunit.xml.dist export-ignore
 /tests export-ignore

--- a/src/Notify/.gitattributes
+++ b/src/Notify/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/React/.gitattributes
+++ b/src/React/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Swup/.gitattributes
+++ b/src/Swup/.gitattributes
@@ -1,6 +1,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore

--- a/src/Turbo/.gitattributes
+++ b/src/Turbo/.gitattributes
@@ -3,7 +3,7 @@
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
 /phpstan.neon.dist export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore

--- a/src/Typed/.gitattributes
+++ b/src/Typed/.gitattributes
@@ -1,6 +1,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore

--- a/src/Vue/.gitattributes
+++ b/src/Vue/.gitattributes
@@ -2,7 +2,7 @@
 /.gitignore export-ignore
 /.symfony.bundle.yaml export-ignore
 /phpunit.xml.dist export-ignore
-/assets/src/*.ts export-ignore
+/assets/src/**/*.ts export-ignore
 /assets/test export-ignore
 /assets/jest.config.js export-ignore
 /tests export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

If `.ts` files are in a subdirectory of assets (like these https://github.com/symfony/ux/tree/2.x/src/LiveComponent/assets/src/Component ), they are still shipping with Composer - i.e. they are not being ignored. I'm not an expert on gitattributes, but this seems to work (according to `git check-attr`).

Most libs don't have this problem, but changed everywhere for consistency.

Cheers!