### PR TITLE
[Translator] Prefix bundle and extension classes with "Ux"

### DIFF
--- a/src/Translator/src/DependencyInjection/UxTranslatorExtension.php
+++ b/src/Translator/src/DependencyInjection/UxTranslatorExtension.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  *
  * @experimental
  */
-class TranslatorExtension extends Extension
+class UxTranslatorExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/src/Translator/src/UxTranslatorBundle.php
+++ b/src/Translator/src/UxTranslatorBundle.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  *
  * @experimental
  */
-class TranslatorBundle extends Bundle
+class UxTranslatorBundle extends Bundle
 {
     public function getPath(): string
     {

--- a/src/Translator/tests/Kernel/EmptyAppKernel.php
+++ b/src/Translator/tests/Kernel/EmptyAppKernel.php
@@ -13,7 +13,7 @@ namespace Symfony\UX\Translator\Tests\Kernel;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\UX\Translator\TranslatorBundle;
+use Symfony\UX\Translator\UxTranslatorBundle;
 
 /**
  * @author Hugo Alliaume <hugo@alliau.me>
@@ -26,7 +26,7 @@ class EmptyAppKernel extends Kernel
 
     public function registerBundles(): iterable
     {
-        return [new TranslatorBundle()];
+        return [new UxTranslatorBundle()];
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)

--- a/src/Translator/tests/Kernel/FrameworkAppKernel.php
+++ b/src/Translator/tests/Kernel/FrameworkAppKernel.php
@@ -15,7 +15,7 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\UX\Translator\TranslatorBundle;
+use Symfony\UX\Translator\UxTranslatorBundle;
 
 /**
  * @author Hugo Alliaume <hugo@alliau.me>
@@ -28,7 +28,7 @@ class FrameworkAppKernel extends Kernel
 
     public function registerBundles(): iterable
     {
-        return [new FrameworkBundle(), new TranslatorBundle()];
+        return [new FrameworkBundle(), new UxTranslatorBundle()];
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)

--- a/src/Translator/tests/UxTranslatorBundleTest.php
+++ b/src/Translator/tests/UxTranslatorBundleTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\Kernel;
 use Symfony\UX\Translator\Tests\Kernel\EmptyAppKernel;
 use Symfony\UX\Translator\Tests\Kernel\FrameworkAppKernel;
 
-class TranslatorBundleTest extends TestCase
+class UxTranslatorBundleTest extends TestCase
 {
     public function provideKernels()
     {
@@ -21,6 +21,6 @@ class TranslatorBundleTest extends TestCase
     public function testBootKernel(Kernel $kernel)
     {
         $kernel->boot();
-        $this->assertArrayHasKey('TranslatorBundle', $kernel->getBundles());
+        $this->assertArrayHasKey('UxTranslatorBundle', $kernel->getBundles());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->

While installing the package for the demo page, I've got the following issue:

>  There is no extension able to load the configuration for "ux_translator" (in "/Users/kocal/workspace-os/symfony-ux/ux.symfony.com/config/packages/ux_translator.yaml"). Looked for namespace "ux_
  translator", found ""framework", "twig", "twig_extra", "webpack_encore", "turbo", "mercure", "web_profiler", "monolog", "debug", "twig_component", "live_component", "chartjs", "cropperjs", "laz
  y_image", "dropzone", "doctrine", "doctrine_migrations", "maker", "babdev_pagerfanta", "autocomplete", "notify", "react", "vue", "svelte", "translator"" in /Users/kocal/workspace-os/symfony-ux/
  ux.symfony.com/config/packages/ux_translator.yaml (which is being imported from "/Users/kocal/workspace-os/symfony-ux/ux.symfony.com/src/Kernel.php").

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/2103975/234497995-550ce874-8445-4dcf-a9bf-5368797be699.png">

(you can also see it in the recipe PR https://github.com/symfony/recipes/pull/1185)

Indeed, I've used `ux_translator` for the `TreeBuilder`'s name and not `translator` (to prevent misundersting with Symfony's Translator PHP version), but the related Bundle and Extension classes were not named correctly.

After the fix, the bundle is correctly loaded:
<img width="1486" alt="image" src="https://user-images.githubusercontent.com/2103975/234498103-f791c0e8-0da2-4867-a3cd-65018774cee4.png">
