### PR TITLE
feat(twig): define the behaviour of boolean attribute values

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.8.0
+
+-   `true` attribute values now render just the attribute name, `false` excludes it entirely.
+
 ## 2.7.0
 
 -   `PreMount` and `PostMount` hooks can now return nothing.

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": ">=8.0",
         "symfony/dependency-injection": "^5.4|^6.0",
+        "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/property-access": "^5.4|^6.0",
         "twig/twig": "^2.0|^3.0"

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -577,7 +577,7 @@ When rendering the component, you can pass an array of html attributes to add:
       My Component!
     </div>
 
-Set an attribute's value to ``null`` to exclude the value when rendering:
+Set an attribute's value to ``true`` to render just the attribute name:
 
 .. code-block:: twig
 
@@ -585,10 +585,23 @@ Set an attribute's value to ``null`` to exclude the value when rendering:
     <input{{ attributes}}/>
 
     {# render component #}
-    {{ component('my_component', { type: 'text', value: '', autofocus: null }) }}
+    {{ component('my_component', { type: 'text', value: '', autofocus: true }) }}
 
     {# renders as: #}
     <input type="text" value="" autofocus/>
+
+Set an attribute's value to ``false`` to exclude the attribute:
+
+.. code-block:: twig
+
+    {# templates/components/my_component.html.twig #}
+    <input{{ attributes}}/>
+
+    {# render component #}
+    {{ component('my_component', { type: 'text', value: '', autofocus: false }) }}
+
+    {# renders as: #}
+    <input type="text" value=""/>
 
 .. versionadded: 2.7
 

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -34,11 +34,18 @@ final class ComponentAttributes
         return array_reduce(
             array_keys($this->attributes),
             function (string $carry, string $key) {
-                if (null === $this->attributes[$key]) {
-                    return "{$carry} {$key}";
+                $value = $this->attributes[$key];
+
+                if (null === $value) {
+                    trigger_deprecation('symfony/ux-twig-component', '2.8.0', 'Passing "null" as an attribute value is deprecated and will throw an exception in 3.0.');
+                    $value = true;
                 }
 
-                return sprintf('%s %s="%s"', $carry, $key, $this->attributes[$key]);
+                return match ($value) {
+                    true => "{$carry} {$key}",
+                    false => $carry,
+                    default => sprintf('%s %s="%s"', $carry, $key, $value),
+                };
             },
             ''
         );

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -86,7 +86,7 @@ final class ComponentExtensionTest extends KernelTestCase
             'class' => 'bar',
             'style' => 'color:red;',
             'value' => '',
-            'autofocus' => null,
+            'autofocus' => true,
         ]);
 
         $this->assertStringContainsString('Component Content (prop value 1)', $output);

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -26,7 +26,7 @@ final class ComponentAttributesTest extends TestCase
             'class' => 'foo',
             'style' => 'color:black;',
             'value' => '',
-            'autofocus' => null,
+            'autofocus' => true,
         ]);
 
         $this->assertSame(' class="foo" style="color:black;" value="" autofocus', (string) $attributes);
@@ -86,5 +86,29 @@ final class ComponentAttributesTest extends TestCase
             'data-live-data-value' => '{}',
             'data-foo-name-value' => 'ryan',
         ], $attributes->all());
+    }
+
+    public function testBooleanBehaviour(): void
+    {
+        $attributes = new ComponentAttributes(['disabled' => true]);
+
+        $this->assertSame(['disabled' => true], $attributes->all());
+        $this->assertSame(' disabled', (string) $attributes);
+
+        $attributes = new ComponentAttributes(['disabled' => false]);
+
+        $this->assertSame(['disabled' => false], $attributes->all());
+        $this->assertSame('', (string) $attributes);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testNullBehaviour(): void
+    {
+        $attributes = new ComponentAttributes(['disabled' => null]);
+
+        $this->assertSame(['disabled' => null], $attributes->all());
+        $this->assertSame(' disabled', (string) $attributes);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #709
| License       | MIT

`true` attribute values now render just the attribute name, `false` excludes it entirely.

```twig
{# component template: #}
<div{{ attributes }}></div>

{# calling template: #}
{{ component('my_component', { autofocus: true, disabled: false }) }}

{# renders as: #}
<div autofocus></div>
```

~I've left the `null` behaviour as-is which is the same as `true`. This does feel weird so perhaps we should deprecate passing `null` as @AmProsius suggests in #709.~ Using `null` is now deprecated.