### PR TITLE
[Live] Smart Rendering! Mix/match live components with external JavaScript

### DIFF
--- a/src/Autocomplete/assets/dist/controller.d.ts
+++ b/src/Autocomplete/assets/dist/controller.d.ts
@@ -1,5 +1,12 @@
 import { Controller } from '@hotwired/stimulus';
 import TomSelect from 'tom-select';
+export interface AutocompletePreConnectOptions {
+    options: any;
+}
+export interface AutocompleteConnectOptions {
+    tomSelect: TomSelect;
+    options: any;
+}
 export default class extends Controller {
     #private;
     static values: {
@@ -23,11 +30,20 @@ export default class extends Controller {
     readonly hasPreloadValue: boolean;
     readonly preloadValue: string;
     tomSelect: TomSelect;
+    private mutationObserver;
+    private isObserving;
     initialize(): void;
     connect(): void;
     disconnect(): void;
+    private getMaxOptions;
     get selectElement(): HTMLSelectElement | null;
     get formElement(): HTMLInputElement | HTMLSelectElement;
     private dispatchEvent;
     get preload(): string | boolean;
+    private resetTomSelect;
+    private changeTomSelectDisabledState;
+    private updateTomSelectPlaceholder;
+    private startMutationObserver;
+    private stopMutationObserver;
+    private onMutations;
 }

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -3,6 +3,14 @@ import TomSelect from 'tom-select';
 import { TPluginHash } from 'tom-select/dist/types/contrib/microplugin';
 import { RecursivePartial, TomSettings, TomTemplates } from 'tom-select/dist/types/types';
 
+export interface AutocompletePreConnectOptions {
+    options: any;
+}
+export interface AutocompleteConnectOptions {
+    tomSelect: TomSelect;
+    options: any;
+}
+
 export default class extends Controller {
     static values = {
         url: String,
@@ -24,13 +32,14 @@ export default class extends Controller {
     declare readonly preloadValue: string;
     tomSelect: TomSelect;
 
+    private mutationObserver: MutationObserver;
+    private isObserving = false;
+
     initialize() {
-        this.element.setAttribute('data-live-ignore', '');
-        if (this.element.id) {
-            const label = document.querySelector(`label[for="${this.element.id}"]`);
-            if (label) {
-                label.setAttribute('data-live-ignore', '');
-            }
+        if (!this.mutationObserver) {
+            this.mutationObserver = new MutationObserver((mutations: MutationRecord[]) => {
+                this.onMutations(mutations);
+            });
         }
     }
 
@@ -48,11 +57,11 @@ export default class extends Controller {
         }
 
         this.tomSelect = this.#createAutocomplete();
+        this.startMutationObserver();
     }
 
     disconnect() {
-        // make sure it will "revert" to the latest innerHTML
-        this.tomSelect.revertSettings.innerHTML = this.element.innerHTML;
+        this.stopMutationObserver();
         this.tomSelect.destroy();
     }
 
@@ -86,10 +95,6 @@ export default class extends Controller {
             onItemAdd: () => {
                 this.tomSelect.setTextboxValue('');
             },
-            onInitialize: function () {
-                const tomSelect = this as any;
-                tomSelect.wrapper.setAttribute('data-live-ignore', '');
-            },
             closeAfterSelect: true,
         };
 
@@ -103,7 +108,7 @@ export default class extends Controller {
 
     #createAutocomplete(): TomSelect {
         const config = this.#mergeObjects(this.#getCommonConfig(), {
-            maxOptions: this.selectElement ? this.selectElement.options.length : 50,
+            maxOptions: this.getMaxOptions(),
         });
 
         return this.#createTomSelect(config);
@@ -111,7 +116,7 @@ export default class extends Controller {
 
     #createAutocompleteWithHtmlContents(): TomSelect {
         const config = this.#mergeObjects(this.#getCommonConfig(), {
-            maxOptions: this.selectElement ? this.selectElement.options.length : 50,
+            maxOptions: this.getMaxOptions(),
             score: (search: string) => {
                 const scoringFunction = this.tomSelect.getScoreFunction(search);
                 return (item: any) => {
@@ -182,6 +187,10 @@ export default class extends Controller {
         return this.#createTomSelect(config);
     }
 
+    private getMaxOptions(): number {
+        return this.selectElement ? this.selectElement.options.length : 50;
+    }
+
     #stripTags(string: string): string {
         return string.replace(/(<([^>]+)>)/gi, '');
     }
@@ -213,9 +222,11 @@ export default class extends Controller {
     }
 
     #createTomSelect(options: RecursivePartial<TomSettings>): TomSelect {
-        this.dispatchEvent('pre-connect', { options });
+        const preConnectPayload: AutocompletePreConnectOptions = { options };
+        this.dispatchEvent('pre-connect', preConnectPayload);
         const tomSelect = new TomSelect(this.formElement, options);
-        this.dispatchEvent('connect', { tomSelect, options });
+        const connectPayload: AutocompleteConnectOptions = { tomSelect, options };
+        this.dispatchEvent('connect', connectPayload);
 
         return tomSelect;
     }
@@ -238,5 +249,155 @@ export default class extends Controller {
         }
 
         return this.preloadValue;
+    }
+
+    private resetTomSelect(): void {
+        if (this.tomSelect) {
+            this.stopMutationObserver();
+            this.tomSelect.clearOptions();
+            this.tomSelect.settings.maxOptions = this.getMaxOptions();
+            this.tomSelect.sync();
+            this.startMutationObserver();
+        }
+    }
+
+    private changeTomSelectDisabledState(isDisabled: boolean): void {
+        this.stopMutationObserver();
+        if (isDisabled) {
+            this.tomSelect.disable();
+        } else {
+            this.tomSelect.enable();
+        }
+        this.startMutationObserver();
+    }
+
+    /**
+     * TomSelect doesn't give us a way to update the placeholder, so most of
+     * this code is copied from TomSelect's source code.
+     *
+     * @private
+     */
+    private updateTomSelectPlaceholder(): void {
+        const input = this.element;
+        let placeholder = input.getAttribute('placeholder') || input.getAttribute('data-placeholder');
+        if (!placeholder && !this.tomSelect.allowEmptyOption) {
+            const option = input.querySelector('option[value=""]');
+
+            if (option) {
+                placeholder = option.textContent;
+            }
+        }
+
+        if (placeholder) {
+            this.stopMutationObserver();
+            this.tomSelect.control_input.setAttribute('placeholder', placeholder);
+            this.startMutationObserver();
+        }
+    }
+
+    private startMutationObserver(): void {
+        if (!this.isObserving) {
+            this.mutationObserver.observe(this.element, {
+                childList: true,
+                subtree: true,
+                attributes: true,
+                characterData: true,
+            });
+            this.isObserving = true;
+        }
+    }
+
+    private stopMutationObserver(): void {
+        if (this.isObserving) {
+            this.mutationObserver.disconnect();
+            this.isObserving = false;
+        }
+    }
+
+    private onMutations(mutations: MutationRecord[]): void {
+        const addedOptionElements: HTMLOptionElement[] = [];
+        const removedOptionElements: HTMLOptionElement[] = [];
+        let hasAnOptionChanged = false;
+        let changeDisabledState = false;
+        let changePlaceholder = false;
+
+        mutations.forEach((mutation) => {
+            switch (mutation.type) {
+                case 'childList':
+                    // look for changes to any <option> elements - e.g. text
+                    if (mutation.target instanceof HTMLOptionElement) {
+                        if (mutation.target.value === '') {
+                            changePlaceholder = true;
+
+                            break;
+                        }
+
+                        hasAnOptionChanged = true;
+                        break;
+                    }
+
+                    // look for new or removed <option> elements
+                    mutation.addedNodes.forEach((node) => {
+                        if (node instanceof HTMLOptionElement) {
+                            // check if a previously-removed is being added back
+                            if (removedOptionElements.includes(node)) {
+                                removedOptionElements.splice(removedOptionElements.indexOf(node), 1);
+                                return;
+                            }
+
+                            addedOptionElements.push(node);
+                        }
+                    });
+                    mutation.removedNodes.forEach((node) => {
+                        if (node instanceof HTMLOptionElement) {
+                            // check if a previously-added is being removed
+                            if (addedOptionElements.includes(node)) {
+                                addedOptionElements.splice(addedOptionElements.indexOf(node), 1);
+                                return;
+                            }
+
+                            removedOptionElements.push(node);
+                        }
+                    });
+                    break;
+                case 'attributes':
+                    // look for changes to any <option> elements (e.g. value attribute)
+                    if (mutation.target instanceof HTMLOptionElement) {
+                        hasAnOptionChanged = true;
+                        break;
+                    }
+
+                    if (mutation.target === this.element && mutation.attributeName === 'disabled') {
+                        changeDisabledState = true;
+
+                        break;
+                    }
+
+                    break;
+                case 'characterData':
+                    // an alternative way for an option's text to change
+                    if (mutation.target instanceof Text && mutation.target.parentElement instanceof HTMLOptionElement) {
+                        if (mutation.target.parentElement.value === '') {
+                            changePlaceholder = true;
+
+                            break;
+                        }
+
+                        hasAnOptionChanged = true;
+                    }
+            }
+        });
+
+        if (hasAnOptionChanged || addedOptionElements.length > 0 || removedOptionElements.length > 0) {
+            this.resetTomSelect();
+        }
+
+        if (changeDisabledState) {
+            this.changeTomSelectDisabledState(this.formElement.disabled);
+        }
+
+        if (changePlaceholder) {
+            this.updateTomSelectPlaceholder();
+        }
     }
 }

--- a/src/Chartjs/assets/dist/controller.d.ts
+++ b/src/Chartjs/assets/dist/controller.d.ts
@@ -4,6 +4,8 @@ export default class extends Controller {
     static values: {
         view: ObjectConstructor;
     };
+    private chart;
     connect(): void;
+    viewValueChanged(): void;
     private dispatchEvent;
 }

--- a/src/Chartjs/assets/dist/controller.js
+++ b/src/Chartjs/assets/dist/controller.js
@@ -2,6 +2,10 @@ import { Controller } from '@hotwired/stimulus';
 import Chart from 'chart.js/auto';
 
 class default_1 extends Controller {
+    constructor() {
+        super(...arguments);
+        this.chart = null;
+    }
     connect() {
         if (!(this.element instanceof HTMLCanvasElement)) {
             throw new Error('Invalid element');
@@ -15,8 +19,23 @@ class default_1 extends Controller {
         if (!canvasContext) {
             throw new Error('Could not getContext() from Element');
         }
-        const chart = new Chart(canvasContext, payload);
-        this.dispatchEvent('connect', { chart });
+        this.chart = new Chart(canvasContext, payload);
+        this.dispatchEvent('connect', { chart: this.chart });
+    }
+    viewValueChanged() {
+        if (this.chart) {
+            this.chart.data = this.viewValue.data;
+            this.chart.options = this.viewValue.options;
+            this.chart.update();
+            const parentElement = this.element.parentElement;
+            if (parentElement && this.chart.options.responsive) {
+                const originalWidth = parentElement.style.width;
+                parentElement.style.width = (parentElement.offsetWidth + 1) + 'px';
+                setTimeout(() => {
+                    parentElement.style.width = originalWidth;
+                }, 0);
+            }
+        }
     }
     dispatchEvent(name, payload) {
         this.dispatch(name, { detail: payload, prefix: 'chartjs' });

--- a/src/LiveComponent/assets/dist/Component/index.d.ts
+++ b/src/LiveComponent/assets/dist/Component/index.d.ts
@@ -22,6 +22,7 @@ export default class Component {
     private nextRequestPromiseResolve;
     private children;
     private parent;
+    private externalMutationTracker;
     constructor(element: HTMLElement, props: any, nestedProps: any, fingerprint: string | null, id: string | null, backend: BackendInterface, elementDriver: ElementDriver);
     _swapBackend(backend: BackendInterface): void;
     addPlugin(plugin: PluginInterface): void;

--- a/src/LiveComponent/assets/dist/Rendering/ChangingItemsTracker.d.ts
+++ b/src/LiveComponent/assets/dist/Rendering/ChangingItemsTracker.d.ts
@@ -1,0 +1,12 @@
+export default class {
+    private changedItems;
+    private removedItems;
+    setItem(itemName: string, newValue: string, previousValue: string | null): void;
+    removeItem(itemName: string, currentValue: string | null): void;
+    getChangedItems(): {
+        name: string;
+        value: string;
+    }[];
+    getRemovedItems(): string[];
+    isEmpty(): boolean;
+}

--- a/src/LiveComponent/assets/dist/Rendering/ElementChanges.d.ts
+++ b/src/LiveComponent/assets/dist/Rendering/ElementChanges.d.ts
@@ -1,0 +1,26 @@
+export default class ElementChanges {
+    private addedClasses;
+    private removedClasses;
+    private styleChanges;
+    private attributeChanges;
+    addClass(className: string): void;
+    removeClass(className: string): void;
+    addStyle(styleName: string, newValue: string, originalValue: string | null): void;
+    removeStyle(styleName: string, originalValue: string): void;
+    addAttribute(attributeName: string, newValue: string, originalValue: string | null): void;
+    removeAttribute(attributeName: string, originalValue: string | null): void;
+    getAddedClasses(): string[];
+    getRemovedClasses(): string[];
+    getChangedStyles(): {
+        name: string;
+        value: string;
+    }[];
+    getRemovedStyles(): string[];
+    getChangedAttributes(): {
+        name: string;
+        value: string;
+    }[];
+    getRemovedAttributes(): string[];
+    applyToElement(element: HTMLElement): void;
+    isEmpty(): boolean;
+}

--- a/src/LiveComponent/assets/dist/Rendering/ExternalMutationTracker.d.ts
+++ b/src/LiveComponent/assets/dist/Rendering/ExternalMutationTracker.d.ts
@@ -1,0 +1,25 @@
+import ElementChanges from './ElementChanges';
+export default class {
+    private element;
+    private shouldTrackChangeCallback;
+    private mutationObserver;
+    private changedElements;
+    changedElementsCount: number;
+    private addedElements;
+    private removedElements;
+    private isStarted;
+    constructor(element: Element, shouldTrackChangeCallback: (element: Element) => boolean);
+    start(): void;
+    stop(): void;
+    getChangedElement(element: Element): ElementChanges | null;
+    getAddedElements(): Element[];
+    wasElementAdded(element: Element): boolean;
+    handlePendingChanges(): void;
+    private onMutations;
+    private handleChildListMutation;
+    private handleAttributeMutation;
+    private handleClassAttributeMutation;
+    private handleStyleAttributeMutation;
+    private handleGenericAttributeMutation;
+    private extractStyles;
+}

--- a/src/LiveComponent/assets/dist/morphdom.d.ts
+++ b/src/LiveComponent/assets/dist/morphdom.d.ts
@@ -1,2 +1,3 @@
 import Component from './Component';
-export declare function executeMorphdom(rootFromElement: HTMLElement, rootToElement: HTMLElement, modifiedFieldElements: Array<HTMLElement>, getElementValue: (element: HTMLElement) => any, childComponents: Component[], findChildComponent: (id: string, element: HTMLElement) => HTMLElement | null, getKeyFromElement: (element: HTMLElement) => string | null): void;
+import ExternalMutationTracker from './Rendering/ExternalMutationTracker';
+export declare function executeMorphdom(rootFromElement: HTMLElement, rootToElement: HTMLElement, modifiedFieldElements: Array<HTMLElement>, getElementValue: (element: HTMLElement) => any, childComponents: Component[], findChildComponent: (id: string, element: HTMLElement) => HTMLElement | null, getKeyFromElement: (element: HTMLElement) => string | null, externalMutationTracker: ExternalMutationTracker): void;

--- a/src/LiveComponent/assets/src/Rendering/ChangingItemsTracker.ts
+++ b/src/LiveComponent/assets/src/Rendering/ChangingItemsTracker.ts
@@ -1,0 +1,87 @@
+/**
+ * Helps track added/changed styles or attributes.
+ */
+export default class {
+    // e.g. a Map with key "color" & value { original: 'previousValue', new: 'newValue' },
+    private changedItems: Map<string, { original: string|null, new: string }> = new Map();
+    private removedItems: Map<string, { original: string|null }> = new Map();
+
+    /**
+     * A "null" previousValue means the item was NOT previously present.
+     */
+    setItem(itemName: string, newValue: string, previousValue: string|null): void {
+        if (this.removedItems.has(itemName)) {
+            // this was previously removed
+
+            const removedRecord = this.removedItems.get(itemName) as { original: string };
+            this.removedItems.delete(itemName);
+
+            if (removedRecord.original === newValue) {
+                // we just set the item to its original value
+                return;
+            }
+        }
+
+        if (this.changedItems.has(itemName)) {
+            // this was previously changed
+            const originalRecord = this.changedItems.get(itemName) as { original: string, new: string };
+            if (originalRecord.original === newValue) {
+                // it just reverted to its original value!
+                this.changedItems.delete(itemName);
+
+                return;
+            }
+
+            // keep the original value, but update the new value
+            this.changedItems.set(itemName, { original: originalRecord.original, new: newValue });
+
+            return;
+        }
+
+        this.changedItems.set(itemName, { original: previousValue, new: newValue });
+    }
+
+    removeItem(itemName: string, currentValue: string|null): void {
+        let trueOriginalValue = currentValue;
+        if (this.changedItems.has(itemName)) {
+            // this was previously changed, so we're just undoing that
+            const originalRecord = this.changedItems.get(itemName) as { original: string, new: string };
+            trueOriginalValue = originalRecord.original;
+
+            this.changedItems.delete(itemName);
+
+            if (trueOriginalValue === null) {
+                // this item was NOT originally present, so do not add it to changed items
+                return;
+            }
+        }
+
+        if (!this.removedItems.has(itemName)) {
+            this.removedItems.set(itemName, { original: trueOriginalValue });
+        }
+    }
+
+    getChangedItems(): { name: string, value: string }[] {
+        const changedItems: { name: string, value: string }[] = [];
+
+        this.changedItems.forEach((value, key) => {
+            changedItems.push({ name: key, value: value.new });
+        });
+
+        return changedItems;
+    }
+
+    getRemovedItems(): string[] {
+        const removedItems: string[] = [];
+
+        this.removedItems.forEach((value, key) => {
+            removedItems.push(key);
+        });
+
+        return removedItems;
+    }
+
+    isEmpty(): boolean {
+        return this.changedItems.size === 0 && this.removedItems.size === 0;
+    }
+}

--- a/src/LiveComponent/assets/src/Rendering/ElementChanges.ts
+++ b/src/LiveComponent/assets/src/Rendering/ElementChanges.ts
@@ -1,0 +1,114 @@
+import ChangingItemsTracker from './ChangingItemsTracker';
+
+/**
+ * Tracks attribute changes for a specific element.
+ */
+export default class ElementChanges {
+    private addedClasses: string[] = [];
+    private removedClasses: string[] = [];
+
+    private styleChanges: ChangingItemsTracker = new ChangingItemsTracker();
+    private attributeChanges: ChangingItemsTracker = new ChangingItemsTracker();
+
+    addClass(className: string) {
+        if (this.removedClasses.includes(className)) {
+            // this was previously removed, so we're just undoing that
+            this.removedClasses = this.removedClasses.filter((name) => name !== className);
+
+            return;
+        }
+
+        if (!this.addedClasses.includes(className)) {
+            this.addedClasses.push(className);
+        }
+    }
+
+    removeClass(className: string) {
+        if (this.addedClasses.includes(className)) {
+            // this was previously added, so we're just undoing that
+            this.addedClasses = this.addedClasses.filter((name) => name !== className);
+
+            return;
+        }
+
+        if (!this.removedClasses.includes(className)) {
+            this.removedClasses.push(className);
+        }
+    }
+
+    addStyle(styleName: string, newValue: string, originalValue: string|null) {
+        this.styleChanges.setItem(styleName, newValue, originalValue);
+    }
+
+    removeStyle(styleName: string, originalValue: string) {
+        this.styleChanges.removeItem(styleName, originalValue);
+    }
+
+    addAttribute(attributeName: string, newValue: string, originalValue: string|null) {
+        this.attributeChanges.setItem(attributeName, newValue, originalValue);
+    }
+
+    removeAttribute(attributeName: string, originalValue: string|null) {
+        this.attributeChanges.removeItem(attributeName, originalValue);
+    }
+
+    getAddedClasses(): string[] {
+        return this.addedClasses;
+    }
+
+    getRemovedClasses(): string[] {
+        return this.removedClasses;
+    }
+
+    getChangedStyles(): { name: string, value: string }[] {
+        return this.styleChanges.getChangedItems();
+    }
+
+    getRemovedStyles(): string[] {
+        return this.styleChanges.getRemovedItems();
+    }
+
+    getChangedAttributes(): { name: string, value: string }[] {
+        return this.attributeChanges.getChangedItems();
+    }
+
+    getRemovedAttributes(): string[] {
+        return this.attributeChanges.getRemovedItems();
+    }
+
+    applyToElement(element: HTMLElement): void {
+        this.addedClasses.forEach((className) => {
+            element.classList.add(className);
+        });
+
+        this.removedClasses.forEach((className) => {
+            element.classList.remove(className);
+        });
+
+        this.styleChanges.getChangedItems().forEach((change) => {
+            element.style.setProperty(change.name, change.value);
+            return;
+        });
+
+        this.styleChanges.getRemovedItems().forEach((styleName) => {
+            element.style.removeProperty(styleName);
+        });
+
+        this.attributeChanges.getChangedItems().forEach((change) => {
+            element.setAttribute(change.name, change.value);
+        });
+
+        this.attributeChanges.getRemovedItems().forEach((attributeName) => {
+            element.removeAttribute(attributeName);
+        });
+    }
+
+    isEmpty(): boolean {
+        return (
+            this.addedClasses.length === 0 &&
+            this.removedClasses.length === 0 &&
+            this.styleChanges.isEmpty() &&
+            this.attributeChanges.isEmpty()
+        );
+    }
+}

--- a/src/LiveComponent/assets/src/Rendering/ExternalMutationTracker.ts
+++ b/src/LiveComponent/assets/src/Rendering/ExternalMutationTracker.ts
@@ -1,0 +1,296 @@
+import ElementChanges from './ElementChanges';
+
+/**
+ * Uses MutationObserver to track changes to the DOM inside a component.
+ *
+ * This is meant to track changes that are made by external code - i.e. not
+ * a change from a component re-render.
+ */
+export default class {
+    private element: Element;
+    private shouldTrackChangeCallback: (element: Element) => boolean;
+    private mutationObserver: MutationObserver;
+    private changedElements: WeakMap<Element, ElementChanges> = new WeakMap();
+    /** For testing */
+    public changedElementsCount = 0;
+    private addedElements: Array<Element> = [];
+    private removedElements: Array<Element> = [];
+    private isStarted = false;
+
+    constructor(element: Element, shouldTrackChangeCallback: (element: Element) => boolean) {
+        this.element = element;
+        this.shouldTrackChangeCallback = shouldTrackChangeCallback;
+        this.mutationObserver = new MutationObserver(this.onMutations.bind(this));
+    }
+
+    start(): void {
+        if (this.isStarted) {
+            return;
+        }
+
+        this.mutationObserver.observe(this.element, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeOldValue: true,
+        });
+        this.isStarted = true;
+    }
+
+    stop(): void {
+        if (this.isStarted) {
+            this.mutationObserver.disconnect();
+
+            this.isStarted = false;
+        }
+    }
+
+    getChangedElement(element: Element): ElementChanges|null {
+        return this.changedElements.has(element) ? this.changedElements.get(element) as ElementChanges : null;
+    }
+
+    getAddedElements(): Element[] {
+        return this.addedElements;
+    }
+
+    wasElementAdded(element: Element): boolean {
+        return this.addedElements.includes(element);
+    }
+
+    /**
+     * Forces any pending mutations to be handled immediately, then clears the queue.
+     */
+    handlePendingChanges(): void {
+        this.onMutations(this.mutationObserver.takeRecords());
+    }
+
+    private onMutations(mutations: MutationRecord[]): void {
+        // keyed by the Element the mutation occurred on, with an array of attribute string names
+        const handledAttributeMutations: WeakMap<Element, string[]> = new WeakMap();
+        for (const mutation of mutations) {
+            const element = mutation.target as Element;
+
+            // ignore mutations that are not inside this component - e.g. inside a child
+            if (!this.shouldTrackChangeCallback(element)) {
+                continue;
+            }
+
+            // ignore changes in elements that were externally-added
+            let isChangeInAddedElement = false;
+            for (const addedElement of this.addedElements) {
+                if (addedElement.contains(element)) {
+                    isChangeInAddedElement = true;
+                    break;
+                }
+            }
+
+            if (isChangeInAddedElement) {
+                continue;
+            }
+
+            switch (mutation.type) {
+                case 'childList':
+                    this.handleChildListMutation(mutation);
+                    break;
+                case 'attributes':
+                    if (!handledAttributeMutations.has(element)) {
+                        handledAttributeMutations.set(element, []);
+                    }
+
+                    // only process the first attribute mutation: it will have the
+                    // true original value, and we'll look at the true new value
+                    if (!(handledAttributeMutations.get(element) as string[]).includes(mutation.attributeName as string)) {
+                        this.handleAttributeMutation(mutation);
+
+                        // add this attribute to the list of handled attributes
+                        handledAttributeMutations.set(
+                            element, [
+                                ...handledAttributeMutations.get(element) as string[],
+                                mutation.attributeName as string
+                            ])
+                        ;
+                    }
+                    break;
+            }
+        }
+    }
+
+    private handleChildListMutation(mutation: MutationRecord): void {
+        // note: we currently ignore removed nodes: if a node is removed
+        // by external code, it will be added back on re-render. Hide
+        // elements instead of removing them.
+        // TODO: at least handle removing previously-added nodes
+
+        mutation.addedNodes.forEach((node) => {
+            if (!(node instanceof Element)) {
+                return;
+            }
+
+            if (this.removedElements.includes(node)) {
+                // this node was removed then added back, so no net change
+                this.removedElements.splice(this.removedElements.indexOf(node), 1);
+
+                return;
+            }
+
+            this.addedElements.push(node);
+        });
+
+        mutation.removedNodes.forEach((node) => {
+            if (!(node instanceof Element)) {
+                return;
+            }
+
+            if (this.addedElements.includes(node)) {
+                // this node was added then removed, so no net change
+                this.addedElements.splice(this.addedElements.indexOf(node), 1);
+
+                return;
+            }
+
+            this.removedElements.push(node);
+        });
+    }
+
+    private handleAttributeMutation(mutation: MutationRecord):void {
+        const element = mutation.target as Element;
+
+        if (!this.changedElements.has(element)) {
+            this.changedElements.set(element, new ElementChanges());
+            this.changedElementsCount++;
+        }
+        const changedElement = this.changedElements.get(element) as ElementChanges;
+
+        switch (mutation.attributeName) {
+            case 'class':
+                this.handleClassAttributeMutation(mutation, changedElement);
+                break;
+            case 'style':
+                this.handleStyleAttributeMutation(mutation, changedElement);
+                break;
+            default:
+                this.handleGenericAttributeMutation(mutation, changedElement);
+        }
+
+        if (changedElement.isEmpty()) {
+            this.changedElements.delete(element);
+            this.changedElementsCount--;
+        }
+    }
+
+    private handleClassAttributeMutation(mutation: MutationRecord, elementChanges: ElementChanges) {
+        const element = mutation.target as Element;
+
+        const previousValue = mutation.oldValue;
+        const previousValues = previousValue ? previousValue.split(' ') : [];
+        previousValues.forEach((value, index) => {
+            const trimmedValue = value.trim();
+            if (trimmedValue !== '') {
+                previousValues[index] = trimmedValue;
+            } else {
+                previousValues.splice(index, 1);
+            }
+        });
+
+        const newValues: string[] = [].slice.call(element.classList);
+        const addedValues = newValues.filter((value) => !previousValues.includes(value));
+        const removedValues = previousValues.filter((value) => !newValues.includes(value));
+
+        addedValues.forEach((value) => {
+            elementChanges.addClass(value);
+        });
+        removedValues.forEach((value) => {
+            elementChanges.removeClass(value);
+        });
+    }
+
+    private handleStyleAttributeMutation(mutation: MutationRecord, elementChanges: ElementChanges) {
+        const element = mutation.target as Element;
+
+        const previousValue = mutation.oldValue || '';
+        const previousStyles = this.extractStyles(previousValue);
+
+        const newValue = element.getAttribute('style') || '';
+        const newStyles = this.extractStyles(newValue);
+
+        const addedOrChangedStyles = Object.keys(newStyles).filter((key) => previousStyles[key] === undefined || previousStyles[key] !== newStyles[key]);
+        const removedStyles = Object.keys(previousStyles).filter((key) => !newStyles[key]);
+
+        addedOrChangedStyles.forEach((style) => {
+            elementChanges.addStyle(
+                style,
+                newStyles[style],
+                previousStyles[style] === undefined ? null : previousStyles[style]
+            );
+        });
+
+        removedStyles.forEach((style) => {
+            elementChanges.removeStyle(
+                style,
+                previousStyles[style]
+            );
+        });
+    }
+
+    private handleGenericAttributeMutation(mutation: MutationRecord, elementChanges: ElementChanges) {
+        const attributeName = mutation.attributeName as string;
+        const element = mutation.target as Element;
+
+        let oldValue = mutation.oldValue;
+        let newValue = element.getAttribute(attributeName) as string;
+        // try to normalize situations like: disabled="disabled"
+        // we don't want the value "disabled" and *no* value to be seen as a change
+        if (oldValue === attributeName) {
+            oldValue = '';
+        }
+        if (newValue === attributeName) {
+            newValue = '';
+        }
+
+        if (!element.hasAttribute(attributeName)) {
+            if (oldValue === null) {
+                // null means the attribute was added, but since it's
+                // not present currently, it was likely later removed
+                // inside this same set of mutations. So, do nothing
+                return;
+            }
+
+            elementChanges.removeAttribute(
+                attributeName,
+                mutation.oldValue as string
+            );
+
+            return;
+        }
+
+        if (newValue === oldValue) {
+            // the attribute was changed, but it matches its current value
+            // likely the value was changed, then changed back all within
+            // the same set of mutations. So, do nothing
+            return;
+        }
+
+        elementChanges.addAttribute(
+            attributeName,
+            element.getAttribute(attributeName) as string,
+            mutation.oldValue
+        );
+    }
+
+    private extractStyles(styles: string): { [key: string]: string } {
+        const styleObject: { [key: string]: string } = {};
+        styles.split(';').forEach((style) => {
+            // split on the first ":" only
+            const parts = style.split(':');
+            // skip invalid styles (likely just whitespace)
+            if (parts.length === 1) {
+                return;
+            }
+
+            const property = parts[0].trim();
+            styleObject[property] = parts.slice(1).join(':').trim();
+        });
+
+        return styleObject;
+    }
+}

--- a/src/LiveComponent/assets/test/Rendering/ChangingItemsTracker.test.ts
+++ b/src/LiveComponent/assets/test/Rendering/ChangingItemsTracker.test.ts
@@ -1,0 +1,88 @@
+import ChangingItemsTracker from '../../src/Rendering/ChangingItemsTracker';
+
+describe('ChangingItemsTracker', () => {
+    it('tracks style change red -> blue -> green', async () => {
+        // red -> blue -> green
+        const items = new ChangingItemsTracker();
+        items.setItem('color', 'blue', 'red');
+        items.setItem('color', 'green', 'blue');
+        expect(items.getChangedItems()).toHaveLength(1);
+        expect(items.getChangedItems()[0]).toEqual({ name: 'color', value: 'green'});
+        expect(items.getRemovedItems()).toHaveLength(0);
+    });
+
+    it('tracks style additions', async () => {
+        const items = new ChangingItemsTracker();
+        items.setItem('color', 'blue', null);
+        items.setItem('color', 'green', 'blue');
+        expect(items.getChangedItems()).toHaveLength(1);
+        expect(items.getChangedItems()[0]).toEqual({ name: 'color', value: 'green'});
+        expect(items.getRemovedItems()).toHaveLength(0);
+    });
+
+    it('tracks style additions then removals', async () => {
+        const items = new ChangingItemsTracker();
+        items.setItem('color', 'blue', null);
+        items.setItem('color', 'green', 'blue');
+        items.removeItem('color', 'green');
+        expect(items.getChangedItems()).toHaveLength(0);
+        // the item was NOT originally present (shown by its "null" as the
+        // previous value in the first setItem() call), so it should not be
+        // included in the list of removed items
+        expect(items.getRemovedItems()).toHaveLength(0);
+    });
+
+    it('tracks style change red -> blue -> red', async () => {
+        const changes = new ChangingItemsTracker();
+        changes.setItem('color', 'blue', 'red');
+        changes.setItem('color', 'red', 'blue');
+        expect(changes.getChangedItems()).toHaveLength(0);
+        expect(changes.getRemovedItems()).toHaveLength(0);
+    });
+
+    it('tracks style change red -> blue -> REMOVED', async () => {
+        const changes = new ChangingItemsTracker();
+        changes.setItem('color', 'blue', 'red');
+        changes.removeItem('color', 'blue');
+        expect(changes.getChangedItems()).toHaveLength(0);
+        expect(changes.getRemovedItems()).toHaveLength(1);
+        expect(changes.getRemovedItems()).toContain('color');
+    });
+
+    it('tracks style removal', async () => {
+        const changes = new ChangingItemsTracker();
+        changes.removeItem('color', 'red');
+        expect(changes.getChangedItems()).toHaveLength(0);
+        expect(changes.getRemovedItems()).toHaveLength(1);
+        expect(changes.getRemovedItems()).toContain('color');
+    });
+
+    it('tracks removal and setting back to original value: red -> blue -> REMOVED -> red', async () => {
+        const changes = new ChangingItemsTracker();
+        changes.setItem('color', 'blue', 'red');
+        changes.removeItem('color', 'blue');
+        changes.setItem('color', 'red', null);
+        expect(changes.getChangedItems()).toHaveLength(0);
+        expect(changes.getRemovedItems()).toHaveLength(0);
+    });
+
+    it('tracks removal and setting back to original when attribute was already present', async () => {
+        const changes = new ChangingItemsTracker();
+        changes.removeItem('color', 'red');
+        changes.setItem('color', 'red', null);
+        expect(changes.getChangedItems()).toHaveLength(0);
+        expect(changes.getRemovedItems()).toHaveLength(0);
+    });
+
+    it('tracks boolean attribute change', async () => {
+        const changes = new ChangingItemsTracker();
+        // both added and were not present before
+        changes.setItem('checked', '', null);
+        changes.setItem('required', '', null);
+        changes.removeItem('required', '');
+        expect(changes.getChangedItems()).toHaveLength(1);
+        expect(changes.getChangedItems()).toContainEqual({ name: 'checked', value: '' });
+        // this attribute was not originally present
+        expect(changes.getRemovedItems()).toHaveLength(0);
+    });
+});

--- a/src/LiveComponent/assets/test/Rendering/ElementChanges.test.ts
+++ b/src/LiveComponent/assets/test/Rendering/ElementChanges.test.ts
@@ -1,0 +1,76 @@
+import ElementChanges from '../../src/Rendering/ElementChanges';
+
+describe('ElementChanges', () => {
+    it('tracks class additions and removals', async () => {
+        const changes = new ElementChanges();
+        changes.addClass('new-class1');
+
+        changes.addClass('new-class2');
+        changes.removeClass('new-class2');
+
+        changes.addClass('new-class3');
+        changes.removeClass('removed-class')
+
+        expect(changes.getAddedClasses()).toHaveLength(2);
+        expect(changes.getAddedClasses()).toContain('new-class1');
+        expect(changes.getAddedClasses()).toContain('new-class3');
+        expect(changes.getRemovedClasses()).toHaveLength(1);
+        expect(changes.getRemovedClasses()).toContain('removed-class');
+    });
+
+    it('tracks style additions and removals', async () => {
+        // red -> blue -> green
+        const changes = new ElementChanges();
+        changes.addStyle('color', 'blue', 'red');
+        changes.addStyle('color', 'green', 'blue');
+
+        changes.addStyle('display', 'none', null);
+
+        changes.removeStyle('margin', '10px');
+
+        expect(changes.getChangedStyles()).toHaveLength(2);
+        expect(changes.getChangedStyles()).toContainEqual({ name: 'color', value: 'green'});
+        expect(changes.getChangedStyles()).toContainEqual({ name: 'display', value: 'none'});
+        expect(changes.getRemovedStyles()).toHaveLength(1);
+        expect(changes.getRemovedStyles()).toContain('margin');
+    });
+
+    it('tracks attribute additions and removals', async () => {
+        const changes = new ElementChanges();
+        // bar -> baz -> qux
+        changes.addAttribute('data-foo', 'baz', 'bar');
+        changes.addAttribute('data-foo', 'qux', 'baz');
+
+        changes.addAttribute('align', 'none', 'block');
+
+        changes.removeAttribute('data-bar', 'some-bar-balue');
+
+        // added, then removed
+        changes.addAttribute('disabled', '', null);
+        changes.removeAttribute('disabled', '');
+
+        expect(changes.getChangedAttributes()).toHaveLength(2);
+        expect(changes.getChangedAttributes()).toContainEqual({ name: 'data-foo', value: 'qux'});
+        expect(changes.getChangedAttributes()).toContainEqual({ name: 'align', value: 'none'});
+        expect(changes.getRemovedAttributes()).toHaveLength(1);
+        expect(changes.getRemovedAttributes()).toContain('data-bar');
+    });
+
+    it('will apply changes to an element', async () => {
+        const element = document.createElement('div');
+        element.className = 'original-class';
+        element.style.color = 'red';
+        element.setAttribute('data-foo', 'bar');
+
+        const changes = new ElementChanges();
+        changes.addClass('new-class');
+        changes.addStyle('color', 'blue', 'red');
+        changes.addAttribute('data-foo', 'baz', 'bar');
+
+        changes.applyToElement(element);
+
+        expect(element.className).toBe('original-class new-class');
+        expect(element.style.color).toBe('blue');
+        expect(element.getAttribute('data-foo')).toBe('baz');
+    });
+});

--- a/src/LiveComponent/assets/test/Rendering/ExternalMutationTracker.test.ts
+++ b/src/LiveComponent/assets/test/Rendering/ExternalMutationTracker.test.ts
@@ -1,0 +1,221 @@
+import ExternalMutationTracker from '../../src/Rendering/ExternalMutationTracker';
+import { htmlToElement } from '../../src/dom_utils';
+
+const mountElement = (html: string): HTMLElement => {
+    const element = htmlToElement(html);
+    document.body.innerHTML = '';
+    document.body.appendChild(element);
+
+    return element;
+}
+
+const createTracker = (html: string): { element: HTMLElement, tracker: ExternalMutationTracker } => {
+    const element = mountElement(html);
+    const tracker = new ExternalMutationTracker(element, () => true);
+    tracker.start();
+
+    return { element, tracker };
+}
+
+/*
+ * This is a hack to get around the fact that MutationObserver doesn't fire synchronously.
+ */
+const shortTimeout = (): Promise<void> => {
+    return new Promise((resolve) => {
+        setTimeout(resolve, 10);
+    });
+}
+
+describe('ExternalMutationTracker', () => {
+    it('can track generic attribute changes', async () => {
+        const { element, tracker } = createTracker(`
+            <div id="original-id" title="I'm a div!" data-changing="original">Text inside!</div>
+        `)
+
+        // change x2
+        element.setAttribute('id', 'middle-id');
+        element.setAttribute('id', 'new-id');
+        // add new
+        element.setAttribute('data-foo', 'bar');
+        // remove
+        element.removeAttribute('title');
+        // add then remove
+        element.setAttribute('disabled', '');
+        element.removeAttribute('disabled');
+        // change, then change back
+        element.setAttribute('data-changing', 'changed');
+        element.setAttribute('data-changing', 'original');
+        // throw some unrelated changes in there
+        element.innerHTML = 'New text! <span>And a span!</span>';
+        await shortTimeout();
+
+        expect(tracker.changedElementsCount).toBe(1);
+        const changes = tracker.getChangedElement(element);
+        if (!changes) {
+            throw new Error('Expected changes to be present');
+        }
+
+        expect(changes.getAddedClasses()).toHaveLength(0);
+        expect(changes.getRemovedClasses()).toHaveLength(0);
+        expect(changes.getChangedStyles()).toHaveLength(0);
+        expect(changes.getRemovedStyles()).toHaveLength(0);
+        expect(changes.getChangedAttributes()).toEqual([
+            { name: 'id', value: 'new-id' },
+            { name: 'data-foo', value: 'bar' },
+        ]);
+        expect(changes.getRemovedAttributes()).toEqual(['title']);
+    });
+
+    it('can track style changes', async () => {
+        const { element, tracker } = createTracker(`
+            <div id="original-id" style="display: none; margin: 10px; flex-basis: auto">Text inside!</div>
+        `)
+
+        // change x2
+        element.style.display = 'block';
+        element.style.display = 'inline';
+        // add new
+        element.style.color = 'red';
+        // add new with a ":" in it
+        element.style.backgroundImage = 'url(https://example.com/image.png)';
+        // remove
+        element.style.removeProperty('margin');
+        // add then remove
+        element.style.setProperty('padding', '10px');
+        element.style.removeProperty('padding');
+        // change, then change back
+        element.style.flexBasis = 'length';
+        element.style.flexBasis = 'auto';
+        await shortTimeout();
+
+        const changes = tracker.getChangedElement(element);
+        if (!changes) {
+            throw new Error('Expected changes to be present');
+        }
+        expect(changes.getAddedClasses()).toHaveLength(0);
+        expect(changes.getRemovedClasses()).toHaveLength(0);
+        expect(changes.getChangedAttributes()).toHaveLength(0);
+        expect(changes.getRemovedAttributes()).toHaveLength(0);
+
+        expect(changes.getChangedStyles()).toEqual([
+            { name: 'display', value: 'inline' },
+            { name: 'color', value: 'red' },
+            { name: 'background-image', value: 'url(https://example.com/image.png)' },
+        ]);
+        expect(changes.getRemovedStyles()).toEqual(['margin']);
+    });
+
+    it('can track class changes', async () => {
+        const { element, tracker } = createTracker(`
+            <div class="first-class second-class">Text inside!</div>
+        `)
+
+        // remove then add back
+        element.classList.remove('second-class');
+        element.classList.add('second-class');
+        // add new (with some whitespace to be sneaky)
+        element.setAttribute('class', ` ${element.getAttribute('class')} new-class `)
+        // remove
+        element.classList.remove('first-class');
+        // add then remove
+        element.classList.add('tmp-class');
+        element.classList.remove('tmp-class');
+        await shortTimeout();
+
+        const changes = tracker.getChangedElement(element);
+        if (!changes) {
+            throw new Error('Expected changes to be present');
+        }
+        expect(changes.getChangedStyles()).toHaveLength(0);
+        expect(changes.getRemovedStyles()).toHaveLength(0);
+        expect(changes.getChangedAttributes()).toHaveLength(0);
+        expect(changes.getRemovedAttributes()).toHaveLength(0);
+
+        expect(changes.getAddedClasses()).toEqual(['new-class']);
+        expect(changes.getRemovedClasses()).toEqual(['first-class']);
+    });
+
+    it('can track added element', async () => {
+        const { element, tracker } = createTracker(`
+            <div>
+                Text inside!
+                <span id="original-span1">the span 1</span>
+                <span id="original-span2">the span 2</span>
+            </div>
+        `)
+
+        const span1 = document.getElementById('original-span1') as HTMLElement;
+        const span2 = document.getElementById('original-span2') as HTMLElement;
+
+        // remove then add back
+        element.removeChild(span1);
+        element.appendChild(span1);
+        // add new
+        element.appendChild(htmlToElement('<span id="new-span">the new span</span>'));
+        // remove
+        element.removeChild(span2);
+        // add then remove
+        const tmpSpan = htmlToElement('<span id="tmp-span">the tmp span</span>');
+        element.appendChild(tmpSpan);
+        element.removeChild(tmpSpan);
+        await shortTimeout();
+
+        const addedElements = tracker.getAddedElements();
+        expect(addedElements).toHaveLength(1);
+        expect(addedElements[0]).toBe(document.getElementById('new-span'));
+    });
+
+    it('ignores changes inside added elements', async () => {
+        const { element, tracker } = createTracker(`
+           <div>Text inside!</div>
+       `);
+
+        const span = document.createElement('span');
+        element.appendChild(span);
+        await shortTimeout();
+
+        expect(tracker.getAddedElements()).toHaveLength(1);
+
+        // just a sanity check to make sure we're tracking
+        element.classList.add('new-class');
+        span.classList.add('new-span-class');
+        span.setAttribute('disabled', '');
+        span.appendChild(document.createElement('div'));
+        await shortTimeout();
+
+        // still just 1 element added
+        expect(tracker.getAddedElements()).toHaveLength(1);
+        expect(tracker.changedElementsCount).toBe(1);
+        expect(tracker.getChangedElement(element)).not.toBeNull()
+    });
+
+    it('ignores changes based on the callback', async () => {
+        const element = mountElement(`
+            <div>Text inside</div>
+        `);
+        // callback now always returns false
+        const tracker = new ExternalMutationTracker(element, () => false);
+        tracker.start();
+
+        const span = document.createElement('span');
+        element.appendChild(span);
+        element.classList.add('new-class');
+
+        await shortTimeout();
+
+        // all changes are ignored
+        expect(tracker.getAddedElements()).toHaveLength(0);
+        expect(tracker.changedElementsCount).toBe(0);
+    });
+
+    it('ignores disabled -> disabled="disabled" non-changes', async () => {
+        const { element, tracker } = createTracker(`
+           <button disabled>Text inside!</button>
+       `);
+
+        element.setAttribute('disabled', 'disabled');
+        await shortTimeout();
+
+        expect(tracker.changedElementsCount).toBe(0);
+    });
+});

--- a/src/LiveComponent/assets/test/controller/render-with-external-changes.test.ts
+++ b/src/LiveComponent/assets/test/controller/render-with-external-changes.test.ts
@@ -1,0 +1,191 @@
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+'use strict';
+
+import { shutdownTests, createTest, initComponent } from '../tools';
+import { getByTestId } from '@testing-library/dom';
+import { htmlToElement } from '../../src/dom_utils';
+
+describe('LiveController rendering with external changes tests', () => {
+    afterEach(() => {
+        shutdownTests();
+    })
+
+    it('will respect attribute changes to a tracked element', async () => {
+        const test = await createTest({ id: 'element-id', isDisabled: false, bonusClass: '', margin: '10px' }, (data: any) => `
+            <div ${initComponent(data)}>
+                <button
+                    data-testid="the-button"
+                    ${data.isDisabled ? 'disabled' : ''}
+                    class="originalclass1 originalclass2 ${data.bonusClass}"
+                    style="margin: ${data.margin}; background-color: red; border-radius: 5px"
+                    title="original title"
+                    id="${data.id}"
+                >I'm a button!</button>
+            </div>
+        `);
+
+        // mess with the elements
+        const button = getByTestId(test.element, 'the-button') as HTMLButtonElement;
+        // add a new attribute
+        button.setAttribute('data-foo', 'bar');
+        // remove an attribute
+        button.removeAttribute('title');
+        // change an attribute that will also be changed on the server
+        button.setAttribute('id', 'changed-externally');
+        // add a new class
+        button.classList.add('externally-added-class');
+        // remove a class
+        button.classList.remove('originalclass2');
+        // change a style
+        button.style.backgroundColor = 'blue';
+        // add a new style
+        button.style.setProperty('padding', '10px');
+        // remove a style
+        button.style.removeProperty('border-radius');
+
+        test.expectsAjaxCall()
+            .serverWillChangeProps((data: any) => {
+                // change the data on the server so the template renders differently
+                data.isDisabled = true;
+                data.bonusClass = 'class-added-by-server';
+                data.margin = '20px';
+                data.id = 'will-be-ignored'
+            });
+
+        await test.component.render();
+
+        const expectedButton = htmlToElement(`
+            <button
+                data-testid="the-button"
+                class="originalclass1 class-added-by-server externally-added-class"
+                style="margin: 20px; background-color: blue; padding: 10px;"
+                id="changed-externally"
+                data-foo="bar"
+                disabled=""
+            >I'm a button!</button>
+        `);
+        expect(test.element.innerHTML.trim()).toBe(expectedButton.outerHTML);
+    });
+
+    it('will not remove an added element', async () => {
+        const test = await createTest({ withBonusElement: false }, (data: any) => `
+            <div ${initComponent(data)}>
+                <div data-testid="inner-div">
+                    Text inside the div
+                    ${data.withBonusElement ? '<div class="bonus-element">Bonus element</div>' : ''}
+                </div>
+            </div>
+        `);
+
+        // add a new element directly inside the root element
+        test.element.appendChild(htmlToElement('<div class="added-outside-element">Added outside element</div>'));
+        const innerDiv = getByTestId(test.element, 'inner-div');
+        // append a new element inside the inner div
+        innerDiv.appendChild(htmlToElement('<div class="added-inside-element-append">Added inside element append</div>'));
+        // prepend a new element inside the inner div
+        innerDiv.prepend(htmlToElement('<div class="added-inside-element-prepend">Added inside element prepend</div>'));
+
+        test.expectsAjaxCall()
+            .serverWillChangeProps((data: any) => {
+                data.withBonusElement = true;
+            });
+
+        await test.component.render();
+
+        // original child + new appended element
+        expect(test.element.children.length).toBe(2);
+        // first child still the innerDiv
+        expect(test.element.children[0]).toBe(innerDiv);
+        // second child is the new added-outside-element
+        expect(test.element.children[1].classList.contains('added-outside-element')).toBe(true);
+
+        // inner div has 5 children: 3 elements + 2 text nodes
+        expect(innerDiv.childNodes.length).toBe(5);
+        expect(innerDiv.childElementCount).toBe(3);
+        // (1) added-inside-element-prepend
+        expect(innerDiv.childNodes[0]).toBe(innerDiv.children[0]);
+        expect(innerDiv.children[0].classList.contains('added-inside-element-prepend')).toBe(true);
+        // (2) Original text inside the div - check that it's a text node
+        expect(innerDiv.childNodes[4].nodeType).toBe(3);
+        expect((innerDiv.childNodes[1].textContent as string).trim()).toBe('Text inside the div');
+        // (3) added-inside-element-append
+        expect(innerDiv.childNodes[2]).toBe(innerDiv.children[1]);
+        expect(innerDiv.children[1].classList.contains('added-inside-element-append')).toBe(true);
+        // (4) bonus-element
+        expect(innerDiv.childNodes[3]).toBe(innerDiv.children[2]);
+        expect(innerDiv.children[2].classList.contains('bonus-element')).toBe(true);
+        // (5) ending whitespace - check that it's a text node
+        expect(innerDiv.childNodes[4].nodeType).toBe(3);
+        expect((innerDiv.childNodes[4].textContent as string).trim()).toBe('');
+    });
+
+    it('keeps external changes across multiple renders', async () => {
+        const test = await createTest({ isDisabled: false, bonusClass: '', withBonusElement: false }, (data: any) => `
+           <div ${initComponent(data)}>
+               <button
+                   data-testid='the-button'
+                   ${data.isDisabled ? 'disabled' : ''}
+                   class='originalclass1 originalclass2 ${data.bonusClass}'
+               >I'm a button!</button>
+               ${data.withBonusElement ? '<div class="bonus-element">Bonus element</div>' : ''}
+           </div>
+       `);
+
+        // mess with the button
+        const button = getByTestId(test.element, 'the-button') as HTMLButtonElement;
+        button.setAttribute('data-foo', 'bar');
+        const addedOutsideElement = htmlToElement('<div class="added-outside-element">Added outside element</div>');
+        test.element.appendChild(addedOutsideElement);
+
+        test.expectsAjaxCall()
+            .serverWillChangeProps((data: any) => {
+                data.isDisabled = true;
+                data.withBonusElement = true;
+            });
+
+        await test.component.render();
+
+        // make sure the changes are still there
+        expect(button.getAttribute('data-foo')).toBe('bar');
+        expect(test.element).toContainElement(addedOutsideElement);
+        expect(test.element.innerHTML).toContain('Bonus element');
+
+        // make some more changes
+        button.classList.add('externally-added-class');
+        button.classList.remove('originalclass2');
+        const secondAddedOutsideElement = htmlToElement('<div class="added-outside-element-2">Added outside element 2</div>');
+        test.element.appendChild(secondAddedOutsideElement);
+        addedOutsideElement.classList.add('class-added-later');
+
+        test.expectsAjaxCall()
+            .serverWillChangeProps((data: any) => {
+                data.bonusClass = 'class-added-by-server';
+                data.withBonusElement = false;
+            });
+
+        await test.component.render();
+
+        // make sure the changes are still there
+        expect(button.getAttribute('data-foo')).toBe('bar');
+        expect(button.classList.contains('externally-added-class')).toBe(true);
+        expect(button.classList.contains('originalclass2')).toBe(false);
+        expect(button.classList.contains('class-added-by-server')).toBe(true);
+        // make sure the new elements are still there
+        expect(test.element).toContainElement(addedOutsideElement);
+        expect(addedOutsideElement.classList.contains('class-added-later')).toBe(true);
+        expect(test.element).toContainElement(secondAddedOutsideElement);
+
+        // bonus element change from server is gone
+        // this verifies that server changes are not being tracked as "external"
+        expect(test.element.innerHTML).not.toContain('Bonus element');
+    });
+});
+

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2204,19 +2204,47 @@ To fix this, add a unique ``data-live-id`` attribute to the root component of ea
 child element. This will helps LiveComponent identify each item in the
 list and correctly determine if a re-render is necessary, or not.
 
+Advanced Functionality
+----------------------
+
+.. _`smart-rerender-algorithm`:
+
+The Smart Re-Render Algorithm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a component re-renders, the new HTML if "morphed" onto the existing
+elements on the page. For example, if the re-render includes a new ``class``
+on an existing element, that class will be added to that element.
+
+The rendering system is also smart enough to know when an element was changed
+by something *outside* of the LiveComponents system: e.g. some JavaScript
+that added a class to an element. In this case, the class will be preserved
+when the component re-renders.
+
+The system doesn't handle every edge case, so here are some things to keep in mind:
+
+* If JavaScript changes an attribute on an element, that change is **preserved**.
+* If JavaScript adds a new element, that element is **preserved**.
+* If JavaScript removes an element that was originally rendered by the component,
+    that change will be **lost**: the element will be re-added during the next re-render.
+* If JavaScript changes the text of an element, that change is **lost**: it will
+    be restored to the text from the server during the next re-render.
+* If an element is moved from one location in the component to another,
+    that change is **lost**: the element will be re-added in its original location
+    during the next re-render.
+
 Skipping Updating Certain Elements
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sometimes you may have an element inside a component that you do *not* want to
-change whenever your component re-renders. For example, some elements managed by
-third-party JavaScript or a form element that is not bound to a model... where you
-don't want a re-render to reset the data the user has entered.
-
-To handle this, add the ``data-live-ignore`` attribute to the element:
+If you have an element inside a component that you do *not* want to change
+when your component re-renders, you can add a ``data-live-ignore`` attribute:
 
 .. code-block:: html
 
     <input name="favorite_color" data-live-ignore>
+
+But you should need this rarely if ever. Even if you write JavaScript that modifies
+an element, that changes is preserved (see :ref:`smart-rerender-algorithm`).
 
 .. note::
 
@@ -2225,7 +2253,7 @@ To handle this, add the ``data-live-ignore`` attribute to the element:
     of the children of the element will be re-rendered, even those with ``data-live-ignore``.
 
 Define another route for your Component
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.7
 

--- a/ux.symfony.com/src/Controller/LiveComponentDemoController.php
+++ b/ux.symfony.com/src/Controller/LiveComponentDemoController.php
@@ -75,4 +75,12 @@ class LiveComponentDemoController extends AbstractController
             'food' => $foodRepository->findOneBy([]),
         ]);
     }
+
+    #[Route('/chartjs', name: 'app_live_components_demo_chartjs')]
+    public function chartJs(LiveDemoRepository $liveDemoRepository): Response
+    {
+        return $this->render('live_component_demo/chartjs.html.twig', parameters: [
+            'demo' => $liveDemoRepository->find('chartjs_updating'),
+        ]);
+    }
 }

--- a/ux.symfony.com/src/Form/MealPlannerForm.php
+++ b/ux.symfony.com/src/Form/MealPlannerForm.php
@@ -31,6 +31,7 @@ class MealPlannerForm extends AbstractType
         $builder->add('meal', ChoiceType::class, [
             'choices' => $choices,
             'placeholder' => 'Which meal is it?',
+            'autocomplete' => true,
         ]);
 
         $builder->addEventListener(
@@ -67,8 +68,8 @@ class MealPlannerForm extends AbstractType
     private function getAvailableFoodChoices(string $meal): array
     {
         $foods = match ($meal) {
-            self::MEAL_BREAKFAST => ['Eggs 🍳', 'Bacon 🥓', 'Strawberries 🍓', 'Croissant 🥐'],
-            self::MEAL_SECOND_BREAKFAST => ['Bagel 🥯', 'Kiwi 🥝', 'Avocado 🥑', ' Wafles 🧇'],
+            self::MEAL_BREAKFAST => ['Eggs 🍳', 'Bacon 🥓', 'Strawberries 🍓', 'Croissant 🥐', 'Other', 'AnOther'],
+            self::MEAL_SECOND_BREAKFAST => ['Bagel 🥯', 'Kiwi 🥝', 'Avocado 🥑', 'Waffles 🧇'],
             self::MEAL_ELEVENSES => ['Pancakes 🥞', 'Salad 🥙', 'Tea ☕️'],
             self::MEAL_LUNCH => ['Sandwich 🥪', 'Cheese 🧀', 'Sushi 🍱'],
             self::MEAL_DINNER => ['Pizza 🍕', 'A Pint 🍺', 'Pasta 🍝'],
@@ -89,6 +90,7 @@ class MealPlannerForm extends AbstractType
             'disabled' => null === $meal,
             // silence real-time "invalid" message when switching "meals"
             'invalid_message' => false,
+            'autocomplete' => true,
         ]);
     }
 }

--- a/ux.symfony.com/src/Service/DinoStatsService.php
+++ b/ux.symfony.com/src/Service/DinoStatsService.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Service;
+
+class DinoStatsService
+{
+    private ?array $rawData = null;
+
+    private const ALL_DINOS = 'all';
+
+    public static function getAllTypes(): array
+    {
+        return [
+            self::ALL_DINOS,
+            'sauropod',
+            'large theropod',
+            'small theropod',
+            'ceratopsian',
+            'euornithopod',
+            'armoured dinosaur',
+        ];
+    }
+
+    public function fetchData(int $start, int $end, array $types): array
+    {
+        $start = abs($start);
+        $end = abs($end);
+
+        $steps = 10;
+        $step = round(($start - $end) / $steps);
+
+        $labels = [];
+        for ($i = 0; $i < $steps; ++$i) {
+            $current = $start - ($i * $step);
+            // generate a random rgb color
+
+            $labels[] = $current.' mya';
+        }
+
+        $datasets = [];
+
+        foreach ($types as $type) {
+            $color = sprintf('rgb(%d, %d, %d, .4)', mt_rand(0, 255), mt_rand(0, 255), mt_rand(0, 255));
+
+            $datasets[] = [
+                'label' => ucwords($type),
+                'data' => $this->getSpeciesCounts($start, $steps, $step, $type),
+                'borderColor' => $color,
+                'backgroundColor' => $color,
+            ];
+        }
+
+        return [
+            'labels' => $labels,
+            'datasets' => $datasets,
+        ];
+    }
+
+    private function getRawData(): array
+    {
+        if (null === $this->rawData) {
+            $this->rawData = json_decode(file_get_contents(__DIR__.'/data/dino-stats.json'), true);
+        }
+
+        return $this->rawData;
+    }
+
+    private function getSpeciesCounts(int $start, int $steps, int $step, string $type): array
+    {
+        $counts = [];
+        for ($i = 0; $i < $steps; ++$i) {
+            $current = round($start - ($i * $step));
+            $counts[] = $this->countSpeciesAt($current, $type);
+        }
+
+        return $counts;
+    }
+
+    private function countSpeciesAt(int $currentYear, string $type): int
+    {
+        $count = 0;
+        foreach ($this->getRawData() as $dino) {
+            if ((self::ALL_DINOS !== $type) && $dino['type'] !== $type) {
+                continue;
+            }
+
+            if ($dino['from'] >= $currentYear && $dino['to'] <= $currentYear) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/ux.symfony.com/src/Service/LiveDemoRepository.php
+++ b/ux.symfony.com/src/Service/LiveDemoRepository.php
@@ -42,6 +42,12 @@ class LiveDemoRepository
                 description: 'Activate an inline editing form with validation.',
                 route: 'app_live_components_demo_inline_edit',
             ),
+            new LiveDemo(
+                'chartjs_updating',
+                name: 'Auto-Updating Chart',
+                description: 'Render & Update a Chart.js chart in real-time.',
+                route: 'app_live_components_demo_chartjs',
+            ),
         ];
     }
 

--- a/ux.symfony.com/src/Service/data/dino-stats.json
+++ b/ux.symfony.com/src/Service/data/dino-stats.json
@@ -1,0 +1,1856 @@
+[
+    {
+        "name": "aardonyx",
+        "type": "sauropod",
+        "from": "199",
+        "to": "189"
+    },
+    {
+        "name": "abelisaurus",
+        "type": "large theropod",
+        "from": "74",
+        "to": "70"
+    },
+    {
+        "name": "achelousaurus",
+        "type": "ceratopsian",
+        "from": "83",
+        "to": "70"
+    },
+    {
+        "name": "achillobator",
+        "type": "large theropod",
+        "from": "99",
+        "to": "84"
+    },
+    {
+        "name": "acrocanthosaurus",
+        "type": "large theropod",
+        "from": "115",
+        "to": "105"
+    },
+    {
+        "name": "aegyptosaurus",
+        "type": "sauropod",
+        "from": "98",
+        "to": "93"
+    },
+    {
+        "name": "afrovenator",
+        "type": "large theropod",
+        "from": "132",
+        "to": "121"
+    },
+    {
+        "name": "agilisaurus",
+        "type": "euornithopod",
+        "from": "169",
+        "to": "159"
+    },
+    {
+        "name": "alamosaurus",
+        "type": "sauropod",
+        "from": "70",
+        "to": "65"
+    },
+    {
+        "name": "albertaceratops",
+        "type": "ceratopsian",
+        "from": "80",
+        "to": "75"
+    },
+    {
+        "name": "albertosaurus",
+        "type": "large theropod",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "alectrosaurus",
+        "type": "large theropod",
+        "from": "90",
+        "to": "70"
+    },
+    {
+        "name": "alioramus",
+        "type": "large theropod",
+        "from": "71",
+        "to": "65"
+    },
+    {
+        "name": "allosaurus",
+        "type": "large theropod",
+        "from": "156",
+        "to": "144"
+    },
+    {
+        "name": "alvarezsaurus",
+        "type": "small theropod",
+        "from": "89",
+        "to": "85"
+    },
+    {
+        "name": "amargasaurus",
+        "type": "sauropod",
+        "from": "132",
+        "to": "127"
+    },
+    {
+        "name": "ammosaurus",
+        "type": "sauropod",
+        "from": "195",
+        "to": "180"
+    },
+    {
+        "name": "ampelosaurus",
+        "type": "sauropod",
+        "from": "71",
+        "to": "65"
+    },
+    {
+        "name": "amygdalodon",
+        "type": "sauropod",
+        "from": "177",
+        "to": "169"
+    },
+    {
+        "name": "anchiceratops",
+        "type": "ceratopsian",
+        "from": "74",
+        "to": "70"
+    },
+    {
+        "name": "anchisaurus",
+        "type": "sauropod",
+        "from": "190",
+        "to": 185
+    },
+    {
+        "name": "ankylosaurus",
+        "type": "armoured dinosaur",
+        "from": "74",
+        "to": "67"
+    },
+    {
+        "name": "anserimimus",
+        "type": "large theropod",
+        "from": "84",
+        "to": "65"
+    },
+    {
+        "name": "antarctosaurus",
+        "type": "sauropod",
+        "from": "84",
+        "to": "65"
+    },
+    {
+        "name": "apatosaurus",
+        "type": "sauropod",
+        "from": "154",
+        "to": "145"
+    },
+    {
+        "name": "aragosaurus",
+        "type": "sauropod",
+        "from": "132",
+        "to": "121"
+    },
+    {
+        "name": "aralosaurus",
+        "type": "euornithopod",
+        "from": "94",
+        "to": "84"
+    },
+    {
+        "name": "archaeoceratops",
+        "type": "ceratopsian",
+        "from": "121",
+        "to": "99"
+    },
+    {
+        "name": "archaeopteryx",
+        "type": "small theropod",
+        "from": "147",
+        "to": 142
+    },
+    {
+        "name": "archaeornithomimus",
+        "type": "small theropod",
+        "from": "95",
+        "to": "70"
+    },
+    {
+        "name": "argentinosaurus",
+        "type": "sauropod",
+        "from": "90",
+        "to": 85
+    },
+    {
+        "name": "arrhinoceratops",
+        "type": "ceratopsian",
+        "from": "72",
+        "to": "67"
+    },
+    {
+        "name": "atlascopcosaurus",
+        "type": "euornithopod",
+        "from": "121",
+        "to": "97"
+    },
+    {
+        "name": "aucasaurus",
+        "type": "large theropod",
+        "from": "84",
+        "to": "71"
+    },
+    {
+        "name": "austrosaurus",
+        "type": "sauropod",
+        "from": "112",
+        "to": "99"
+    },
+    {
+        "name": "avaceratops",
+        "type": "ceratopsian",
+        "from": "80",
+        "to": "75"
+    },
+    {
+        "name": "avimimus",
+        "type": "small theropod",
+        "from": "80",
+        "to": "75"
+    },
+    {
+        "name": "bactrosaurus",
+        "type": "euornithopod",
+        "from": "84",
+        "to": "71"
+    },
+    {
+        "name": "bagaceratops",
+        "type": "ceratopsian",
+        "from": "85",
+        "to": "80"
+    },
+    {
+        "name": "bambiraptor",
+        "type": "small theropod",
+        "from": "84",
+        "to": "71"
+    },
+    {
+        "name": "barapasaurus",
+        "type": "sauropod",
+        "from": "185",
+        "to": "170"
+    },
+    {
+        "name": "barosaurus",
+        "type": "sauropod",
+        "from": "155",
+        "to": "145"
+    },
+    {
+        "name": "baryonyx",
+        "type": "large theropod",
+        "from": "125",
+        "to": 120
+    },
+    {
+        "name": "becklespinax",
+        "type": "large theropod",
+        "from": "142",
+        "to": "132"
+    },
+    {
+        "name": "beipiaosaurus",
+        "type": "small theropod",
+        "from": "127",
+        "to": "121"
+    },
+    {
+        "name": "bellusaurus",
+        "type": "sauropod",
+        "from": "180",
+        "to": "159"
+    },
+    {
+        "name": "borogovia",
+        "type": "small theropod",
+        "from": "84",
+        "to": "65"
+    },
+    {
+        "name": "brachiosaurus",
+        "type": "sauropod",
+        "from": "155",
+        "to": "140"
+    },
+    {
+        "name": "brachylophosaurus",
+        "type": "euornithopod",
+        "from": "89",
+        "to": "88"
+    },
+    {
+        "name": "brachytrachelopan",
+        "type": "sauropod",
+        "from": "150",
+        "to": 145
+    },
+    {
+        "name": "buitreraptor",
+        "type": "small theropod",
+        "from": "99",
+        "to": "90"
+    },
+    {
+        "name": "camarasaurus",
+        "type": "sauropod",
+        "from": "150",
+        "to": "140"
+    },
+    {
+        "name": "camptosaurus",
+        "type": "euornithopod",
+        "from": "155",
+        "to": "145"
+    },
+    {
+        "name": "carcharodontosaurus",
+        "type": "large theropod",
+        "from": "98",
+        "to": "94"
+    },
+    {
+        "name": "carnotaurus",
+        "type": "large theropod",
+        "from": "70",
+        "to": 65
+    },
+    {
+        "name": "caudipteryx",
+        "type": "small theropod",
+        "from": "125",
+        "to": "122"
+    },
+    {
+        "name": "cedarpelta",
+        "type": "armoured dinosaur",
+        "from": "142",
+        "to": "127"
+    },
+    {
+        "name": "centrosaurus",
+        "type": "ceratopsian",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "ceratosaurus",
+        "type": "large theropod",
+        "from": "153",
+        "to": "148"
+    },
+    {
+        "name": "cetiosauriscus",
+        "type": "sauropod",
+        "from": "175",
+        "to": "160"
+    },
+    {
+        "name": "cetiosaurus",
+        "type": "sauropod",
+        "from": "170",
+        "to": "160"
+    },
+    {
+        "name": "chaoyangsaurus",
+        "type": "ceratopsian",
+        "from": "152",
+        "to": "145"
+    },
+    {
+        "name": "chasmosaurus",
+        "type": "ceratopsian",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "chindesaurus",
+        "type": "small theropod",
+        "from": "227",
+        "to": "210"
+    },
+    {
+        "name": "chinshakiangosaurus",
+        "type": "sauropod",
+        "from": "159",
+        "to": "142"
+    },
+    {
+        "name": "chirostenotes",
+        "type": "small theropod",
+        "from": "79",
+        "to": "67"
+    },
+    {
+        "name": "chubutisaurus",
+        "type": "sauropod",
+        "from": "112",
+        "to": "99"
+    },
+    {
+        "name": "chungkingosaurus",
+        "type": "armoured dinosaur",
+        "from": "159",
+        "to": "142"
+    },
+    {
+        "name": "citipati",
+        "type": "small theropod",
+        "from": "81",
+        "to": "75"
+    },
+    {
+        "name": "coelophysis",
+        "type": "small theropod",
+        "from": "225",
+        "to": "190"
+    },
+    {
+        "name": "coelurus",
+        "type": "small theropod",
+        "from": "155",
+        "to": "145"
+    },
+    {
+        "name": "coloradisaurus",
+        "type": "sauropod",
+        "from": "221",
+        "to": "210"
+    },
+    {
+        "name": "compsognathus",
+        "type": "small theropod",
+        "from": "145",
+        "to": "140"
+    },
+    {
+        "name": "conchoraptor",
+        "type": "small theropod",
+        "from": "81",
+        "to": "76"
+    },
+    {
+        "name": "confuciusornis",
+        "type": "small theropod",
+        "from": "127",
+        "to": "121"
+    },
+    {
+        "name": "corythosaurus",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "cryolophosaurus",
+        "type": "large theropod",
+        "from": "170",
+        "to": 165
+    },
+    {
+        "name": "dacentrurus",
+        "type": "armoured dinosaur",
+        "from": "154",
+        "to": "150"
+    },
+    {
+        "name": "daspletosaurus",
+        "type": "large theropod",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "datousaurus",
+        "type": "sauropod",
+        "from": "170",
+        "to": 165
+    },
+    {
+        "name": "deinocheirus",
+        "type": "large theropod",
+        "from": "70",
+        "to": "66"
+    },
+    {
+        "name": "deinonychus",
+        "type": "small theropod",
+        "from": "120",
+        "to": "110"
+    },
+    {
+        "name": "deltadromeus",
+        "type": "large theropod",
+        "from": "99",
+        "to": "94"
+    },
+    {
+        "name": "dicraeosaurus",
+        "type": "sauropod",
+        "from": "150",
+        "to": "135"
+    },
+    {
+        "name": "dilophosaurus",
+        "type": "large theropod",
+        "from": "190",
+        "to": 185
+    },
+    {
+        "name": "diplodocus",
+        "type": "sauropod",
+        "from": "155",
+        "to": "145"
+    },
+    {
+        "name": "dromaeosaurus",
+        "type": "small theropod",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "dromiceiomimus",
+        "type": "large theropod",
+        "from": "74",
+        "to": "70"
+    },
+    {
+        "name": "dryosaurus",
+        "type": "euornithopod",
+        "from": "155",
+        "to": "140"
+    },
+    {
+        "name": "dryptosaurus",
+        "type": "large theropod",
+        "from": "84",
+        "to": "65"
+    },
+    {
+        "name": "dubreuillosaurus",
+        "type": "large theropod",
+        "from": "169",
+        "to": "164"
+    },
+    {
+        "name": "edmontonia",
+        "type": "armoured dinosaur",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "edmontosaurus",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "65"
+    },
+    {
+        "name": "einiosaurus",
+        "type": "ceratopsian",
+        "from": "74",
+        "to": 69
+    },
+    {
+        "name": "elaphrosaurus",
+        "type": "large theropod",
+        "from": "154",
+        "to": "151"
+    },
+    {
+        "name": "emausaurus",
+        "type": "armoured dinosaur",
+        "from": "190",
+        "to": "180"
+    },
+    {
+        "name": "eolambia",
+        "type": "euornithopod",
+        "from": "99",
+        "to": "94"
+    },
+    {
+        "name": "eoraptor",
+        "type": "small theropod",
+        "from": "228",
+        "to": 223
+    },
+    {
+        "name": "eotyrannus",
+        "type": "large theropod",
+        "from": "127",
+        "to": "121"
+    },
+    {
+        "name": "equijubus",
+        "type": "euornithopod",
+        "from": "127",
+        "to": "99"
+    },
+    {
+        "name": "erketu",
+        "type": "sauropod",
+        "from": 145,
+        "to": 135
+    },
+    {
+        "name": "erlikosaurus",
+        "type": "small theropod",
+        "from": "99",
+        "to": "89"
+    },
+    {
+        "name": "euhelopus",
+        "type": "sauropod",
+        "from": "154",
+        "to": "142"
+    },
+    {
+        "name": "euoplocephalus",
+        "type": "armoured dinosaur",
+        "from": "76",
+        "to": "70"
+    },
+    {
+        "name": "europasaurus",
+        "type": "sauropod",
+        "from": "154",
+        "to": "151"
+    },
+    {
+        "name": "eustreptospondylus",
+        "type": "large theropod",
+        "from": "165",
+        "to": 160
+    },
+    {
+        "name": "fukuiraptor",
+        "type": "large theropod",
+        "from": "121",
+        "to": "99"
+    },
+    {
+        "name": "fukuisaurus",
+        "type": "euornithopod",
+        "from": "121",
+        "to": "99"
+    },
+    {
+        "name": "gallimimus",
+        "type": "large theropod",
+        "from": "74",
+        "to": "70"
+    },
+    {
+        "name": "gargoyleosaurus",
+        "type": "armoured dinosaur",
+        "from": "154",
+        "to": "142"
+    },
+    {
+        "name": "garudimimus",
+        "type": "large theropod",
+        "from": "99",
+        "to": "89"
+    },
+    {
+        "name": "gasosaurus",
+        "type": "small theropod",
+        "from": "170",
+        "to": "160"
+    },
+    {
+        "name": "gasparinisaura",
+        "type": "euornithopod",
+        "from": "86",
+        "to": "71"
+    },
+    {
+        "name": "gastonia",
+        "type": "armoured dinosaur",
+        "from": "142",
+        "to": "127"
+    },
+    {
+        "name": "giganotosaurus",
+        "type": "large theropod",
+        "from": "112",
+        "to": "90"
+    },
+    {
+        "name": "gilmoreosaurus",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "70"
+    },
+    {
+        "name": "giraffatitan",
+        "type": "sauropod",
+        "from": "154",
+        "to": "142"
+    },
+    {
+        "name": "gobisaurus",
+        "type": "armoured dinosaur",
+        "from": "121",
+        "to": "99"
+    },
+    {
+        "name": "gorgosaurus",
+        "type": "large theropod",
+        "from": "80",
+        "to": "73"
+    },
+    {
+        "name": "goyocephale",
+        "type": "large theropod",
+        "from": "81",
+        "to": "75"
+    },
+    {
+        "name": "graciliceratops",
+        "type": "ceratopsian",
+        "from": "99",
+        "to": "84"
+    },
+    {
+        "name": "gryposaurus",
+        "type": "euornithopod",
+        "from": "86",
+        "to": "71"
+    },
+    {
+        "name": "guaibasaurus",
+        "type": "small theropod",
+        "from": "221",
+        "to": "210"
+    },
+    {
+        "name": "guanlong",
+        "type": "small theropod",
+        "from": "159",
+        "to": "154"
+    },
+    {
+        "name": "hadrosaurus",
+        "type": "euornithopod",
+        "from": "78",
+        "to": "74"
+    },
+    {
+        "name": "hagryphus",
+        "type": "small theropod",
+        "from": "76",
+        "to": 71
+    },
+    {
+        "name": "haplocanthosaurus",
+        "type": "sauropod",
+        "from": "154",
+        "to": "142"
+    },
+    {
+        "name": "harpymimus",
+        "type": "small theropod",
+        "from": "121",
+        "to": "99"
+    },
+    {
+        "name": "herrerasaurus",
+        "type": "small theropod",
+        "from": "228",
+        "to": 223
+    },
+    {
+        "name": "hesperosaurus",
+        "type": "armoured dinosaur",
+        "from": "154",
+        "to": "142"
+    },
+    {
+        "name": "heterodontosaurus",
+        "type": "euornithopod",
+        "from": "205",
+        "to": 200
+    },
+    {
+        "name": "heyuannia",
+        "type": "small theropod",
+        "from": "72",
+        "to": "68"
+    },
+    {
+        "name": "homalocephale",
+        "type": "euornithopod",
+        "from": "72",
+        "to": "68"
+    },
+    {
+        "name": "huayangosaurus",
+        "type": "armoured dinosaur",
+        "from": "170",
+        "to": "160"
+    },
+    {
+        "name": "hylaeosaurus",
+        "type": "armoured dinosaur",
+        "from": "150",
+        "to": "135"
+    },
+    {
+        "name": "hypacrosaurus",
+        "type": "euornithopod",
+        "from": "70",
+        "to": 65
+    },
+    {
+        "name": "hypsilophodon",
+        "type": "euornithopod",
+        "from": "125",
+        "to": 120
+    },
+    {
+        "name": "iguanodon",
+        "type": "euornithopod",
+        "from": "140",
+        "to": "110"
+    },
+    {
+        "name": "indosuchus",
+        "type": "large theropod",
+        "from": "71",
+        "to": "65"
+    },
+    {
+        "name": "irritator",
+        "type": "large theropod",
+        "from": "112",
+        "to": "99"
+    },
+    {
+        "name": "isisaurus",
+        "type": "sauropod",
+        "from": "71",
+        "to": "65"
+    },
+    {
+        "name": "janenschia",
+        "type": "sauropod",
+        "from": "154",
+        "to": "151"
+    },
+    {
+        "name": "jaxartosaurus",
+        "type": "euornithopod",
+        "from": "94",
+        "to": "84"
+    },
+    {
+        "name": "jingshanosaurus",
+        "type": "sauropod",
+        "from": "205",
+        "to": "190"
+    },
+    {
+        "name": "jinzhousaurus",
+        "type": "euornithopod",
+        "from": "127",
+        "to": "121"
+    },
+    {
+        "name": "jobaria",
+        "type": "sauropod",
+        "from": "132",
+        "to": "94"
+    },
+    {
+        "name": "juravenator",
+        "type": "small theropod",
+        "from": "154",
+        "to": "151"
+    },
+    {
+        "name": "kentrosaurus",
+        "type": "armoured dinosaur",
+        "from": "155",
+        "to": "150"
+    },
+    {
+        "name": "khaan",
+        "type": "small theropod",
+        "from": "81",
+        "to": "75"
+    },
+    {
+        "name": "kotasaurus",
+        "type": "sauropod",
+        "from": "205",
+        "to": "180"
+    },
+    {
+        "name": "kritosaurus",
+        "type": "euornithopod",
+        "from": "78",
+        "to": "74"
+    },
+    {
+        "name": "lambeosaurus",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "lapparentosaurus",
+        "type": "sauropod",
+        "from": "169",
+        "to": "164"
+    },
+    {
+        "name": "leaellynasaura",
+        "type": "euornithopod",
+        "from": "115",
+        "to": "110"
+    },
+    {
+        "name": "leptoceratops",
+        "type": "ceratopsian",
+        "from": "67",
+        "to": "65"
+    },
+    {
+        "name": "lesothosaurus",
+        "type": "euornithopod",
+        "from": "213",
+        "to": "200"
+    },
+    {
+        "name": "liaoceratops",
+        "type": "ceratopsian",
+        "from": "127",
+        "to": "121"
+    },
+    {
+        "name": "ligabuesaurus",
+        "type": "sauropod",
+        "from": "121",
+        "to": "99"
+    },
+    {
+        "name": "liliensternus",
+        "type": "small theropod",
+        "from": "205",
+        "to": "202"
+    },
+    {
+        "name": "lophorhothon",
+        "type": "euornithopod",
+        "from": "84",
+        "to": "71"
+    },
+    {
+        "name": "lophostropheus",
+        "type": "large theropod",
+        "from": "203",
+        "to": "196"
+    },
+    {
+        "name": "lufengosaurus",
+        "type": "sauropod",
+        "from": "200",
+        "to": "195"
+    },
+    {
+        "name": "lurdusaurus",
+        "type": "euornithopod",
+        "from": "121",
+        "to": "112"
+    },
+    {
+        "name": "lycorhinus",
+        "type": "euornithopod",
+        "from": "205",
+        "to": "195"
+    },
+    {
+        "name": "magyarosaurus",
+        "type": "sauropod",
+        "from": "71",
+        "to": "65"
+    },
+    {
+        "name": "maiasaura",
+        "type": "euornithopod",
+        "from": "80",
+        "to": "75"
+    },
+    {
+        "name": "majungasaurus",
+        "type": "large theropod",
+        "from": "84",
+        "to": "71"
+    },
+    {
+        "name": "malawisaurus",
+        "type": "sauropod",
+        "from": "121",
+        "to": "112"
+    },
+    {
+        "name": "mamenchisaurus",
+        "type": "sauropod",
+        "from": "155",
+        "to": "145"
+    },
+    {
+        "name": "mapusaurus",
+        "type": "large theropod",
+        "from": "99",
+        "to": "94"
+    },
+    {
+        "name": "marshosaurus",
+        "type": "large theropod",
+        "from": "154",
+        "to": "142"
+    },
+    {
+        "name": "masiakasaurus",
+        "type": "small theropod",
+        "from": "84",
+        "to": "71"
+    },
+    {
+        "name": "massospondylus",
+        "type": "sauropod",
+        "from": "208",
+        "to": "204"
+    },
+    {
+        "name": "maxakalisaurus",
+        "type": "sauropod",
+        "from": "80",
+        "to": 75
+    },
+    {
+        "name": "megalosaurus",
+        "type": "large theropod",
+        "from": "170",
+        "to": "155"
+    },
+    {
+        "name": "melanorosaurus",
+        "type": "sauropod",
+        "from": "227",
+        "to": "221"
+    },
+    {
+        "name": "metriacanthosaurus",
+        "type": "large theropod",
+        "from": "159",
+        "to": "154"
+    },
+    {
+        "name": "microceratus",
+        "type": "ceratopsian",
+        "from": "86",
+        "to": "66"
+    },
+    {
+        "name": "micropachycephalosaurus",
+        "type": "ceratopsian",
+        "from": "84",
+        "to": "71"
+    },
+    {
+        "name": "microraptor",
+        "type": "small theropod",
+        "from": "125",
+        "to": "122"
+    },
+    {
+        "name": "minmi",
+        "type": "armoured dinosaur",
+        "from": "121",
+        "to": "112"
+    },
+    {
+        "name": "monolophosaurus",
+        "type": "large theropod",
+        "from": "180",
+        "to": "159"
+    },
+    {
+        "name": "mononykus",
+        "type": "small theropod",
+        "from": "81",
+        "to": "68"
+    },
+    {
+        "name": "mussaurus",
+        "type": "sauropod",
+        "from": "221",
+        "to": "210"
+    },
+    {
+        "name": "muttaburrasaurus",
+        "type": "euornithopod",
+        "from": "110",
+        "to": "100"
+    },
+    {
+        "name": "nanshiungosaurus",
+        "type": "large theropod",
+        "from": "84",
+        "to": "71"
+    },
+    {
+        "name": "nedoceratops",
+        "type": "ceratopsian",
+        "from": "67",
+        "to": "65"
+    },
+    {
+        "name": "nemegtosaurus",
+        "type": "sauropod",
+        "from": "72",
+        "to": "68"
+    },
+    {
+        "name": "neovenator",
+        "type": "large theropod",
+        "from": "127",
+        "to": "121"
+    },
+    {
+        "name": "neuquenosaurus",
+        "type": "sauropod",
+        "from": "71",
+        "to": "65"
+    },
+    {
+        "name": "nigersaurus",
+        "type": "sauropod",
+        "from": "121",
+        "to": "99"
+    },
+    {
+        "name": "nipponosaurus",
+        "type": "euornithopod",
+        "from": "89",
+        "to": "84"
+    },
+    {
+        "name": "noasaurus",
+        "type": "small theropod",
+        "from": "84",
+        "to": "65"
+    },
+    {
+        "name": "nodosaurus",
+        "type": "armoured dinosaur",
+        "from": "110",
+        "to": "100"
+    },
+    {
+        "name": "nomingia",
+        "type": "small theropod",
+        "from": "72",
+        "to": "68"
+    },
+    {
+        "name": "nothronychus",
+        "type": "large theropod",
+        "from": "94",
+        "to": "89"
+    },
+    {
+        "name": "nqwebasaurus",
+        "type": "small theropod",
+        "from": "159",
+        "to": "132"
+    },
+    {
+        "name": "omeisaurus",
+        "type": "sauropod",
+        "from": "169",
+        "to": "159"
+    },
+    {
+        "name": "opisthocoelicaudia",
+        "type": "sauropod",
+        "from": "72",
+        "to": "68"
+    },
+    {
+        "name": "ornitholestes",
+        "type": "small theropod",
+        "from": "150",
+        "to": "144"
+    },
+    {
+        "name": "ornithomimus",
+        "type": "large theropod",
+        "from": "74",
+        "to": "65"
+    },
+    {
+        "name": "orodromeus",
+        "type": "euornithopod",
+        "from": "74",
+        "to": 69
+    },
+    {
+        "name": "oryctodromeus",
+        "type": "euornithopod",
+        "from": "99",
+        "to": "94"
+    },
+    {
+        "name": "othnielia",
+        "type": "euornithopod",
+        "from": "154",
+        "to": "142"
+    },
+    {
+        "name": "ouranosaurus",
+        "type": "euornithopod",
+        "from": "115",
+        "to": "100"
+    },
+    {
+        "name": "oviraptor",
+        "type": "small theropod",
+        "from": "85",
+        "to": "75"
+    },
+    {
+        "name": "pachycephalosaurus",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "65"
+    },
+    {
+        "name": "pachyrhinosaurus",
+        "type": "ceratopsian",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "panoplosaurus",
+        "type": "armoured dinosaur",
+        "from": "79",
+        "to": "75"
+    },
+    {
+        "name": "pantydraco",
+        "type": "euornithopod",
+        "from": 199,
+        "to": 189
+    },
+    {
+        "name": "paralititan",
+        "type": "sauropod",
+        "from": "99",
+        "to": "94"
+    },
+    {
+        "name": "parasaurolophus",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "parksosaurus",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "patagosaurus",
+        "type": "sauropod",
+        "from": "164",
+        "to": "159"
+    },
+    {
+        "name": "pelicanimimus",
+        "type": "small theropod",
+        "from": "127",
+        "to": "121"
+    },
+    {
+        "name": "pelorosaurus",
+        "type": "sauropod",
+        "from": "125",
+        "to": 120
+    },
+    {
+        "name": "pentaceratops",
+        "type": "ceratopsian",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "piatnitzkysaurus",
+        "type": "large theropod",
+        "from": "164",
+        "to": "159"
+    },
+    {
+        "name": "pinacosaurus",
+        "type": "armoured dinosaur",
+        "from": "81",
+        "to": "75"
+    },
+    {
+        "name": "plateosaurus",
+        "type": "sauropod",
+        "from": "210",
+        "to": 205
+    },
+    {
+        "name": "podokesaurus",
+        "type": "small theropod",
+        "from": "195",
+        "to": "180"
+    },
+    {
+        "name": "poekilopleuron",
+        "type": "large theropod",
+        "from": "169",
+        "to": "164"
+    },
+    {
+        "name": "polacanthus",
+        "type": "armoured dinosaur",
+        "from": "125",
+        "to": 120
+    },
+    {
+        "name": "prenocephale",
+        "type": "euornithopod",
+        "from": "80",
+        "to": "65"
+    },
+    {
+        "name": "probactrosaurus",
+        "type": "euornithopod",
+        "from": "121",
+        "to": "99"
+    },
+    {
+        "name": "proceratosaurus",
+        "type": "small theropod",
+        "from": "169",
+        "to": "164"
+    },
+    {
+        "name": "procompsognathus",
+        "type": "small theropod",
+        "from": "221",
+        "to": "210"
+    },
+    {
+        "name": "prosaurolophus",
+        "type": "euornithopod",
+        "from": "77",
+        "to": "75"
+    },
+    {
+        "name": "protarchaeopteryx",
+        "type": "small theropod",
+        "from": "122",
+        "to": "120"
+    },
+    {
+        "name": "protoceratops",
+        "type": "ceratopsian",
+        "from": "74",
+        "to": "70"
+    },
+    {
+        "name": "protohadros",
+        "type": "euornithopod",
+        "from": "99",
+        "to": "94"
+    },
+    {
+        "name": "psittacosaurus",
+        "type": "ceratopsian",
+        "from": "120",
+        "to": "100"
+    },
+    {
+        "name": "quaesitosaurus",
+        "type": "sauropod",
+        "from": "86",
+        "to": "84"
+    },
+    {
+        "name": "rebbachisaurus",
+        "type": "sauropod",
+        "from": "112",
+        "to": "99"
+    },
+    {
+        "name": "rhabdodon",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "70"
+    },
+    {
+        "name": "rhoetosaurus",
+        "type": "sauropod",
+        "from": "177",
+        "to": "169"
+    },
+    {
+        "name": "rinchenia",
+        "type": "small theropod",
+        "from": "72",
+        "to": "68"
+    },
+    {
+        "name": "riojasaurus",
+        "type": "sauropod",
+        "from": "221",
+        "to": "210"
+    },
+    {
+        "name": "rugops",
+        "type": "large theropod",
+        "from": "95",
+        "to": 90
+    },
+    {
+        "name": "saichania",
+        "type": "armoured dinosaur",
+        "from": "80",
+        "to": 75
+    },
+    {
+        "name": "saltasaurus",
+        "type": "sauropod",
+        "from": "70",
+        "to": "65"
+    },
+    {
+        "name": "saltopus",
+        "type": "small theropod",
+        "from": "221",
+        "to": "210"
+    },
+    {
+        "name": "sarcosaurus",
+        "type": "small theropod",
+        "from": "202",
+        "to": "195"
+    },
+    {
+        "name": "saurolophus",
+        "type": "euornithopod",
+        "from": "74",
+        "to": "70"
+    },
+    {
+        "name": "sauropelta",
+        "type": "armoured dinosaur",
+        "from": "121",
+        "to": "94"
+    },
+    {
+        "name": "saurophaganax",
+        "type": "large theropod",
+        "from": "154",
+        "to": "142"
+    },
+    {
+        "name": "saurornithoides",
+        "type": "small theropod",
+        "from": "85",
+        "to": "80"
+    },
+    {
+        "name": "scelidosaurus",
+        "type": "armoured dinosaur",
+        "from": "208",
+        "to": "194"
+    },
+    {
+        "name": "scutellosaurus",
+        "type": "armoured dinosaur",
+        "from": "205",
+        "to": "202"
+    },
+    {
+        "name": "secernosaurus",
+        "type": "euornithopod",
+        "from": "71",
+        "to": "65"
+    },
+    {
+        "name": "segisaurus",
+        "type": "small theropod",
+        "from": "195",
+        "to": "180"
+    },
+    {
+        "name": "segnosaurus",
+        "type": "large theropod",
+        "from": "97",
+        "to": "88"
+    },
+    {
+        "name": "shamosaurus",
+        "type": "armoured dinosaur",
+        "from": "121",
+        "to": "99"
+    },
+    {
+        "name": "shanag",
+        "type": "small theropod",
+        "from": "126",
+        "to": "142"
+    },
+    {
+        "name": "shantungosaurus",
+        "type": "euornithopod",
+        "from": "78",
+        "to": "74"
+    },
+    {
+        "name": "shunosaurus",
+        "type": "sauropod",
+        "from": "170",
+        "to": "160"
+    },
+    {
+        "name": "shuvuuia",
+        "type": "small theropod",
+        "from": "75",
+        "to": "81"
+    },
+    {
+        "name": "silvisaurus",
+        "type": "armoured dinosaur",
+        "from": "121",
+        "to": "112"
+    },
+    {
+        "name": "sinocalliopteryx",
+        "type": "small theropod",
+        "from": "125",
+        "to": 120
+    },
+    {
+        "name": "sinornithosaurus",
+        "type": "small theropod",
+        "from": "122",
+        "to": "120"
+    },
+    {
+        "name": "sinosauropteryx",
+        "type": "small theropod",
+        "from": "122",
+        "to": "120"
+    },
+    {
+        "name": "sinovenator",
+        "type": "small theropod",
+        "from": "127",
+        "to": "121"
+    },
+    {
+        "name": "sinraptor",
+        "type": "large theropod",
+        "from": "169",
+        "to": "142"
+    },
+    {
+        "name": "sonidosaurus",
+        "type": "sauropod",
+        "from": "89",
+        "to": "65"
+    },
+    {
+        "name": "spinosaurus",
+        "type": "large theropod",
+        "from": "95",
+        "to": "70"
+    },
+    {
+        "name": "staurikosaurus",
+        "type": "large theropod",
+        "from": "227",
+        "to": "221"
+    },
+    {
+        "name": "stegoceras",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "stegosaurus",
+        "type": "armoured dinosaur",
+        "from": "155",
+        "to": "145"
+    },
+    {
+        "name": "stenopelix",
+        "type": "ceratopsian",
+        "from": "127",
+        "to": "121"
+    },
+    {
+        "name": "struthiomimus",
+        "type": "small theropod",
+        "from": "76",
+        "to": "74"
+    },
+    {
+        "name": "struthiosaurus",
+        "type": "armoured dinosaur",
+        "from": "83",
+        "to": "75"
+    },
+    {
+        "name": "styracosaurus",
+        "type": "ceratopsian",
+        "from": "76",
+        "to": "70"
+    },
+    {
+        "name": "suchomimus",
+        "type": "large theropod",
+        "from": "121",
+        "to": "112"
+    },
+    {
+        "name": "supersaurus",
+        "type": "sauropod",
+        "from": "154",
+        "to": "142"
+    },
+    {
+        "name": "talarurus",
+        "type": "armoured dinosaur",
+        "from": "99",
+        "to": "89"
+    },
+    {
+        "name": "tanius",
+        "type": "euornithopod",
+        "from": "89",
+        "to": "65"
+    },
+    {
+        "name": "tarbosaurus",
+        "type": "large theropod",
+        "from": "74",
+        "to": "70"
+    },
+    {
+        "name": "tarchia",
+        "type": "armoured dinosaur",
+        "from": "75",
+        "to": "68"
+    },
+    {
+        "name": "telmatosaurus",
+        "type": "euornithopod",
+        "from": "84",
+        "to": "65"
+    },
+    {
+        "name": "tenontosaurus",
+        "type": "euornithopod",
+        "from": "120",
+        "to": "110"
+    },
+    {
+        "name": "thecodontosaurus",
+        "type": "sauropod",
+        "from": "227",
+        "to": "205"
+    },
+    {
+        "name": "therizinosaurus",
+        "type": "large theropod",
+        "from": "85",
+        "to": "70"
+    },
+    {
+        "name": "thescelosaurus",
+        "type": "euornithopod",
+        "from": "76",
+        "to": "67"
+    },
+    {
+        "name": "torosaurus",
+        "type": "ceratopsian",
+        "from": "70",
+        "to": "65"
+    },
+    {
+        "name": "torvosaurus",
+        "type": "large theropod",
+        "from": "155",
+        "to": "144"
+    },
+    {
+        "name": "triceratops",
+        "type": "ceratopsian",
+        "from": "68",
+        "to": "66"
+    },
+    {
+        "name": "troodon",
+        "type": "small theropod",
+        "from": "74",
+        "to": "65"
+    },
+    {
+        "name": "tsagantegia",
+        "type": "armoured dinosaur",
+        "from": "99",
+        "to": "84"
+    },
+    {
+        "name": "tsintaosaurus",
+        "type": "euornithopod",
+        "from": "84",
+        "to": "71"
+    },
+    {
+        "name": "tuojiangosaurus",
+        "type": "armoured dinosaur",
+        "from": "157",
+        "to": "154"
+    },
+    {
+        "name": "tylocephale",
+        "type": "euornithopod",
+        "from": "75",
+        "to": "72"
+    },
+    {
+        "name": "tyrannosaurus",
+        "type": "large theropod",
+        "from": "68",
+        "to": "66"
+    },
+    {
+        "name": "udanoceratops",
+        "type": "ceratopsian",
+        "from": "81",
+        "to": "75"
+    },
+    {
+        "name": "unenlagia",
+        "type": "small theropod",
+        "from": "94",
+        "to": "86"
+    },
+    {
+        "name": "urbacodon",
+        "type": "small theropod",
+        "from": "95",
+        "to": 90
+    },
+    {
+        "name": "utahraptor",
+        "type": "large theropod",
+        "from": "112",
+        "to": "100"
+    },
+    {
+        "name": "valdosaurus",
+        "type": "euornithopod",
+        "from": "142",
+        "to": "121"
+    },
+    {
+        "name": "velociraptor",
+        "type": "small theropod",
+        "from": "74",
+        "to": "70"
+    },
+    {
+        "name": "vulcanodon",
+        "type": "sauropod",
+        "from": "205",
+        "to": "202"
+    },
+    {
+        "name": "yandusaurus",
+        "type": "euornithopod",
+        "from": "169",
+        "to": "159"
+    },
+    {
+        "name": "yangchuanosaurus",
+        "type": "large theropod",
+        "from": "160",
+        "to": "144"
+    },
+    {
+        "name": "yimenosaurus",
+        "type": "sauropod",
+        "from": "195",
+        "to": "190"
+    },
+    {
+        "name": "yingshanosaurus",
+        "type": "armoured dinosaur",
+        "from": "159",
+        "to": "142"
+    },
+    {
+        "name": "yinlong",
+        "type": "ceratopsian",
+        "from": "159",
+        "to": "154"
+    },
+    {
+        "name": "yuanmousaurus",
+        "type": "sauropod",
+        "from": "180",
+        "to": "159"
+    },
+    {
+        "name": "yunnanosaurus",
+        "type": "sauropod",
+        "from": "205",
+        "to": "190"
+    },
+    {
+        "name": "zalmoxes",
+        "type": "euornithopod",
+        "from": "69",
+        "to": 64
+    },
+    {
+        "name": "zephyrosaurus",
+        "type": "euornithopod",
+        "from": "120",
+        "to": "110"
+    },
+    {
+        "name": "zuniceratops",
+        "type": "ceratopsian",
+        "from": "94",
+        "to": "89"
+    }
+]

--- a/ux.symfony.com/src/Twig/DinoChartComponent.php
+++ b/ux.symfony.com/src/Twig/DinoChartComponent.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Twig;
+
+use App\Service\DinoStatsService;
+use Symfony\UX\Chartjs\Builder\ChartBuilderInterface;
+use Symfony\UX\Chartjs\Model\Chart;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+
+#[AsLiveComponent('dino_chart')]
+class DinoChartComponent
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)]
+    public array $currentTypes = ['all', 'large theropod', 'small theropod'];
+
+    #[LiveProp(writable: true)]
+    public int $fromYear = -200;
+    #[LiveProp(writable: true)]
+    public int $toYear = -65;
+
+    public function __construct(
+        private DinoStatsService $dinoStatsService,
+        private ChartBuilderInterface $chartBuilder,
+    ) {
+    }
+
+    #[ExposeInTemplate]
+    public function getChart(): Chart
+    {
+        $chart = $this->chartBuilder->createChart(Chart::TYPE_LINE);
+        $chart->setData($this->dinoStatsService->fetchData(
+            $this->fromYear,
+            $this->toYear,
+            $this->currentTypes
+        ));
+
+        $chart->setOptions([
+            // set title plugin
+            'plugins' => [
+                'title' => [
+                    'display' => true,
+                    'text' => sprintf(
+                        'Dinos specie count from %dmya to %dmya',
+                        abs($this->fromYear),
+                        abs($this->toYear)
+                    ),
+                ],
+            ],
+            'maintainAspectRatio' => false,
+        ]);
+
+        return $chart;
+    }
+
+    #[ExposeInTemplate]
+    public function allTypes(): array
+    {
+        return DinoStatsService::getAllTypes();
+    }
+}

