### PR TITLE
[LiveComponent] resetForm() method to get a fresh form

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1506,6 +1506,21 @@ Now, when the form is submitted, it will execute the ``save()`` method
 via Ajax. If the form fails validation, it will re-render with the
 errors. And if it's successful, it will redirect.
 
+Resetting the Form
+~~~~~~~~~~~~~~~~~~
+
+After submitting a form via an action, you might want to "reset" the form
+back to its initial state so you can use it again. Do that by calling
+``resetForm()`` in your action instead of redirecting::
+
+    #[LiveAction]
+    public function save(EntityManagerInterface $entityManager)
+    {
+        // ...
+
+        $this->resetForm();
+    }
+
 Using Actions to Change your Form: CollectionType
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -62,6 +62,8 @@ trait ComponentWithFormTrait
     #[LiveProp(writable: true)]
     public array $validatedFields = [];
 
+    private bool $shouldAutoSubmitForm = true;
+
     /**
      * Return the full, top-level, Form object that this component uses.
      */
@@ -107,7 +109,7 @@ trait ComponentWithFormTrait
     #[PreReRender]
     public function submitFormOnRender(): void
     {
-        if (!$this->getFormInstance()->isSubmitted()) {
+        if ($this->shouldAutoSubmitForm) {
             $this->submitForm($this->isValidated);
         }
     }
@@ -134,6 +136,18 @@ trait ComponentWithFormTrait
         return $this->formName;
     }
 
+    /**
+     * Reset the form to its initial state, so it can be used again.
+     */
+    private function resetForm(): void
+    {
+        // prevent the system from trying to submit this reset form
+        $this->shouldAutoSubmitForm = false;
+        $this->formInstance = null;
+        $this->formView = null;
+        $this->formValues = $this->extractFormValues($this->getForm(), $this->getFormInstance());
+    }
+
     private function submitForm(bool $validateAll = true): void
     {
         if (null !== $this->formView) {
@@ -142,6 +156,7 @@ trait ComponentWithFormTrait
 
         $form = $this->getFormInstance();
         $form->submit($this->formValues);
+        $this->shouldAutoSubmitForm = false;
 
         if ($validateAll) {
             // mark the entire component as validated

--- a/src/LiveComponent/tests/Fixtures/Component/FormComponentWithManyDifferentFieldsType.php
+++ b/src/LiveComponent/tests/Fixtures/Component/FormComponentWithManyDifferentFieldsType.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Form\FormWithManyDifferentFieldsType;
@@ -41,5 +42,18 @@ class FormComponentWithManyDifferentFieldsType extends AbstractController
             FormWithManyDifferentFieldsType::class,
             $this->initialData
         );
+    }
+
+    #[LiveAction]
+    public function submitAndResetForm()
+    {
+        $this->submitForm();
+        $this->resetForm();
+    }
+
+    #[LiveAction]
+    public function resetFormWithoutSubmitting()
+    {
+        $this->resetForm();
     }
 }

--- a/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
@@ -23,6 +23,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
 
 /**
  * @author Jakub Caban <kuba.iluvatar@gmail.com>
@@ -33,7 +34,9 @@ class FormWithManyDifferentFieldsType extends AbstractType
     {
         $builder
             ->add('text', TextType::class)
-            ->add('textarea', TextareaType::class)
+            ->add('textarea', TextareaType::class, [
+                'constraints' => [new Length(max: 5, maxMessage: 'textarea is too long')]
+            ])
             ->add('range', RangeType::class)
             ->add('choice', ChoiceType::class, [
                 'choices' => [

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -294,11 +294,8 @@ PostMount Hook
 
     The ``PostMount`` hook was added in TwigComponents 2.1.
 
-When a component is mounted with the passed data, if an item cannot be
-mounted on the component, an exception is thrown. You can intercept this
-behavior and "catch" this extra data with a ``PostMount`` hook method. This
-method accepts the extra data as an argument and must return an array. If
-the returned array is empty, the exception will be avoided::
+After a component is instantiated and its data mounted, you can run extra
+code via the ``PostMount`` hook::
 
     // src/Components/Alert.php
     use Symfony\UX\TwigComponent\Attribute\PostMount;
@@ -319,18 +316,8 @@ the returned array is empty, the exception will be avoided::
 
 A ``PostMount`` method can also receive an array ``$data`` argument, which
 will contain any props passed to the component that have *not* yet been processed,
-i.e. because they don't correspond to any property. You can handle and remove those
-here. For example, imagine an extra ``autoChooseType`` prop were passed when
-creating the ``Alert`` component:
-
-.. code-block:: twig
-
-    {{ component('Alert', {
-        message: 'Danger Will Robinson!',
-        autoChooseType: true,
-    }) }}
-
-You can handle this prop via a ``#[PostMount]`` hook::
+i.e. because they don't correspond to any property. You can handle these props,
+remove them from the ``$data`` and return the array::
 
     // src/Components/Alert.php
     #[AsTwigComponent]
@@ -342,7 +329,7 @@ You can handle this prop via a ``#[PostMount]`` hook::
         #[PostMount]
         public function processAutoChooseType(array $data): array
         {
-            if (array_key_exists('autoChooseType', $data) && $data['autoChooseType']) {
+            if ($data['autoChooseType'] ?? false) {
                 if (str_contains($this->message, 'danger')) {
                     $this->type = 'danger';
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | None - but from conversation on Slack
| License       | MIT

Hi!

Makes it possible to submit a form to a `LiveAction` then "reset" the form so that you can allow the component to render again with a fresh form.

Cheers!
