### PR TITLE
[Live] Adding a "key" attribute that can be used when rendering a collection of children

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -578,7 +578,7 @@ option::
 
 Now you can bind this to a field on the frontend that uses that same format:
 
-.. code-block:: twig
+.. code-block:: html+twig
 
     <input type="date" data-model="publishOn">
 
@@ -2547,16 +2547,35 @@ form.
 Rendering Quirks with List of Embedded Components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Imagine your component renders a list of embedded components and
-that list is updated as the user types into a search box. Most of the
-time, this works *fine*. But in some cases, as the list of items
-changes, a child component will re-render even though it was there
-before *and* after the list changed. This can cause that child component
-to lose some state (i.e. it re-renders with its original live props data).
+Rendering Quirks with List of Embedded Components
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To fix this, add a unique ``data-live-id`` attribute to the root component of each
-child element. This will helps LiveComponent identify each item in the
-list and correctly determine if a re-render is necessary, or not.
+Imagine your component renders a list of child components and
+the list changes as the user types into a search box... or by clicking
+"delete" on an item. In this case, the wrong children may be removed
+or existing child components may not disappear when they should.
+
+.. versionadded:: 2.8
+
+    The ``key`` prop was added in Symfony UX Live Component 2.8.
+
+To fix this, add a ``key`` prop to each child component that's unique
+to that component:
+
+.. code-block:: twig
+
+    {# templates/components/invoice.html.twig #}
+    {% for lineItem in lineItems %}
+        {{ component('invoice_line_item', {
+            productId: lineItem.productId,
+            key: lineItem.id,
+        }) }}
+    {% endfor %}
+
+The ``key`` will be used to generate a ``data-live-id`` attribute,
+which will be used to identify each child component. You can
+also pass in a ``data-live-id`` attribute directly, but ``key`` is
+a bit more convenient.
 
 Advanced Functionality
 ----------------------

--- a/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
+++ b/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
@@ -64,6 +64,10 @@ final class AddLiveAttributesSubscriber implements EventSubscriberInterface, Ser
             $attributes = $attributes->defaults($variables[$attributesKey]->all());
         }
 
+        // "key" is a special attribute: don't actually render it
+        // this is used inside LiveControllerAttributesCreator
+        $attributes = $attributes->without(LiveControllerAttributesCreator::KEY_PROP_NAME);
+
         $variables[$attributesKey] = $attributes;
 
         $event->setVariables($variables);

--- a/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
+++ b/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
@@ -53,7 +53,13 @@ class InterceptChildComponentRenderSubscriber implements EventSubscriberInterfac
         $childFingerprints = $parentComponent->getExtraMetadata(self::CHILDREN_FINGERPRINTS_METADATA_KEY);
 
         // get the deterministic id for this child, but without incrementing the counter yet
-        $deterministicId = $event->getInputProps()['data-live-id'] ?? $this->getDeterministicIdCalculator()->calculateDeterministicId(increment: false);
+        if (isset($event->getInputProps()['data-live-id'])) {
+            $deterministicId = $event->getInputProps()['data-live-id'];
+        } else {
+            $key = $event->getInputProps()[LiveControllerAttributesCreator::KEY_PROP_NAME] ?? null;
+            $deterministicId = $this->getDeterministicIdCalculator()->calculateDeterministicId(increment: false, key: $key);
+        }
+
         if (!isset($childFingerprints[$deterministicId])) {
             // child fingerprint wasn't set, it is likely a new child, allow it to render fully
             return;

--- a/src/LiveComponent/src/Twig/DeterministicTwigIdCalculator.php
+++ b/src/LiveComponent/src/Twig/DeterministicTwigIdCalculator.php
@@ -37,8 +37,11 @@ class DeterministicTwigIdCalculator
      * called this method 3 times on the same line during one request, you will
      * get the same value back if you call it 3 times on a future request for
      * that same file & line.
+     *
+     * @param bool        $increment Whether to increment the counter for this file+line
+     * @param string|null $key       An optional key to use instead of the incremented counter
      */
-    public function calculateDeterministicId(bool $increment = true): string
+    public function calculateDeterministicId(bool $increment = true, string $key = null): string
     {
         $lineData = $this->guessTemplateInfo();
 
@@ -48,9 +51,9 @@ class DeterministicTwigIdCalculator
         }
 
         $id = sprintf(
-            'live-%s-%d',
+            'live-%s-%s',
             crc32($fileAndLine),
-            $this->lineAndFileCounts[$fileAndLine]
+            null !== $key ? $key : $this->lineAndFileCounts[$fileAndLine]
         );
 
         if ($increment) {

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -31,6 +31,13 @@ use Symfony\UX\TwigComponent\MountedComponent;
  */
 class LiveControllerAttributesCreator
 {
+    /**
+     * Prop name that can be passed into a component to keep it unique in a loop.
+     *
+     * This is used to generate the unique data-live-id for the child component.
+     */
+    public const KEY_PROP_NAME = 'key';
+
     public function __construct(
         private LiveComponentMetadataFactory $metadataFactory,
         private LiveComponentHydrator $hydrator,
@@ -70,7 +77,8 @@ class LiveControllerAttributesCreator
 
         if ($isChildComponent) {
             if (!isset($mountedAttributes->all()['data-live-id'])) {
-                $id = $deterministicId ?: $this->idCalculator->calculateDeterministicId();
+                $id = $deterministicId ?: $this->idCalculator
+                    ->calculateDeterministicId(key: $mounted->getInputProps()[self::KEY_PROP_NAME] ?? null);
                 $attributesCollection->setLiveId($id);
                 // we need to add this to the mounted attributes so that it is
                 // will be included in the "attributes" part of the props data.

--- a/src/LiveComponent/tests/Fixtures/Component/TodoListWithKeysComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/TodoListWithKeysComponent.php
@@ -12,23 +12,17 @@
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
-use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
-use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity1;
 
-#[AsLiveComponent('todo_item')]
-final class TodoItemComponent
+#[AsLiveComponent('todo_list_with_keys')]
+final class TodoListWithKeysComponent
 {
     use DefaultActionTrait;
 
     #[LiveProp(writable: true)]
-    public string $text = '';
+    public string $name = '';
 
-    #[LiveProp(updateFromParent: true)]
-    public int $textLength = 0;
-
-    // here just to force a checksum to be needed, helps make tests more robust
-    #[LiveProp(writable: false)]
-    public string $readonlyValue = 'readonly';
+    #[LiveProp]
+    public array $items = [];
 }

--- a/src/LiveComponent/tests/Fixtures/templates/components/todo_list_with_keys.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/todo_list_with_keys.html.twig
@@ -1,0 +1,13 @@
+<div{{ attributes }}>
+    Todo List: {{ name }}
+
+    <ul>
+    {% for key, item in items %}
+        {{ component('todo_item', {
+            text: item.text,
+            textLength: item.text|length,
+            key: 'the-key'~key,
+        }) }}
+    {% endfor %}
+    </ul>
+</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | None
| License       | MIT

Found this while building some components. When you render an array of child components, we need a `data-live-id` on each one, which is how we identify which component is which in case some are reordered or removed. But, adding a `data-live-id` is ugly, so this allows a simpler `key` attribute, like any other frontend framework.

Cheers!