### PR TITLE
[Live] Fix parent->child fingerprint problem + always match child component

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -10,6 +10,11 @@
 public User $user;
 ```
 
+-   [BC BREAK]: Child components are no longer automatically re-rendered when
+    a parent component re-renders and the value of one of the props passed to
+    the child has changed. Pass `acceptUpdatesFromParent: true` to any `LiveProp`
+    on the child component to re-enable this behavior.
+
 -   Non-persisted entity objects can now be used with `LiveProp`: it will be
     serialized using the serializer.
 

--- a/src/LiveComponent/assets/dist/Backend/Backend.d.ts
+++ b/src/LiveComponent/assets/dist/Backend/Backend.d.ts
@@ -1,8 +1,16 @@
 import BackendRequest from './BackendRequest';
+export interface ChildrenFingerprints {
+    [key: string]: {
+        fingerprint: string;
+        tag: string;
+    };
+}
 export interface BackendInterface {
     makeRequest(props: any, actions: BackendAction[], updated: {
         [key: string]: any;
-    }, childrenFingerprints: any): BackendRequest;
+    }, children: ChildrenFingerprints, updatedPropsFromParent: {
+        [key: string]: any;
+    }): BackendRequest;
 }
 export interface BackendAction {
     name: string;
@@ -13,5 +21,7 @@ export default class implements BackendInterface {
     constructor(url: string, csrfToken?: string | null);
     makeRequest(props: any, actions: BackendAction[], updated: {
         [key: string]: any;
-    }, childrenFingerprints: any): BackendRequest;
+    }, children: ChildrenFingerprints, updatedPropsFromParent: {
+        [key: string]: any;
+    }): BackendRequest;
 }

--- a/src/LiveComponent/assets/dist/Backend/RequestBuilder.d.ts
+++ b/src/LiveComponent/assets/dist/Backend/RequestBuilder.d.ts
@@ -1,11 +1,13 @@
-import { BackendAction } from './Backend';
+import { BackendAction, ChildrenFingerprints } from './Backend';
 export default class {
     private url;
     private readonly csrfToken;
     constructor(url: string, csrfToken?: string | null);
     buildRequest(props: any, actions: BackendAction[], updated: {
         [key: string]: any;
-    }, childrenFingerprints: any): {
+    }, children: ChildrenFingerprints, updatedPropsFromParent: {
+        [key: string]: any;
+    }): {
         url: string;
         fetchOptions: RequestInit;
     };

--- a/src/LiveComponent/assets/dist/Component/ValueStore.d.ts
+++ b/src/LiveComponent/assets/dist/Component/ValueStore.d.ts
@@ -2,14 +2,16 @@ export default class {
     private props;
     private dirtyProps;
     private pendingProps;
+    private updatedPropsFromParent;
     constructor(props: any);
     get(name: string): any;
     has(name: string): boolean;
     set(name: string, value: any): boolean;
     getOriginalProps(): any;
     getDirtyProps(): any;
+    getUpdatedPropsFromParent(): any;
     flushDirtyPropsToPending(): void;
     reinitializeAllProps(props: any): void;
     pushPendingPropsBackToDirty(): void;
-    reinitializeProvidedProps(props: any): boolean;
+    storeNewPropsFromParent(props: any): boolean;
 }

--- a/src/LiveComponent/assets/dist/Component/index.d.ts
+++ b/src/LiveComponent/assets/dist/Component/index.d.ts
@@ -51,7 +51,7 @@ export default class Component {
     emitSelf(name: string, data: any): void;
     private performEmit;
     private doEmit;
-    updateFromNewElement(toEl: HTMLElement): boolean;
+    updateFromNewElementFromParentRender(toEl: HTMLElement): void;
     onChildComponentModelUpdate(modelName: string, value: any, childComponent: Component): void;
     private tryStartingRequest;
     private performRequest;

--- a/src/LiveComponent/assets/dist/dom_utils.d.ts
+++ b/src/LiveComponent/assets/dist/dom_utils.d.ts
@@ -8,5 +8,4 @@ export declare function getModelDirectiveFromElement(element: HTMLElement, throw
 export declare function elementBelongsToThisComponent(element: Element, component: Component): boolean;
 export declare function cloneHTMLElement(element: HTMLElement): HTMLElement;
 export declare function htmlToElement(html: string): HTMLElement;
-export declare function cloneElementWithNewTagName(element: Element, newTag: string): HTMLElement;
 export declare function getElementAsTagText(element: HTMLElement): string;

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -28,7 +28,10 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
             default: number;
         };
         id: StringConstructor;
-        fingerprint: StringConstructor;
+        fingerprint: {
+            type: StringConstructor;
+            default: string;
+        };
     };
     readonly nameValue: string;
     readonly urlValue: string;

--- a/src/LiveComponent/assets/src/Backend/Backend.ts
+++ b/src/LiveComponent/assets/src/Backend/Backend.ts
@@ -1,12 +1,18 @@
 import BackendRequest from './BackendRequest';
 import RequestBuilder from './RequestBuilder';
 
+export interface ChildrenFingerprints {
+    // key is the id of the child component
+    [key: string]: {fingerprint: string, tag: string}
+}
+
 export interface BackendInterface {
     makeRequest(
         props: any,
         actions: BackendAction[],
         updated: {[key: string]: any},
-        childrenFingerprints: any
+        children: ChildrenFingerprints,
+        updatedPropsFromParent: {[key: string]: any},
     ): BackendRequest;
 }
 
@@ -26,13 +32,15 @@ export default class implements BackendInterface {
         props: any,
         actions: BackendAction[],
         updated: {[key: string]: any},
-        childrenFingerprints: any
+        children: ChildrenFingerprints,
+        updatedPropsFromParent: {[key: string]: any},
     ): BackendRequest {
         const { url, fetchOptions } = this.requestBuilder.buildRequest(
             props,
             actions,
             updated,
-            childrenFingerprints
+            children,
+            updatedPropsFromParent
         );
 
         return new BackendRequest(

--- a/src/LiveComponent/assets/src/dom_utils.ts
+++ b/src/LiveComponent/assets/src/dom_utils.ts
@@ -250,19 +250,6 @@ export function htmlToElement(html: string): HTMLElement {
     return child;
 }
 
-// Inspired by https://stackoverflow.com/questions/13389751/change-tag-using-javascript
-export function cloneElementWithNewTagName(element: Element, newTag: string): HTMLElement {
-    const originalTag = element.tagName;
-    const startRX = new RegExp('^<' + originalTag, 'i');
-    const endRX = new RegExp(originalTag + '>$', 'i');
-    const startSubst = '<' + newTag;
-    const endSubst = newTag + '>';
-
-    const newHTML = element.outerHTML.replace(startRX, startSubst).replace(endRX, endSubst);
-
-    return htmlToElement(newHTML);
-}
-
 /**
  * Returns just the outer element's HTML as a string - useful for error messages.
  *

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -43,7 +43,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
         listeners: { type: Array, default: [] },
         debounce: { type: Number, default: 150 },
         id: String,
-        fingerprint: String,
+        fingerprint: { type: String, default: '' },
     };
 
     declare readonly nameValue: string;

--- a/src/LiveComponent/assets/src/morphdom.ts
+++ b/src/LiveComponent/assets/src/morphdom.ts
@@ -1,4 +1,4 @@
-import { cloneElementWithNewTagName, cloneHTMLElement, setValueOnElement } from './dom_utils';
+import { cloneHTMLElement, setValueOnElement } from './dom_utils';
 import morphdom from 'morphdom';
 import { normalizeAttributesForComparison } from './normalize_attributes_for_comparison';
 import Component from './Component';
@@ -17,16 +17,6 @@ export function executeMorphdom(
     const childComponentMap: Map<HTMLElement, Component> = new Map();
     childComponents.forEach((childComponent) => {
         childComponentMap.set(childComponent.element, childComponent);
-        if (!childComponent.id) {
-            throw new Error('Child is missing id.');
-        }
-        const childComponentToElement = findChildComponent(childComponent.id, rootToElement);
-        if (childComponentToElement && childComponentToElement.tagName !== childComponent.element.tagName) {
-            // we need to "correct" the tag name for the child to match the "from"
-            // so that we always get a "diff", not a remove/add
-            const newTag = cloneElementWithNewTagName(childComponentToElement, childComponent.element.tagName);
-            childComponentToElement.replaceWith(newTag);
-        }
     });
 
     morphdom(rootFromElement, rootToElement, {
@@ -55,7 +45,9 @@ export function executeMorphdom(
                 if (childComponentMap.has(fromEl)) {
                     const childComponent = childComponentMap.get(fromEl) as Component;
 
-                    return childComponent.updateFromNewElement(toEl);
+                    childComponent.updateFromNewElementFromParentRender(toEl);
+
+                    return false;
                 }
 
                 // if this field's value has been modified since this HTML was

--- a/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
+++ b/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
@@ -7,10 +7,11 @@ describe('buildRequest', () => {
             { firstName: 'Ryan' },
             [],
             { firstName: 'Kevin' },
-            { 'child-component': '123' }
+            { 'child-component': {fingerprint: '123', tag: 'div' } },
+            {}
         );
 
-        expect(url).toEqual('/_components?existing_param=1&props=%7B%22firstName%22%3A%22Ryan%22%7D&updated=%7B%22firstName%22%3A%22Kevin%22%7D&childrenFingerprints=%7B%22child-component%22%3A%22123%22%7D');
+        expect(url).toEqual('/_components?existing_param=1&props=%7B%22firstName%22%3A%22Ryan%22%7D&updated=%7B%22firstName%22%3A%22Kevin%22%7D&children=%7B%22child-component%22%3A%7B%22fingerprint%22%3A%22123%22%2C%22tag%22%3A%22div%22%7D%7D');
         expect(fetchOptions.method).toEqual('GET');
         expect(fetchOptions.headers).toEqual({
             Accept: 'application/vnd.live-component+html',
@@ -26,7 +27,8 @@ describe('buildRequest', () => {
                 args: { sendNotification: '1' },
             }],
             { firstName: 'Kevin' },
-            { 'child-component': '123' }
+            { 'child-component': {fingerprint: '123', tag: 'div' } },
+            {}
         );
 
         expect(url).toEqual('/_components/saveData');
@@ -39,7 +41,7 @@ describe('buildRequest', () => {
         expect(fetchOptions.body).toEqual(JSON.stringify({
             props: { firstName: 'Ryan' },
             updated: { firstName: 'Kevin' },
-            childrenFingerprints: { 'child-component': '123' },
+            children: { 'child-component': { fingerprint: '123', tag: 'div' } },
             args: { sendNotification: '1' },
         }));
     });
@@ -56,6 +58,7 @@ describe('buildRequest', () => {
                 args: { sendNotification: '0' },
             }],
             { firstName: 'Kevin' },
+            {},
             {}
         );
 
@@ -81,6 +84,7 @@ describe('buildRequest', () => {
             { firstName: 'Ryan'.repeat(1000) },
             [],
             { firstName: 'Kevin'.repeat(1000) },
+            {},
             {}
         );
 
@@ -94,6 +98,38 @@ describe('buildRequest', () => {
         expect(fetchOptions.body).toEqual(JSON.stringify({
             props: { firstName: 'Ryan'.repeat(1000) },
             updated: { firstName: 'Kevin'.repeat(1000) },
+        }));
+    });
+
+    it('sends propsFromParent when specified', () => {
+        const builder = new RequestBuilder('/_components?existing_param=1', '_the_csrf_token');
+        const { url } = builder.buildRequest(
+            { firstName: 'Ryan' },
+            [],
+            { firstName: 'Kevin' },
+            { },
+            { count: 5 }
+        );
+
+        expect(url).toEqual('/_components?existing_param=1&props=%7B%22firstName%22%3A%22Ryan%22%7D&updated=%7B%22firstName%22%3A%22Kevin%22%7D&propsFromParent=%7B%22count%22%3A5%7D');
+
+        // do a POST
+        const { fetchOptions } = builder.buildRequest(
+            { firstName: 'Ryan' },
+            [{
+                name: 'saveData',
+                args: { sendNotification: '1' },
+            }],
+            { firstName: 'Kevin' },
+            {},
+            { count: 5 },
+        );
+
+        expect(fetchOptions.body).toEqual(JSON.stringify({
+            props: { firstName: 'Ryan' },
+            updated: { firstName: 'Kevin' },
+            propsFromParent: { count: 5 },
+            args: { sendNotification: '1' },
         }));
     });
 });

--- a/src/LiveComponent/assets/test/ValueStore.test.ts
+++ b/src/LiveComponent/assets/test/ValueStore.test.ts
@@ -241,7 +241,7 @@ describe('ValueStore', () => {
         expect(container.getOriginalProps()).toEqual({ city: 'Grand Rapids', user: 'Kevin', product: 5 });
     });
 
-    const reinitializeProvidedPropsDataset = [
+    const storeNewPropsFromParentDataset = [
         {
             props: {},
             newProps: {},
@@ -329,12 +329,12 @@ describe('ValueStore', () => {
             changed: true,
         },
     ];
-    reinitializeProvidedPropsDataset.forEach(({ props, newProps, expectedProps, changed }) => {
-        it(`reinitializeProvidedProps(${JSON.stringify(newProps)}) with data ${JSON.stringify(props)} results in ${JSON.stringify(expectedProps)}`, () => {
+    storeNewPropsFromParentDataset.forEach(({ props, newProps, expectedProps, changed }) => {
+        it(`storeNewPropsFromParent(${JSON.stringify(newProps)}) with data ${JSON.stringify(props)} results in ${JSON.stringify(expectedProps)}`, () => {
             const store = new ValueStore(props);
-            const actualChanged = store.reinitializeProvidedProps(newProps);
-            expect(store.getOriginalProps()).toEqual(expectedProps);
+            const actualChanged = store.storeNewPropsFromParent(newProps);
             expect(actualChanged).toEqual(changed);
+            expect(store.getUpdatedPropsFromParent()).toEqual(changed ? newProps : {});
         });
     });
 });

--- a/src/LiveComponent/src/Attribute/LiveProp.php
+++ b/src/LiveComponent/src/Attribute/LiveProp.php
@@ -41,16 +41,30 @@ final class LiveProp
      */
     private ?string $fieldName;
 
+    private bool $acceptUpdatesFromParent;
+
+    /**
+     * @param bool|array $writable         If true, this property can be changed by the frontend.
+     *                                     Or set to an array of paths within this object/array
+     *                                     that are writable.
+     * @param bool       $updateFromParent if true, while a parent component is re-rendering,
+     *                                     if the parent passes in this prop and it changed
+     *                                     from the value used when originally rendering
+     *                                     this child, the value in the child will be updated
+     *                                     to match the new value and the child will be re-rendered
+     */
     public function __construct(
         bool|array $writable = false,
         ?string $hydrateWith = null,
         ?string $dehydrateWith = null,
         ?string $fieldName = null,
+        bool $updateFromParent = false
     ) {
         $this->writable = $writable;
         $this->hydrateWith = $hydrateWith;
         $this->dehydrateWith = $dehydrateWith;
         $this->fieldName = $fieldName;
+        $this->acceptUpdatesFromParent = $updateFromParent;
     }
 
     /**
@@ -109,5 +123,10 @@ final class LiveProp
         }
 
         return $this->fieldName;
+    }
+
+    public function acceptUpdatesFromParent(): bool
+    {
+        return $this->acceptUpdatesFromParent;
     }
 }

--- a/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
+++ b/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
@@ -70,7 +70,8 @@ class InterceptChildComponentRenderSubscriber implements EventSubscriberInterfac
 
         $rendered = $childPartialRenderer->renderChildComponent(
             $deterministicId,
-            $childFingerprints[$deterministicId],
+            $childFingerprints[$deterministicId]['fingerprint'],
+            $childFingerprints[$deterministicId]['tag'],
             $event->getName(),
             $event->getInputProps(),
         );

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -203,7 +203,9 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
      *     data: array,
      *     args: array,
      *     actions: array
-     *     childrenFingerprints: array
+     *     // has "fingerprint" and "tag" string key, keyed by component id
+     *     children: array
+     *     propsFromParent: array
      * }
      */
     private static function parseDataFor(Request $request): array
@@ -215,7 +217,8 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
                     'updated' => self::parseJsonFromQuery($request, 'updated'),
                     'args' => [],
                     'actions' => [],
-                    'childrenFingerprints' => self::parseJsonFromQuery($request, 'childrenFingerprints'),
+                    'children' => self::parseJsonFromQuery($request, 'children'),
+                    'propsFromParent' => self::parseJsonFromQuery($request, 'propsFromParent'),
                 ];
             } else {
                 $requestData = $request->toArray();
@@ -225,7 +228,8 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
                     'updated' => $requestData['updated'] ?? [],
                     'args' => $requestData['args'] ?? [],
                     'actions' => $requestData['actions'] ?? [],
-                    'childrenFingerprints' => $requestData['childrenFingerprints'] ?? [],
+                    'children' => $requestData['children'] ?? [],
+                    'propsFromParent' => $requestData['propsFromParent'] ?? [],
                 ];
             }
 
@@ -336,14 +340,15 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
             $component,
             $this->parseDataFor($request)['props'],
             $this->parseDataFor($request)['updated'],
-            $metadataFactory->getMetadata($componentName)
+            $metadataFactory->getMetadata($componentName),
+            $this->parseDataFor($request)['propsFromParent']
         );
 
         $mountedComponent = new MountedComponent($componentName, $component, $componentAttributes);
 
         $mountedComponent->addExtraMetadata(
             InterceptChildComponentRenderSubscriber::CHILDREN_FINGERPRINTS_METADATA_KEY,
-            $this->parseDataFor($request)['childrenFingerprints']
+            $this->parseDataFor($request)['children']
         );
 
         return $mountedComponent;

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
@@ -42,14 +42,23 @@ class LiveComponentMetadata
         return $this->livePropsMetadata;
     }
 
-    public function getReadonlyPropPaths(): array
+    /**
+     * Looks at an array of "input prop" values and sees which of these correspond
+     * with LiveProps that accept updates from the parent.
+     *
+     * Returns the final array of "input props" that should be used to update
+     * LiveProps on the component.
+     */
+    public function getOnlyPropsThatAcceptUpdatesFromParent(array $inputProps): array
     {
-        $writableProps = array_filter($this->livePropsMetadata, function ($livePropMetadata) {
-            return !$livePropMetadata->isIdentityWritable();
+        $writableProps = array_filter($this->livePropsMetadata, function (LivePropMetadata $livePropMetadata) {
+            return $livePropMetadata->acceptUpdatesFromParent();
         });
 
-        return array_map(function ($livePropMetadata) {
+        $propNames = array_map(function ($livePropMetadata) {
             return $livePropMetadata->getName();
         }, $writableProps);
+
+        return array_intersect_key($inputProps, array_flip($propNames));
     }
 }

--- a/src/LiveComponent/src/Metadata/LivePropMetadata.php
+++ b/src/LiveComponent/src/Metadata/LivePropMetadata.php
@@ -78,4 +78,9 @@ final class LivePropMetadata
     {
         return $this->liveProp->isIdentityWritable();
     }
+
+    public function acceptUpdatesFromParent(): bool
+    {
+        return $this->liveProp->acceptUpdatesFromParent();
+    }
 }

--- a/src/LiveComponent/src/Util/FingerprintCalculator.php
+++ b/src/LiveComponent/src/Util/FingerprintCalculator.php
@@ -15,8 +15,15 @@ namespace Symfony\UX\LiveComponent\Util;
 
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
+use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadata;
 
 /**
+ * Calculates a fingerprint that is unique to the original input props passed
+ * into the component and that also set props that "accept updates from parent".
+ *
+ * This is used for child components, to determine when the parent has changed
+ * certain props that should trigger the child to re-render.
+ *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
  * @experimental
@@ -31,9 +38,15 @@ class FingerprintCalculator
     ) {
     }
 
-    public function calculateFingerprint(array $data): string
+    public function calculateFingerprint(array $inputProps, LiveComponentMetadata $liveMetadata): string
     {
-        $normalizedData = $this->objectNormalizer->normalize($data, context: [LiveComponentHydrator::LIVE_CONTEXT => true]);
+        $fingerprintProps = $liveMetadata->getOnlyPropsThatAcceptUpdatesFromParent($inputProps);
+
+        if (0 === \count($fingerprintProps)) {
+            return '';
+        }
+
+        $normalizedData = $this->objectNormalizer->normalize($fingerprintProps, context: [LiveComponentHydrator::LIVE_CONTEXT => true]);
 
         return base64_encode(hash_hmac('sha256', serialize($normalizedData), $this->secret, true));
     }

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -77,8 +77,13 @@ class LiveControllerAttributesCreator
                 $mountedAttributes = $mountedAttributes->defaults(['data-live-id' => $id]);
             }
 
-            $fingerprint = $this->fingerprintCalculator->calculateFingerprint($mounted->getInputProps());
-            $attributesCollection->setFingerprint($fingerprint);
+            $fingerprint = $this->fingerprintCalculator->calculateFingerprint(
+                $mounted->getInputProps(),
+                $this->metadataFactory->getMetadata($mounted->getName())
+            );
+            if ($fingerprint) {
+                $attributesCollection->setFingerprint($fingerprint);
+            }
         }
 
         $dehydratedProps = $this->dehydrateComponent(

--- a/src/LiveComponent/tests/Fixtures/Component/TodoItemComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/TodoItemComponent.php
@@ -23,6 +23,9 @@ final class TodoItemComponent
     #[LiveProp(writable: true)]
     public string $text = '';
 
+    #[LiveProp(updateFromParent: true)]
+    public int $textLength = 0;
+
     // here just to force a checksum to be needed, helps make tests more robust
     #[LiveProp(writable: false)]
     public string $readonlyValue = 'readonly';

--- a/src/LiveComponent/tests/Fixtures/config/doctrine/Embeddable2.orm.xml
+++ b/src/LiveComponent/tests/Fixtures/config/doctrine/Embeddable2.orm.xml
@@ -3,8 +3,6 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
-
-
     <embeddable name="Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Embeddable2">
         <field name="name" type="string" />
     </embeddable>

--- a/src/LiveComponent/tests/Fixtures/templates/components/todo_list.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/todo_list.html.twig
@@ -3,7 +3,7 @@
 
     <ul>
     {% for item in items %}
-        {% set componentProps = { text: item.text } %}
+        {% set componentProps = { text: item.text, textLength: item.text|length } %}
         {% if includeDataLiveId %}
             {% set componentProps = componentProps|merge({'data-live-id': ('todo-item-' ~ loop.index) }) %}
         {% endif %}

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -97,11 +97,12 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertArrayHasKey('data-live-id', $attributesProps);
 
         // fingerprints
-        // first and last both have the same input - thus fingerprint
-        $this->assertSame('sH/Rwn0x37n3KyMWQLa6OBPgglriBZqlwPLnm/EQTlE=', $lis->first()->attr('data-live-fingerprint-value'));
-        $this->assertSame('sH/Rwn0x37n3KyMWQLa6OBPgglriBZqlwPLnm/EQTlE=', $lis->last()->attr('data-live-fingerprint-value'));
+        // first and last both have the same length "text" input, and since "textLength"
+        // is the only updateFromParent prop, they should have the same fingerprint
+        $this->assertSame('7uQSVj4d4n3/RCVRkyLDCW9vLBxIAQVCEb1Rr3CJpfc=', $lis->first()->attr('data-live-fingerprint-value'));
+        $this->assertSame('7uQSVj4d4n3/RCVRkyLDCW9vLBxIAQVCEb1Rr3CJpfc=', $lis->last()->attr('data-live-fingerprint-value'));
         // middle has a different fingerprint
-        $this->assertSame('cuOKkrHC9lOmBa6dyVZ3S0REdw4CKCwJgLDdrVoTb2g=', $lis->eq(1)->attr('data-live-fingerprint-value'));
+        $this->assertSame('XSdvsiDR8VG0GFDQbOnj74XfSmfL6WrzMbSQcdIRhSs=', $lis->eq(1)->attr('data-live-fingerprint-value'));
     }
 
     public function testItDoesNotOverrideDataLiveIdIfSpecified(): void

--- a/src/LiveComponent/tests/Unit/Attribute/LivePropTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/LivePropTest.php
@@ -71,4 +71,14 @@ final class LivePropTest extends TestCase
         $this->assertFalse($liveProp3->isIdentityWritable());
         $this->assertSame(['bar'], $liveProp3->writablePaths());
     }
+
+    // test updateFromParent property being set and accessed with acceptUpdatesFromParent()
+    public function testUpdateFromParent(): void
+    {
+        $liveProp = new LiveProp();
+        $this->assertFalse($liveProp->acceptUpdatesFromParent());
+
+        $liveProp2 = new LiveProp(updateFromParent: true);
+        $this->assertTrue($liveProp2->acceptUpdatesFromParent());
+    }
 }

--- a/src/LiveComponent/tests/Unit/Metadata/LiveComponentMetadataTest.php
+++ b/src/LiveComponent/tests/Unit/Metadata/LiveComponentMetadataTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Unit\Metadata;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadata;
+use Symfony\UX\LiveComponent\Metadata\LivePropMetadata;
+use Symfony\UX\TwigComponent\ComponentMetadata;
+
+class LiveComponentMetadataTest extends TestCase
+{
+    public function testGetOnlyPropsThatAcceptUpdatesFromParent()
+    {
+        $propMetadatas = [
+            new LivePropMetadata('noUpdateFromParent1', new LiveProp(updateFromParent: false), null, false),
+            new LivePropMetadata('noUpdateFromParent2', new LiveProp(updateFromParent: false), null, false),
+            new LivePropMetadata('yesUpdateFromParent1', new LiveProp(updateFromParent: true), null, false),
+            new LivePropMetadata('yesUpdateFromParent2', new LiveProp(updateFromParent: true), null, false),
+        ];
+        $liveComponentMetadata = new LiveComponentMetadata(new ComponentMetadata([]), $propMetadatas);
+        $inputProps = [
+            'noUpdateFromParent1' => 'foo',
+            'yesUpdateFromParent1' => 'bar',
+            'totallyUnrelated' => 'baz',
+        ];
+        $expected = ['yesUpdateFromParent1' => 'bar'];
+        $actual = $liveComponentMetadata->getOnlyPropsThatAcceptUpdatesFromParent($inputProps);
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

Another boring PR from me to prep for 2.8 :P. This is caused by a few different changes to the system mixing together. Fixes:

A) If a parent component re-renders and the "input props" that are passed to the child differ, the child should re-render with the updated "input props". That broken in 2.8 due to a checksum problem. No fixed, and a new `updateFromParent` was added to opt into this behavior, which makes most parent-child situations simpler.

B) When a parent component re-renders and the "input props" that are passed to the child have NOT changed, we render a "dummy" child element (so that we don't need to use the CPU to render a component that doesn't need to be updated). This was already the case, but until now, we always rendered as a `div` (even if the original child were an `li`). I had thought we could "get away" with this (as we are discarding that fake, empty element anyways), but we couldn't. So now we render the correct tag always.

Cheers!