### PR TITLE
[TwigComponent] Fix opening of default block inside an open twig block

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -30,10 +30,7 @@ class TwigPreLexer
         $this->line = $startingLine;
     }
 
-    /**
-     * @param bool $insideOfBlock Are we sub-parsing the content inside a block?
-     */
-    public function preLexComponents(string $input, bool $insideOfBlock = false): string
+    public function preLexComponents(string $input): string
     {
         $this->input = $input;
         $this->length = \strlen($input);
@@ -79,11 +76,10 @@ class TwigPreLexer
                     continue;
                 }
 
-                // if we're already inside a component, and we're not inside a block,
+                // if we're already inside a component,
                 // *and* we've just found a new component, then we should try to
                 // open the default block
-                if (!$insideOfBlock
-                    && !empty($this->currentComponents)
+                if (!empty($this->currentComponents)
                     && !$this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock']) {
                     $output .= $this->addDefaultBlock();
                 }
@@ -365,7 +361,7 @@ class TwigPreLexer
         $blockContents = $this->consumeUntilEndBlock();
 
         $subLexer = new self($this->line);
-        $output .= $subLexer->preLexComponents($blockContents, true);
+        $output .= $subLexer->preLexComponents($blockContents);
 
         $this->consume($closingTag);
         $output .= '{% endblock %}';

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -62,9 +62,19 @@ final class TwigPreLexerTest extends TestCase
             'Hello {% block foo_block %}Foo{% endblock %}{{ component(\'foo\') }}{% block bar_block %}Bar{% endblock %}',
         ];
 
-        yield 'component_with_embedded_component_inside_block' => [
+        yield 'component_with_component_inside_block' => [
             '<twig:foo><twig:block name="foo_block"><twig:bar /></twig:block></twig:foo>',
             '{% component \'foo\' %}{% block foo_block %}{{ component(\'bar\') }}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_embedded_component_inside_block' => [
+            '<twig:foo><twig:block name="foo_block"><twig:bar><twig:baz /></twig:bar></twig:block></twig:foo>',
+            '{% component \'foo\' %}{% block foo_block %}{% component \'bar\' %}{% block content %}{{ component(\'baz\') }}{% endblock %}{% endcomponent %}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_embedded_component' => [
+            '<twig:foo>foo_content<twig:bar><twig:baz /></twig:bar></twig:foo>',
+            '{% component \'foo\' %}{% block content %}foo_content{% component \'bar\' %}{% block content %}{{ component(\'baz\') }}{% endblock %}{% endcomponent %}{% endblock %}{% endcomponent %}',
         ];
 
         yield 'attribute_with_no_value' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | 
| License       | MIT

## Symptom

SyntaxError when using a Embedded Component inside a block

`A template that extends another one cannot include content outside Twig blocks. Did you forget to put the content inside a {% block %} tag?`

## Reproduce

Embed a component inside a twig block.

```twig
<twig:Foo>
    <twig:block name="foo_block">
        <twig:Foo>
            <twig:Foo />
        </twig:Foo>
    </twig:block>
</twig:Foo>
```

## Problem

This currently renders to 

```twig
{% component 'Foo' %}
    {% block foo_block %}
        {% component 'Foo' %}
            {{ component('Foo') }}
        {% endcomponent %}
    {% endblock %}
{% endcomponent %}
```

The last `{{ component('Foo') }}` should be enclosed within a `content` block.

Note: the error won't happen if another non-whitespace character is used before the last `<twig:Foo />`, because then the transformed output contains a `content` block for that. It ony happens when lexing a twig block with a component inside which immediately has another component inside it.

## Cause

https://github.com/symfony/ux/blob/2.x/src/TwigComponent/src/Twig/TwigPreLexer.php#L82-L89 checks imo incorrectly whether it's inside a block already. As long as a new component is being processed it's OK to open a new default `content` block. (see solution)

## Solution

This PR will lex the above twig syntax to:

```twig
{% component 'Foo' %}
    {% block foo_block %}
        {% component 'Foo' %}
            {% block content %}{{ component('Foo') }}{% endblock %}
        {% endcomponent %}
    {% endblock %}
{% endcomponent %}
```

Even a content block inside a content block is still OK, because the block is part of another component's template.

```twig
<twig:Foo>
    foo_content
    <twig:block name="foo_block">
        <twig:Foo>
            <twig:Foo />
        </twig:Foo>
    </twig:block>
</twig:Foo>
```

```twig
{% component 'Foo' %}
    {% block content %}foo_content{% endblock %}
    {% block foo_block %}
        {% component 'Foo' %}
            {% block content %}{{ component('Foo') }}{% endblock %}
        {% endcomponent %}
    {% endblock %}
{% endcomponent %}
```

Note that regular block content is (still) NOT enclosed inside a default block.

```twig
<twig:Foo>
    foo_content
    <twig:block name="foo_block">
        foo_block_content
        <twig:Foo>
            <twig:Foo />
        </twig:Foo>
    </twig:block>
</twig:Foo>
```

```twig
{% component 'Foo' %}
    {% block content %}foo_content{% endblock %}
    {% block foo_block %}
        foo_block_content
        {% component 'Foo' %}
        {% block content %}{{ component('Foo') }}{% endblock %}
        {% endcomponent %}
    {% endblock %}
{% endcomponent %}
```