--- a/ux.symfony.com/templates/components/dino_chart.html.twig
+++ b/ux.symfony.com/templates/components/dino_chart.html.twig
@@ -1,0 +1,53 @@
+<div {{ attributes }}>
+    <div class="row">
+        <div class="col-2">
+            <label for="fromYear" class="form-label">
+                From: <code><small>({{ fromYear|abs }} mya)</small></code>
+            </label>
+            <input
+                type="range"
+                class="form-range"
+                id="fromYear"
+                data-model="fromYear"
+                min="-200"
+                max="{{ toYear }}"
+            >
+        </div>
+
+        <div class="col-2">
+            <label for="toYear" class="form-label">
+                To: <code><small>({{ toYear|abs }} mya)</small></code>
+            </label>
+            <input
+                type="range"
+                class="form-range"
+                id="toYear"
+                data-model="toYear"
+                min="{{ fromYear }}"
+                max="-65"
+            >
+        </div>
+
+        <div class="col-8">
+            <label for="dinoTypes" class="form-label">Choose Dino Types</label>
+            <select
+                data-model="currentTypes"
+                multiple
+                id="dinoTypes"
+                {{ stimulus_controller('symfony/ux-autocomplete/autocomplete') }}
+            >
+                {% for type in allTypes %}
+                    <option value="{{ type }}">{{ type }}</option>
+                {% endfor %}
+            </select>
+        </div>
+    </div>
+
+    <hr>
+
+    <div style="min-height: 400px;">
+        {{ render_chart(chart) }}
+    </div>
+
+    <small>Source: <a href="https://www.nhm.ac.uk/">National History Museum</a> courtesy of https://github.com/kjanjua26/jurassic-park</small>
+</div>

