### PR TITLE
[Live] Ignore problems with writing bad types for writable paths

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Entity/CategoryFixtureEntity.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/CategoryFixtureEntity.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class CategoryFixtureEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private ?string $name = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -23,6 +23,7 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\BlogPostWithSerializationContext
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Embeddable2;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Money;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Temperature;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\CategoryFixtureEntity;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Embeddable1;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity1;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity2;
@@ -1066,6 +1067,19 @@ final class LiveComponentHydratorTest extends KernelTestCase
                     $this->assertSame(1, $object->nonNullableInt->value);
                 });
         }, 80100];
+
+        yield 'writable_path_with_type_problem_ignored' => [function () {
+            return HydrationTest::create(new class() {
+                #[LiveProp(writable: ['name'])]
+                public CategoryFixtureEntity $category;
+            })
+                ->mountWith(['category' => new CategoryFixtureEntity()])
+                ->assertObjectAfterHydration(function (object $object) {
+                    // dehydrating category.name=null does not cause issues
+                    // even though setName() does not allow null
+                    $this->assertNull($object->category->getName());
+                });
+        }];
     }
 
     public function testHydrationFailsIfChecksumMissing(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | None
| License       | MIT

Found when building some components. The motivating use-case is where you have a writable property that starts null but the setter method does NOT allow null (this is common with entity properties and methods). When that null is rehydrated later, we attempt to call the setter with a null value, which explodes.

This makes for a better UX... though with a sprinkle of magic to make it happen. Without this, you would need to make your setter methods allow null (e.g. `setName(?string $name)`) *just* because the original property starts as null.

Cheers!