### PR TITLE
[LiveComponent] Updating docs to use .defaults() method

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -839,15 +839,17 @@ The following hooks are available (along with the arguments that are passed):
 Adding a Stimulus Controller to your Component Root Element
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.7
+.. versionadded:: 2.9
 
-    The ``add()`` method was introduced in TwigComponents 2.7.
+    The ability to use the ``defaults()`` method with ``stimulus_controller()``
+    was added in TwigComponents 2.9 and requires ``symfony/stimulus-bundle``.
+    Previously, ``stimulus_controller()`` was passed to ``attributes.add()``.
 
 To add a custom Stimulus controller to your root component element:
 
 .. code-block:: html+twig
 
-    <div {{ attributes.add(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
+    <div {{ attributes.defaults(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
 
 Loading States
 --------------

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -899,14 +899,15 @@ final class LiveComponentHydratorTest extends KernelTestCase
                     return [
                         'year' => $this->createdAt->format('Y'),
                         'month' => $this->createdAt->format('m'),
+                        'day' => $this->createdAt->format('d'),
                     ];
                 }
 
                 public function hydrateDate($data)
                 {
                     return \DateTime::createFromFormat(
-                        'Y-m',
-                        sprintf('%s-%s', $data['year'], $data['month'])
+                        'Y-m-d',
+                        sprintf('%s-%s-%s', $data['year'], $data['month'], $data['day'])
                     );
                 }
             })
@@ -914,13 +915,13 @@ final class LiveComponentHydratorTest extends KernelTestCase
                    'createdAt' => new \DateTime('2023-03-05 9:23', new \DateTimeZone('America/New_York')),
                ])
                 ->assertDehydratesTo([
-                   'createdAt' => ['year' => 2023, 'month' => 3],
+                   'createdAt' => ['year' => 2023, 'month' => 3, 'day' => 5],
                ])
                 ->userUpdatesProps([
-                   'createdAt' => ['year' => 2024, 'month' => 4],
+                   'createdAt' => ['year' => 2024, 'month' => 4, 'day' => 5],
                ])
                 ->assertObjectAfterHydration(function (object $object) {
-                    $this->assertSame('2024-04', $object->createdAt->format('Y-m'));
+                    $this->assertSame('2024-04-05', $object->createdAt->format('Y-m-d'));
                 })
             ;
         }];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (to docs)
| New feature?  | no
| Tickets       | None - reported on Slack
| License       | MIT

The TwigComponent docs were updated previously, but not LiveComponent.

Cheers!