### PR TITLE
More precisely initializing services/config for asset mapper

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
                 echo "${{ steps.changes.outputs.STATUS }}"
                 exit 1
 
-    tests-php-low-deps:
+    tests-php72-low-deps:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
@@ -102,7 +102,7 @@ jobs:
               run: php vendor/bin/simple-phpunit
               working-directory: src/LazyImage
 
-    tests-php8-low-deps:
+    tests-php80-low-deps:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
@@ -147,7 +147,7 @@ jobs:
             - name: Translator Tests
               run: php vendor/bin/simple-phpunit
               working-directory: src/Translator
-    tests-php-high-deps:
+    tests-php80-high-deps:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
@@ -275,6 +275,69 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   working-directory: src/Vue
+            - name: Vue Tests
+              run: php vendor/bin/simple-phpunit
+              working-directory: src/Vue
+
+    tests-php81-low-deps:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.1'
+
+            - name: Chartjs Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                  working-directory: src/Chartjs
+                  dependency-versions: lowest
+            - name: Chartjs Tests
+              working-directory: src/Chartjs
+              run: php vendor/bin/simple-phpunit
+
+            - name: Notify Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                  working-directory: src/Notify
+                  dependency-versions: lowest
+            - name: Notify Tests
+              working-directory: src/Notify
+              run: php vendor/bin/simple-phpunit
+
+            - name: React Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                  working-directory: src/React
+                  dependency-versions: lowest
+            - name: React Tests
+              run: php vendor/bin/simple-phpunit
+              working-directory: src/React
+
+            - name: StimulusBundle Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                working-directory: src/StimulusBundle
+                dependency-versions: lowest
+            - name: StimulusBundle Tests
+              working-directory: src/StimulusBundle
+              run: php vendor/bin/simple-phpunit
+
+            - name: Svelte Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                  working-directory: src/Svelte
+                  dependency-versions: lowest
+            - name: Svelte Tests
+              run: php vendor/bin/simple-phpunit
+              working-directory: src/Svelte
+
+            - name: Vue Dependencies
+              uses: ramsey/composer-install@v2
+              with:
+                  working-directory: src/Vue
+                  dependency-versions: lowest
             - name: Vue Tests
               run: php vendor/bin/simple-phpunit
               working-directory: src/Vue

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
@@ -48,7 +48,7 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
             ]);
         }
 
