### PR TITLE
[LiveComponent] Fix minor misalignment in documentation

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2772,7 +2772,7 @@ reason to re-render it.
 
 To fix this, you have two options:
 
-1. Make the ``key`` dynamic so it will be different after adding a new item::
+\1) Make the ``key`` dynamic so it will be different after adding a new item:
 
 .. code-block:: twig
 
@@ -2780,10 +2780,12 @@ To fix this, you have two options:
         key: 'new_line_item_'~lineItems|length,
     }) }}
 
-2. Reset the state of the ``InvoiceLineItemForm`` component after it's saved::
+\2) Reset the state of the ``InvoiceLineItemForm`` component after it's saved::
 
     // src/Twig/InvoiceLineItemForm.php
     // ...
+
+    #[AsLiveComponent]
     class InvoiceLineItemForm
     {
         // ...


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| License       | MIT

One the LiveComponent document page, two following blocs were not aligned at the end of the [Rendering Quirks with List of Embedded Components](https://symfony.com/bundles/ux-live-component/current/index.html#rendering-quirks-with-list-of-embedded-components) section.

| Before | After (preview mode) |
| -- | -- |
| <img width="914" alt="before" src="https://user-images.githubusercontent.com/1359581/235380357-3ea2ea23-af2b-4153-b70d-96ec3fe7fce6.png"> | <img width="875" alt="after" src="https://user-images.githubusercontent.com/1359581/235380364-858229cc-59bc-4b7b-9433-5f68b33b0d39.png"> |
