### PR TITLE
[Live] Removing docs showing the proxied component

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2621,6 +2621,7 @@ class ComponentRegistry {
             const interval = setInterval(() => {
                 const component = this.componentMapByElement.get(element);
                 if (component) {
+                    clearInterval(interval);
                     resolve(component);
                 }
                 count++;

--- a/src/LiveComponent/assets/src/ComponentRegistry.ts
+++ b/src/LiveComponent/assets/src/ComponentRegistry.ts
@@ -25,6 +25,7 @@ export default class {
             const interval = setInterval(() => {
                 const component = this.componentMapByElement.get(element);
                 if (component) {
+                    clearInterval(interval);
                     resolve(component);
                 }
                 count++;

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -771,13 +771,11 @@ controller and put it around (or attached to) your root component element:
         toggleMode() {
             // e.g. set some live property called "mode" on your component
             this.component.set('mode', 'editing');
-            // you can also say
-            this.component.mode = 'editing';
+            // then, trigger a re-render to get the fresh HTML
+            this.component.render();
 
             // or call an action
             this.component.action('save', { arg1: 'value1' });
-            // you can also say:
-            this.component.save({ arg1: 'value1'});
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

3 small things:

1) The docs were wrong - calling `this.component.set()` does not, on its own, trigger a re-render. `this.component.render()` is also needed.
2) When using `getComponent()`, the `Proxy` wrapped object is not returned, so doing things like `this.someModel = 'bar'` does not work. And I think we shouldn't make it work - the `Proxy` is just some unnecessary magic and it would add complexity to introduce it here.
3) The interval was never cleared - minor, but we were running the interval a few extra times after returning times.

Cheers!