### PR TITLE
[Live] Removing usage of "key" which may not be set

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 -   Added support for using [OptionGroups](https://tom-select.js.org/examples/optgroups/).
 
-
 ## 2.7.0
 
 -   Add `assets/src` to `.gitattributes` to exclude them from the installation

--- a/src/LiveComponent/src/DependencyInjection/Compiler/ComponentDefaultActionPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/ComponentDefaultActionPass.php
@@ -33,7 +33,7 @@ final class ComponentDefaultActionPass implements CompilerPassInterface
             $defaultAction = trim($component[0]['default_action'] ?? '__invoke', '()');
 
             if (!method_exists($class, $defaultAction)) {
-                throw new \LogicException(sprintf('Live component "%s" (%s) requires the default action method "%s".%s', $class, $component[0]['key'], $defaultAction, '__invoke' === $defaultAction ? ' Either add this method or use the DefaultActionTrait' : ''));
+                throw new \LogicException(sprintf('Live component "%s" requires the default action method "%s".%s', $class, $defaultAction, '__invoke' === $defaultAction ? ' Either add this method or use the DefaultActionTrait' : ''));
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

`key` - aka the component name - is now optional at this point.