### PR TITLE
[Notify] Using Chatter in the docs to show how to use MercureOptions to pass topics

### DIFF
--- a/ux.symfony.com/.env
+++ b/ux.symfony.com/.env
@@ -39,5 +39,5 @@ DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/mercure-notifier ###
-MERCURE_DSN=mercure://default?topic=/demo/notifier
+MERCURE_DSN=mercure://default
 ###< symfony/mercure-notifier ###

--- a/ux.symfony.com/config/packages/notifier.yaml
+++ b/ux.symfony.com/config/packages/notifier.yaml
@@ -1,6 +1,7 @@
 framework:
     notifier:
         chatter_transports:
+            # MERCURE_DSN is defined in .env or should be set by you
             custom_mercure_chatter_transport: '%env(MERCURE_DSN)%'
         #    slack: '%env(SLACK_DSN)%'
         #    telegram: '%env(TELEGRAM_DSN)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | Fix #876
| License       | MIT

Hi!

Using `NotifierInterface` is just a shortcut if you need to send a notification to multiple channels. In this case, Mercure only supports chatter types anyways. Using Chatter directly gives us control to choose the topics, which is much more realistic.

Cheers!