### PR TITLE
Remove extra word from sentence

### DIFF
--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -58,7 +58,7 @@ need to adjust your JavaScript to work properly. The best solution is to
 write your JavaScript using
 `Stimulus`_ or something similar.
 
-We also recommend that you place your ``script`` tags live inside your
+We also recommend that you place your ``script`` tags inside your
 ``head`` tag so that they aren't reloaded on every navigation (Turbo
 re-executes any ``script`` tags inside ``body`` on every navigation).
 Add a ``defer`` attribute to each ``script`` tag to prevent it from


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR fixes documentation on https://symfony.com/bundles/ux-turbo/current/index.html
The first sentence in paragraph 2 of this section is confusing to read: https://symfony.com/bundles/ux-turbo/current/index.html

I'm not sure if the sentence should read:
`We also recommend that you place your script tags inside your head tag ` OR
`We also recommend that your script tags live inside your head tag `
The current version is a combination of the 2. This PR fixes that.