### PR TITLE
[TwigComponent] Ignore twig comments when prelexing

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -40,6 +40,14 @@ class TwigPreLexer
         $output = '';
 
         while ($this->position < $this->length) {
+            // ignore content inside twig comments, see #838
+            if ($this->consume('{#')) {
+                $output .= '{#';
+                $output .= $this->consumeUntil('#}');
+                $this->consume('#}');
+                $output .= '#}';
+            }
+
             if ($this->consume('<twig:')) {
                 $componentName = $this->consumeComponentName();
 

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -166,5 +166,10 @@ final class TwigPreLexerTest extends TestCase
             '<twig:foobar my:attribute="yo"></twig:foobar>',
             '{% component \'foobar\' with { \'my:attribute\': \'yo\' } %}{% endcomponent %}',
         ];
+
+        yield 'ignore_twig_comment' => [
+            '{# <twig:Alert/> #} <twig:Alert/>',
+            '{# <twig:Alert/> #} {{ component(\'Alert\') }}',
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Tickets       | Fix #838
| License       | MIT


This PR ignores {# twig comments content. Is this really the only way to comment in Twig 🤔?