### PR TITLE
Changed code block to match example

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -272,7 +272,7 @@ Add an input to the template:
     <div {{ attributes }}>
         <input type="number" data-model="max">
 
-        Generating a number between 9 and {{ max }}
+        Generating a number between 0 and {{ max }}
         <strong>{{ this.randomNumber }}</strong>
     </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
>
| License       | MIT

Changed number in code block so that it matches the reset of the example code
