### PR TITLE
[TwigComponent] Convert camelCase attributes to dashed attributes

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -44,7 +44,7 @@ final class ComponentAttributes
                 return match ($value) {
                     true => "{$carry} {$key}",
                     false => $carry,
-                    default => sprintf('%s %s="%s"', $carry, $key, $value),
+                    default => sprintf('%s %s="%s"', $carry, strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $key)), $value),
                 };
             },
             ''

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component.html.twig
@@ -1,4 +1,4 @@
-{% component table with { caption: 'data table', headers: ['key', 'value'], data: [[1, 2], [3, 4]] } %}
+{% component table with { caption: 'data table', headers: ['key', 'value'], data: [[1, 2], [3, 4]], dataSort: 'asc' } %}
     {% block th %}custom th ({{ parent() }}){% endblock %}
     {% block td %}custom td ({{ parent() }}){% endblock %}
 

--- a/src/TwigComponent/tests/Fixtures/templates/tags/embedded_component.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/tags/embedded_component.html.twig
@@ -1,4 +1,4 @@
-<twig:table caption='data table' :headers='["key", "value"]' :data='[[1, 2], [3, 4]]'>
+<twig:table caption='data table' :headers='["key", "value"]' :data='[[1, 2], [3, 4]]' dataSort='asc'>
         <twig:block name="th">custom th ({{ parent() }})</twig:block>
         <twig:block name="td">custom td ({{ parent() }})</twig:block>
 

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -87,10 +87,12 @@ final class ComponentExtensionTest extends KernelTestCase
             'style' => 'color:red;',
             'value' => '',
             'autofocus' => true,
+            'data-size' => 'md',
+            'dataVariant' => 'success',
         ]);
 
         $this->assertStringContainsString('Component Content (prop value 1)', $output);
-        $this->assertStringContainsString('<button class="foo bar" type="button" style="color:red;" value="" autofocus>', $output);
+        $this->assertStringContainsString('<button class="foo bar" type="button" style="color:red;" value="" autofocus data-size="md" data-variant="success">', $output);
 
         $output = $this->renderComponent('with_attributes', [
             'prop' => 'prop value 2',
@@ -146,6 +148,7 @@ final class ComponentExtensionTest extends KernelTestCase
     {
         $output = self::getContainer()->get(Environment::class)->render('embedded_component.html.twig');
 
+        $this->assertStringContainsString('data-sort="asc"', $output);
         $this->assertStringContainsString('<caption>data table</caption>', $output);
         $this->assertStringContainsString('custom th (key)', $output);
         $this->assertStringContainsString('custom td (1)', $output);

--- a/src/TwigComponent/tests/Integration/ComponentLexerTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentLexerTest.php
@@ -41,6 +41,7 @@ class ComponentLexerTest extends KernelTestCase
     {
         $output = self::getContainer()->get(Environment::class)->render('tags/embedded_component.html.twig');
 
+        $this->assertStringContainsString('data-sort="asc"', $output);
         $this->assertStringContainsString('<caption>data table</caption>', $output);
         $this->assertStringContainsString('custom th (key)', $output);
         $this->assertStringContainsString('custom td (1)', $output);

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -27,9 +27,11 @@ final class ComponentAttributesTest extends TestCase
             'style' => 'color:black;',
             'value' => '',
             'autofocus' => true,
+            'data-size' => 'md',
+            'dataVariant' => 'success',
         ]);
 
-        $this->assertSame(' class="foo" style="color:black;" value="" autofocus', (string) $attributes);
+        $this->assertSame(' class="foo" style="color:black;" value="" autofocus data-size="md" data-variant="success"', (string) $attributes);
     }
 
     public function testCanSetDefaults(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #874 
| License       | MIT

This PR convert camelCase attributes to dashed attributes!

The following HTML Twig component syntax
```twig
<twig:Button dataModalTarget="modal" dataModalToggle="modal">Open</twig:Button>
```
will be render as
```html
<button data-modal-target="modal" data-modal-toggle="modal">Open</button>
```