### PR TITLE
Introduce a new syntax for twig component

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -26,6 +26,7 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Serializer\MoneyNormalizer;
 use Symfony\UX\TwigComponent\TwigComponentBundle;
 use Twig\Environment;
 use Zenstruck\Foundry\ZenstruckFoundryBundle;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -112,6 +113,8 @@ final class Kernel extends BaseKernel
             ->set(MoneyNormalizer::class)->autoconfigure()->autowire()
             ->set(Entity2Normalizer::class)->autoconfigure()->autowire()
             ->load(__NAMESPACE__.'\\Component\\', __DIR__.'/Component')
+            ->set(TestingDeterministicIdTwigExtension::class)
+                ->args([service('ux.live_component.deterministic_id_calculator')])
         ;
     }
 

--- a/src/LiveComponent/tests/Fixtures/TestingDeterministicIdTwigExtension.php
+++ b/src/LiveComponent/tests/Fixtures/TestingDeterministicIdTwigExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures;
+
+use Symfony\UX\LiveComponent\Twig\DeterministicTwigIdCalculator;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class TestingDeterministicIdTwigExtension extends AbstractExtension
+{
+    public function __construct(private DeterministicTwigIdCalculator $deterministicIdCalculator)
+    {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('get_id_for_test', [$this, 'getIdForTest']),
+        ];
+    }
+
+    public function getIdForTest(): string
+    {
+        return $this->deterministicIdCalculator->calculateDeterministicId();
+    }
+}

--- a/src/LiveComponent/tests/Integration/Twig/DeterministicTwigIdCalculatorTest.php
+++ b/src/LiveComponent/tests/Integration/Twig/DeterministicTwigIdCalculatorTest.php
@@ -14,35 +14,15 @@ namespace Symfony\UX\LiveComponent\Tests\Integration;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\LiveComponent\Twig\DeterministicTwigIdCalculator;
 use Twig\Environment;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
 final class DeterministicTwigIdCalculatorTest extends KernelTestCase
 {
     public function testReturnsDeterministicId(): void
     {
-        $deterministicIdCalculator = new DeterministicTwigIdCalculator();
-        $twigExtension = new class($deterministicIdCalculator) extends AbstractExtension {
-            public function __construct(private DeterministicTwigIdCalculator $deterministicIdCalculator)
-            {
-            }
-
-            public function getFunctions(): array
-            {
-                return [
-                    new TwigFunction('get_id_for_test', [$this, 'getIdForTest']),
-                ];
-            }
-
-            public function getIdForTest(): string
-            {
-                return $this->deterministicIdCalculator->calculateDeterministicId();
-            }
-        };
-
         /** @var Environment $twig */
         $twig = self::getContainer()->get('twig');
-        $twig->addExtension($twigExtension);
+        /** @var DeterministicTwigIdCalculator $deterministicIdCalculator */
+        $deterministicIdCalculator = self::getContainer()->get('ux.live_component.deterministic_id_calculator');
 
         $rendered = $twig->render('deterministic_id.html.twig');
         $this->assertStringContainsString('Deterministic Id Line1-1: "live-3860148629-0"', $rendered);

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.8.0
 
+-   Add new HTML syntax for rendering components: `<twig:ComponentName>`
 -   `true` attribute values now render just the attribute name, `false` excludes it entirely.
 
 -   The first argument to `AsTwigComponent` is now optional and defaults to the class name.

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -24,6 +24,8 @@ use Symfony\UX\TwigComponent\ComponentRendererInterface;
 use Symfony\UX\TwigComponent\ComponentStack;
 use Symfony\UX\TwigComponent\DependencyInjection\Compiler\TwigComponentPass;
 use Symfony\UX\TwigComponent\Twig\ComponentExtension;
+use Symfony\UX\TwigComponent\Twig\ComponentLexer;
+use Symfony\UX\TwigComponent\Twig\TwigEnvironmentConfigurator;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -73,5 +75,11 @@ final class TwigComponentExtension extends Extension
             ->addTag('container.service_subscriber', ['key' => ComponentRenderer::class, 'id' => 'ux.twig_component.component_renderer'])
             ->addTag('container.service_subscriber', ['key' => ComponentFactory::class, 'id' => 'ux.twig_component.component_factory'])
         ;
+
+        $container->register('ux.twig_component.twig.lexer', ComponentLexer::class);
+
+        $container->register('ux.twig_component.twig.environment_configurator', TwigEnvironmentConfigurator::class)
+            ->setDecoratedService(new Reference('twig.configurator.environment'))
+            ->setArguments([new Reference('ux.twig_component.twig.environment_configurator.inner')]);
     }
 }

