### PR TITLE
[TwigComponent] Support passing blocks to nested embedded components

### DIFF
--- a/src/TwigComponent/src/BlockStack.php
+++ b/src/TwigComponent/src/BlockStack.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\UX\TwigComponent;
+
+use Twig\Template;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ *
+ * @internal
+ */
+final class BlockStack
+{
+    private const OUTER_BLOCK_PREFIX = 'outer__';
+    public const OUTER_BLOCK_FALLBACK_NAME = self::OUTER_BLOCK_PREFIX.'block_fallback';
+
+    /**
+     * @var array<string, array<int, array<int, string>>>
+     */
+    private array $stack;
+
+    public function convert(array $blocks, int $targetEmbeddedTemplateIndex): array
+    {
+        $newBlocks = [];
+        foreach ($blocks as $blockName => $block) {
+            // Keep already converted outer blocks untouched
+            if (str_starts_with($blockName, self::OUTER_BLOCK_PREFIX)) {
+                $newBlocks[$blockName] = $block;
+                continue;
+            }
+
+            // Determine the location of the block where it is defined in the host Template.
+            // Each component has its own embedded template. That template's index uniquely
+            // identifies the block definition.
+            $hostEmbeddedTemplateIndex = $this->findHostEmbeddedTemplateIndex();
+
+            if (0 === $hostEmbeddedTemplateIndex) {
+                // If there is no embedded template index, that means we're in a normal template.
+                // It wouldn't make sense to make these available as outer blocks,
+                // since the block is already printed in place.
+                continue;
+            }
+
+            // Change the name of outer blocks to something unique so blocks of nested components aren't overridden,
+            // which otherwise might cause a recursion loop when nesting components.
+            $newName = self::OUTER_BLOCK_PREFIX.$blockName.'_'.mt_rand();
+            $newBlocks[$newName] = $block;
+
+            // The host index combined with the index of the embedded template where the block can be used (target)
+            // allows us to remember the link between the original name and the new randomized name.
+            // That way we can map a call like `block(outerBlocks.block_name)` to the randomized name.
+            $this->stack[$blockName][$targetEmbeddedTemplateIndex][$hostEmbeddedTemplateIndex] = $newName;
+        }
+
+        return $newBlocks;
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        $callingEmbeddedTemplateIndex = $this->findCallingEmbeddedTemplateIndex();
+        $hostEmbeddedTemplateIndex = $this->findHostEmbeddedTemplateIndexFromCaller();
+
+        return $this->stack[$name][$callingEmbeddedTemplateIndex][$hostEmbeddedTemplateIndex] ?? self::OUTER_BLOCK_FALLBACK_NAME;
+    }
+
+    private function findHostEmbeddedTemplateIndex(): int
+    {
+        $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS | \DEBUG_BACKTRACE_PROVIDE_OBJECT);
+
+        $componentTemplateClassName = null;
+
+        foreach ($backtrace as $trace) {
+            if (isset($trace['object']) && $trace['object'] instanceof Template) {
+                $classname = $trace['object']::class;
+                $templateIndex = $this->getTemplateIndexFromTemplateClassname($classname);
+                if ($templateIndex) {
+                    // If there's no template index, then we're in a component template
+                    // and we need to go up until we find the embedded template
+                    // (which will have the block definitions).
+                    return $templateIndex;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    private function findCallingEmbeddedTemplateIndex(): int
+    {
+        $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS | \DEBUG_BACKTRACE_PROVIDE_OBJECT);
+
+        foreach ($backtrace as $trace) {
+            if (isset($trace['object']) && $trace['object'] instanceof Template) {
+                return $this->getTemplateIndexFromTemplateClassname($trace['object']::class);
+            }
+        }
+    }
+
+    private function findHostEmbeddedTemplateIndexFromCaller(): int
+    {
+        $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS | \DEBUG_BACKTRACE_PROVIDE_OBJECT);
+
+        $blockCallerStack = [];
+        $renderer = null;
+
+        foreach ($backtrace as $trace) {
+            if (isset($trace['object']) && $trace['object'] instanceof Template) {
+                $classname = $trace['object']::class;
+                $templateIndex = $this->getTemplateIndexFromTemplateClassname($classname);
+                if (null === $renderer) {
+                    if ($templateIndex) {
+                        // This class is an embedded template.
+                        // Next class is either the renderer or a previous template that's passing blocks through.
+                        $blockCallerStack[$classname] = $classname;
+                        continue;
+                    }
+                    // If it's not an embedded template anymore, we've reached the renderer.
+                    // From now on we'll travel back up the hierarchy.
+                    $renderer = $classname;
+                    continue;
+                }
+                if ($classname === $renderer || isset($blockCallerStack[$classname])) {
+                    continue;
+                }
+
+                if (!$templateIndex) {
+                    continue;
+                }
+
+                // This is the first template that's not part of the callstack,
+                // so it's the template that has the outer block definition.
+                return $templateIndex;
+            }
+        }
+
+        // If the component is not an embedded one, just return 0, so the fallback content (aka nothing) is used.
+        return 0;
+    }
+
+    private function getTemplateIndexFromTemplateClassname(string $classname): int
+    {
+        return (int) substr($classname, strrpos($classname, '___') + 3);
+    }
+}

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -71,7 +71,13 @@ final class ComponentRenderer implements ComponentRendererInterface
     {
         $context[PreRenderEvent::EMBEDDED] = true;
 
-        return $this->preRender($this->factory->create($name, $props), $context)->getVariables();
+        $embeddedContext = $this->preRender($this->factory->create($name, $props), $context)->getVariables();
+
+        if (!isset($embeddedContext['outerBlocks'])) {
+            $embeddedContext['outerBlocks'] = new BlockStack();
+        }
+
+        return $embeddedContext;
     }
 
     private function preRender(MountedComponent $mounted, array $context = []): PreRenderEvent

--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -35,7 +35,7 @@ final class ComponentNode extends EmbedNode
         $compiler->addDebugInfo($this);
 
         $compiler
-            ->raw('$props = $this->extensions[')
+            ->write('$embeddedContext = $this->extensions[')
             ->string(ComponentExtension::class)
             ->raw(']->embeddedContext(')
             ->string($this->getAttribute('component'))
@@ -47,9 +47,15 @@ final class ComponentNode extends EmbedNode
             ->raw(");\n")
         ;
 
-        $this->addGetTemplate($compiler);
+        $compiler->write('$embeddedBlocks = $embeddedContext[')
+            ->string('outerBlocks')
+            ->raw(']->convert($blocks, ')
+            ->raw($this->getAttribute('index'))
+            ->raw(");\n")
+        ;
 
-        $compiler->raw('->display($props);');
+        $this->addGetTemplate($compiler);
+        $compiler->raw('->display($embeddedContext, $embeddedBlocks);');
         $compiler->raw("\n");
     }
 }

