### PR TITLE
Added installation process for UX Autocomplete without Flex

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -27,6 +27,32 @@ Then install the bundle using Composer and Symfony Flex:
     # or use yarn
     $ yarn install --force
     $ yarn watch
+    
+If you don't have Symfony Flex in your project:
+
+.. code-block:: terminal
+
+    $ composer require symfony/ux-autocomplete
+
+    # Don't forget to install the JavaScript dependencies as well and compile
+    $ npm install @symfony/ux-autocomplete
+    $ npm install tom-select
+    $ npm run watch
+
+    # or use yarn
+    $ yarn add @symfony/ux-autocomplete
+    $ yarn add tom-select
+    $ yarn watch
+
+Don't forget to add ``symfony/ux-autocomplete`` to your bundles list in ``config/bundles.php``
+
+Add the route config in ``config/routes/ux_autocomplete.yaml``
+
+.. code-block:: text
+
+   ux_autocomplete:
+    resource: '@AutocompleteBundle/config/routes.php'
+    prefix: '/autocomplete'
 
 Usage in a Form (without Ajax)
 ------------------------------

--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -34,16 +34,29 @@ If you don't have Symfony Flex in your project:
 
     $ composer require symfony/ux-autocomplete
 
-    # Don't forget to install the JavaScript dependencies as well and compile
-    $ npm install @symfony/ux-autocomplete
     $ npm install tom-select
+    # or use yarn
+    $ yarn add tom-select
+
+Add ``@symfony/ux-autocomplete`` assets path in your ``package.json``
+
+.. code-block:: test
+
+     "devDependencies": {
+       "@symfony/ux-autocomplete": "file:vendor/symfony/ux-autocomplete/assets",
+     },
+     
+Don't forget to install the JavaScript dependencies as well and compile
+
+.. code-block:: terminal
+
+    $ npm install --force
     $ npm run watch
 
     # or use yarn
-    $ yarn add @symfony/ux-autocomplete
-    $ yarn add tom-select
+    $ yarn install --force
     $ yarn watch
-
+    
 Don't forget to add ``symfony/ux-autocomplete`` to your bundles list in ``config/bundles.php``
 
 Add the route config in ``config/routes/ux_autocomplete.yaml``


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
Added installation process for UX Autocomplete without Flex that was missing.