### PR TITLE
[Live] Reverting back to simpler serialize for fingerprint calculator

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -270,7 +270,7 @@ jobs:
             - name: Notify Tests
               working-directory: src/Notify
               run: php vendor/bin/simple-phpunit
-              
+
             - name: Translator Dependencies
               uses: ramsey/composer-install@v2
               with:

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -194,7 +194,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
 
         $container->register('ux.live_component.deterministic_id_calculator', DeterministicTwigIdCalculator::class);
         $container->register('ux.live_component.fingerprint_calculator', FingerprintCalculator::class)
-            ->setArguments([new Reference('serializer'), '%kernel.secret%']);
+            ->setArguments(['%kernel.secret%']);
 
         $container->setAlias(ComponentValidatorInterface::class, ComponentValidator::class);
 

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -36,7 +36,6 @@ use Symfony\UX\TwigComponent\ComponentAttributes;
  */
 final class LiveComponentHydrator
 {
-    public const LIVE_CONTEXT = 'live-component';
     private const ATTRIBUTES_KEY = '@attributes';
     private const CHECKSUM_KEY = '@checksum';
 

--- a/src/LiveComponent/src/Twig/DeterministicTwigIdCalculator.php
+++ b/src/LiveComponent/src/Twig/DeterministicTwigIdCalculator.php
@@ -102,7 +102,7 @@ class DeterministicTwigIdCalculator
 
         // update template name
         // START CHANGE
-        // don't check name poroperty
+        // don't check name property
         // if (null !== $template && null === $this->name) {
         if (null !== $template) {
             // END CHANGE

--- a/src/LiveComponent/src/Util/FingerprintCalculator.php
+++ b/src/LiveComponent/src/Util/FingerprintCalculator.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Symfony\UX\LiveComponent\Util;
 
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadata;
 
 /**
@@ -33,7 +31,6 @@ use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadata;
 class FingerprintCalculator
 {
     public function __construct(
-        private NormalizerInterface $objectNormalizer,
         private string $secret,
     ) {
     }
@@ -46,8 +43,6 @@ class FingerprintCalculator
             return '';
         }
 
-        $normalizedData = $this->objectNormalizer->normalize($fingerprintProps, context: [LiveComponentHydrator::LIVE_CONTEXT => true]);
-
-        return base64_encode(hash_hmac('sha256', serialize($normalizedData), $this->secret, true));
+        return base64_encode(hash_hmac('sha256', serialize($fingerprintProps), $this->secret, true));
     }
 }

--- a/src/LiveComponent/tests/Fixtures/templates/components/todo_list_with_keys.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/todo_list_with_keys.html.twig
@@ -3,11 +3,7 @@
 
     <ul>
     {% for key, item in items %}
-        {{ component('todo_item', {
-            text: item.text,
-            textLength: item.text|length,
-            key: 'the-key'~key,
-        }) }}
+        {{ component('todo_item', { text: item.text, textLength: item.text|length, key: 'the-key'~key }) }}
     {% endfor %}
     </ul>
 </div>

--- a/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
@@ -109,9 +109,9 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
         $fingerprints = [];
         foreach ($fingerprintValues as $key => $fingerprintValue) {
             // creating fingerprints keys to match todo_list_with_keys.html.twig
-            $fingerprints['live-4172682817-the-key'.$key] = $fingerprintValue;
+            $fingerprints['live-1745423312-the-key'.$key] = $fingerprintValue;
         }
-        $fingerprints['live-4172682817-the-key1'] = 'wrong fingerprint';
+        $fingerprints['live-1745423312-the-key1'] = 'wrong fingerprint';
 
         $urlSimple = $this->doBuildUrlForComponent('todo_list_with_keys', []);
         $urlWithChangedFingerprints = $this->doBuildUrlForComponent('todo_list_with_keys', $fingerprints);
@@ -120,14 +120,15 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
             ->visit($urlSimple)
             ->assertSuccessful()
             ->assertHtml()
+            ->dump()
             ->assertElementCount('ul li', 3)
             // check for the live-id we expect based on the key
-            ->assertContains('data-live-id="live-4172682817-the-key0"')
+            ->assertContains('data-live-id="live-1745423312-the-key0"')
             ->assertNotContains('key="the-key0"')
             ->visit($urlWithChangedFingerprints)
-            ->assertContains('<li data-live-id="live-4172682817-the-key0"></li>')
+            ->assertContains('<li data-live-id="live-1745423312-the-key0"></li>')
             // this one is changed, so it renders a full element
-            ->assertContains('<li data-live-name-value="todo_item" data-live-id="live-4172682817-the-key1"')
+            ->assertContains('<li data-live-name-value="todo_item" data-live-id="live-1745423312-the-key1"')
         ;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #831 
| License       | MIT

This reverts #725. The problem is that using the serializer opens all kinds of cans of worms, including circular reference problems.

So, do we still have the big performance problem of #725? I'm not sure. We now only calculate the fingerprint based on LiveProps with `updateFromParent`.