### PR TITLE
Added warning for list of embedded components

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2356,8 +2356,9 @@ cause the child to re-render (but it *can* - keep reading). Or, if
 a model in a child updates, it won't also update that model in its parent
 (but it *can* - keep reading).
 
-The parent-child system is *smart*. And with a few tricks, you can make
-it behave exactly like you need.
+The parent-child system is *smart*. And with a few tricks
+(:ref:`such as the key prop for lists of embedded components <rendering-quirks-with-list-of-embedded-components>`),
+you can make it behave exactly like you need.
 
 .. _child-component-independent-rerender:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

As discussed on slack with @weaverryan , I think the `key` trick for lists of embedded components is an easy footgun and thus should be pointed as soon as the docs introduce the subject. I'm open for better wording or placement.
