### PR TITLE
[LiveComponent] Fix calculateFingerprint with big objects

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -174,7 +174,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
 
         $container->register('ux.live_component.deterministic_id_calculator', DeterministicTwigIdCalculator::class);
         $container->register('ux.live_component.fingerprint_calculator', FingerprintCalculator::class)
-            ->setArguments(['%kernel.secret%']);
+            ->setArguments([new Reference('serializer'), '%kernel.secret%']);
 
         $container->setAlias(ComponentValidatorInterface::class, ComponentValidator::class);
 

--- a/src/LiveComponent/src/Util/FingerprintCalculator.php
+++ b/src/LiveComponent/src/Util/FingerprintCalculator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Symfony package.
  *
@@ -11,6 +13,9 @@
 
 namespace Symfony\UX\LiveComponent\Util;
 
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\UX\LiveComponent\LiveComponentHydrator;
+
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
@@ -20,12 +25,16 @@ namespace Symfony\UX\LiveComponent\Util;
  */
 class FingerprintCalculator
 {
-    public function __construct(private string $secret)
-    {
+    public function __construct(
+        private NormalizerInterface $objectNormalizer,
+        private string $secret,
+    ) {
     }
 
     public function calculateFingerprint(array $data): string
     {
-        return base64_encode(hash_hmac('sha256', serialize($data), $this->secret, true));
+        $normalizedData = $this->objectNormalizer->normalize($data, context: [LiveComponentHydrator::LIVE_CONTEXT => true]);
+
+        return base64_encode(hash_hmac('sha256', serialize($normalizedData), $this->secret, true));
     }
 }

--- a/src/LiveComponent/tests/Integration/Util/FingerprintCalculatorTest.php
+++ b/src/LiveComponent/tests/Integration/Util/FingerprintCalculatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Integration\Util;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity1;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use function Zenstruck\Foundry\create;
+
+final class FingerprintCalculatorTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testFingerprintEqual()
+    {
+        $fingerprintCalculator = self::getContainer()->get('ux.live_component.fingerprint_calculator');
+
+        $entityOne = create(Entity1::class)->object();
+
+        $entityTwo = clone $entityOne;
+
+        self::assertNotSame(
+            spl_object_id($entityOne),
+            spl_object_id($entityTwo)
+        );
+
+        self::assertSame(
+            $fingerprintCalculator->calculateFingerprint([$entityOne]),
+            $fingerprintCalculator->calculateFingerprint([$entityTwo])
+        );
+    }
+
+    public function testFingerprintNotEqual()
+    {
+        $fingerprintCalculator = self::getContainer()->get('ux.live_component.fingerprint_calculator');
+
+        $entityOne = create(Entity1::class)->object();
+
+        $entityTwo = create(Entity1::class)->object();
+
+        self::assertNotSame(
+            $fingerprintCalculator->calculateFingerprint([$entityOne]),
+            $fingerprintCalculator->calculateFingerprint([$entityTwo])
+        );
+    }
+}

--- a/src/TwigComponent/src/Attribute/PostMount.php
+++ b/src/TwigComponent/src/Attribute/PostMount.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Symfony\UX\TwigComponent\Attribute;
-
 /*
  * This file is part of the Symfony package.
  *
@@ -10,6 +8,8 @@ namespace Symfony\UX\TwigComponent\Attribute;
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+namespace Symfony\UX\TwigComponent\Attribute;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/TwigComponent/src/Attribute/PreMount.php
+++ b/src/TwigComponent/src/Attribute/PreMount.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Symfony\UX\TwigComponent\Attribute;
-
 /*
  * This file is part of the Symfony package.
  *
@@ -10,6 +8,8 @@ namespace Symfony\UX\TwigComponent\Attribute;
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+namespace Symfony\UX\TwigComponent\Attribute;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\TwigComponent\Twig;
 
 use Twig\Compiler;

--- a/src/TwigComponent/src/Twig/ComponentTokenParser.php
+++ b/src/TwigComponent/src/Twig/ComponentTokenParser.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\TwigComponent\Twig;
 
 use Symfony\UX\TwigComponent\ComponentFactory;

--- a/src/TwigComponent/tests/Fixtures/Component/ParentFormComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/ParentFormComponent.php
@@ -12,7 +12,6 @@
 namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
 
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
-use Symfony\UX\TwigComponent\Tests\Fixtures\Service\ServiceA;
 
 #[AsTwigComponent('parent_form_component')]
 final class ParentFormComponent

--- a/src/TwigComponent/tests/Fixtures/Component/TextareaComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/TextareaComponent.php
@@ -12,7 +12,6 @@
 namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
 
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
-use Symfony\UX\TwigComponent\Tests\Fixtures\Service\ServiceA;
 
 #[AsTwigComponent('textarea_component')]
 final class TextareaComponent


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | N/A
| License       | MIT

This pull request will fix an issue for large objects (for example entities with a large relations) with in the FingerprintCalculator

While working with liveComponents I noticed my project getting slower and slower. After some digging I found out that in the calculateFingerprint function the data is serialized. When an entity with relations passes by it will serialize the entity and its child objects. This takes a considerable amount of time and is not needed.
