### PR TITLE
[Live] Adding missing format property

### DIFF
--- a/src/LiveComponent/src/Attribute/LiveProp.php
+++ b/src/LiveComponent/src/Attribute/LiveProp.php
@@ -45,6 +45,8 @@ final class LiveProp
      */
     private ?string $fieldName;
 
+    private ?string $format;
+
     private bool $acceptUpdatesFromParent;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

I forgot to define the property - this is technically allowed (so things worked), but deprecated and a disaster of an idea ;).

Cheers!