### PR TITLE
[Autocomplete] Opt-out from auto updates if the root has a live id

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -30,6 +30,9 @@ class default_1 extends Controller {
         this.isObserving = false;
     }
     initialize() {
+        if (this.element.hasAttribute('data-live-id')) {
+            return;
+        }
         if (this.requiresLiveIgnore()) {
             this.element.setAttribute('data-live-ignore', '');
             if (this.element.id) {

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -36,6 +36,10 @@ export default class extends Controller {
     private isObserving = false;
 
     initialize() {
+        if (this.element.hasAttribute('data-live-id')) {
+            return;
+        }
+
         if (this.requiresLiveIgnore()) {
             // unfortunately, TomSelect does enough weird things that, for a
             // multi select, if the HTML in the `<select>` element changes,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | -
| License       | MIT

When I have a form with dependent fields I can tell when a dependency changes
and if I use a custom `data-live-id` attribute which calculated based on the
dependencies the dynamic fields will re-render correctly and fixes the issue
with multi-select fields.

For example this seems to work well:

```php
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
            ->add('department', null, [
                'autocomplete' => true,
            ])
        ;

        $formModifier = function (FormInterface $form, Department $department = null) {
            $members = $department ? $this->organizationMemberRepository->findByDepartment($department) : [];
            $form->add('participatingMembers', null, [
                'autocomplete' => true,
                'choices' => $members,
                'attr' => [
                    'data-live-id' => 'participating-members-'.$department?->getId(),
                ],
            ]);
        };

        /// ...
    }
