### PR TITLE
[TwigComponent] Fix MountedComponent::$extraMetadata type doc

### DIFF
--- a/src/TwigComponent/src/MountedComponent.php
+++ b/src/TwigComponent/src/MountedComponent.php
@@ -21,7 +21,7 @@ final class MountedComponent
     /**
      * Any extra metadata that might be useful to set.
      *
-     * @var array<string, string>
+     * @var array<string, mixed>
      */
     private array $extraMetadata = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | -
| License       | MIT

MountedComponent::getExtraMetadata() has `mixed` as return type and it returns elements from this array.
