### PR TITLE
[TwigComponent] Add 'host' context when rendering embedded components

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.9.0
+
+-   Add `host` context, available in embedded components
+
 ## 2.8.0
 
 -   Add new HTML syntax for rendering components: `<twig:ComponentName>`

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -91,6 +91,9 @@ final class ComponentRenderer implements ComponentRendererInterface
             // add the component as "this"
             ['this' => $component],
 
+            // add the "host" component when rendering an embedded component
+            isset($context[PreRenderEvent::EMBEDDED], $context['this']) && true === $context[PreRenderEvent::EMBEDDED] ? ['host' => $context['this']] : [],
+
             // add computed properties proxy
             ['computed' => new ComputedPropertiesProxy($component)],
 

--- a/src/TwigComponent/tests/Fixtures/Component/ComponentWithEmbeddedContentBar.php
+++ b/src/TwigComponent/tests/Fixtures/Component/ComponentWithEmbeddedContentBar.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent('embedded_content_bar')]
+final class ComponentWithEmbeddedContentBar
+{
+    public $id;
+    public $propGivenThis;
+    public $propGivenHost;
+
+    public function getSomething()
+    {
+        return "you called Bar{$this->id}";
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/Component/ComponentWithEmbeddedContentFoo.php
+++ b/src/TwigComponent/tests/Fixtures/Component/ComponentWithEmbeddedContentFoo.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent('embedded_content_foo')]
+final class ComponentWithEmbeddedContentFoo
+{
+    public function getSomething()
+    {
+        return 'you called Foo';
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/Component/NestedComponentWrapper.php
+++ b/src/TwigComponent/tests/Fixtures/Component/NestedComponentWrapper.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent('nested_component_wrapper')]
+final class NestedComponentWrapper
+{
+    public function getSomething()
+    {
+        return 'you called wrapper';
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/templates/components/embedded_content_bar.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/embedded_content_bar.html.twig
@@ -1,0 +1,9 @@
+<h1>A Bar component</h1>
+
+propGivenHost in Bar{{ id }}: {{ propGivenHost }}
+propGivenThis in Bar{{ id }}: {{ propGivenThis }}
+this in Bar{{ id }}: {{ this.something }}
+
+<div class='embedded content in Bar{{ id }}'>
+{% block content %}{% endblock %}
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/embedded_content_foo.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/embedded_content_foo.html.twig
@@ -1,0 +1,4 @@
+<h1>A Foo component</h1>
+<div class='embedded content in Foo'>
+{% block content %}{% endblock %}
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/nested_component_wrapper.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/nested_component_wrapper.html.twig
@@ -1,0 +1,9 @@
+This at root: {{ this.something }}
+<twig:embedded_content_foo>
+host from embedded content in Foo element: {{ host.something }}
+this from embedded content in Foo element: {{ this.something }}
+
+<twig:embedded_content_bar :propGivenThis="this.something" :propGivenHost="host.something" id='1' >
+    <twig:embedded_content_bar :propGivenThis="this.something" :propGivenHost="host.something" id='2' />
+</twig:embedded_content_bar>
+</twig:embedded_content_foo>

--- a/src/TwigComponent/tests/Fixtures/templates/nested_components.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/nested_components.html.twig
@@ -1,0 +1,1 @@
+<twig:nested_component_wrapper />

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -151,6 +151,40 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('custom td (1)', $output);
     }
 
+    public function testCanRenderNestedEmbeddedComponentReferencingHost(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('nested_components.html.twig');
+
+        $this->assertStringContainsString(<<<string
+            This at root: you called wrapper
+            <h1>A Foo component</h1>
+            <div class='embedded content in Foo'>
+            host from embedded content in Foo element: you called wrapper
+            this from embedded content in Foo element: you called Foo
+
+            <h1>A Bar component</h1>
+
+            propGivenHost in Bar1: you called wrapper
+            propGivenThis in Bar1: you called Foo
+            this in Bar1: you called Bar1
+
+            <div class='embedded content in Bar1'>
+            <h1>A Bar component</h1>
+
+            propGivenHost in Bar2: you called Foo
+            propGivenThis in Bar2: you called Bar1
+            this in Bar2: you called Bar2
+
+            <div class='embedded content in Bar2'>
+            </div>
+
+            </div>
+            </div>
+            string,
+            $output
+        );
+    }
+
     public function testComponentWithNamespace(): void
     {
         $output = $this->renderComponent('foo:bar:baz');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | 
| License       | MIT

## Problem

It's not possible to access properties and methods of a component that's using embedded components from within the embedded content (or other embedded blocks).

## Reproduce

Create a wrapper component, which is including some components that have embedded content

`Component.php`
```php
final class Component
{
    public function getSomething(): string
    {
        return 'sf-ux rules!';
    }
}
```

`component.html.twig`
```twig
<twig:foo>
    <twig:bar :deepVar="this.something" />
</twig:foo>
```

`foo.html.twig` (given a Foo.php, with empty class, not important)
```twig
<div>
    {% block content %}{% endblock %}
</div>
```
`bar.html.twig` (given a Bar.php, with empty class, not important)
```twig
{{ dump(deepVar) }}
```

## Expected behavior

The template renders like (with some `dump` markup of course)

```html
<div>
    sf-ux rules!
</div>
```

## Actual behavior

```html
<div>
    null
</div>
```

## Cause

While rendering an embedded component the generated template will contain something like
```php
$props = $this->extensions["Symfony\\UX\\TwigComponent\\Twig\\ComponentExtension"]->embeddedContext("foo", twig_to_array([]), $context);
        $this->loadTemplate("foo.html.twig", "foo.html.twig", 10, "732315364")->display($props);
```

The `$props` is the context used when rendering the embedded content, which is being composed by https://github.com/symfony/ux/blob/2.x/src/TwigComponent/src/ComponentRenderer.php#L92. 

And there's the problem: the original `$context` contains `this`, but when rendering the `Foo` component `this` becomes a reference to `Foo` and the reference to the original `Component` is lost.
Imo this behavior is perfectly normal after all, knowing how the rendering works now. I.e. `this` _should_ reference `Foo`, because the block is being embedded in the template of `foo.html.twig`, so while rendering `Foo`, but it makes sense that in the above template you want to be able to access properties from the "host" component, the component which is embedding some other component.

## Solution

Add a `host` entry to the context referencing the component which is embedding the nested components.

---
PS: I'm not sure whether I ought to classify this as a bug or as a feature. It's perhaps not a bug in the sense that it's just not possible right now. On the other hand, it is imo something that you'd expect to be able to do, so then it might be a bug after all. You tell me 🙂 

For now I classified it as a feature. If it shouldn't be I would have to remove the CHANGELOG entry.