### PR TITLE
[Live] Complex hydration fixes for 2.8

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -35,6 +35,7 @@
         "doctrine/annotations": "^1.0",
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.7",
+        "phpdocumentor/reflection-docblock": "5.x-dev",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/form": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -541,8 +541,11 @@ the ``Context`` attribute from Symfony's serializer::
     If your property has writable paths, those will be normalized/denormalized
     using the same `Context` set on the property itself.
 
-Or, you can take full control over the (de)hydration process by setting the ``hydrateWith``
-and ``dehydrateWith`` options on ``LiveProp``. For example::
+Using the serializer isn't meant to work out-of-the-box in every possible situation
+and it's always simpler to use scalar `LiveProp` values instead of complex objects.
+If you're having (de)hydrating a complex object, you can take full control by
+setting the ``hydrateWith`` and ``dehydrateWith`` options on ``LiveProp``. For
+example::
 
     class ComponentWithAddressDto
     {

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
@@ -61,7 +61,6 @@ class LiveComponentMetadataFactory
                 $property->getName(),
                 $attribute->newInstance(),
                 $type ? $type->getName() : null,
-                $type ? $type->allowsNull() : false,
                 $type ? $type->isBuiltin() : false,
             );
         }

--- a/src/LiveComponent/src/Metadata/LivePropMetadata.php
+++ b/src/LiveComponent/src/Metadata/LivePropMetadata.php
@@ -26,7 +26,6 @@ final class LivePropMetadata
         private string $name,
         private LiveProp $liveProp,
         private ?string $typeName,
-        private bool $allowsNull,
         private bool $isBuiltIn,
     ) {
     }
@@ -39,11 +38,6 @@ final class LivePropMetadata
     public function getType(): ?string
     {
         return $this->typeName;
-    }
-
-    public function allowsNull(): bool
-    {
-        return $this->allowsNull;
     }
 
     public function isBuiltIn(): bool

--- a/src/LiveComponent/tests/Fixtures/Entity/TodoItemFixtureEntity.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/TodoItemFixtureEntity.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class TodoItemFixtureEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private ?string $name = null;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=TodoListFixtureEntity::class, inversedBy="todoItems")
+     */
+    private TodoListFixtureEntity $todoList;
+
+    /**
+     * @param string $name
+     */
+    public function __construct(string $name = null)
+    {
+        $this->name = $name;
+    }
+
+    public function getTodoList(): TodoListFixtureEntity
+    {
+        return $this->todoList;
+    }
+
+    public function setTodoList(?TodoListFixtureEntity $todoList): self
+    {
+        $this->todoList = $todoList;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Entity/TodoListFixtureEntity.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/TodoListFixtureEntity.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class TodoListFixtureEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    public string $listTitle = '';
+
+    /**
+     * @ORM\OneToMany(targetEntity=TodoItemFixtureEntity::class, mappedBy="todoList")
+     */
+    private Collection $todoItems;
+
+    public function __construct(string $listTitle = '')
+    {
+        $this->listTitle = $listTitle;
+        $this->todoItems = new ArrayCollection();
+    }
+
+    public function getTodoItems(): Collection
+    {
+        return $this->todoItems;
+    }
+
+    public function addTodoItem(TodoItemFixtureEntity $todoItem): self
+    {
+        if (!$this->todoItems->contains($todoItem)) {
+            $this->todoItems[] = $todoItem;
+            $todoItem->setTodoList($this);
+        }
+
+        return $this;
+    }
+
+    public function removeTodoItem(TodoItemFixtureEntity $todoItem): self
+    {
+        if ($this->todoItems->removeElement($todoItem)) {
+            // set the owning side to null (unless already changed)
+            if ($todoItem->getTodoList() === $this) {
+                $todoItem->setTodoList(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/ux.symfony.com/src/Controller/LiveComponentDemoController.php
+++ b/ux.symfony.com/src/Controller/LiveComponentDemoController.php
@@ -43,9 +43,9 @@ class LiveComponentDemoController extends AbstractController
             ]);
         }
 
-        return $this->renderForm('live_component_demo/form_collection_type.html.twig', [
+        return $this->render('live_component_demo/form_collection_type.html.twig', [
             'form' => $form,
-            'todo' => $todoList,
+            'todoList' => $todoList,
             'demo' => $liveDemoRepository->find('form-collection-type'),
         ]);
     }

--- a/ux.symfony.com/src/Form/TodoItemForm.php
+++ b/ux.symfony.com/src/Form/TodoItemForm.php
@@ -12,7 +12,11 @@ class TodoItemForm extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('description')
+            ->add('description', null, [
+                // added because setDescription() doesn't allow null
+                // it would be simpler to make the arg to that method nullable
+                'empty_data' => '',
+            ])
             ->add('priority')
         ;
     }

--- a/ux.symfony.com/src/Form/TodoListForm.php
+++ b/ux.symfony.com/src/Form/TodoListForm.php
@@ -15,6 +15,9 @@ class TodoListForm extends AbstractType
         $builder
             ->add('name', null, [
                 'label' => 'List name',
+                // added because setName() doesn't allow null
+                // it would be simpler to make the arg to that method nullable
+                'empty_data' => '',
             ])
             ->add('todoItems', LiveCollectionType::class, [
                 'entry_type' => TodoItemForm::class,

--- a/ux.symfony.com/templates/live_component_demo/form_collection_type.html.twig
+++ b/ux.symfony.com/templates/live_component_demo/form_collection_type.html.twig
@@ -19,7 +19,7 @@
 {% block demo_content %}
     {{ component('todo_list_form', {
         form: form,
-        todoList: todo.id ? todo : null
+        todoList: todoList
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #740 
| License       | MIT

In 2.8, we have the ability to (de)hydrate non-persisted entity objects. That makes user's life a lot simpler, but when you do this, there are a lot of edge cases. This smashes a few more of those:

Cheers!