### PR TITLE
[Live] Fix nested props persisting

### DIFF
--- a/src/LiveComponent/assets/dist/Component/ElementDriver.d.ts
+++ b/src/LiveComponent/assets/dist/Component/ElementDriver.d.ts
@@ -1,9 +1,6 @@
 export interface ElementDriver {
     getModelName(element: HTMLElement): string | null;
-    getComponentProps(rootElement: HTMLElement): {
-        props: any;
-        nestedProps: any;
-    };
+    getComponentProps(rootElement: HTMLElement): any;
     findChildComponentElement(id: string, element: HTMLElement): HTMLElement | null;
     getKeyFromElement(element: HTMLElement): string | null;
 }

--- a/src/LiveComponent/assets/dist/Component/ValueStore.d.ts
+++ b/src/LiveComponent/assets/dist/Component/ValueStore.d.ts
@@ -1,17 +1,15 @@
 export default class {
     private props;
-    private nestedProps;
     private dirtyProps;
     private pendingProps;
-    constructor(props: any, nestedProps: any);
+    constructor(props: any);
     get(name: string): any;
     has(name: string): boolean;
     set(name: string, value: any): boolean;
     getOriginalProps(): any;
-    getOriginalNestedProps(): any;
     getDirtyProps(): any;
     flushDirtyPropsToPending(): void;
-    reinitializeAllProps(props: any, nestedProps: any): void;
+    reinitializeAllProps(props: any): void;
     pushPendingPropsBackToDirty(): void;
     reinitializeProvidedProps(props: any): boolean;
 }

