### PR TITLE
[Site] Fixing "copy" button breaking onto next line on some smaller screens

### DIFF
--- a/ux.symfony.com/assets/styles/_terminal.scss
+++ b/ux.symfony.com/assets/styles/_terminal.scss
@@ -19,6 +19,9 @@
 .terminal-code a.filename-header {
     color: white;
     display: inline-block;
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .terminal-wrapper .terminal-controls {
@@ -61,6 +64,9 @@
 }
 .terminal-code .btn-copy:hover {
     background-color: $n-600;
+}
+.terminal-code .code-buttons {
+    white-space: nowrap;
 }
 /* copy button inside the code block itself */
 .terminal-code .terminal-body .code-buttons {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

Before:

<img width="387" alt="Screenshot 2023-05-10 at 12 04 49 PM" src="https://github.com/symfony/ux/assets/121003/87415e95-7221-4cce-82cb-0acc380f3723">

After:

<img width="383" alt="Screenshot 2023-05-10 at 12 04 34 PM" src="https://github.com/symfony/ux/assets/121003/2098431b-d5c7-413f-9b7a-916ff058a380">

Cheers!