### PR TITLE
[Translator] Tweaking composer description to match repo description

### DIFF
--- a/src/Translator/composer.json
+++ b/src/Translator/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "symfony/ux-translator",
     "type": "symfony-bundle",
-    "description": "Symfony Translator for JavaScript",
+    "description": "Exposes Symfony Translations directly to JavaScript.",
     "keywords": [
         "symfony-ux"
     ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | Nene
| License       | MIT

GitHub repository descriptions on each sub-tree split are now synchronized to the `description` in `composer.json` (except for this one, which was updated on the repo first... now going backwards to update it in composer.json).
