### PR TITLE
[Live] Fixing bug with ComponentWithFormTrait and empty collections

### DIFF
--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -235,7 +235,7 @@ trait ComponentWithFormTrait
             // is already correct. For example, an expanded ChoiceType with
             // options "text" and "phone" would already have a value in the format
             // ["text"] (assuming "text" is checked and "phone" is not).
-            if (!($child->vars['expanded'] ?? false) && \count($child->children) > 0) {
+            if (!($child->vars['expanded'] ?? false) && ($child->vars['compound'] ?? false)) {
                 $values[$name] = $this->extractFormValues($child);
 
                 continue;

--- a/src/LiveComponent/tests/Fixtures/Dto/BlogPost.php
+++ b/src/LiveComponent/tests/Fixtures/Dto/BlogPost.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Dto;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -22,5 +23,11 @@ class BlogPost
     #[Length(min: 100, minMessage: 'The content field is too short')]
     public $content;
 
-    public $comments = [];
+    public $comments;
+
+    public function __construct()
+    {
+        // makes the class more complex & realistic - e.g. like an entity
+        $this->comments = new ArrayCollection();
+    }
 }

--- a/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
@@ -120,7 +120,6 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
             ->visit($urlSimple)
             ->assertSuccessful()
             ->assertHtml()
-            ->dump()
             ->assertElementCount('ul li', 3)
             // check for the live-id we expect based on the key
             ->assertContains('data-live-id="live-1745423312-the-key0"')

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -101,12 +101,22 @@ class ComponentWithFormTest extends KernelTestCase
         ;
 
         $div = $crawler->filter('[data-controller="live"]');
-        $liveProps = json_decode($div->attr('data-live-props-value'), true);
+        $dehydratedProps = json_decode($div->attr('data-live-props-value'), true);
         // the embedded validated field should be gone, since its data is gone
         $this->assertEquals(
             ['blog_post_form.content'],
-            $liveProps['validatedFields']
+            $dehydratedProps['validatedFields']
         );
+
+        $browser
+            // empty the collection
+            ->post('/_components/form_with_collection_type/removeComment', [
+                'body' => json_encode(['props' => $dehydratedProps, 'args' => ['index' => '1']]),
+                'headers' => ['X-CSRF-TOKEN' => $token],
+            ])
+            ->assertStatus(422)
+            ->assertNotContains('<textarea id="blog_post_form_comments_')
+        ;
     }
 
     public function testFormRemembersValidationFromInitialForm(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #568
| License       | MIT

Empty collection objects - e.g. ArrayCollection - would not recursively tranform from their object to the underlying array if the collection was empty. I think this will fix the old #568 /cc @jcrombez.

Cheers!