--- a/src/TwigComponent/src/Twig/ComponentLexer.php
+++ b/src/TwigComponent/src/Twig/ComponentLexer.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Twig;
+
+use Twig\Lexer;
+use Twig\Source;
+use Twig\TokenStream;
+
+/**
+ * @author Mathèo Daninos <matheo.daninos@gmail.com>
+ *
+ * @internal
+ *
+ * thanks to @giorgiopogliani for the inspiration on this lexer <3
+ *
+ * @see https://github.com/giorgiopogliani/twig-components
+ */
+class ComponentLexer extends Lexer
+{
+    public function tokenize(Source $source): TokenStream
+    {
+        $preLexer = new TwigPreLexer();
+        $preparsed = $preLexer->preLexComponents($source->getCode());
+
+        return parent::tokenize(
+            new Source(
+                $preparsed,
+                $source->getName(),
+                $source->getPath()
+            )
+        );
+    }
+}

--- a/src/TwigComponent/src/Twig/TwigEnvironmentConfigurator.php
+++ b/src/TwigComponent/src/Twig/TwigEnvironmentConfigurator.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Twig;
+
+use Symfony\Bundle\TwigBundle\DependencyInjection\Configurator\EnvironmentConfigurator;
+use Twig\Environment;
+
+class TwigEnvironmentConfigurator
+{
+    private EnvironmentConfigurator $decorated;
+
+    public function __construct(
+        EnvironmentConfigurator $decorated
+    ) {
+        $this->decorated = $decorated;
+    }
+
+    public function configure(Environment $environment): void
+    {
+        $this->decorated->configure($environment);
+
+        $environment->setLexer(new ComponentLexer($environment));
+    }
+}

