### PR TITLE
[Twig] Working around bug where the new lexer causes the extension set to load too early

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentLexer.php
+++ b/src/TwigComponent/src/Twig/ComponentLexer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\TwigComponent\Twig;
 
+use Twig\Environment;
 use Twig\Lexer;
 use Twig\Source;
 use Twig\TokenStream;
@@ -26,8 +27,27 @@ use Twig\TokenStream;
  */
 class ComponentLexer extends Lexer
 {
+    private Environment $env;
+    private array $options;
+    private bool $isConstructed = false;
+
+    public function __construct(Environment $env, array $options = [])
+    {
+        $this->env = $env;
+        $this->options = $options;
+    }
+
     public function tokenize(Source $source): TokenStream
     {
+        // odd behavior is because the parent constructor causes the extension set
+        // to be initialized earlier than it normally would be.
+        // https://github.com/symfony/ux/issues/835
+        if (!$this->isConstructed) {
+            parent::__construct($this->env, $this->options);
+
+            $this->isConstructed = true;
+        }
+
         $preLexer = new TwigPreLexer();
         $preparsed = $preLexer->preLexComponents($source->getCode());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #835
| License       | MIT

Well, I don't love this fix :/. Normally, Twig's `Lexer` class is not instantiated inside `Environment` until it's needed. However, if you inject your own `Lexer`, then you must instantiate it early... AND it needs to extend `Lexer`, whose constructor cases the extension set to initialize. This is an ugly fix - but it works. 

Should this be considered a Twig bug? - e.g. perhaps all the work done inside the Lexer's constructor should be delayed until it's needed - https://github.com/twigphp/Twig/blob/f5ee1b6815a28fbab6e6fbb8c48b7964f0d93dd4/src/Lexer.php#L51-L152

Either way, it seems harmless to work around it here for the moment.