### PR TITLE
[TwigComponent] Fix lexer to escape truthy attribute names

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -193,7 +193,7 @@ class TwigPreLexer
                     throw new SyntaxError(sprintf('Expected "=" after ":%s" when parsing the "<twig:%s" syntax.', $key, $componentName), $this->line);
                 }
 
-                $attributes[] = sprintf('%s: true', $key);
+                $attributes[] = sprintf('%s: true', preg_match('/[-:]/', $key) ? "'$key'" : $key);
                 $this->consumeWhitespace();
                 continue;
             }

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -167,6 +167,11 @@ final class TwigPreLexerTest extends TestCase
             '{% component \'foobar\' with { \'my:attribute\': \'yo\' } %}{% endcomponent %}',
         ];
 
+        yield 'component_with_truthy_attribute' => [
+            '<twig:foobar data-turbo-stream></twig:foobar>',
+            '{% component \'foobar\' with { \'data-turbo-stream\': true } %}{% endcomponent %}',
+        ];
+
         yield 'ignore_twig_comment' => [
             '{# <twig:Alert/> #} <twig:Alert/>',
             '{# <twig:Alert/> #} {{ component(\'Alert\') }}',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #...
| License       | MIT

Missed this one :disappointed: 