### PR TITLE
[Autocomplete] When min chars is not set, keep loading after initial load

### DIFF
--- a/src/Autocomplete/assets/dist/controller.d.ts
+++ b/src/Autocomplete/assets/dist/controller.d.ts
@@ -14,10 +14,7 @@ export default class extends Controller {
         optionsAsHtml: BooleanConstructor;
         noResultsFoundText: StringConstructor;
         noMoreResultsText: StringConstructor;
-        minCharacters: {
-            type: NumberConstructor;
-            default: number;
-        };
+        minCharacters: NumberConstructor;
         tomSelectOptions: ObjectConstructor;
         preload: StringConstructor;
     };
@@ -26,12 +23,14 @@ export default class extends Controller {
     readonly noMoreResultsTextValue: string;
     readonly noResultsFoundTextValue: string;
     readonly minCharactersValue: number;
+    readonly hasMinCharactersValue: boolean;
     readonly tomSelectOptionsValue: object;
     readonly hasPreloadValue: boolean;
     readonly preloadValue: string;
     tomSelect: TomSelect;
     private mutationObserver;
     private isObserving;
+    private hasLoadedChoicesPreviously;
     initialize(): void;
     connect(): void;
     disconnect(): void;

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -28,6 +28,7 @@ class default_1 extends Controller {
         super(...arguments);
         _default_1_instances.add(this);
         this.isObserving = false;
+        this.hasLoadedChoicesPreviously = false;
     }
     initialize() {
         if (this.requiresLiveIgnore()) {
@@ -49,7 +50,7 @@ class default_1 extends Controller {
     }
     connect() {
         if (this.urlValue) {
-            this.tomSelect = __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createAutocompleteWithRemoteData).call(this, this.urlValue, this.minCharactersValue);
+            this.tomSelect = __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createAutocompleteWithRemoteData).call(this, this.urlValue, this.hasMinCharactersValue ? this.minCharactersValue : null);
             return;
         }
         if (this.optionsAsHtmlValue) {
@@ -291,8 +292,17 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
             })
                 .catch(() => callback([], []));
         },
-        shouldLoad: function (query) {
-            return query.length >= minCharacterLength;
+        shouldLoad: (query) => {
+            if (null !== minCharacterLength) {
+                return query.length >= minCharacterLength;
+            }
+            if (this.hasLoadedChoicesPreviously) {
+                return true;
+            }
+            if (query.length > 0) {
+                this.hasLoadedChoicesPreviously = true;
+            }
+            return query.length >= 3;
         },
         optgroupField: 'group_by',
         score: function (search) {
@@ -334,7 +344,7 @@ default_1.values = {
     optionsAsHtml: Boolean,
     noResultsFoundText: String,
     noMoreResultsText: String,
-    minCharacters: { type: Number, default: 3 },
+    minCharacters: Number,
     tomSelectOptions: Object,
     preload: String,
 };

--- a/src/Autocomplete/src/Doctrine/SearchEscaper.php
+++ b/src/Autocomplete/src/Doctrine/SearchEscaper.php
@@ -48,7 +48,11 @@ class SearchEscaper
         $lexer->moveNext();
         $token = $lexer->lookahead;
 
-        if (200 <= $token['type']) {
+        // backwards compat for when $token changed from array to object
+        // https://github.com/doctrine/lexer/pull/79
+        $type = \is_array($token) ? $token['type'] : $token->type;
+
+        if (200 <= $type) {
             return true;
         }
 

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -99,7 +99,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'allow_options_create' => false,
             'no_results_found_text' => 'No results found',
             'no_more_results_text' => 'No more results',
-            'min_characters' => 3,
+            'min_characters' => null,
             'max_results' => 10,
             'preload' => 'focus',
         ]);

--- a/src/Turbo/tests/app/Entity/Artist.php
+++ b/src/Turbo/tests/app/Entity/Artist.php
@@ -11,41 +11,28 @@
 
 namespace App\Entity;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\UX\Turbo\Attribute\Broadcast;
 
 /**
- * @ORM\Entity
- *
- * @Broadcast
- *
  * @author Rick Kuipers <rick@levelup-it.com>
  */
 #[Broadcast]
+#[ORM\Entity]
 class Artist
 {
-    /**
-     * @ORM\Column(type="integer")
-     *
-     * @ORM\Id
-     *
-     * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int|null
-     */
-    public $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(type: 'integer')]
+    public ?int $id = null;
+
+    #[ORM\Column]
+    public string $name = '';
 
     /**
-     * @ORM\Column
-     *
-     * @var string
+     * @var Collection<int, Song>
      */
-    public $name = '';
-
-    /**
-     * @ORM\OneToMany(targetEntity="App\Entity\Song", mappedBy="artist")
-     *
-     * @var Song[]
-     */
-    public $songs;
+    #[ORM\OneToMany(targetEntity: Song::class, mappedBy: 'artist')]
+    public Collection $songs;
 }

