### PR TITLE
[Twig] Fixing a bug where a stringable attribute was converted too late

### DIFF
--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -86,6 +86,7 @@ final class ComponentFactory
         // ensure remaining data is scalar
         foreach ($data as $key => $value) {
             if ($value instanceof \Stringable) {
+                $data[$key] = (string) $value;
                 continue;
             }
 

--- a/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
@@ -100,14 +100,14 @@ final class ComponentFactoryTest extends KernelTestCase
 
     public function testStringableObjectCanBePassedToComponent(): void
     {
-        $attributes = (string) $this->factory()->create('component_a', ['propB' => 'B', 'data-item-id-param' => new class() {
+        $attributes = $this->factory()->create('component_a', ['propB' => 'B', 'data-item-id-param' => new class() {
             public function __toString(): string
             {
                 return 'test';
             }
-        }])->getAttributes();
+        }])->getAttributes()->all();
 
-        self::assertSame(' data-item-id-param="test"', $attributes);
+        self::assertSame(['data-item-id-param' => 'test'], $attributes);
     }
 
     public function testTwigComponentServiceTagMustHaveKey(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #741
| License       | MIT

This caused LiveComponents to try to use the Stringable object in its checksum and to json_encode() the object into the props data, instead of using the final, string value. Basically, we cast to the string earlier.
