### PR TITLE
[StimulusBundle] Marking only the AssetMapper integration as experimental

### DIFF
--- a/src/StimulusBundle/README.md
+++ b/src/StimulusBundle/README.md
@@ -1,12 +1,9 @@
 # StimulusBundle: Symfony integration with Stimulus!
 
-**EXPERIMENTAL** This bundle is currently experimental. It is possible that
-backwards-compatibility breaks could happen between minor versions.
-
 This bundle adds integration between Symfony, Stimulus and Symfony UX:
 
 -   A) Twig `stimulus_*` functions & filters to add Stimulus controllers, actions & targets in your templates;
--   B) Integration with Symfony UX & AssetMapper;
+-   B) Integration with Symfony UX & AssetMapper (this integration is [experimental](https://symfony.com/doc/current/contributing/code/experimental.html)
 -   C) A helper service to build the Stimulus data attributes and use them in your services.
 
 [Read the documentation][1]

--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -1,13 +1,10 @@
 StimulusBundle: Symfony integration with Stimulus
 =================================================
 
-**EXPERIMENTAL** This bundle is currently experimental. It is possible that
-backwards-compatibility breaks could happen between minor versions.
-
 This bundle adds integration between Symfony, `Stimulus`_ and Symfony UX:
 
 A) Twig `stimulus_*` functions & filters to add Stimulus controllers, actions & targets in your templates;
-B) Integration with Symfony UX & AssetMapper;
+B) Integration with Symfony UX & AssetMapper (this integration is `experimental`_)
 C) A helper service to build the Stimulus data attributes and use them in your services.
 
 Installation
@@ -314,3 +311,4 @@ is running in debug mode.
 .. _`parameters`: https://stimulus.hotwired.dev/reference/actions#action-parameters
 .. _`Stimulus Targets`: https://stimulus.hotwired.dev/reference/targets
 .. _`StimulusBundle Flex recipe`: https://github.com/symfony/recipes/tree/main/symfony/stimulus-bundle
+.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html

--- a/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
+++ b/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
@@ -23,8 +23,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 final class StimulusExtension extends Extension implements PrependExtensionInterface, ConfigurationInterface

--- a/src/StimulusBundle/src/Dto/StimulusAttributes.php
+++ b/src/StimulusBundle/src/Dto/StimulusAttributes.php
@@ -16,8 +16,6 @@ use Twig\Environment;
 /**
  * Helper to build Stimulus-related HTML attributes.
  *
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 class StimulusAttributes implements \Stringable, \IteratorAggregate

--- a/src/StimulusBundle/src/Helper/StimulusHelper.php
+++ b/src/StimulusBundle/src/Helper/StimulusHelper.php
@@ -16,8 +16,6 @@ use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 
 /**
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 final class StimulusHelper

--- a/src/StimulusBundle/src/StimulusBundle.php
+++ b/src/StimulusBundle/src/StimulusBundle.php
@@ -14,8 +14,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\UX\StimulusBundle\DependencyInjection\Compiler\RemoveAssetMapperServicesCompiler;
 
 /**
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 final class StimulusBundle extends Bundle

--- a/src/StimulusBundle/src/Twig/StimulusTwigExtension.php
+++ b/src/StimulusBundle/src/Twig/StimulusTwigExtension.php
@@ -18,8 +18,6 @@ use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 /**
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 final class StimulusTwigExtension extends AbstractExtension


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yesish
| New feature?  | no
| Tickets       | Addresses https://github.com/symfony/ux/issues/907#issuecomment-1566108993
| License       | MIT

StimulusBundle should not really be experimental. The `stimulus_*` Twig functions were ported from WebpackEncoreBundle and should work the same (if they don't, that would be a bug).

The only part that should be experimental is the AssetMapper integration. 

Cheers!