### PR TITLE
[LiveComponent] Throw clear error when using union types for LiveProps

### DIFF
--- a/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
@@ -71,6 +71,9 @@ class LiveComponentMetadataFactory
             }
 
             $type = $property->getType();
+            if ($type instanceof \ReflectionUnionType || $type instanceof \ReflectionIntersectionType) {
+                throw new \LogicException(sprintf('Union or intersection types are not supported for LiveProps. You may want to change the type of property %s in %s.', $property->getName(), $property->getDeclaringClass()->getName()));
+            }
             $metadatas[$property->getName()] = new LivePropMetadata(
                 $property->getName(),
                 $attribute->newInstance(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #853
| License       | MIT

As mentioned in https://github.com/symfony/ux/issues/853#issuecomment-1538949120, supporting union types for LiveProps will be quite tricky. Given that, at least a clear error should be thrown.