--- a/src/Turbo/tests/app/Entity/Book.php
+++ b/src/Turbo/tests/app/Entity/Book.php
@@ -15,30 +15,17 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\UX\Turbo\Attribute\Broadcast;
 
 /**
- * @ORM\Entity
- *
- * @Broadcast
- *
  * @author Kévin Dunglas <kevin@dunglas.fr>
  */
 #[Broadcast]
+#[ORM\Entity]
 class Book
 {
-    /**
-     * @ORM\Column(type="integer")
-     *
-     * @ORM\Id
-     *
-     * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int|null
-     */
-    public $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(type: 'integer')]
+    public ?int $id = null;
 
-    /**
-     * @ORM\Column
-     *
-     * @var string
-     */
-    public $title = '';
+    #[ORM\Column]
+    public string $title = '';
 }

--- a/src/Turbo/tests/app/Entity/Song.php
+++ b/src/Turbo/tests/app/Entity/Song.php
@@ -15,37 +15,20 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\UX\Turbo\Attribute\Broadcast;
 
 /**
- * @ORM\Entity
- *
- * @Broadcast(topics={"@='songs_by_artist_' ~ (entity.artist ? entity.artist.id : null)", "songs"})
- *
  * @author Rick Kuipers <rick@levelup-it.com>
  */
 #[Broadcast(topics: ['@="songs_by_artist_" ~ (entity.artist ? entity.artist.id : null)', 'songs'])]
+#[ORM\Entity]
 class Song
 {
-    /**
-     * @ORM\Column(type="integer")
-     *
-     * @ORM\Id
-     *
-     * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int|null
-     */
-    public $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(type: 'integer')]
+    public ?string $id = null;
 
-    /**
-     * @ORM\Column
-     *
-     * @var string
-     */
-    public $title = '';
+    #[ORM\Column]
+    public string $title = '';
 
-    /**
-     * @ORM\ManyToOne(targetEntity=Artist::class, inversedBy="songs")
-     *
-     * @var Artist|null
-     */
-    public $artist;
+    #[ORM\ManyToOne(targetEntity: Artist::class, inversedBy: 'songs')]
+    public ?Artist $artist = null;
 }

--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -14,6 +14,7 @@ namespace App;
 use App\Entity\Artist;
 use App\Entity\Book;
 use App\Entity\Song;
+use Composer\InstalledVersions;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\DebugBundle\DebugBundle;
@@ -84,7 +85,7 @@ class Kernel extends BaseKernel
                 'mappings' => [
                     'App' => [
                         'is_bundle' => false,
-                        'type' => 'annotation',
+                        'type' => 'attribute',
                         'dir' => '%kernel.project_dir%/Entity',
                         'prefix' => 'App\Entity',
                         'alias' => 'App',
@@ -92,6 +93,12 @@ class Kernel extends BaseKernel
                 ],
             ],
         ];
+
+        // https://github.com/doctrine/DoctrineBundle/pull/1661
+        $doctrineBundleVersion = InstalledVersions::getVersion('doctrine/doctrine-bundle');
+        if (null !== $doctrineBundleVersion && version_compare($doctrineBundleVersion, '2.9.0', '>=')) {
+            $doctrineConfig['orm']['report_fields_where_declared'] = true;
+        }
 
         $container
             ->extension('doctrine', $doctrineConfig);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | From conversation on Slack!
| License       | MIT

This helps with the case where you type 3 characters, get a load, then backspace (or clear all the characters) and loading stops and you can't get new options.

You can see the current behavior by going to https://ux.symfony.com/autocomplete, typing "ban", then backspacing. You will only see "banana" as an option, even if you clear it, unless you guess the first 3 chars of some other option.

Cheers!