### PR TITLE
[Doc] Fix embedded LiveComponents example

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2605,7 +2605,7 @@ In the ``EditPost`` template, you render the
 
             {{ component('MarkdownTextarea', {
                 name: 'post[content]',
-                dataModel: 'value:post.content',
+                dataModel: 'post.content:value',
                 label: 'Content',
             }) }}
 


### PR DESCRIPTION
Child and parent props are swapped in example compared to documentation, leading to confusion.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | ~
| License       | MIT

As per documentation in he previous paragraph, `dataModel` prop full length must be written with the form `parentProp:childProp`.
