### PR TITLE
[TwigComponent] Fixing bug where traditional blocks aren't handled correctly

### DIFF
--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -52,6 +52,16 @@ final class TwigPreLexerTest extends TestCase
             '{% component \'foo\' %}{% block foo_block %}Foo{% endblock %}{% endcomponent %}',
         ];
 
+        yield 'component_with_traditional_block' => [
+            '<twig:foo>{% block foo_block %}Foo{% endblock %}</twig:foo>',
+            '{% component \'foo\' %}{% block foo_block %}Foo{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'traditional_blocks_around_component_do_not_confuse' => [
+            'Hello {% block foo_block %}Foo{% endblock %}<twig:foo />{% block bar_block %}Bar{% endblock %}',
+            'Hello {% block foo_block %}Foo{% endblock %}{{ component(\'foo\') }}{% block bar_block %}Bar{% endblock %}',
+        ];
+
         yield 'component_with_embedded_component_inside_block' => [
             '<twig:foo><twig:block name="foo_block"><twig:bar /></twig:block></twig:foo>',
             '{% component \'foo\' %}{% block foo_block %}{{ component(\'bar\') }}{% endblock %}{% endcomponent %}',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fixes part of https://github.com/symfony/ux/issues/844#issuecomment-1542637242
| License       | MIT

Using `{% block traditional_block %}` inside of a `<twig:Component` syntax should now work. However, even though I tried to make the TwigPreLexer a bit more intelligent than just a regex parser, it's reaching its limits of complexity. Even this fix will break down if the user adds extra whitespace - e.g. `{%       block traditional_block %}`. It's likely that `TwigPreLexer` will need to be converted to an actual Lexer -> token stream -> parser type of a system. On the bright side, that would make it easier to integrate into Twig core if we ever chose to do that (the parser wouldn't convert over directly, but the lexer & tokens in theory would).

Cheers!
