### PR TITLE
[Translator] Type and documentation fixes

### DIFF
--- a/src/Translator/assets/dist/translator.d.ts
+++ b/src/Translator/assets/dist/translator.d.ts
@@ -4,7 +4,7 @@ export type TranslationsType = Record<DomainType, {
     parameters: ParametersType;
 }>;
 export type NoParametersType = Record<string, never>;
-export type ParametersType = Record<string, string | number> | NoParametersType;
+export type ParametersType = Record<string, string | number | Date> | NoParametersType;
 export type RemoveIntlIcuSuffix<T> = T extends `${infer U}+intl-icu` ? U : T;
 export type DomainsOf<M> = M extends Message<infer Translations, LocaleType> ? keyof Translations : never;
 export type LocaleOf<M> = M extends Message<TranslationsType, infer Locale> ? Locale : never;

--- a/src/Translator/assets/src/translator.ts
+++ b/src/Translator/assets/src/translator.ts
@@ -14,7 +14,7 @@ export type LocaleType = string;
 
 export type TranslationsType = Record<DomainType, { parameters: ParametersType }>;
 export type NoParametersType = Record<string, never>;
-export type ParametersType = Record<string, string | number> | NoParametersType;
+export type ParametersType = Record<string, string | number | Date> | NoParametersType;
 
 export type RemoveIntlIcuSuffix<T> = T extends `${infer U}+intl-icu` ? U : T;
 export type DomainsOf<M> = M extends Message<infer Translations, LocaleType> ? keyof Translations : never;

--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -61,16 +61,17 @@ Configuring the default locale
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, the default locale is ``en`` (English) that you can configure through many ways (in order of priority):
-1. With ``setLocale('your-locale')`` from ``@symfony/ux-translator`` package
-2. Or with ``<html data-symfony-ux-translator-locale="your-locale">`` attribute
-3. Or with ``<html lang="your-locale">`` attribute
+
+#. With ``setLocale('your-locale')`` from ``@symfony/ux-translator`` package
+#. Or with ``<html data-symfony-ux-translator-locale="your-locale">`` attribute
+#. Or with ``<html lang="your-locale">`` attribute
 
 Importing and using translations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you use the Symfony Flex recipe, you can import the ``trans()`` function and your translations in your assets from the file `assets/translator.js`.
+If you use the Symfony Flex recipe, you can import the ``trans()`` function and your translations in your assets from the file ``assets/translator.js``.
 
-Translations are available as named exports, by using the translation's id transformed in uppercase snake-case (e.g.: `my.translation` becomes `MY_TRANSLATION`),
+Translations are available as named exports, by using the translation's id transformed in uppercase snake-case (e.g.: ``my.translation`` becomes ``MY_TRANSLATION``),
 so you can import them like this:
 
 .. code-block:: javascript

--- a/yarn.lock
+++ b/yarn.lock
@@ -6412,6 +6412,16 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svelte-jester@^2.3:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/svelte-jester/-/svelte-jester-2.3.2.tgz#9eb818da30807bbcc940b6130d15b2c34408d64f"
+  integrity sha512-JtxSz4FWAaCRBXbPsh4LcDs4Ua7zdXgLC0TZvT1R56hRV0dymmNP+abw67DTPF7sQPyNxWsOKd0Sl7Q8SnP8kg==
+
+svelte@^3.0:
+  version "3.58.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.58.0.tgz#d3e6f103efd6129e51c7d709225ad3b4c052b64e"
+  integrity sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==
+
 swup@^2.0, swup@^2.0.13:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/swup/-/swup-2.0.19.tgz#dfb5c0f3d63e21089403fcad8d117c87a2b7eab0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->

When working on the demo page, I've faced an issue about `Date` which was unuasable as translation parameter, but it should as we can use it to format date/datetime.

The documentation rendering was a bit broken too, I'm not familiar with RST, but it should be fixed.

Also, when running `yarn install`, the `yarn.lock` change, so I commited it aswell.