--- a/ux.symfony.com/templates/live_component_demo/chartjs.html.twig
+++ b/ux.symfony.com/templates/live_component_demo/chartjs.html.twig
@@ -1,0 +1,21 @@
+{% extends 'liveDemoBase.html.twig' %}
+
+{% block code_block_left %}
+    {% component code_block with { filename: 'src/Twig/DinoChartComponent.php', height: '400px' } %}
+        {% block content %}
+            {{- source('@src/Twig/DinoChartComponent.php')|cleanup_php_file -}}
+        {% endblock %}
+    {% endcomponent %}
+{% endblock %}
+
+{% block code_block_right %}
+    {% component code_block with { filename: 'templates/components/dino_chart.html.twig', height: '400px' } %}
+        {% block content %}
+            {{- source('components/dino_chart.html.twig') -}}
+        {% endblock %}
+    {% endcomponent %}
+{% endblock %}
+
+{% block demo_content %}
+    {{ component('dino_chart') }}
+{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yesish
| New feature?  | yes
| Tickets       | Fixes #702, Fixes #490, Fixes #515, Fixes #270, Fixes Bug H on https://github.com/symfony/ux/issues/102, Fixes #354 Replaces #519
| License       | MIT

Hi!

This fixes the biggest pain-point with LiveComponents: mixing them with custom JavaScript. Before this PR, a lot of things were difficult/weird: keeping modals open, collapsing content (#702), using JS widgets like Autocomplete or a date picker, and more. The best part? Everything works automatically with you needing to do anything.

With this PR, a new philosophy is born: **start with a live component, then mix in any "extras" you want with Stimulus controllers**.

The new "smart rendering" system isn't designed to catch everything (see the docs), but I think it will catch 95%+ of the situations. Here are 2 cool things that now work out-of-the-box:

A) ux-autocomplete + Live components works perfectly now - even if the available options completely change - the "dependent form fields" example has been updated to use autocomplete on both fields 🔥 

https://user-images.githubusercontent.com/121003/224790239-3b723fa0-1eb7-4f27-bd71-a04bf32687f1.mp4

B) I added a new demo of Live Components + Autocomplete + Chartjs. What you see is done without needing to write any JavaScript:

https://user-images.githubusercontent.com/121003/224789304-ac1228a8-57eb-4797-8df0-245bd767872b.mp4

### How Does it Work?

If you care about the technical details, we leverage a `MutationObserver` to watch your component for changes made by anything *other* than live components. Those changes are "tracked". Then, during re-render, we use that info to *keep* those custom changes.

Cheers!