### PR TITLE
[Live] Simplify new form docs

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1287,7 +1287,7 @@ make it easy to deal with forms::
          * with that data. The value - data - could be anything.
          */
         #[LiveProp(fieldName: 'data')]
-        public Post $post;
+        public Post $post = null;
 
         /**
          * Used to re-create the PostType form for re-rendering.
@@ -1353,31 +1353,21 @@ This is possible thanks to the team work of two pieces:
    yet by the user, its validation errors are cleared so that they
    aren't displayed.
 
-Making the Post Object Optional for a "New Form" Component
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Build the "New Post" Form Component
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The previous component could be used to edit an existing post or create
-a new post. But either way, the component *requires* you to pass it
-a ``post`` property.
+The previous component can already be used to edit an existing post or create
+a new post. For a new post, either pass in a new ``Post`` object to ``pass``,
+or omit it entirely to let the ``post`` property default to ``null``:
 
-Tou can make that optional by adding a ``mount()`` method::
+.. code-block:: twig
 
-    #[AsLiveComponent]
-    class PostForm extends AbstractController
-    {
-        // ...
-        #[LiveProp(fieldName: 'data')]
-        public Post $post;
+    {# templates/post/new.html.twig #}
+    {# ... #}
 
-        public function mount(Post $post = null)
-        {
-            $this->post = $post ?? new Post();
-        }
-    }
-
-If a ``post`` variable is passed to ``component()``, then it will
-be passed to the ``mount()`` method where you either use it, or
-create a new ``Post``.
+    {{ component('PostForm', {
+        form: form
+    }) }}
 
 Form Rendering Problems
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1487,7 +1477,7 @@ automatically. Let's add the ``save()`` action to the component::
             $this->addFlash('success', 'Post saved!');
 
             return $this->redirectToRoute('app_post_show', [
-                'id' => $this->post->getId(),
+                'id' => $post->getId(),
             ]);
         }
     }

--- a/src/Turbo/src/Doctrine/BroadcastListener.php
+++ b/src/Turbo/src/Doctrine/BroadcastListener.php
@@ -65,7 +65,7 @@ final class BroadcastListener implements ResetInterface
             return;
         }
 
-        $em = $eventArgs->getObjectManager();
+        $em = method_exists($eventArgs, 'getObjectManager') ? $eventArgs->getObjectManager() : $eventArgs->getEntityManager();
         $uow = $em->getUnitOfWork();
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
             $this->storeEntitiesToPublish($em, $entity, 'createdEntities');
@@ -89,7 +89,7 @@ final class BroadcastListener implements ResetInterface
             return;
         }
 
-        $em = $eventArgs->getObjectManager();
+        $em = method_exists($eventArgs, 'getObjectManager') ? $eventArgs->getObjectManager() : $eventArgs->getEntityManager();
 
         try {
             foreach ($this->createdEntities as $entity) {

--- a/ux.symfony.com/templates/components/RegistrationForm.html.twig
+++ b/ux.symfony.com/templates/components/RegistrationForm.html.twig
@@ -4,12 +4,13 @@
     {% if isSuccessful %}
         <div>Welcome {{ newUserEmail}}!</div>
     {% else %}
-        <form
-            novalidate
-            data-action="live#action"
-            data-action-name="prevent|saveRegistration"
-            data-model="on(change)|*"
-        >
+        {{ form_start(form, {
+            attr: {
+                'novalidate': true,
+                'data-action': 'live#action',
+                'data-action-name': 'prevent|saveRegistration',
+            }
+        }) }}
             {{ form_row(form.email) }}
             {{ form_row(form.password) }}
             {{ form_row(form.terms) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

I changed this section in the docs in 2.8, once it WAS legal to have non-persisted entities on a `LiveProp`. But I'm not sure why I did it this way. It's easier to default to `null`. The only caveat is that you should use `$post = $this->getFormInstance()->getData();` to get the `Post` object instead of `$this->post`, but we already show that in the docs ( did fix one spot that didn't).