### PR TITLE
bumping CHANGELOG for 2.8

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.8.0
+
+-   The autocomplete will now update if any of the `option` elements inside of
+    it change, including the empty / placeholder element. Additionally, if the
+    `select` or `input` element's `disabled` attribute changes, the autocomplete
+    instance will update accordingly. This makes Autocomplete work perfectly inside
+    of a LiveComponent.
+
 ## 2.7.0
 
 -   Add `assets/src` to `.gitattributes` to exclude them from the installation

--- a/src/Chartjs/CHANGELOG.md
+++ b/src/Chartjs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.8.0
+
+-   The chart will now automatically re-render if the `view` Stimulus value
+    (i.e. the `data-symfony--ux-chartjs--chart-view-value` attribute) changes.
+    This makes Chart.js work perfectly inside of a LiveComponent.
+
 ## 2.7.0
 
 -   The `chartjs:connect` JavaScript event now bubbles up.

--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -15,9 +15,25 @@ public User $user;
 
 -   Better support for using arrays with `LiveProp`.
 
+-   Smart rendering system! If you have JavaScript that makes changes to
+    the DOM inside a live component, those changes will now be _kept_ when
+    the component is re-rendered. This has limitations - see the documentation.
+
 -   Added support for setting `writable` to a property that is an object
     (previously, only scalar values were supported). The object is passed
     through the serializer.
+
+-   Invalid data sent by the user is now handled in a robust way. Previously,
+    if the user sent invalid data (e.g. a string for a `LiveProp` that has
+    an `int` type), the component update would break. Now, if the new data
+    cannot be hydrated onto the object during a re-render, the last valid
+    value is used.
+
+-   Several bug fixes to parent - child components - see #700.
+
+-   Fixed handling of boolean attributes to a component - see #710.
+
+-   Fixed performance calculating component fingerprint for large components.
 
 ## 2.7.0
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

2.8 coming soon - a BIG release for live components. Waiting on, at least, #738 so that all the changes can be validated on ux.symfony.com.