--- a/src/TwigComponent/src/Twig/ComponentTokenParser.php
+++ b/src/TwigComponent/src/Twig/ComponentTokenParser.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\TwigComponent\Twig;
 
+use Symfony\UX\TwigComponent\BlockStack;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\ArrayExpression;
@@ -60,6 +61,17 @@ final class ComponentTokenParser extends AbstractTokenParser
             new Token(Token::BLOCK_START_TYPE, '', $token->getLine()),
             new Token(Token::NAME_TYPE, 'extends', $token->getLine()),
             $parentToken,
+            new Token(Token::BLOCK_END_TYPE, '', $token->getLine()),
+
+            // Add an empty block which can act as a fallback for when an outer
+            // block is referenced that is not passed in from the embedded component.
+            // See BlockStack::__call()
+            new Token(Token::BLOCK_START_TYPE, '', $token->getLine()),
+            new Token(Token::NAME_TYPE, 'block', $token->getLine()),
+            new Token(Token::NAME_TYPE, BlockStack::OUTER_BLOCK_FALLBACK_NAME, $token->getLine()),
+            new Token(Token::BLOCK_END_TYPE, '', $token->getLine()),
+            new Token(Token::BLOCK_START_TYPE, '', $token->getLine()),
+            new Token(Token::NAME_TYPE, 'endblock', $token->getLine()),
             new Token(Token::BLOCK_END_TYPE, '', $token->getLine()),
         ]);
 

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponent.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponent
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponent1.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponent1.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponent1
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponent2.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponent2.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponent2
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponent3.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponent3.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponent3
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponent4.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponent4.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponent4
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponent5.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponent5.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponent5
+{
+    public string $divComponentName = 'foo';
+
+    public function someFunction(): string
+    {
+        return 'calling DivComponent';
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponent6.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponent6.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponent6
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponentNoPass.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponentNoPass.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponentNoPass
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponentWrapper.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponentWrapper.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponentWrapper
+{
+    public string $divComponentWrapperName = 'bar';
+
+    public function someFunction(): string
+    {
+        return 'calling DivComponentWrapper';
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/Component/DivComponentWrapper2.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DivComponentWrapper2.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class DivComponentWrapper2
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/GenericElement.php
+++ b/src/TwigComponent/tests/Fixtures/Component/GenericElement.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent]
+final class GenericElement
+{
+    public string $element;
+    public string $id = 'symfonyIsAwesome';
+
+    public function someFunction(): string
+    {
+        return 'calling GenericElement';
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponent.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponent.html.twig
@@ -1,0 +1,6 @@
+<twig:GenericElement element="div" class="divComponent">
+    {{ block(outerBlocks.content) }}
+    {% block foo %}
+        {{ block(outerBlocks.foo) }}
+    {% endblock %}
+</twig:GenericElement>

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponent1.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponent1.html.twig
@@ -1,0 +1,3 @@
+{% block content %}{% endblock %}
+
+<twig:GenericElement element="div" class="divComponent">{% block content %}{% endblock %}</twig:GenericElement>

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponent2.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponent2.html.twig
@@ -1,0 +1,8 @@
+{% block content %}{% endblock %}
+
+<twig:GenericElement element="div" class="divComponent">
+    {{ block(outerBlocks.content) }}
+    {% block foo %}
+        {{ block(outerBlocks.foo) }} & {{ block(outerBlocks.foo) }}
+    {% endblock %}
+</twig:GenericElement>

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponent3.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponent3.html.twig
@@ -1,0 +1,6 @@
+<twig:GenericElement element="div" class="divComponent">
+    {{ block(outerBlocks.content) }}
+    {% block foo %}
+        {{ parent() }} + {{ block(outerBlocks.foo) }}
+    {% endblock %}
+</twig:GenericElement>

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponent4.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponent4.html.twig
@@ -1,0 +1,6 @@
+<twig:GenericElement element="div" class="divComponent">
+    DIV CONTENT: {{ block(outerBlocks.content) }}
+    {% block foo %}
+        {{ block(outerBlocks.foo) }}
+    {% endblock %}
+</twig:GenericElement>

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponent5.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponent5.html.twig
@@ -1,0 +1,7 @@
+<twig:GenericElement element="div" class="divComponent">
+    I can access my own properties: {{ divComponentName }}.
+    I can access the id of the Generic Element: {{ id }}.
+    This refers to the Generic Element: {{ this.someFunction }}.
+    I have access to outer context variables like {{ name }}.
+    {{ block(outerBlocks.content) }}
+</twig:GenericElement>

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponent6.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponent6.html.twig
@@ -1,0 +1,6 @@
+<twig:GenericElement element="div" class="divComponent">
+    {{ block(outerBlocks.content) ?: parent() }}
+    {% block foo %}
+        {{ block(outerBlocks.foo) ?: parent() }}
+    {% endblock %}
+</twig:GenericElement>

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponentNoPass.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponentNoPass.html.twig
@@ -1,0 +1,1 @@
+<twig:GenericElement element="div" class="divComponent"></twig:GenericElement>

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponentWrapper.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponentWrapper.html.twig
@@ -1,0 +1,6 @@
+<twig:DivComponent4>
+    WRAPPER CONTENT: {{ block(outerBlocks.content) }}
+    {% block foo %}
+        I'm fixing foo content
+    {% endblock %}
+</twig:DivComponent4>

--- a/src/TwigComponent/tests/Fixtures/templates/components/DivComponentWrapper2.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/DivComponentWrapper2.html.twig
@@ -1,0 +1,4 @@
+<twig:DivComponent4>
+    WRAPPER CONTENT: {{ block(outerBlocks.content) }}
+    I don't have a foo block, so it will be considered empty.
+</twig:DivComponent4>

--- a/src/TwigComponent/tests/Fixtures/templates/components/GenericElement.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/GenericElement.html.twig
@@ -1,0 +1,10 @@
+<{{ element }}{{ attributes }}>
+    {%- block content -%}
+        The Generic Element could have some default content, although it does not make sense in this example.
+    {%- endblock -%}
+    <span class="foo">
+    {% block foo %}
+        The Generic Element default foo block
+    {%- endblock -%}
+    </span>
+</{{ element }}>

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_basic.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_basic.html.twig
@@ -1,0 +1,4 @@
+<div id="rendered-in-place">{% block not_passed_down %}This block is rendered in place, since there's no extend happening{% endblock %}</div>
+
+{% set name = 'Fabien' %}
+<twig:DivComponent>Hello {{ name }}!{% block not_passed_down %}{% endblock %}</twig:DivComponent>

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_complex_nesting.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_complex_nesting.html.twig
@@ -1,0 +1,12 @@
+<twig:DivComponent>
+    Content 1
+    <twig:DivComponent>
+        Content 2
+        <twig:DivComponent>
+            Content 3
+            <twig:block name="foo">Override foo3</twig:block>
+        </twig:DivComponent>
+        <twig:block name="foo">Override foo2</twig:block>
+    </twig:DivComponent>
+    <twig:block name="foo">Override foo1</twig:block>
+</twig:DivComponent>

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_complex_nesting2.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_complex_nesting2.html.twig
@@ -1,0 +1,11 @@
+<twig:DivComponent>
+    Content 1
+    <twig:DivComponent>
+        Content 2
+        <twig:DivComponent>
+            Content 3
+            <twig:block name="foo">Override foo3</twig:block>
+        </twig:DivComponent>
+    </twig:DivComponent>
+    <twig:block name="foo">Override foo1</twig:block>
+</twig:DivComponent>

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_complex_nesting_deep.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_complex_nesting_deep.html.twig
@@ -1,0 +1,6 @@
+<twig:DivComponentWrapper>
+    Content from wrapper
+</twig:DivComponentWrapper>
+<twig:DivComponentWrapper2>
+    Content from wrapper
+</twig:DivComponentWrapper2>

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_context.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_context.html.twig
@@ -1,0 +1,7 @@
+{% set name = 'Fabien' %}
+<twig:DivComponent5>
+    I can access the id from Generic Element as well: {{ id }}.
+    I can access the properties from DivComponent as well: {{ divComponentName }}.
+    The less obvious thing is that at this level "this" refers to the component where the content block is used, i.e. the Generic Element.
+    Therefore, functions through this will be {{ this.someFunction }}.
+</twig:DivComponent5>

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_example1.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_example1.html.twig
@@ -1,0 +1,1 @@
+<twig:DivComponent1>Hello world!</twig:DivComponent1>

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_no_pass.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_no_pass.html.twig
@@ -1,0 +1,4 @@
+<twig:DivComponentNoPass>
+    Hello world!
+    <twig:block name="foo">Foo content is not used</twig:block>
+</twig:DivComponentNoPass>

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_outer_blocks.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_outer_blocks.html.twig
@@ -1,0 +1,4 @@
+<twig:DivComponent2>
+    Hello world!
+    <twig:block name="foo">Override foo</twig:block>
+</twig:DivComponent2>

--- a/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_outer_blocks_parent.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/embedded_component_blocks_outer_blocks_parent.html.twig
@@ -1,0 +1,4 @@
+<twig:DivComponent3>
+    Hello world!
+    <twig:block name="foo">Override foo</twig:block>
+</twig:DivComponent3>

--- a/src/TwigComponent/tests/Fixtures/templates/non_embedded_component_blocks.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/non_embedded_component_blocks.html.twig
@@ -1,0 +1,1 @@
+<twig:DivComponent/>

--- a/src/TwigComponent/tests/Fixtures/templates/non_embedded_component_blocks_with_fallback.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/non_embedded_component_blocks_with_fallback.html.twig
@@ -1,0 +1,3 @@
+<twig:DivComponent6/>
+
+<twig:DivComponent6>Override content<twig:block name="foo">Override foo</twig:block></twig:DivComponent6>

--- a/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
@@ -151,7 +151,7 @@ final class ComponentFactoryTest extends KernelTestCase
     public function testCannotGetConfigByNameForNonRegisteredComponent(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown component "invalid". The registered components are: component_a');
+        $this->expectExceptionMessageMatches('/^Unknown component "invalid"\. The registered components are:.* component_a/');
 
         $this->factory()->metadataFor('invalid');
     }
@@ -159,7 +159,7 @@ final class ComponentFactoryTest extends KernelTestCase
     public function testCannotGetInvalidComponent(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown component "invalid". The registered components are: component_a');
+        $this->expectExceptionMessageMatches('/^Unknown component "invalid"\. The registered components are:.* component_a/');
 
         $this->factory()->get('invalid');
     }

--- a/src/TwigComponent/tests/Integration/EmbeddedComponentTest.php
+++ b/src/TwigComponent/tests/Integration/EmbeddedComponentTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+final class EmbeddedComponentTest extends KernelTestCase
+{
+    /**
+     * Rule 1: A block is not passed into an embedded component, since it would be rendered in place ànd in the component's template.
+     */
+    public function testABlockIsNotPassedIntoAnEmbeddedComponent(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('embedded_component_blocks_basic.html.twig');
+
+        // rule 1
+        $this->assertStringContainsString('<div id="rendered-in-place">This block is rendered in place, since there\'s no extend happening</div>', $output);
+        $this->assertStringNotContainsString('<div class="divComponent">Hello Fabien!This block is rendered in place, since there\'s no extend happening</div>', $output);
+    }
+
+    /**
+     * Rule 2: An embedded component has access to the (outer) context.
+     */
+    public function testAnEmbeddedComponentHasContextAccess(): void
+    {
+        $this->assertStringContainsStringIgnoringIndentation(
+            '<div class="divComponent">Hello Fabien!',
+            self::getContainer()->get(Environment::class)->render('embedded_component_blocks_basic.html.twig')
+        );
+    }
+
+    /**
+     * Rule 3: A block is only passed one level down, via the display() function on the embedded Template that's representing a component instance.
+     */
+    public function testABlockIsOnlyPassedOneLevelDown(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('embedded_component_blocks_no_pass.html.twig');
+
+        $this->assertStringContainsStringIgnoringIndentation('<div class="divComponent">The Generic Element could have some default content, although it does not make sense in this example.<span class="foo">The Generic Element default foo block</span></div>', $output);
+        $this->assertStringNotContainsString('Hello world!', $output);
+        $this->assertStringNotContainsString('Foo content is not used', $output);
+    }
+
+    /**
+     * Rule 4: Inside that component's template you can use it, but NOT within a nested component. The latter is repeating rule 1.
+     */
+    public function testABlockIsNotPassedToNestedComponents(): void
+    {
+        $this->assertStringContainsStringIgnoringIndentation(
+            'Hello world!<div class="divComponent"><span class="foo">The Generic Element default foo block</span></div>',
+            self::getContainer()->get(Environment::class)->render('embedded_component_blocks_example1.html.twig')
+        );
+    }
+
+    /**
+     * Rule 5: If you want to use that block inside a component's template within a nested component,
+     *         then you can do so via the outerBlocks variable. For example: "block(outerBlocks.content)"
+     * Rule 6: You can use it multiple times, just like any other "block()" call
+     * Rule 7: If you want to pass that outer block along to the template of that nested component,
+     *         You can use it inside the block definition with the embedded component.
+     */
+    public function testBlockCanBeUsedWithinNestedViaTheOuterBlocks(): void
+    {
+        $this->assertStringContainsStringIgnoringIndentation(
+            'Hello world!<div class="divComponent">Hello world!<span class="foo">Override foo & Override foo</span></div>',
+            self::getContainer()->get(Environment::class)->render('embedded_component_blocks_outer_blocks.html.twig')
+        );
+    }
+
+    /**
+     * Rule 8: Defining a block for a component overrides any default content that block has in the component's template.
+     *         This also means that when passing block down that you will lose that default content.
+     *         That can be avoided by using {{ parent() }} like you normally would.
+     */
+    public function testBlockDefinitionsPassingDownOuterBlocksOverrideDefaultContent(): void
+    {
+        $this->assertStringContainsStringIgnoringIndentation(
+            '<div class="divComponent">Hello world!<span class="foo">The Generic Element default foo block + Override foo</span></div>',
+            self::getContainer()->get(Environment::class)->render('embedded_component_blocks_outer_blocks_parent.html.twig')
+        );
+    }
+
+    /**
+     * Rule 9: Passing blocks also works with nesting a component inside another instance of the same component.
+     */
+    public function testDeepNesting(): void
+    {
+        $this->assertStringContainsStringIgnoringIndentation(
+            '<div class="divComponent">Content 1<div class="divComponent">Content 2<div class="divComponent">Content 3<span class="foo">Override foo3</span></div><span class="foo">Override foo2</span></div><span class="foo">Override foo1</span></div>',
+            self::getContainer()->get(Environment::class)->render('embedded_component_blocks_complex_nesting.html.twig')
+        );
+    }
+
+    /**
+     * Rule 10: Missing outer blocks use a fallback block so that nothing is rendered, and no unknown block error occurs.
+     */
+    public function testItCanHandleMissingOuterBlocks(): void
+    {
+        $this->assertStringContainsStringIgnoringIndentation(
+            '<div class="divComponent">Content 1<div class="divComponent">Content 2<div class="divComponent">Content 3<span class="foo">Override foo3</span></div><span class="foo"></span></div><span class="foo">Override foo1</span></div>',
+            self::getContainer()->get(Environment::class)->render('embedded_component_blocks_complex_nesting2.html.twig')
+        );
+    }
+
+    /**
+     * Rule 11: To pass blocks down multiple levels, each level needs to define the block,
+     *          so it can be used for its parent block (of the nested component).
+     *          Not defining a block (and not passing said block along) will be considered as a missing block (see rule 10).
+     */
+    public function testPassingDownBlocksMultipleLevelsNeedsToBeDoneManually(): void
+    {
+        $this->assertStringContainsStringIgnoringIndentation(
+            '<div class="divComponent">DIV CONTENT: WRAPPER CONTENT: Content from wrapper<span class="foo">I\'m fixing foo content</span></div><div class="divComponent">DIV CONTENT: WRAPPER CONTENT: Content from wrapperI don\'t have a foo block, so it will be considered empty.<span class="foo"></span></div>',
+            self::getContainer()->get(Environment::class)->render('embedded_component_blocks_complex_nesting_deep.html.twig')
+        );
+    }
+
+    /**
+     * Rule 12: Blocks defined within an embedded component can access the context of the block they are replacing.
+     */
+    public function testBlockDefinitionCanAccessTheContextOfTheDestinationBlocks(): void
+    {
+        $this->assertStringContainsStringIgnoringIndentation(
+            '<div class="divComponent">I can access my own properties: foo.I can access the id of the Generic Element: symfonyIsAwesome.This refers to the Generic Element: calling GenericElement.I have access to outer context variables like Fabien.I can access the id from Generic Element as well: symfonyIsAwesome.I can access the properties from DivComponent as well: foo.The less obvious thing is that at this level "this" refers to the component where the content block is used, i.e. the Generic Element.Therefore, functions through this will be calling GenericElement.<span class="foo">The Generic Element default foo block</span></div>',
+            self::getContainer()->get(Environment::class)->render('embedded_component_blocks_context.html.twig')
+        );
+    }
+
+    public function testANonEmbeddedComponentRendersOuterBlocksEmpty(): void
+    {
+        $this->assertStringContainsStringIgnoringIndentation(
+            '<div class="divComponent"><span class="foo"></span></div>',
+            self::getContainer()->get(Environment::class)->render('non_embedded_component_blocks.html.twig')
+        );
+    }
+
+    public function testANonEmbeddedComponentCanRenderParentBlocksAsFallback(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('non_embedded_component_blocks_with_fallback.html.twig');
+        $this->assertStringContainsStringIgnoringIndentation(
+            '<div class="divComponent">The Generic Element could have some default content, although it does not make sense in this example.<span class="foo">The Generic Element default foo block</span></div>',
+            $output
+        );
+
+        $this->assertStringContainsStringIgnoringIndentation(
+            '<div class="divComponent">Override content<span class="foo">Override foo</span></div>',
+            $output
+        );
+    }
+
+    private function assertStringContainsStringIgnoringIndentation(string $needle, string $haystack): void
+    {
+        $this->assertStringContainsString($needle, str_replace(["\n", '    '], '', $haystack));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #844
| License       | MIT

The fix for #844, and a better solution then a manual passthrough workaround, is literally just passing the blocks from the "host Template" to the embedded Template, ~~so that the blocks are merged with the embedded template's blocks, overriding them~~ but altering their name and using a special `outerBloocks` variable to map the block name to the new name (see https://github.com/symfony/ux/pull/920#issuecomment-1585814290).

This means that the example from https://github.com/symfony/ux/issues/844#issuecomment-1534575433 (tweaked a bit)

```twig
{# anywhere #}
{% set name = 'Fabien' %}
<twig:DivComponent>
    Hello {{ name }}!
</twig:DivComponent>
```

```twig
{# DivComponent.html.twig #}
<twig:GenericElement element="div" class="divComponent">
    {{ block(outerBlocks.content) }}
</twig:GenericElement>
```

```twig
{# GenericElement.html.twig #}
<{{ element }}{{ attributes }}>
  {%- block content -%}{%- endblock -%}
</{{ element }}>
```

Results in

```twig
<div class="divComponent">Hello Fabien!</div>
```

See the tests for more elaborate examples showing the access to context variables, multi-level overrides, etc.