### PR TITLE
[Live] Adding failing test case for updating individual parts of deeply writable paths

### DIFF
--- a/src/LiveComponent/assets/dist/Component/ElementDriver.d.ts
+++ b/src/LiveComponent/assets/dist/Component/ElementDriver.d.ts
@@ -1,6 +1,9 @@
 export interface ElementDriver {
     getModelName(element: HTMLElement): string | null;
-    getComponentProps(rootElement: HTMLElement): any;
+    getComponentProps(rootElement: HTMLElement): {
+        props: any;
+        nestedProps: any;
+    };
     findChildComponentElement(id: string, element: HTMLElement): HTMLElement | null;
     getKeyFromElement(element: HTMLElement): string | null;
 }

--- a/src/LiveComponent/assets/dist/Component/ValueStore.d.ts
+++ b/src/LiveComponent/assets/dist/Component/ValueStore.d.ts
@@ -1,18 +1,17 @@
 export default class {
-    private readonly identifierKey;
     private props;
+    private nestedProps;
     private dirtyProps;
     private pendingProps;
-    constructor(props: any);
+    constructor(props: any, nestedProps: any);
     get(name: string): any;
     has(name: string): boolean;
     set(name: string, value: any): boolean;
     getOriginalProps(): any;
+    getOriginalNestedProps(): any;
     getDirtyProps(): any;
     flushDirtyPropsToPending(): void;
-    reinitializeAllProps(props: any): void;
+    reinitializeAllProps(props: any, nestedProps: any): void;
     pushPendingPropsBackToDirty(): void;
     reinitializeProvidedProps(props: any): boolean;
-    private isPropNameTopLevel;
-    private findIdentifier;
 }

