### PR TITLE
Skip test if FWBundle 6.3 or higher is NOT available

### DIFF
--- a/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
@@ -9,6 +9,7 @@
 
 namespace Symfony\UX\StimulusBundle\Tests\AssetMapper;
 
+use Composer\InstalledVersions;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\UX\StimulusBundle\Tests\fixtures\StimulusTestKernel;
@@ -20,6 +21,10 @@ class StimulusControllerLoaderFunctionalTest extends WebTestCase
 
     public function testFullApplicationLoad()
     {
+        if (InstalledVersions::getVersion('symfony/framework-bundle') < '6.3') {
+            $this->markTestSkipped('This test requires symfony/framework-bundle 6.3+');
+        }
+
         $filesystem = new Filesystem();
         $filesystem->remove(__DIR__.'/../fixtures/var/cache');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

If FWBundle 6.2 or lower is installed, then there is no AssetMapper support, so skip the test.

Cheers!