--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -1,0 +1,316 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Twig;
+
+/**
+ * Rewrites <twig:component> syntaxes to {% component %} syntaxes.
+ */
+class TwigPreLexer
+{
+    private string $input;
+    private int $length;
+    private int $position = 0;
+    private int $line;
+    /** @var array<string: name, bool: hasDefaultBlock> */
+    private array $currentComponents = [];
+
+    public function __construct(int $startingLine = 1)
+    {
+        $this->line = $startingLine;
+    }
+
+    public function preLexComponents(string $input): string
+    {
+        $this->input = $input;
+        $this->length = \strlen($input);
+        $output = '';
+
+        while ($this->position < $this->length) {
+            if ($this->consume('<twig:')) {
+                $componentName = $this->consumeComponentName();
+
+                if ('block' === $componentName) {
+                    // if we're already inside the "default" block, let's close it
+                    if (!empty($this->currentComponents) && $this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock']) {
+                        $output .= '{% endblock %}';
+
+                        $this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock'] = false;
+                    }
+
+                    $output .= $this->consumeBlock();
+
+                    continue;
+                }
+
+                $attributes = $this->consumeAttributes();
+                $isSelfClosing = $this->consume('/>');
+                if (!$isSelfClosing) {
+                    $this->consume('>');
+                    $this->currentComponents[] = ['name' => $componentName, 'hasDefaultBlock' => false];
+                }
+
+                $output .= "{% component {$componentName}".($attributes ? " with { {$attributes} }" : '').' %}';
+                if ($isSelfClosing) {
+                    $output .= '{% endcomponent %}';
+                }
+
+                continue;
+            }
+
+            if (!empty($this->currentComponents) && $this->check('</twig:')) {
+                $this->consume('</twig:');
+                $closingComponentName = $this->consumeComponentName();
+                $this->consume('>');
+
+                $lastComponent = array_pop($this->currentComponents);
+                $lastComponentName = $lastComponent['name'];
+
+                if ($closingComponentName !== $lastComponentName) {
+                    throw new \RuntimeException("Expected closing tag '</twig:{$lastComponentName}>' but found '</twig:{$closingComponentName}>' at line {$this->line}");
+                }
+
+                // we've reached the end of this component. If we're inside the
+                // default block, let's close it
+                if ($lastComponent['hasDefaultBlock']) {
+                    $output .= '{% endblock %}';
+                }
+
+                $output .= '{% endcomponent %}';
+
+                continue;
+            }
+
+            $char = $this->consumeChar();
+            if ("\n" === $char) {
+                ++$this->line;
+            }
+
+            // handle adding a default block if needed
+            if (!empty($this->currentComponents)
+                && !$this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock']
+                && preg_match('/\S/', $char)
+            ) {
+                $this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock'] = true;
+                $output .= '{% block content %}';
+            }
+
+            $output .= $char;
+        }
+
+        if (!empty($this->currentComponents)) {
+            $lastComponent = array_pop($this->currentComponents)['name'];
+            throw new \RuntimeException(sprintf('Expected closing tag "</twig:%s>" not found at line %d.', $lastComponent, $this->line));
+        }
+
+        return $output;
+    }
+
+    private function consumeComponentName(): string
+    {
+        $start = $this->position;
+        while ($this->position < $this->length && preg_match('/[A-Za-z0-9_]/', $this->input[$this->position])) {
+            ++$this->position;
+        }
+        $componentName = substr($this->input, $start, $this->position - $start);
+
+        if (empty($componentName)) {
+            throw new \RuntimeException("Expected component name at line {$this->line}");
+        }
+
+        return $componentName;
+    }
+
+    private function consumeAttributes(): string
+    {
+        $attributes = [];
+
+        while ($this->position < $this->length && !$this->check('>') && !$this->check('/>')) {
+            $this->consumeWhitespace();
+            if ($this->check('>') || $this->check('/>')) {
+                break;
+            }
+
+            $isAttributeDynamic = false;
+
+            // :someProp="dynamicVar"
+            if ($this->check(':')) {
+                $this->consume(':');
+                $isAttributeDynamic = true;
+            }
+
+            $key = $this->consumeComponentName();
+
+            // <twig:component someProp> -> someProp: true
+            if (!$this->check('=')) {
+                $attributes[] = sprintf('%s: true', $key);
+                $this->consumeWhitespace();
+                continue;
+            }
+
+            $this->expectAndConsumeChar('=');
+            $quote = $this->consumeChar(["'", '"']);
+
+            // someProp="{{ dynamicVar }}"
+            if ($this->consume('{{')) {
+                $this->consumeWhitespace();
+                $attributeValue = rtrim($this->consumeUntil('}'));
+                $this->expectAndConsumeChar('}');
+                $this->expectAndConsumeChar('}');
+                $this->consumeUntil($quote);
+                $isAttributeDynamic = true;
+            } else {
+                $attributeValue = $this->consumeUntil($quote);
+            }
+            $this->expectAndConsumeChar($quote);
+
+            if ($isAttributeDynamic) {
+                $attributes[] = sprintf('%s: %s', $key, $attributeValue);
+            } else {
+                $attributes[] = sprintf("%s: '%s'", $key, str_replace("'", "\'", $attributeValue));
+            }
+
+            $this->consumeWhitespace();
+        }
+
+        return implode(', ', $attributes);
+    }
+
+    private function consume(string $string): bool
+    {
+        if (substr($this->input, $this->position, \strlen($string)) === $string) {
+            $this->position += \strlen($string);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function consumeChar($validChars = null): string
+    {
+        if ($this->position >= $this->length) {
+            throw new \RuntimeException('Unexpected end of input');
+        }
+
+        $char = $this->input[$this->position];
+
+        if (null !== $validChars && !\in_array($char, (array) $validChars, true)) {
+            throw new \RuntimeException('Expected one of ['.implode('', (array) $validChars)."] but found '{$char}' at line {$this->line}");
+        }
+
+        ++$this->position;
+
+        return $char;
+    }
+
+    private function consumeUntil(string $endString): string
+    {
+        $start = $this->position;
+        $endCharLength = \strlen($endString);
+
+        while ($this->position < $this->length) {
+            if (substr($this->input, $this->position, $endCharLength) === $endString) {
+                break;
+            }
+
+            if ("\n" === $this->input[$this->position]) {
+                ++$this->line;
+            }
+            ++$this->position;
+        }
+
+        return substr($this->input, $start, $this->position - $start);
+    }
+
+    private function consumeWhitespace(): void
+    {
+        while ($this->position < $this->length && preg_match('/\s/', $this->input[$this->position])) {
+            if ("\n" === $this->input[$this->position]) {
+                ++$this->line;
+            }
+            ++$this->position;
+        }
+    }
+
+    /**
+     * Checks that the next character is the one given and consumes it.
+     */
+    private function expectAndConsumeChar(string $char): void
+    {
+        if (1 !== \strlen($char)) {
+            throw new \InvalidArgumentException('Expected a single character');
+        }
+
+        if ($this->position >= $this->length || $this->input[$this->position] !== $char) {
+            throw new \RuntimeException("Expected '{$char}' but found '{$this->input[$this->position]}' at line {$this->line}");
+        }
+        ++$this->position;
+    }
+
+    private function check(string $chars): bool
+    {
+        $charsLength = \strlen($chars);
+        if ($this->position + $charsLength > $this->length) {
+            return false;
+        }
+
+        for ($i = 0; $i < $charsLength; ++$i) {
+            if ($this->input[$this->position + $i] !== $chars[$i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function consumeBlock(): string
+    {
+        $attributes = $this->consumeAttributes();
+        $this->consume('>');
+
+        $blockName = '';
+        foreach (explode(', ', $attributes) as $attr) {
+            [$key, $value] = explode(': ', $attr);
+            if ('name' === $key) {
+                $blockName = trim($value, "'");
+                break;
+            }
+        }
+
+        if (empty($blockName)) {
+            throw new \RuntimeException("Expected block name at line {$this->line}");
+        }
+
+        $output = "{% block {$blockName} %}";
+
+        $closingTag = '</twig:block>';
+        if (!$this->doesStringEventuallyExist($closingTag)) {
+            throw new \RuntimeException("Expected closing tag '{$closingTag}' for block '{$blockName}' at line {$this->line}");
+        }
+        $blockContents = $this->consumeUntil($closingTag);
+
+        $subLexer = new self($this->line);
+        $output .= $subLexer->preLexComponents($blockContents);
+
+        $this->consume($closingTag);
+        $output .= '{% endblock %}';
+
+        return $output;
+    }
+
+    private function doesStringEventuallyExist(string $needle): bool
+    {
+        $remainingString = substr($this->input, $this->position);
+
+        return str_contains($remainingString, $needle);
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/templates/tags/embedded_component.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/tags/embedded_component.html.twig
@@ -1,0 +1,8 @@
+<twig:table caption='data table' :headers='["key", "value"]' :data='[[1, 2], [3, 4]]'>
+        <twig:block name="th">custom th ({{ parent() }})</twig:block>
+        <twig:block name="td">custom td ({{ parent() }})</twig:block>
+
+        <twig:block name="footer">
+                My footer
+        </twig:block>
+</twig:table>

--- a/src/TwigComponent/tests/Fixtures/templates/tags/open_tag.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/tags/open_tag.html.twig
@@ -1,0 +1,2 @@
+<twig:component_a propA propB="hello">
+</twig:component_a>

--- a/src/TwigComponent/tests/Fixtures/templates/tags/self_close_tag.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/tags/self_close_tag.html.twig
@@ -1,0 +1,1 @@
+<twig:component_a propA propB='hello'/>

--- a/src/TwigComponent/tests/Integration/ComponentLexerTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentLexerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+/**
+ * @author Mathèo Daninos <matheo.daninos@gmail.com>
+ *
+ * @internal
+ */
+class ComponentLexerTest extends KernelTestCase
+{
+    public function testComponentSyntaxOpenTags(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('tags/open_tag.html.twig');
+
+        $this->assertStringContainsString('propA: 1', $output);
+        $this->assertStringContainsString('propB: hello', $output);
+    }
+
+    public function testComponentSyntaxSelfCloseTags(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('tags/self_close_tag.html.twig');
+
+        $this->assertStringContainsString('propA: 1', $output);
+        $this->assertStringContainsString('propB: hello', $output);
+    }
+
+    public function testComponentSyntaxCanRenderEmbeddedComponent(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('tags/embedded_component.html.twig');
+
+        $this->assertStringContainsString('<caption>data table</caption>', $output);
+        $this->assertStringContainsString('custom th (key)', $output);
+        $this->assertStringContainsString('custom td (1)', $output);
+    }
+}

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\TwigComponent\Twig\TwigPreLexer;
+
+final class TwigPreLexerTest extends TestCase
+{
+    /**
+     * @dataProvider getLexTests
+     */
+    public function testPreLex(string $input, string $expectedOutput): void
+    {
+        $lexer = new TwigPreLexer();
+        $this->assertSame($expectedOutput, $lexer->preLexComponents($input));
+    }
+
+    public function getLexTests(): iterable
+    {
+        yield 'simple_component' => [
+            '<twig:foo />',
+            '{% component foo %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_attributes' => [
+            '<twig:foo bar="baz" with_quotes="It\'s with quotes" />',
+            "{% component foo with { bar: 'baz', with_quotes: 'It\'s with quotes' } %}{% endcomponent %}",
+        ];
+
+        yield 'component_with_dynamic_attributes' => [
+            '<twig:foo dynamic="{{ dynamicVar }}" :otherDynamic="anotherVar" />',
+            '{% component foo with { dynamic: dynamicVar, otherDynamic: anotherVar } %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_closing_tag' => [
+            '<twig:foo></twig:foo>',
+            '{% component foo %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_block' => [
+            '<twig:foo><twig:block name="foo_block">Foo</twig:block></twig:foo>',
+            '{% component foo %}{% block foo_block %}Foo{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_embedded_component_inside_block' => [
+            '<twig:foo><twig:block name="foo_block"><twig:bar /></twig:block></twig:foo>',
+            '{% component foo %}{% block foo_block %}{% component bar %}{% endcomponent %}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'attribute_with_no_value' => [
+            '<twig:foo bar />',
+            '{% component foo with { bar: true } %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_default_block_content' => [
+            '<twig:foo>Foo</twig:foo>',
+            '{% component foo %}{% block content %}Foo{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_default_block_that_holds_a_component_and_multi_blocks' => [
+            '<twig:foo>Foo <twig:bar /><twig:block name="other_block">Other block</twig:block></twig:foo>',
+            '{% component foo %}{% block content %}Foo {% component bar %}{% endcomponent %}{% endblock %}{% block other_block %}Other block{% endblock %}{% endcomponent %}',
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       |  
| License       | MIT

Hey all! This PR introduces a new syntax that is more component-oriented 😁


🚨 Just updated this description to feat with the last modification

The problem is: I use components with a lot of parameters, and I use a lot the embedded component feature. So I quickly end up with a hard-to-read template.
So here introduce a new syntax:
``` php
<t:myComponent parameter1 parameter2='foo'>
```
instead of:
```php
{{ component('myComponent', { parameter1: true, parameter2: 'foo' }) }}
```
The old syntax is not removed. This PR gives the ability to choose.

Here is a more realistic example:
```php
{% extends 'admin.html.twig' %}

{% block dashboard %}
    <t:userDashboard :user="user.id" isAdmin graph="linear" primary>
        <t:block name="actions">
            <t:userActions isAdmin/>
        </t:block>
        <t:block name="footer">
            <t:userDashBoardFooter/>
        </t:block>
    </t:userDashboard>
{% endblock %}
```
instead of
```php
{% extends 'admin.html.twig' %}

{% block dashboard %}
    {% component 'userDashboard' with {user: user.id, isAdmin: true, graph: 'linear', primary: true} %}
        {% block actions %}
            {{ component('userActions', {isAdmin: 'true'}) }}
        {% endblock %}
        {% block footer %}
            {{ component('userDashboardFooter') }}
        {% endblock %}
    {% endcomponent %}
{% endblock %}
```

So here is a quick summary:

- you can use <t:component/>, <t:component></t:component>
- you also have a special syntax for nested block <t:block name="blockName"></t:block>
- you can use ':' just before your attribute for a value that should be compiled by twig  <t:component :user="user.id"> equal to  <t:component :user="{{ user.id }}">
- you now have a content block by default. For example, if you have:
``` php
<t:component :user="user.id">
  <div>
     // my content
  <div>
<t:component/>
```
then in your component template

```php
{% block content %}
 // your comment will be display here
{% endblock %}
```

Piouffff!!!! A lot of stuff going on here 😎

This PR is inspired a lot by this library: https://github.com/giorgiopogliani/twig-components

Thanks for your time.
Cheers! 😁