### PR TITLE
[TwigComponent] Fix lexer to escape attribute name when it contains dashes

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -200,7 +200,7 @@ class TwigPreLexer
                 $attributeValue = $this->consumeAttributeValue($quote);
             }
 
-            $attributes[] = sprintf('%s: %s', $key, $attributeValue);
+            $attributes[] = sprintf('%s: %s', preg_match('/[-:]/', $key) ? "'$key'" : $key, $attributeValue);
 
             $this->expectAndConsumeChar($quote);
             $this->consumeWhitespace();

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -151,5 +151,20 @@ final class TwigPreLexerTest extends TestCase
             ] }) }}
             EOF
         ];
+
+        yield 'component_with_dashed_attribute' => [
+            '<twig:foobar data-action="foo#bar"></twig:foobar>',
+            '{% component \'foobar\' with { \'data-action\': \'foo#bar\' } %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_dashed_attribute_self_closing' => [
+            '<twig:foobar data-action="foo#bar" />',
+            '{{ component(\'foobar\', { \'data-action\': \'foo#bar\' }) }}',
+        ];
+
+        yield 'component_with_colon_attribute' => [
+            '<twig:foobar my:attribute="yo"></twig:foobar>',
+            '{% component \'foobar\' with { \'my:attribute\': \'yo\' } %}{% endcomponent %}',
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Hello :) back from holidays and now testing new features, so this is the second thing I've found.
Will open an issue about the first one.