### PR TITLE
remove / character in the list of allowed character

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -123,7 +123,7 @@ class TwigPreLexer
     private function consumeComponentName(string $customExceptionMessage = null): string
     {
         $start = $this->position;
-        while ($this->position < $this->length && preg_match('/[A-Za-z0-9_:@\-\/.]/', $this->input[$this->position])) {
+        while ($this->position < $this->length && preg_match('/[A-Za-z0-9_:@\-.]/', $this->input[$this->position])) {
             ++$this->position;
         }
 

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -62,6 +62,11 @@ final class TwigPreLexerTest extends TestCase
             '{{ component(\'foo\', { bar: true }) }}',
         ];
 
+        yield 'attribute_with_no_value_and_no_attributes' => [
+            '<twig:foo/>',
+            '{{ component(\'foo\') }}',
+        ];
+
         yield 'component_with_default_block_content' => [
             '<twig:foo>Foo</twig:foo>',
             '{% component \'foo\' %}{% block content %}Foo{% endblock %}{% endcomponent %}',
@@ -82,10 +87,6 @@ final class TwigPreLexerTest extends TestCase
         yield 'component_with_character_-_on_his_name' => [
             '<twig:foo-bar></twig:foo-bar>',
             '{% component \'foo-bar\' %}{% endcomponent %}',
-        ];
-        yield 'component_with_character_/_on_his_name' => [
-            '<twig:foo/bar></twig:foo/bar>',
-            '{% component \'foo/bar\' %}{% endcomponent %}',
         ];
         yield 'component_with_character_._on_his_name' => [
             '<twig:foo.bar></twig:foo.bar>',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | 
| License       | MIT


By allowing the / character in #806, we introduce a bug. You can't now use the self-closing syntax because it enters in conflict with the component name.
```php
<twig:foo/>
```
The Lexer thinks now that the name is `foo/`
I just remove the / from the allowing list, tell me if you think we should go a bit further.