-        if (interface_exists(AssetMapperInterface::class)) {
+        if ($this->isAssetMapperAvailable($container)) {
             $container->prependExtensionConfig('framework', [
                 'asset_mapper' => [
                     'paths' => [
@@ -154,5 +154,20 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
                 new Reference('property_accessor'),
                 new Reference('ux.autocomplete.entity_search_util'),
             ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/Chartjs/composer.json
+++ b/src/Chartjs/composer.json
@@ -32,7 +32,7 @@
         "symfony/config": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
-        "symfony/stimulus-bundle": "^2.9"
+        "symfony/stimulus-bundle": "^2.9.1"
     },
     "require-dev": {
         "symfony/framework-bundle": "^5.4|^6.0",

--- a/src/Chartjs/src/DependencyInjection/ChartjsExtension.php
+++ b/src/Chartjs/src/DependencyInjection/ChartjsExtension.php
@@ -50,7 +50,7 @@ class ChartjsExtension extends Extension implements PrependExtensionInterface
 
     public function prepend(ContainerBuilder $container)
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -61,5 +61,20 @@ class ChartjsExtension extends Extension implements PrependExtensionInterface
                 ],
             ],
         ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/Cropperjs/src/DependencyInjection/CropperjsExtension.php
+++ b/src/Cropperjs/src/DependencyInjection/CropperjsExtension.php
@@ -53,7 +53,7 @@ class CropperjsExtension extends Extension implements PrependExtensionInterface
 
     public function prepend(ContainerBuilder $container)
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -64,5 +64,20 @@ class CropperjsExtension extends Extension implements PrependExtensionInterface
                 ],
             ],
         ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/Dropzone/src/DependencyInjection/DropzoneExtension.php
+++ b/src/Dropzone/src/DependencyInjection/DropzoneExtension.php
@@ -34,7 +34,7 @@ class DropzoneExtension extends Extension implements PrependExtensionInterface
             $container->prependExtensionConfig('twig', ['form_themes' => ['@Dropzone/form_theme.html.twig']]);
         }
 
-        if (interface_exists(AssetMapperInterface::class)) {
+        if ($this->isAssetMapperAvailable($container)) {
             $container->prependExtensionConfig('framework', [
                 'asset_mapper' => [
                     'paths' => [
@@ -52,5 +52,20 @@ class DropzoneExtension extends Extension implements PrependExtensionInterface
             ->addTag('form.type')
             ->setPublic(false)
         ;
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/LazyImage/src/DependencyInjection/LazyImageExtension.php
+++ b/src/LazyImage/src/DependencyInjection/LazyImageExtension.php
@@ -57,7 +57,7 @@ class LazyImageExtension extends Extension implements PrependExtensionInterface
 
     public function prepend(ContainerBuilder $container)
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -68,5 +68,20 @@ class LazyImageExtension extends Extension implements PrependExtensionInterface
                 ],
             ],
         ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -64,7 +64,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             $container->prependExtensionConfig('twig', ['form_themes' => ['@LiveComponent/form_theme.html.twig']]);
         }
 
-        if (interface_exists(AssetMapperInterface::class)) {
+        if ($this->isAssetMapperAvailable($container)) {
             $container->prependExtensionConfig('framework', [
                 'asset_mapper' => [
                     'paths' => [
@@ -212,5 +212,20 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             ->addTag('form.type')
             ->setPublic(false)
         ;
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/Notify/composer.json
+++ b/src/Notify/composer.json
@@ -34,7 +34,7 @@
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/mercure-bundle": "^0.3.4",
         "symfony/mercure-notifier": "^5.4|^6.0",
-        "symfony/stimulus-bundle": "^2.9",
+        "symfony/stimulus-bundle": "^2.9.1",
         "symfony/twig-bundle": "^5.4|^6.0"
     },
     "require-dev": {

--- a/src/Notify/src/DependencyInjection/NotifyExtension.php
+++ b/src/Notify/src/DependencyInjection/NotifyExtension.php
@@ -43,7 +43,7 @@ final class NotifyExtension extends ConfigurableExtension implements PrependExte
 
     public function prepend(ContainerBuilder $container)
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -54,5 +54,20 @@ final class NotifyExtension extends ConfigurableExtension implements PrependExte
                 ],
             ],
         ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/React/composer.json
+++ b/src/React/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "symfony/stimulus-bundle": "^2.9"
+        "symfony/stimulus-bundle": "^2.9.1"
     },
     "require-dev": {
         "symfony/asset-mapper": "6.3.x-dev",

--- a/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
+++ b/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
@@ -49,7 +49,7 @@ final class StimulusExtension extends Extension implements PrependExtensionInter
 
     public function prepend(ContainerBuilder $container)
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -89,5 +89,20 @@ final class StimulusExtension extends Extension implements PrependExtensionInter
             ->end();
 
         return $treeBuilder;
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/Svelte/composer.json
+++ b/src/Svelte/composer.json
@@ -33,7 +33,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "symfony/stimulus-bundle": "^2.9"
+        "symfony/stimulus-bundle": "^2.9.1"
     },
     "require-dev": {
         "symfony/asset-mapper": "6.3.x-dev",

--- a/src/Svelte/src/DependencyInjection/SvelteExtension.php
+++ b/src/Svelte/src/DependencyInjection/SvelteExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\Svelte\DependencyInjection;
 
 use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\AssetMapper\Compiler\AssetCompilerPathResolverTrait;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -43,19 +44,21 @@ class SvelteExtension extends Extension implements PrependExtensionInterface, Co
             ->setPublic(false)
         ;
 
-        $container->setDefinition('svelte.asset_mapper.svelte_controller_loader_compiler', new Definition(SvelteControllerLoaderAssetCompiler::class))
-            ->setArguments([
-                $config['controllers_path'],
-                $config['name_glob'],
-            ])
-            // run before the core JavaScript compiler
-            ->addTag('asset_mapper.compiler', ['priority' => 100])
-        ;
+        // on older versions, the absence of this trait will trigger an error if the service is loaded
+        if (trait_exists(AssetCompilerPathResolverTrait::class)) {
+            $container->setDefinition('svelte.asset_mapper.svelte_controller_loader_compiler', new Definition(SvelteControllerLoaderAssetCompiler::class))
+                ->setArguments([
+                    $config['controllers_path'],
+                    $config['name_glob'],
+                ])
+                // run before the core JavaScript compiler
+                ->addTag('asset_mapper.compiler', ['priority' => 100]);
+        }
     }
 
     public function prepend(ContainerBuilder $container)
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -94,5 +97,20 @@ class SvelteExtension extends Extension implements PrependExtensionInterface, Co
             ->end();
 
         return $treeBuilder;
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/Swup/src/DependencyInjection/SwupExtension.php
+++ b/src/Swup/src/DependencyInjection/SwupExtension.php
@@ -27,7 +27,7 @@ class SwupExtension extends Extension implements PrependExtensionInterface
 
     public function prepend(ContainerBuilder $container)
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -38,5 +38,20 @@ class SwupExtension extends Extension implements PrependExtensionInterface
                 ],
             ],
         ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/Translator/src/DependencyInjection/UxTranslatorExtension.php
+++ b/src/Translator/src/DependencyInjection/UxTranslatorExtension.php
@@ -40,7 +40,7 @@ class UxTranslatorExtension extends Extension implements PrependExtensionInterfa
 
     public function prepend(ContainerBuilder $container)
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -52,5 +52,20 @@ class UxTranslatorExtension extends Extension implements PrependExtensionInterfa
                 ],
             ],
         ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -35,7 +35,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "symfony/stimulus-bundle": "^2.9"
+        "symfony/stimulus-bundle": "^2.9.1"
     },
     "require-dev": {
         "doctrine/annotations": "^1.12",

--- a/src/Turbo/src/DependencyInjection/TurboExtension.php
+++ b/src/Turbo/src/DependencyInjection/TurboExtension.php
@@ -90,7 +90,7 @@ final class TurboExtension extends Extension implements PrependExtensionInterfac
 
     public function prepend(ContainerBuilder $container): void
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -104,5 +104,20 @@ final class TurboExtension extends Extension implements PrependExtensionInterfac
                 ],
             ],
         ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -36,7 +36,7 @@
     "require-dev": {
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/stimulus-bundle": "^2.9",
+        "symfony/stimulus-bundle": "^2.9.1",
         "symfony/twig-bundle": "^5.4|^6.0",
         "symfony/webpack-encore-bundle": "^1.15"
     },

--- a/src/Typed/src/DependencyInjection/TypedExtension.php
+++ b/src/Typed/src/DependencyInjection/TypedExtension.php
@@ -27,7 +27,7 @@ class TypedExtension extends Extension implements PrependExtensionInterface
 
     public function prepend(ContainerBuilder $container)
     {
-        if (!interface_exists(AssetMapperInterface::class)) {
+        if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
 
@@ -38,5 +38,20 @@ class TypedExtension extends Extension implements PrependExtensionInterface
                 ],
             ],
         ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (!interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        // check that FrameworkBundle 6.3 or higher is installed
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (!isset($bundlesMetadata['FrameworkBundle'])) {
+            return false;
+        }
+
+        return is_file($bundlesMetadata['FrameworkBundle']['path'].'/Resources/config/asset_mapper.php');
     }
 }

--- a/src/Vue/composer.json
+++ b/src/Vue/composer.json
@@ -33,7 +33,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "symfony/stimulus-bundle": "^2.9"
+        "symfony/stimulus-bundle": "^2.9.1"
     },
     "require-dev": {
         "symfony/asset-mapper": "6.3.x-dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #907
| License       | MIT

Hi!

A few fixes for the new 2.9 version, which included a lot of under-the-hood changes to support asset mapper. These shouldn't be noticed by users and hopefully this will smooth out the final bumps:

A) Avoid prepending the `asset_mapper` config unless FWBundle 6.3 is present. I don't love the solution - but it should work well enough, especially as this applies to asset mapper users and that is still experimental.

B) Avoid registering a few asset mapper services that, on older versions of PHP/Symfony, may cause a container explosion due to a trait that won't be present.

C) Plug some holes in the CI to test lower deps. The CI really needs to become much more dynamic than it is now, but this makes sure that all packages are tested for highest/lowest deps.

Cheers!