--- a/src/LiveComponent/assets/dist/Component/index.d.ts
+++ b/src/LiveComponent/assets/dist/Component/index.d.ts
@@ -23,7 +23,7 @@ export default class Component {
     private children;
     private parent;
     private externalMutationTracker;
-    constructor(element: HTMLElement, props: any, nestedProps: any, fingerprint: string | null, id: string | null, backend: BackendInterface, elementDriver: ElementDriver);
+    constructor(element: HTMLElement, props: any, fingerprint: string | null, id: string | null, backend: BackendInterface, elementDriver: ElementDriver);
     _swapBackend(backend: BackendInterface): void;
     addPlugin(plugin: PluginInterface): void;
     connect(): void;

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -16,10 +16,6 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     static values: {
         url: StringConstructor;
         props: ObjectConstructor;
-        nestedProps: {
-            type: ObjectConstructor;
-            default: {};
-        };
         csrf: StringConstructor;
         debounce: {
             type: NumberConstructor;
@@ -30,7 +26,6 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     };
     readonly urlValue: string;
     readonly propsValue: any;
-    readonly nestedPropsValue: any;
     readonly csrfValue: string;
     readonly hasDebounceValue: boolean;
     readonly debounceValue: number;

--- a/src/LiveComponent/assets/src/Component/ElementDriver.ts
+++ b/src/LiveComponent/assets/src/Component/ElementDriver.ts
@@ -3,7 +3,7 @@ import {getModelDirectiveFromElement} from '../dom_utils';
 export interface ElementDriver {
     getModelName(element: HTMLElement): string|null;
 
-    getComponentProps(rootElement: HTMLElement): { props: any, nestedProps: any };
+    getComponentProps(rootElement: HTMLElement): any;
 
     /**
      * Given an HtmlElement and a child id, find the root element for that child.
@@ -29,12 +29,8 @@ export class StandardElementDriver implements ElementDriver {
 
     getComponentProps(rootElement: HTMLElement): any {
         const propsJson = rootElement.dataset.livePropsValue ?? '{}';
-        const nestedPropsJson = rootElement.dataset.liveNestedPropsValue ?? '{}';
 
-        return {
-            props: JSON.parse(propsJson),
-            nestedProps: JSON.parse(nestedPropsJson),
-        }
+        return JSON.parse(propsJson);
     }
 
     findChildComponentElement(id: string, element: HTMLElement): HTMLElement|null {

--- a/src/LiveComponent/assets/src/Component/ValueStore.ts
+++ b/src/LiveComponent/assets/src/Component/ValueStore.ts
@@ -10,13 +10,6 @@ export default class {
     private props: any = {};
 
     /**
-     * A list of extra, nested props added to make them available as models.
-     *
-     * @private
-     */
-    private nestedProps: any = {};
-
-    /**
      * A list of props that have been "dirty" (changed) since the last request to the server.
      */
     private dirtyProps: {[key: string]: any} = {};
@@ -27,9 +20,8 @@ export default class {
      */
     private pendingProps: {[key: string]: any} = {};
 
-    constructor(props: any, nestedProps: any) {
+    constructor(props: any) {
         this.props = props;
-        this.nestedProps = nestedProps;
     }
 
     /**
@@ -50,8 +42,8 @@ export default class {
             return this.pendingProps[normalizedName];
         }
 
-        if (this.nestedProps[normalizedName] !== undefined) {
-            return this.nestedProps[normalizedName];
+        if (this.props[normalizedName] !== undefined) {
+            return this.props[normalizedName];
         }
 
         return getDeepData(this.props, normalizedName);
@@ -86,10 +78,6 @@ export default class {
         return { ...this.props };
     }
 
-    getOriginalNestedProps(): any {
-        return { ...this.nestedProps };
-    }
-
     getDirtyProps(): any {
         return { ...this.dirtyProps };
     }
@@ -105,9 +93,8 @@ export default class {
     /**
      * Called when an update request finishes successfully.
      */
-    reinitializeAllProps(props: any, nestedProps: any): void {
+    reinitializeAllProps(props: any): void {
         this.props = props;
-        this.nestedProps = nestedProps;
         this.pendingProps = {};
     }
 

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -64,20 +64,19 @@ export default class Component {
     /**
      * @param element The root element
      * @param props   Readonly component props
-     * @param nestedProps   Extra nested prop values that can be used as models
      * @param fingerprint
      * @param id      Some unique id to identify this component. Needed to be a child component
      * @param backend Backend instance for updating
      * @param elementDriver Class to get "model" name from any element.
      */
-    constructor(element: HTMLElement, props: any, nestedProps: any, fingerprint: string|null, id: string|null, backend: BackendInterface, elementDriver: ElementDriver) {
+    constructor(element: HTMLElement, props: any, fingerprint: string|null, id: string|null, backend: BackendInterface, elementDriver: ElementDriver) {
         this.element = element;
         this.backend = backend;
         this.elementDriver = elementDriver;
         this.id = id;
         this.fingerprint = fingerprint;
 
-        this.valueStore = new ValueStore(props, nestedProps);
+        this.valueStore = new ValueStore(props);
         this.unsyncedInputsTracker = new UnsyncedInputsTracker(this, elementDriver);
         this.hooks = new HookManager();
         this.resetPromise();
@@ -230,7 +229,7 @@ export default class Component {
      * @param toEl
      */
     updateFromNewElement(toEl: HTMLElement): boolean {
-        const { props } = this.elementDriver.getComponentProps(toEl);
+        const props = this.elementDriver.getComponentProps(toEl);
 
         // if no props are on the element, use the existing element completely
         // this means the parent is signaling that the child does not need to be re-rendered
@@ -399,8 +398,8 @@ export default class Component {
             throw error;
         }
 
-        const { props: newProps, nestedProps: newNestedProps } = this.elementDriver.getComponentProps(newElement);
-        this.valueStore.reinitializeAllProps(newProps, newNestedProps);
+        const newProps = this.elementDriver.getComponentProps(newElement);
+        this.valueStore.reinitializeAllProps(newProps);
 
         // make sure we've processed all external changes before morphing
         this.externalMutationTracker.handlePendingChanges();

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -37,7 +37,6 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     static values = {
         url: String,
         props: Object,
-        nestedProps: { type: Object, default: {} },
         csrf: String,
         debounce: { type: Number, default: 150 },
         id: String,
@@ -46,7 +45,6 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
 
     declare readonly urlValue: string;
     declare readonly propsValue: any;
-    declare readonly nestedPropsValue: any;
     declare readonly csrfValue: string;
     declare readonly hasDebounceValue: boolean;
     declare readonly debounceValue: number;
@@ -72,7 +70,6 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
         this.component = new Component(
             this.element,
             this.propsValue,
-            this.nestedPropsValue,
             this.fingerprintValue,
             id,
             new Backend(this.urlValue, this.csrfValue),

--- a/src/LiveComponent/assets/test/Component/index.test.ts
+++ b/src/LiveComponent/assets/test/Component/index.test.ts
@@ -28,7 +28,6 @@ const makeTestComponent = (): { component: Component, backend: MockBackend } => 
     const component = new Component(
         document.createElement('div'),
         { firstName: '' },
-        {},
         null,
         null,
         backend,

--- a/src/LiveComponent/assets/test/ValueStore.test.ts
+++ b/src/LiveComponent/assets/test/ValueStore.test.ts
@@ -4,13 +4,11 @@ describe('ValueStore', () => {
     const getDataset = [
         {
             props: { firstName: 'Ryan' },
-            nestedProps: {},
             name: 'firstName',
             expected: 'Ryan',
         },
         {
             props: {},
-            nestedProps: {},
             name: 'firstName',
             expected: undefined,
         },
@@ -20,15 +18,12 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
-            nestedProps: {},
             name: 'user.firstName',
             expected: 'Ryan',
         },
         {
             props: {
                 user: 5,
-            },
-            nestedProps: {
                 'user.firstName': 'Ryan',
             },
             name: 'user.firstName',
@@ -37,8 +32,8 @@ describe('ValueStore', () => {
         {
             props: {
                 user: 111,
+                'user.FirstName': 'Ryan'
             },
-            nestedProps: { 'user.FirstName': 'Ryan' },
             name: 'user',
             expected: 111,
         },
@@ -48,7 +43,6 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
-            nestedProps: {},
             name: 'user',
             expected: {
                 firstName: 'Ryan',
@@ -56,13 +50,11 @@ describe('ValueStore', () => {
         },
         {
             props: { firstName: null },
-            nestedProps: {},
             name: 'firstName',
             expected: null,
         },
         {
             props: { firstName: 'Ryan' },
-            nestedProps: {},
             updated: [ { prop: 'firstName', value: 'Kevin' }],
             name: 'firstName',
             expected: 'Kevin',
@@ -73,16 +65,15 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
-            nestedProps: {},
             updated: [ { prop: 'user.firstName', value: 'Kevin' }],
             name: 'user.firstName',
             expected: 'Kevin',
         },
     ];
 
-    getDataset.forEach(({ props, nestedProps, name, expected, updated = [] }) => {
+    getDataset.forEach(({ props, name, expected, updated = [] }) => {
         it(`get("${name}") with data ${JSON.stringify(props)} returns ${JSON.stringify(expected)}`, () => {
-            const store = new ValueStore(props, nestedProps);
+            const store = new ValueStore(props);
             updated.forEach(({ prop, value }) => {
                 store.set(prop, value);
             });
@@ -93,13 +84,11 @@ describe('ValueStore', () => {
     const hasDataset = [
         {
             props: { firstName: 'Ryan' },
-            nestedProps: {},
             name: 'firstName',
             expected: true,
         },
         {
             props: { firstName: 'Ryan' },
-            nestedProps: {},
             name: 'lastName',
             expected: false,
         },
@@ -109,15 +98,14 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
-            nestedProps: {},
             name: 'user.firstName',
             expected: true,
         },
         {
             props: {
                 user: 5,
+                'user.firstName': 'Ryan'
             },
-            nestedProps: { 'user.firstName': 'Ryan' },
             name: 'user.firstName',
             expected: true,
         },
@@ -127,15 +115,14 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
-            nestedProps: {},
             name: 'user.lastName',
             expected: false,
         },
         {
             props: {
                 user: 111,
+                'user.firstName': 'Ryan'
             },
-            nestedProps: { 'user.firstName': 'Ryan'},
             name: 'user',
             expected: true,
         },
@@ -145,21 +132,19 @@ describe('ValueStore', () => {
                     firstName: 'Ryan',
                 },
             },
-            nestedProps: {},
             name: 'user',
             expected: true,
         },
         {
             props: { firstName: null },
-            nestedProps: {},
             name: 'firstName',
             expected: true,
         },
     ];
 
-    hasDataset.forEach(({ props, nestedProps, name, expected }) => {
+    hasDataset.forEach(({ props, name, expected }) => {
         it(`has("${name}") with data ${JSON.stringify(props)} returns ${JSON.stringify(expected)}`, () => {
-            const store = new ValueStore(props, nestedProps);
+            const store = new ValueStore(props);
             expect(store.has(name)).toEqual(expected);
         });
     });
@@ -213,14 +198,14 @@ describe('ValueStore', () => {
 
     setDataset.forEach(({ props, set, to, expected }) => {
         it(`set("${set}", ${JSON.stringify(to)}) with data ${JSON.stringify(props)} results in ${JSON.stringify(expected)}`, () => {
-            const store = new ValueStore(props, {});
+            const store = new ValueStore(props);
             store.set(set, to);
             expect(store.getDirtyProps()).toEqual(expected);
         });
     });
 
     it('correctly tracks pending changes', () => {
-        const store = new ValueStore({ firstName: 'Ryan' }, {});
+        const store = new ValueStore({ firstName: 'Ryan' });
 
         store.set('firstName', 'Kevin');
         store.flushDirtyPropsToPending();
@@ -232,17 +217,17 @@ describe('ValueStore', () => {
 
         // imitate an Ajax success (but the server changes the data)
         store.flushDirtyPropsToPending();
-        store.reinitializeAllProps({ firstName: 'KEVIN' }, {});
+        store.reinitializeAllProps({ firstName: 'KEVIN' });
         expect(store.get('firstName')).toEqual('KEVIN');
 
         // imitate an Ajax success where the value is changed during the request
-        store.reinitializeAllProps({ firstName: 'Ryan' }, {});
+        store.reinitializeAllProps({ firstName: 'Ryan' });
         store.set('firstName', 'Kevin');
         store.flushDirtyPropsToPending();
         store.set('firstName', 'Wouter');
         expect(store.get('firstName')).toEqual('Wouter');
         // ajax call finishes, the props has updated correctly
-        store.reinitializeAllProps({ firstName: 'Kevin' }, {});
+        store.reinitializeAllProps({ firstName: 'Kevin' });
         // the updating state still exists
         expect(store.get('firstName')).toEqual('Wouter');
     });
@@ -251,7 +236,6 @@ describe('ValueStore', () => {
     it('getOriginalProps() returns props', () => {
         const container = new ValueStore(
             { city: 'Grand Rapids', user: 'Kevin', product: 5 },
-            { 'product.name': 'Banana'}
         );
 
         expect(container.getOriginalProps()).toEqual({ city: 'Grand Rapids', user: 'Kevin', product: 5 });
@@ -347,7 +331,7 @@ describe('ValueStore', () => {
     ];
     reinitializeProvidedPropsDataset.forEach(({ props, newProps, expectedProps, changed }) => {
         it(`reinitializeProvidedProps(${JSON.stringify(newProps)}) with data ${JSON.stringify(props)} results in ${JSON.stringify(expectedProps)}`, () => {
-            const store = new ValueStore(props, {});
+            const store = new ValueStore(props);
             const actualChanged = store.reinitializeProvidedProps(newProps);
             expect(store.getOriginalProps()).toEqual(expectedProps);
             expect(actualChanged).toEqual(changed);

--- a/src/LiveComponent/assets/test/controller/model.test.ts
+++ b/src/LiveComponent/assets/test/controller/model.test.ts
@@ -9,12 +9,7 @@
 
 'use strict';
 
-import {
-    createTest,
-    createTestWithNested,
-    initComponent,
-    shutdownTests,
-} from '../tools';
+import { createTest, initComponent, shutdownTests } from '../tools';
 import { getByLabelText, getByTestId, getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 
@@ -217,17 +212,16 @@ describe('LiveController data-model Tests', () => {
         expect(test.component.valueStore.getOriginalProps()).toEqual({ user: { name: 'Ryan Weaver' } });
     });
 
-    it('can use models from nestedProps', async () => {
-        const test = await createTestWithNested(
-            { user: 5 },
-            {'user.name': 'Ryan'},
-            (props: any, nestedProps) => `
-                <div ${initComponent(props, { nestedProps })}>
+    it('can use models from nested props', async () => {
+        const test = await createTest(
+            { user: 5, 'user.name': 'Ryan' },
+            (props: any) => `
+                <div ${initComponent(props)}>
                     <input
                         data-model="user.name"
                     >
 
-                    Name: ${nestedProps['user.name']}
+                    Name: ${props['user.name']}
                 </div>
         `);
 
@@ -237,8 +231,7 @@ describe('LiveController data-model Tests', () => {
         await userEvent.type(test.queryByDataModel('user.name'), ' Weaver');
 
         await waitFor(() => expect(test.element).toHaveTextContent('Name: Ryan Weaver'));
-        expect(test.component.valueStore.getOriginalProps()).toEqual({ user: 5 });
-        expect(test.component.valueStore.getOriginalNestedProps()).toEqual({ 'user.name': 'Ryan Weaver' });
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ user: 5, 'user.name': 'Ryan Weaver' });
     });
 
     it('sends correct data for checkbox fields', async () => {

--- a/src/LiveComponent/assets/test/dom_utils.test.ts
+++ b/src/LiveComponent/assets/test/dom_utils.test.ts
@@ -13,7 +13,7 @@ import Backend from '../src/Backend/Backend';
 import {StandardElementDriver} from '../src/Component/ElementDriver';
 
 const createStore = function(props: any = {}): ValueStore {
-    return new ValueStore(props, {});
+    return new ValueStore(props);
 }
 
 describe('getValueFromElement', () => {
@@ -217,7 +217,6 @@ describe('elementBelongsToThisComponent', () => {
     const createComponent = (html: string, childComponents: Component[] = []) => {
         const component = new Component(
             htmlToElement(html),
-            {},
             {},
             null,
             'some-id-' + Math.floor((Math.random() * 100)),

--- a/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
+++ b/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
@@ -53,7 +53,7 @@ class InterceptChildComponentRenderSubscriber implements EventSubscriberInterfac
         $childFingerprints = $parentComponent->getExtraMetadata(self::CHILDREN_FINGERPRINTS_METADATA_KEY);
 
         // get the deterministic id for this child, but without incrementing the counter yet
-        $deterministicId = $event->getProps()['data-live-id'] ?? $this->getDeterministicIdCalculator()->calculateDeterministicId(increment: false);
+        $deterministicId = $event->getInputProps()['data-live-id'] ?? $this->getDeterministicIdCalculator()->calculateDeterministicId(increment: false);
         if (!isset($childFingerprints[$deterministicId])) {
             // child fingerprint wasn't set, it is likely a new child, allow it to render fully
             return;
@@ -72,7 +72,7 @@ class InterceptChildComponentRenderSubscriber implements EventSubscriberInterfac
             $deterministicId,
             $childFingerprints[$deterministicId],
             $event->getName(),
-            $event->getProps(),
+            $event->getInputProps(),
         );
         $event->setRenderedString($rendered);
     }

--- a/src/LiveComponent/src/Util/DehydratedProps.php
+++ b/src/LiveComponent/src/Util/DehydratedProps.php
@@ -24,16 +24,11 @@ class DehydratedProps
     /**
      * Array keyed by the frontend LiveProp name (e.g. product) and set to the dehydrated value.
      *
-     * @var array<string, mixed>
-     */
-    private array $propValues = [];
-
-    /**
-     * Array keyed by the full nested path (e.g. "product.name") and set to the dehydrated value.
+     * Nested paths can be used like "product.name".
      *
      * @var array<string, mixed>
      */
-    private array $nestedPathValues = [];
+    private array $propValues = [];
 
     /**
      * Create this object from the extra "props" identifiers passed to/from the frontend.
@@ -53,13 +48,6 @@ class DehydratedProps
     {
         $props = new static();
         foreach ($updatedPaths as $frontendName => $dehydratedValue) {
-            if (str_contains($frontendName, '.')) {
-                [$frontendName, $nestedPath] = explode('.', $frontendName, 2);
-                $props->addNestedProp($frontendName, $nestedPath, $dehydratedValue);
-
-                continue;
-            }
-
             $props->addPropValue($frontendName, $dehydratedValue);
         }
 
@@ -74,7 +62,7 @@ class DehydratedProps
     public function addNestedProp(string $frontendName, string $nestedPath, mixed $pathValue): void
     {
         $fullPath = $frontendName.'.'.$nestedPath;
-        $this->nestedPathValues[$fullPath] = $pathValue;
+        $this->propValues[$fullPath] = $pathValue;
     }
 
     public function removePropValue(string $key): void
@@ -100,7 +88,7 @@ class DehydratedProps
     {
         $fullPath = $propName.'.'.$nestedPath;
 
-        return \array_key_exists($fullPath, $this->nestedPathValues);
+        return \array_key_exists($fullPath, $this->propValues);
     }
 
     public function getNestedPathValue(string $propName, string $nestedPath): mixed
@@ -111,13 +99,13 @@ class DehydratedProps
 
         $fullPath = $propName.'.'.$nestedPath;
 
-        return $this->nestedPathValues[$fullPath];
+        return $this->propValues[$fullPath];
     }
 
     public function getNestedPathsForProperty(string $prop): array
     {
         $nestedPaths = [];
-        foreach ($this->nestedPathValues as $fullPath => $value) {
+        foreach ($this->propValues as $fullPath => $value) {
             if (str_starts_with($fullPath, $prop.'.')) {
                 $nestedPaths[] = substr($fullPath, \strlen($prop) + 1);
             }
@@ -130,7 +118,7 @@ class DehydratedProps
     {
         $clone = clone $this;
         foreach ($expectedNestedPaths as $nestedPath) {
-            unset($clone->nestedPathValues[$prop.'.'.$nestedPath]);
+            unset($clone->propValues[$prop.'.'.$nestedPath]);
         }
 
         return $clone->getNestedPathsForProperty($prop);
@@ -139,10 +127,5 @@ class DehydratedProps
     public function getProps(): array
     {
         return $this->propValues;
-    }
-
-    public function getNestedProps(): array
-    {
-        return $this->nestedPathValues;
     }
 }

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -75,9 +75,6 @@ class LiveControllerAttributesCreator
             $mountedAttributes
         );
         $attributesCollection->addProps($dehydratedProps->getProps());
-        if ($dehydratedProps->getNestedProps()) {
-            $attributesCollection->addNestedProps($dehydratedProps->getNestedProps());
-        }
 
         if ($this->csrfTokenManager && $metadata->get('csrf')) {
             $attributesCollection->addLiveCsrf(

--- a/src/LiveComponent/tests/Unit/Util/DehydratedPropsTest.php
+++ b/src/LiveComponent/tests/Unit/Util/DehydratedPropsTest.php
@@ -23,20 +23,15 @@ class DehydratedPropsTest extends TestCase
             'firstName' => 'Ryan',
             'address' => ['street' => '123 Main St', 'city' => 'New York'],
             'product' => 5,
-        ], $dehydratedProps->getProps());
-        $this->assertSame([
             'address.city' => 'New York',
             'product.name' => 'marshmallows',
             'product.price' => '25.99',
             'product.category.title' => 'campfire food',
-        ], $dehydratedProps->getNestedProps());
+        ], $dehydratedProps->getProps());
 
         // now reverse the process
         $propsFromArray = DehydratedProps::createFromPropsArray($dehydratedProps->getProps());
         $this->assertEquals($dehydratedProps->getProps(), $propsFromArray->getProps());
-
-        $updatedProps = DehydratedProps::createFromUpdatedArray($dehydratedProps->getNestedProps());
-        $this->assertEquals($dehydratedProps->getNestedProps(), $updatedProps->getNestedProps());
     }
 
     public function testRemovePropValue(): void

--- a/src/TwigComponent/src/Event/PreCreateForRenderEvent.php
+++ b/src/TwigComponent/src/Event/PreCreateForRenderEvent.php
@@ -24,7 +24,7 @@ final class PreCreateForRenderEvent extends Event
 
     public function __construct(
         private string $name,
-        private array $props = []
+        private array $inputProps = []
     ) {
     }
 
@@ -34,11 +34,19 @@ final class PreCreateForRenderEvent extends Event
     }
 
     /**
-     * @return array the array of data passed to originally create this component
+     * @deprecated since 2.8, use getInputProps() instead.
      */
     public function getProps(): array
     {
-        return $this->props;
+        return $this->inputProps;
+    }
+
+    /**
+     * @return array the array of "input" data passed to originally create this component
+     */
+    public function getInputProps(): array
+    {
+        return $this->inputProps;
     }
 
     public function setRenderedString(string $renderedString): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       |  None
| License       | MIT

A fix to the new, unreleased hydration system upgrade. Previously, if a nested value changed, we sent that value via Ajax on `updated` (e.g. `product.name: 'foo'`), but the that new value was not part of the `props` returned back. And so, on the next request, the new value (`foo`) was missing. Fortunately, this clarified that the system needed to be a bit simpler.

Cheers!