### PR TITLE
fix(autocomplete): Use absolute path to generate next page url

### DIFF
--- a/src/Autocomplete/src/Controller/EntityAutocompleteController.php
+++ b/src/Autocomplete/src/Controller/EntityAutocompleteController.php
@@ -46,7 +46,7 @@ final class EntityAutocompleteController
         if ($data->hasNextPage) {
             $parameters = array_merge($request->attributes->all('_route_params'), $request->query->all(), ['page' => $page + 1]);
 
-            $nextPage = $this->urlGenerator->generate($request->attributes->get('_route'), $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
+            $nextPage = $this->urlGenerator->generate($request->attributes->get('_route'), $parameters);
         }
 
         return new JsonResponse([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Tickets       | Fix #772 
| License       | MIT

This will generate `next_page` URL based on absolute path instead of absolute URL. 

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
