### PR TITLE
Minor cleanup to instructions for lazy-loading Vue.js controllers

### DIFF
--- a/src/Vue/doc/index.rst
+++ b/src/Vue/doc/index.rst
@@ -66,7 +66,7 @@ Finally, to load your Vue components, add the following lines to ``assets/app.js
     // they are not necessary.
     registerVueControllerComponents(require.context('./vue/controllers', true, /\.vue$/));
 
-    // If you prefer to lazy-load your Vue.js controller components, in order to reduce to keep the JavaScript bundle the smallest as possible,
+    // If you prefer to lazy-load your Vue.js controller components, in order to keep the JavaScript bundle the smallest as possible,
     // and improve performance, you can use the following line instead:
     //registerVueControllerComponents(require.context('./vue/controllers', true, /\.vue$/, 'lazy'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | no
| Tickets       | See below.
| License       | MIT

Minor documentation-only change that removes duplicative phrasing from instructions for lazy-loading Vue.js controllers in app.js.
