### PR TITLE
Fix misleading PHPDoc

### DIFF
--- a/src/Autocomplete/src/AutocompleteResults.php
+++ b/src/Autocomplete/src/AutocompleteResults.php
@@ -14,7 +14,7 @@ namespace Symfony\UX\Autocomplete;
 final class AutocompleteResults
 {
     /**
-     * @param list<array{label: string, value: mixed}> $results
+     * @param list<array{text: string, value: mixed}> $results
      */
     public function __construct(
         public array $results,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT

As seen in AutocompleteResultsExecutor, keys are value and text.
