### PR TITLE
[LiveComponent] Added type mixed to $value property and added string $className to mach HydrationExtensionInterface

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -700,7 +700,7 @@ a custom ``Food`` object, a hydration extension might look like this::
             return is_subclass_of($className, Food::class);
         }
 
-        public function hydrate($value)
+        public function hydrate(mixed $value, string $className): ?object
         {
             return new Food($value['name'], $value['isCooked']);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no
| License       | MIT

Documentation example for writing the hydrate method was not compatible with the HydrationExtensionInterface. 
Corrected the example so the code can be copy-pasted without errors.