--- a/src/LiveComponent/assets/dist/Component/index.d.ts
+++ b/src/LiveComponent/assets/dist/Component/index.d.ts
@@ -22,7 +22,7 @@ export default class Component {
     private nextRequestPromiseResolve;
     private children;
     private parent;
-    constructor(element: HTMLElement, props: any, fingerprint: string | null, id: string | null, backend: BackendInterface, elementDriver: ElementDriver);
+    constructor(element: HTMLElement, props: any, nestedProps: any, fingerprint: string | null, id: string | null, backend: BackendInterface, elementDriver: ElementDriver);
     _swapBackend(backend: BackendInterface): void;
     addPlugin(plugin: PluginInterface): void;
     connect(): void;

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -16,6 +16,10 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     static values: {
         url: StringConstructor;
         props: ObjectConstructor;
+        nestedProps: {
+            type: ObjectConstructor;
+            default: {};
+        };
         csrf: StringConstructor;
         debounce: {
             type: NumberConstructor;
@@ -26,6 +30,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     };
     readonly urlValue: string;
     readonly propsValue: any;
+    readonly nestedPropsValue: any;
     readonly csrfValue: string;
     readonly hasDebounceValue: boolean;
     readonly debounceValue: number;

--- a/src/LiveComponent/assets/src/Component/ElementDriver.ts
+++ b/src/LiveComponent/assets/src/Component/ElementDriver.ts
@@ -3,7 +3,7 @@ import {getModelDirectiveFromElement} from '../dom_utils';
 export interface ElementDriver {
     getModelName(element: HTMLElement): string|null;
 
-    getComponentProps(rootElement: HTMLElement): any;
+    getComponentProps(rootElement: HTMLElement): { props: any, nestedProps: any };
 
     /**
      * Given an HtmlElement and a child id, find the root element for that child.
@@ -28,11 +28,13 @@ export class StandardElementDriver implements ElementDriver {
     }
 
     getComponentProps(rootElement: HTMLElement): any {
-        if (!rootElement.dataset.livePropsValue) {
-            return null;
-        }
+        const propsJson = rootElement.dataset.livePropsValue ?? '{}';
+        const nestedPropsJson = rootElement.dataset.liveNestedPropsValue ?? '{}';
 
-        return JSON.parse(rootElement.dataset.livePropsValue as string);
+        return {
+            props: JSON.parse(propsJson),
+            nestedProps: JSON.parse(nestedPropsJson),
+        }
     }
 
     findChildComponentElement(id: string, element: HTMLElement): HTMLElement|null {

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -63,19 +63,20 @@ export default class Component {
     /**
      * @param element The root element
      * @param props   Readonly component props
+     * @param nestedProps   Extra nested prop values that can be used as models
      * @param fingerprint
      * @param id      Some unique id to identify this component. Needed to be a child component
      * @param backend Backend instance for updating
      * @param elementDriver Class to get "model" name from any element.
      */
-    constructor(element: HTMLElement, props: any, fingerprint: string|null, id: string|null, backend: BackendInterface, elementDriver: ElementDriver) {
+    constructor(element: HTMLElement, props: any, nestedProps: any, fingerprint: string|null, id: string|null, backend: BackendInterface, elementDriver: ElementDriver) {
         this.element = element;
         this.backend = backend;
         this.elementDriver = elementDriver;
         this.id = id;
         this.fingerprint = fingerprint;
 
-        this.valueStore = new ValueStore(props);
+        this.valueStore = new ValueStore(props, nestedProps);
         this.unsyncedInputsTracker = new UnsyncedInputsTracker(this, elementDriver);
         this.hooks = new HookManager();
         this.resetPromise();
@@ -218,7 +219,7 @@ export default class Component {
      * @param toEl
      */
     updateFromNewElement(toEl: HTMLElement): boolean {
-        const props = this.elementDriver.getComponentProps(toEl);
+        const { props } = this.elementDriver.getComponentProps(toEl);
 
         // if no props are on the element, use the existing element completely
         // this means the parent is signaling that the child does not need to be re-rendered
@@ -389,7 +390,8 @@ export default class Component {
         // normalize new element into non-loading state before diff
         this.hooks.triggerHook('loading.state:finished', newElement);
 
-        this.valueStore.reinitializeAllProps(this.elementDriver.getComponentProps(newElement));
+        const { props: newProps, nestedProps: newNestedProps } = this.elementDriver.getComponentProps(newElement);
+        this.valueStore.reinitializeAllProps(newProps, newNestedProps);
 
         executeMorphdom(
             this.element,

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -37,6 +37,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     static values = {
         url: String,
         props: Object,
+        nestedProps: { type: Object, default: {} },
         csrf: String,
         debounce: { type: Number, default: 150 },
         id: String,
@@ -45,6 +46,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
 
     declare readonly urlValue: string;
     declare readonly propsValue: any;
+    declare readonly nestedPropsValue: any;
     declare readonly csrfValue: string;
     declare readonly hasDebounceValue: boolean;
     declare readonly debounceValue: number;
@@ -70,6 +72,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
         this.component = new Component(
             this.element,
             this.propsValue,
+            this.nestedPropsValue,
             this.fingerprintValue,
             id,
             new Backend(this.urlValue, this.csrfValue),

--- a/src/LiveComponent/assets/test/Component/index.test.ts
+++ b/src/LiveComponent/assets/test/Component/index.test.ts
@@ -1,11 +1,9 @@
-import Component, {proxifyComponent} from '../../src/Component';
+import Component, { proxifyComponent } from '../../src/Component';
 import {BackendAction, BackendInterface} from '../../src/Backend/Backend';
-import {
-    StandardElementDriver
-} from '../../src/Component/ElementDriver';
+import { StandardElementDriver } from '../../src/Component/ElementDriver';
 import BackendRequest from '../../src/Backend/BackendRequest';
 import { Response } from 'node-fetch';
-import {waitFor} from '@testing-library/dom';
+import { waitFor } from '@testing-library/dom';
 import BackendResponse from '../../src/Backend/BackendResponse';
 
 interface MockBackend extends BackendInterface {
@@ -29,7 +27,8 @@ const makeTestComponent = (): { component: Component, backend: MockBackend } => 
 
     const component = new Component(
         document.createElement('div'),
-        {firstName: ''},
+        { firstName: '' },
+        {},
         null,
         null,
         backend,

--- a/src/LiveComponent/assets/test/ValueStore.test.ts
+++ b/src/LiveComponent/assets/test/ValueStore.test.ts
@@ -4,11 +4,13 @@ describe('ValueStore', () => {
     const getDataset = [
         {
             props: { firstName: 'Ryan' },
+            nestedProps: {},
             name: 'firstName',
             expected: 'Ryan',
         },
         {
             props: {},
+            nestedProps: {},
             name: 'firstName',
             expected: undefined,
         },
@@ -18,27 +20,35 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
+            nestedProps: {},
             name: 'user.firstName',
             expected: 'Ryan',
         },
         {
-            // because "@id" exists, it represents the "identity" for "user"
             props: {
-                user: {
-                    '@id': 111,
-                    firstName: 'Ryan'
-                }
+                user: 5,
             },
+            nestedProps: {
+                'user.firstName': 'Ryan',
+            },
+            name: 'user.firstName',
+            expected: 'Ryan',
+        },
+        {
+            props: {
+                user: 111,
+            },
+            nestedProps: { 'user.FirstName': 'Ryan' },
             name: 'user',
             expected: 111,
         },
         {
-            // because NO "@id" exists, the entire object is the identity
             props: {
                 user: {
                     firstName: 'Ryan',
                 },
             },
+            nestedProps: {},
             name: 'user',
             expected: {
                 firstName: 'Ryan',
@@ -46,11 +56,13 @@ describe('ValueStore', () => {
         },
         {
             props: { firstName: null },
+            nestedProps: {},
             name: 'firstName',
             expected: null,
         },
         {
             props: { firstName: 'Ryan' },
+            nestedProps: {},
             updated: [ { prop: 'firstName', value: 'Kevin' }],
             name: 'firstName',
             expected: 'Kevin',
@@ -61,15 +73,16 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
+            nestedProps: {},
             updated: [ { prop: 'user.firstName', value: 'Kevin' }],
             name: 'user.firstName',
             expected: 'Kevin',
         },
     ];
 
-    getDataset.forEach(({ props, name, expected, updated = [] }) => {
+    getDataset.forEach(({ props, nestedProps, name, expected, updated = [] }) => {
         it(`get("${name}") with data ${JSON.stringify(props)} returns ${JSON.stringify(expected)}`, () => {
-            const store = new ValueStore(props);
+            const store = new ValueStore(props, nestedProps);
             updated.forEach(({ prop, value }) => {
                 store.set(prop, value);
             });
@@ -80,11 +93,13 @@ describe('ValueStore', () => {
     const hasDataset = [
         {
             props: { firstName: 'Ryan' },
+            nestedProps: {},
             name: 'firstName',
             expected: true,
         },
         {
             props: { firstName: 'Ryan' },
+            nestedProps: {},
             name: 'lastName',
             expected: false,
         },
@@ -94,6 +109,15 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
+            nestedProps: {},
+            name: 'user.firstName',
+            expected: true,
+        },
+        {
+            props: {
+                user: 5,
+            },
+            nestedProps: { 'user.firstName': 'Ryan' },
             name: 'user.firstName',
             expected: true,
         },
@@ -103,16 +127,15 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
+            nestedProps: {},
             name: 'user.lastName',
             expected: false,
         },
         {
             props: {
-                user: {
-                    '@id': 111,
-                    firstName: 'Ryan',
-                },
+                user: 111,
             },
+            nestedProps: { 'user.firstName': 'Ryan'},
             name: 'user',
             expected: true,
         },
@@ -122,19 +145,21 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
+            nestedProps: {},
             name: 'user',
             expected: true,
         },
         {
             props: { firstName: null },
+            nestedProps: {},
             name: 'firstName',
             expected: true,
         },
     ];
 
-    hasDataset.forEach(({ props, name, expected }) => {
+    hasDataset.forEach(({ props, nestedProps, name, expected }) => {
         it(`has("${name}") with data ${JSON.stringify(props)} returns ${JSON.stringify(expected)}`, () => {
-            const store = new ValueStore(props);
+            const store = new ValueStore(props, nestedProps);
             expect(store.has(name)).toEqual(expected);
         });
     });
@@ -158,10 +183,7 @@ describe('ValueStore', () => {
         },
         {
             props: {
-                user: {
-                    '@id': 123,
-                    firstName: 'Ryan'
-                }
+                user: 123,
             },
             set: 'user',
             to: 456,
@@ -191,14 +213,14 @@ describe('ValueStore', () => {
 
     setDataset.forEach(({ props, set, to, expected }) => {
         it(`set("${set}", ${JSON.stringify(to)}) with data ${JSON.stringify(props)} results in ${JSON.stringify(expected)}`, () => {
-            const store = new ValueStore(props);
+            const store = new ValueStore(props, {});
             store.set(set, to);
             expect(store.getDirtyProps()).toEqual(expected);
         });
     });
 
     it('correctly tracks pending changes', () => {
-        const store = new ValueStore({ firstName: 'Ryan' });
+        const store = new ValueStore({ firstName: 'Ryan' }, {});
 
         store.set('firstName', 'Kevin');
         store.flushDirtyPropsToPending();
@@ -210,17 +232,17 @@ describe('ValueStore', () => {
 
         // imitate an Ajax success (but the server changes the data)
         store.flushDirtyPropsToPending();
-        store.reinitializeAllProps({ firstName: 'KEVIN' });
+        store.reinitializeAllProps({ firstName: 'KEVIN' }, {});
         expect(store.get('firstName')).toEqual('KEVIN');
 
         // imitate an Ajax success where the value is changed during the request
-        store.reinitializeAllProps({ firstName: 'Ryan' });
+        store.reinitializeAllProps({ firstName: 'Ryan' }, {});
         store.set('firstName', 'Kevin');
         store.flushDirtyPropsToPending();
         store.set('firstName', 'Wouter');
         expect(store.get('firstName')).toEqual('Wouter');
         // ajax call finishes, the props has updated correctly
-        store.reinitializeAllProps({ firstName: 'Kevin' });
+        store.reinitializeAllProps({ firstName: 'Kevin' }, {});
         // the updating state still exists
         expect(store.get('firstName')).toEqual('Wouter');
     });
@@ -228,10 +250,11 @@ describe('ValueStore', () => {
 
     it('getOriginalProps() returns props', () => {
         const container = new ValueStore(
-            { city: 'Grand Rapids', user: 'Kevin' },
+            { city: 'Grand Rapids', user: 'Kevin', product: 5 },
+            { 'product.name': 'Banana'}
         );
 
-        expect(container.getOriginalProps()).toEqual({ city: 'Grand Rapids', user: 'Kevin'});
+        expect(container.getOriginalProps()).toEqual({ city: 'Grand Rapids', user: 'Kevin', product: 5 });
     });
 
     const reinitializeProvidedPropsDataset = [
@@ -271,22 +294,13 @@ describe('ValueStore', () => {
         },
         {
             props: {
-                user: {
-                    '@id': 123,
-                    firstName: 'Ryan',
-                }
+                user: 123,
             },
             newProps: {
-                user: {
-                    '@id': 456,
-                    firstName: 'Kevin',
-                }
+                user: 456,
             },
             expectedProps: {
-                user: {
-                    '@id': 456,
-                    firstName: 'Kevin',
-                }
+                user: 456,
             },
             changed: true,
         },
@@ -313,12 +327,9 @@ describe('ValueStore', () => {
         },
         {
             props: {
-                user: {
-                    '@id': 123,
-                    firstName: 'Ryan',
-                }
+                user: 123,
             },
-            // identifier switches from `@id` to object being the identifier
+            // identifier switches to an array identifier
             newProps: {
                 user: {
                     firstName: 'Kevin',
@@ -333,35 +344,10 @@ describe('ValueStore', () => {
             },
             changed: true,
         },
-        {
-            props: {
-                user: {
-                    '@id': 123,
-                    firstName: 'Ryan',
-                }
-            },
-            // the user has already changed the "firstName" path to "Ryan"
-            // now the server responds with the original firstName data
-            // that should NOT trigger that this prop "changed". And the
-            // writable path should not be updated.
-            newProps: {
-                user: {
-                    '@id': 123,
-                    firstName: 'Kevin',
-                }
-            },
-            expectedProps: {
-                user: {
-                    '@id': 123,
-                    firstName: 'Ryan',
-                }
-            },
-            changed: false,
-        },
     ];
     reinitializeProvidedPropsDataset.forEach(({ props, newProps, expectedProps, changed }) => {
         it(`reinitializeProvidedProps(${JSON.stringify(newProps)}) with data ${JSON.stringify(props)} results in ${JSON.stringify(expectedProps)}`, () => {
-            const store = new ValueStore(props);
+            const store = new ValueStore(props, {});
             const actualChanged = store.reinitializeProvidedProps(newProps);
             expect(store.getOriginalProps()).toEqual(expectedProps);
             expect(actualChanged).toEqual(changed);

--- a/src/LiveComponent/assets/test/controller/child.test.ts
+++ b/src/LiveComponent/assets/test/controller/child.test.ts
@@ -177,7 +177,7 @@ describe('Component parent -> child initialization and rendering tests', () => {
             </div>
         `;
 
-        // a simpler version of the child is returned from the prent component's re-render
+        // a simpler version of the child is returned from the parent component's re-render
         const childReturnedFromParentCall = `
             <div ${initComponent(
                 { toUppercase: true }, // new prop value (firstName is not sent as it is writable)

--- a/src/LiveComponent/assets/test/dom_utils.test.ts
+++ b/src/LiveComponent/assets/test/dom_utils.test.ts
@@ -13,7 +13,7 @@ import Backend from '../src/Backend/Backend';
 import {StandardElementDriver} from '../src/Component/ElementDriver';
 
 const createStore = function(props: any = {}): ValueStore {
-    return new ValueStore(props);
+    return new ValueStore(props, {});
 }
 
 describe('getValueFromElement', () => {
@@ -217,6 +217,7 @@ describe('elementBelongsToThisComponent', () => {
     const createComponent = (html: string, childComponents: Component[] = []) => {
         const component = new Component(
             htmlToElement(html),
+            {},
             {},
             null,
             'some-id-' + Math.floor((Math.random() * 100)),

--- a/src/LiveComponent/src/Twig/LiveComponentRuntime.php
+++ b/src/LiveComponent/src/Twig/LiveComponentRuntime.php
@@ -41,7 +41,7 @@ final class LiveComponentRuntime
             $mounted->getAttributes(),
             $this->metadataFactory->getMetadata($mounted->getName())
         );
-        $params = ['_live_component' => $name] + ['props' => json_encode($props)];
+        $params = ['_live_component' => $name] + ['props' => json_encode($props->getProps())];
 
         $metadata = $this->factory->metadataFor($mounted->getName());
 

--- a/src/LiveComponent/src/Util/DehydratedProps.php
+++ b/src/LiveComponent/src/Util/DehydratedProps.php
@@ -21,233 +21,128 @@ namespace Symfony\UX\LiveComponent\Util;
  */
 class DehydratedProps
 {
-    private array $identifierValues = [];
-    private array $writablePathValues = [];
+    /**
+     * Array keyed by the frontend LiveProp name (e.g. product) and set to the dehydrated value.
+     *
+     * @var array<string, mixed>
+     */
+    private array $propValues = [];
 
-    public function __construct(private bool $allowMissingIdentifierValues = false)
+    /**
+     * Array keyed by the full nested path (e.g. "product.name") and set to the dehydrated value.
+     *
+     * @var array<string, mixed>
+     */
+    private array $nestedPathValues = [];
+
+    /**
+     * Create this object from the extra "props" identifiers passed to/from the frontend.
+     */
+    public static function createFromPropsArray(array $propIdentifierValues): self
     {
+        $props = new static();
+        $props->propValues = $propIdentifierValues;
+
+        return $props;
     }
 
-    public static function createFromArray(array $props): self
+    /**
+     * Create this object from the "updated" props passed from the frontend to the backend.
+     */
+    public static function createFromUpdatedArray(array $updatedPaths): self
     {
-        $dehydratedOriginalProps = new static();
-        foreach ($props as $frontendName => $value) {
-            if (!\is_array($value) || !isset($value['@id'])) {
-                $dehydratedOriginalProps->addIdentifierValue($frontendName, $value);
+        $props = new static();
+        foreach ($updatedPaths as $frontendName => $dehydratedValue) {
+            if (str_contains($frontendName, '.')) {
+                [$frontendName, $nestedPath] = explode('.', $frontendName, 2);
+                $props->addNestedProp($frontendName, $nestedPath, $dehydratedValue);
 
                 continue;
             }
 
-            // grab the identifier value
-            $dehydratedOriginalProps->addIdentifierValue($frontendName, $value['@id']);
-            unset($value['@id']);
-            $dehydratedOriginalProps->writablePathValues[$frontendName] = $value;
-        }
-
-        return $dehydratedOriginalProps;
-    }
-
-    /**
-     * Created from a flattened array of props, where writable paths are keys with ".".
-     *
-     * For example:
-     *  [
-     *     'foo' => 'bar',
-     *     'foo.bar' => 'baz',
-     *  ]
-     */
-    public static function createFromUpdatedArray(array $props): self
-    {
-        $dehydratedOriginalProps = new static(allowMissingIdentifierValues: true);
-        foreach ($props as $frontendName => $value) {
-            // if frontendName contains ".", it's a writable path
-            // else it's an identifier
-            // set appropriately
-            if (str_contains($frontendName, '.')) {
-                [$propName, $writablePath] = explode('.', $frontendName, 2);
-                $dehydratedOriginalProps->addWritablePathValue($propName, $writablePath, $value);
-            } else {
-                $dehydratedOriginalProps->addIdentifierValue($frontendName, $value);
-            }
-        }
-
-        return $dehydratedOriginalProps;
-    }
-
-    public function addIdentifierValue(string $frontendName, mixed $dehydratedValue): void
-    {
-        $this->identifierValues[$frontendName] = $dehydratedValue;
-    }
-
-    public function addWritablePathValue(string $frontendName, string $writablePath, mixed $pathValue): void
-    {
-        if (!\array_key_exists($frontendName, $this->identifierValues) && !$this->allowMissingIdentifierValues) {
-            throw new \InvalidArgumentException(sprintf('The identifier for the property "%s" has not been set yet.', $frontendName));
-        }
-
-        if (!isset($this->writablePathValues[$frontendName])) {
-            $this->writablePathValues[$frontendName] = [];
-        }
-
-        $this->writablePathValues[$frontendName] = self::setValueDeeplyOntoArray(
-            $this->writablePathValues[$frontendName],
-            $writablePath,
-            $pathValue
-        );
-    }
-
-    public function toArray(): array
-    {
-        $props = $this->identifierValues;
-        foreach ($this->writablePathValues as $propName => $writablePathValues) {
-            if (!\array_key_exists($propName, $props)) {
-                throw new \InvalidArgumentException(sprintf('The identifier for the property "%s" has not been set yet.', $propName));
-            }
-
-            $props[$propName] = array_merge(
-                ['@id' => $this->identifierValues[$propName]],
-                $writablePathValues
-            );
+            $props->addPropValue($frontendName, $dehydratedValue);
         }
 
         return $props;
     }
 
-    public function removeIdentifierValue(string $key): void
+    public function addPropValue(string $frontendName, mixed $dehydratedValue): void
     {
-        unset($this->identifierValues[$key]);
+        $this->propValues[$frontendName] = $dehydratedValue;
     }
 
-    public function getIdentifierValue(string $propName, mixed $default = null): mixed
+    public function addNestedProp(string $frontendName, string $nestedPath, mixed $pathValue): void
     {
-        if (!$this->hasIdentifierValue($propName)) {
+        $fullPath = $frontendName.'.'.$nestedPath;
+        $this->nestedPathValues[$fullPath] = $pathValue;
+    }
+
+    public function removePropValue(string $key): void
+    {
+        unset($this->propValues[$key]);
+    }
+
+    public function getPropValue(string $propName, mixed $default = null): mixed
+    {
+        if (!$this->hasPropValue($propName)) {
             return $default;
         }
 
-        return $this->identifierValues[$propName];
+        return $this->propValues[$propName];
     }
 
-    public function hasIdentifierValue(string $propName): bool
+    public function hasPropValue(string $propName): bool
     {
-        return \array_key_exists($propName, $this->identifierValues);
+        return \array_key_exists($propName, $this->propValues);
     }
 
-    public function hasWritablePathValue(string $propName, string $writablePath): bool
+    public function hasNestedPathValue(string $propName, string $nestedPath): bool
     {
-        if (!\array_key_exists($propName, $this->writablePathValues)) {
-            return false;
+        $fullPath = $propName.'.'.$nestedPath;
+
+        return \array_key_exists($fullPath, $this->nestedPathValues);
+    }
+
+    public function getNestedPathValue(string $propName, string $nestedPath): mixed
+    {
+        if (!$this->hasNestedPathValue($propName, $nestedPath)) {
+            throw new \InvalidArgumentException(sprintf('The nested path "%s.%s" does not exist.', $propName, $nestedPath));
         }
 
-        $currentArray = $this->writablePathValues[$propName];
-        $parts = explode('.', $writablePath);
-        foreach ($parts as $part) {
-            if (!\array_key_exists($part, $currentArray)) {
-                return false;
+        $fullPath = $propName.'.'.$nestedPath;
+
+        return $this->nestedPathValues[$fullPath];
+    }
+
+    public function getNestedPathsForProperty(string $prop): array
+    {
+        $nestedPaths = [];
+        foreach ($this->nestedPathValues as $fullPath => $value) {
+            if (str_starts_with($fullPath, $prop.'.')) {
+                $nestedPaths[] = substr($fullPath, \strlen($prop) + 1);
             }
-
-            $currentArray = $currentArray[$part];
         }
 
-        return true;
+        return $nestedPaths;
     }
 
-    public function getWritablePathValue(string $propName, string $writablePath): mixed
-    {
-        if (!$this->hasWritablePathValue($propName, $writablePath)) {
-            throw new \InvalidArgumentException(sprintf('The writable path "%s.%s" does not exist.', $propName, $writablePath));
-        }
-
-        $currentValue = $this->writablePathValues[$propName];
-        $parts = explode('.', $writablePath);
-        foreach ($parts as $part) {
-            if (!\array_key_exists($part, $currentValue)) {
-                return false;
-            }
-
-            $currentValue = $currentValue[$part];
-        }
-
-        return $currentValue;
-    }
-
-    public function getWritablePathsForProperty(string $prop): array
-    {
-        if (!\array_key_exists($prop, $this->writablePathValues)) {
-            return [];
-        }
-
-        $paths = $this->writablePathValues[$prop];
-
-        return $this->flattenArray($paths);
-    }
-
-    public function calculateUnexpectedWritablePathsForProperty(string $prop, array $writablePaths): array
+    public function calculateUnexpectedNestedPathsForProperty(string $prop, array $expectedNestedPaths): array
     {
         $clone = clone $this;
-        foreach ($writablePaths as $writablePath) {
-            $clone->removeWritablePathValue($prop, $writablePath);
+        foreach ($expectedNestedPaths as $nestedPath) {
+            unset($clone->nestedPathValues[$prop.'.'.$nestedPath]);
         }
 
-        return $clone->getWritablePathsForProperty($prop);
+        return $clone->getNestedPathsForProperty($prop);
     }
 
-    private static function setValueDeeplyOntoArray(array $array, string $path, mixed $value): array
+    public function getProps(): array
     {
-        if (!str_contains($path, '.')) {
-            $array[$path] = $value;
-
-            return $array;
-        }
-
-        [$firstPath, $remainingPath] = explode('.', $path, 2);
-        if (!isset($array[$firstPath])) {
-            $array[$firstPath] = [];
-        }
-
-        $array[$firstPath] = self::setValueDeeplyOntoArray($array[$firstPath], $remainingPath, $value);
-
-        return $array;
+        return $this->propValues;
     }
 
-    /**
-     * Transforms the multi-dimensional array into a flat array of paths
-     * separated by ".".
-     */
-    private function flattenArray(mixed $paths, string $prefix = ''): array
+    public function getNestedProps(): array
     {
-        $flattened = [];
-        foreach ($paths as $key => $value) {
-            if (\is_array($value)) {
-                $flattened = array_merge($flattened, $this->flattenArray($value, $key.'.'));
-            } else {
-                $flattened[] = $prefix.$key;
-            }
-        }
-
-        return $flattened;
-    }
-
-    private function removeWritablePathValue(string $prop, mixed $writablePath): void
-    {
-        if (!\array_key_exists($prop, $this->writablePathValues)) {
-            return;
-        }
-
-        $currentArray = &$this->writablePathValues[$prop];
-        $parts = explode('.', $writablePath);
-        $count = 0;
-        foreach ($parts as $part) {
-            ++$count;
-            if (!\array_key_exists($part, $currentArray)) {
-                return;
-            }
-
-            if ($count === \count($parts)) {
-                unset($currentArray[$part]);
-
-                return;
-            }
-            $currentArray = &$currentArray[$part];
-        }
+        return $this->nestedPathValues;
     }
 }

--- a/src/LiveComponent/src/Util/LiveAttributesCollection.php
+++ b/src/LiveComponent/src/Util/LiveAttributesCollection.php
@@ -62,6 +62,11 @@ final class LiveAttributesCollection
         $this->attributes['data-live-props-value'] = $dehydratedProps;
     }
 
+    public function addNestedProps(array $nestedProps): void
+    {
+        $this->attributes['data-live-nested-props-value'] = $nestedProps;
+    }
+
     public function getProps(): array
     {
         if (!\array_key_exists('data-live-props-value', $this->attributes)) {

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -74,7 +74,10 @@ class LiveControllerAttributesCreator
             $mounted->getComponent(),
             $mountedAttributes
         );
-        $attributesCollection->addProps($dehydratedProps);
+        $attributesCollection->addProps($dehydratedProps->getProps());
+        if ($dehydratedProps->getNestedProps()) {
+            $attributesCollection->addNestedProps($dehydratedProps->getNestedProps());
+        }
 
         if ($this->csrfTokenManager && $metadata->get('csrf')) {
             $attributesCollection->addLiveCsrf(
@@ -90,7 +93,7 @@ class LiveControllerAttributesCreator
         return 'live_component_'.$componentName;
     }
 
-    private function dehydrateComponent(string $name, object $component, ComponentAttributes $attributes): array
+    private function dehydrateComponent(string $name, object $component, ComponentAttributes $attributes): DehydratedProps
     {
         $liveMetadata = $this->metadataFactory->getMetadata($name);
 

--- a/src/LiveComponent/tests/Functional/Controller/BatchActionControllerTest.php
+++ b/src/LiveComponent/tests/Functional/Controller/BatchActionControllerTest.php
@@ -31,7 +31,7 @@ final class BatchActionControllerTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/with_actions', ['json' => ['props' => $dehydrated]])
+            ->get('/_components/with_actions', ['json' => ['props' => $dehydrated->getProps()]])
             ->assertSuccessful()
             ->assertSee('initial')
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
@@ -78,7 +78,7 @@ final class BatchActionControllerTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/alt/alternate_route', ['json' => ['props' => $dehydrated]])
+            ->get('/alt/alternate_route', ['json' => ['props' => $dehydrated->getProps()]])
             ->assertSuccessful()
             ->assertSee('count: 0')
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
@@ -109,7 +109,7 @@ final class BatchActionControllerTest extends KernelTestCase
 
         $this->browser()
             ->post('/_components/with_actions/_batch', ['json' => [
-                'props' => $dehydrated,
+                'props' => $dehydrated->getProps(),
                 'actions' => [],
             ]])
             ->assertStatus(400)
@@ -122,7 +122,7 @@ final class BatchActionControllerTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/with_actions', ['json' => ['props' => $dehydrated]])
+            ->get('/_components/with_actions', ['json' => ['props' => $dehydrated->getProps()]])
             ->assertSuccessful()
             ->interceptRedirects()
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
@@ -150,7 +150,7 @@ final class BatchActionControllerTest extends KernelTestCase
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
         $this->browser()
-            ->get('/_components/with_actions', ['json' => ['props' => $dehydrated]])
+            ->get('/_components/with_actions', ['json' => ['props' => $dehydrated->getProps()]])
             ->assertSuccessful()
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
                 $rootElement = $crawler->filter('ul')->first();
@@ -178,7 +178,7 @@ final class BatchActionControllerTest extends KernelTestCase
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
         $this->browser()
-            ->get('/_components/with_actions', ['json' => ['props' => $dehydrated]])
+            ->get('/_components/with_actions', ['json' => ['props' => $dehydrated->getProps()]])
             ->assertSuccessful()
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
                 $rootElement = $crawler->filter('ul')->first();

--- a/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
@@ -99,7 +99,7 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
                     AddLiveAttributesSubscriberTest::TODO_ITEM_DETERMINISTIC_PREFIX
                 ), $content);
                 $this->assertStringContainsString(sprintf(
-                    '<div data-live-id="%s1" data-live-fingerprint-value="gn9PcPUqL0tkeLSw0ZuhOj96dwIpiBmJPoO5NPync2o&#x3D;" data-live-props-value="&#x7B;&quot;readonlyValue&quot;&#x3A;&quot;readonly&quot;,&quot;&#x40;attributes&quot;&#x3A;&#x7B;&quot;data-live-id&quot;&#x3A;&quot;live-289310975-1&quot;&#x7D;,&quot;&#x40;checksum&quot;&#x3A;&quot;Mmk7CzYtwHxb9ZieJcds2bgEGxT43aUwuxezWIhZRuQ&#x3D;&quot;&#x7D;"></div>',
+                    '<div data-live-id="%s1" data-live-fingerprint-value="gn9PcPUqL0tkeLSw0ZuhOj96dwIpiBmJPoO5NPync2o&#x3D;" data-live-props-value="&#x7B;&quot;readonlyValue&quot;&#x3A;&quot;readonly&quot;,&quot;&#x40;attributes&quot;&#x3A;&#x7B;&quot;data-live-id&quot;&#x3A;&quot;live-289310975-1&quot;&#x7D;,&quot;&#x40;checksum&quot;&#x3A;&quot;i2TRqypfPSDPlQJXcjODG6FL53m1IxSTY6tLHtMBW6M&#x3D;&quot;&#x7D;"></div>',
                     AddLiveAttributesSubscriberTest::TODO_ITEM_DETERMINISTIC_PREFIX
                 ), $content);
                 $this->assertStringContainsString(sprintf(
@@ -123,7 +123,7 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
         $dehydratedProps = $this->dehydrateComponent($component);
 
         $queryData = [
-            'props' => json_encode($dehydratedProps),
+            'props' => json_encode($dehydratedProps->getProps()),
         ];
 
         if ($childrenFingerprints) {

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -45,7 +45,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/component1?props='.urlencode(json_encode($dehydrated)))
+            ->get('/_components/component1?props='.urlencode(json_encode($dehydrated->getProps())))
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Prop1: '.$entity->id)
@@ -61,7 +61,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/alt/alternate_route?props='.urlencode(json_encode($dehydrated)))
+            ->get('/alt/alternate_route?props='.urlencode(json_encode($dehydrated->getProps())))
             ->assertSuccessful()
             ->assertOn('/alt/alternate_route', parts: ['path'])
             ->assertContains('From alternate route. (count: 0)')
@@ -75,7 +75,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated)))
+            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated->getProps())))
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Count: 1')
@@ -85,7 +85,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             })
             ->post('/_components/component2/increase', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode(['props' => $dehydrated]),
+                'body' => json_encode(['props' => $dehydrated->getProps()]),
             ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
@@ -100,7 +100,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/alt/alternate_route?props='.urlencode(json_encode($dehydrated)))
+            ->get('/alt/alternate_route?props='.urlencode(json_encode($dehydrated->getProps())))
             ->assertSuccessful()
             ->assertContains('count: 0')
             ->use(function (Crawler $crawler) use (&$token) {
@@ -109,7 +109,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             })
             ->post('/alt/alternate_route/increase', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode(['props' => $dehydrated]),
+                'body' => json_encode(['props' => $dehydrated->getProps()]),
             ])
             ->assertSuccessful()
             ->assertOn('/alt/alternate_route/increase')
@@ -177,12 +177,12 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/disabled_csrf?props='.urlencode(json_encode($dehydrated)))
+            ->get('/_components/disabled_csrf?props='.urlencode(json_encode($dehydrated->getProps())))
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Count: 1')
             ->post('/_components/disabled_csrf/increase', [
-                'body' => json_encode(['props' => $dehydrated]),
+                'body' => json_encode(['props' => $dehydrated->getProps()]),
             ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
@@ -198,7 +198,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ->visit('/render-template/render_component2')
             ->assertSuccessful()
             ->assertSee('PreReRenderCalled: No')
-            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated)))
+            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated->getProps())))
             ->assertSuccessful()
             ->assertSee('PreReRenderCalled: Yes')
         ;
@@ -211,7 +211,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated)))
+            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated->getProps())))
             ->assertSuccessful()
             ->use(function (Crawler $crawler) use (&$token) {
                 // get a valid token to use for actions
@@ -221,7 +221,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             // with no custom header, it redirects like a normal browser
             ->post('/_components/component2/redirect', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode(['props' => $dehydrated]),
+                'body' => json_encode(['props' => $dehydrated->getProps()]),
             ])
             ->assertRedirectedTo('/')
 
@@ -231,7 +231,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
                     'Accept' => 'application/vnd.live-component+html',
                     'X-CSRF-TOKEN' => $token,
                 ],
-                'body' => json_encode(['props' => $dehydrated]),
+                'body' => json_encode(['props' => $dehydrated->getProps()]),
             ])
             ->assertStatus(204)
             ->assertHeaderEquals('Location', '/')
@@ -248,7 +248,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         $arguments = ['arg1' => 'hello', 'arg2' => 666, 'custom' => '33.3'];
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/component6?props='.urlencode(json_encode($dehydrated)))
+            ->get('/_components/component6?props='.urlencode(json_encode($dehydrated->getProps())))
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Arg1: not provided')
@@ -261,7 +261,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ->post('/_components/component6/inject', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
                 'body' => json_encode([
-                    'props' => $dehydrated,
+                    'props' => $dehydrated->getProps(),
                     'args' => $arguments,
                 ]),
             ])
@@ -279,7 +279,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/with_nullable_entity?props='.urlencode(json_encode($dehydrated)))
+            ->get('/_components/with_nullable_entity?props='.urlencode(json_encode($dehydrated->getProps())))
             ->assertSuccessful()
             ->assertContains('Prop1: default')
         ;

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -35,7 +35,7 @@ class ComponentWithFormTest extends KernelTestCase
 
     public function testFormValuesRebuildAfterFormChanges(): void
     {
-        $dehydratedProps = $this->dehydrateComponent($this->mountComponent('form_with_collection_type'));
+        $dehydratedProps = $this->dehydrateComponent($this->mountComponent('form_with_collection_type'))->getProps();
 
         $browser = $this->browser();
         $crawler = $browser
@@ -127,7 +127,7 @@ class ComponentWithFormTest extends KernelTestCase
         // component should recognize that it is already submitted
         $this->assertTrue($component->isValidated);
 
-        $dehydratedProps = $this->dehydrateComponent($mounted);
+        $dehydratedProps = $this->dehydrateComponent($mounted)->getProps();
         $updatedProps = [
             'blog_post_form.content' => 'changed description',
             'validatedFields' => array_merge(
@@ -158,7 +158,7 @@ class ComponentWithFormTest extends KernelTestCase
             ]
         );
 
-        $dehydratedProps = $this->dehydrateComponent($mounted);
+        $dehydratedProps = $this->dehydrateComponent($mounted)->getProps();
         $this->assertSame([
             'text' => '',
             'textarea' => '',
@@ -239,7 +239,7 @@ class ComponentWithFormTest extends KernelTestCase
 
     public function testLiveCollectionTypeAddButtonsByDefault(): void
     {
-        $dehydrated = $this->dehydrateComponent($this->mountComponent('form_with_live_collection_type'));
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('form_with_live_collection_type'))->getProps();
 
         $this->browser()
             ->get('/_components/form_with_live_collection_type?props='.urlencode(json_encode($dehydrated)))
@@ -250,7 +250,7 @@ class ComponentWithFormTest extends KernelTestCase
 
     public function testLiveCollectionTypeFieldsAddedAndRemoved(): void
     {
-        $dehydratedProps = $this->dehydrateComponent($this->mountComponent('form_with_live_collection_type'));
+        $dehydratedProps = $this->dehydrateComponent($this->mountComponent('form_with_live_collection_type'))->getProps();
         $updatedProps = [];
         $token = null;
 
@@ -325,7 +325,7 @@ class ComponentWithFormTest extends KernelTestCase
 
     public function testDataModelAttributeAutomaticallyAdded(): void
     {
-        $dehydrated = $this->dehydrateComponent($this->mountComponent('form_with_collection_type'));
+        $dehydrated = $this->dehydrateComponent($this->mountComponent('form_with_collection_type'))->getProps();
 
         $this->browser()
             ->get('/_components/form_with_collection_type?props='.urlencode(json_encode($dehydrated)))

--- a/src/LiveComponent/tests/LiveComponentTestHelper.php
+++ b/src/LiveComponent/tests/LiveComponentTestHelper.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\LiveComponent\Tests;
 
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadataFactory;
+use Symfony\UX\LiveComponent\Util\DehydratedProps;
 use Symfony\UX\TwigComponent\ComponentAttributes;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\MountedComponent;
@@ -42,7 +43,7 @@ trait LiveComponentTestHelper
         return $this->factory()->create($name, $data);
     }
 
-    private function dehydrateComponent(MountedComponent $mounted): array
+    private function dehydrateComponent(MountedComponent $mounted): DehydratedProps
     {
         $liveMetadataFactory = self::getContainer()->get('ux.live_component.metadata_factory');
         \assert($liveMetadataFactory instanceof LiveComponentMetadataFactory);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #720
| License       | MIT

In the unreleased code, writing a "deep" path to an array `LiveProp` is broken (e.g. `formValues` in `ComponentWithFormTrait` when you have an embedded form). Test case here, solution coming shortly.