### PR TITLE
Asset mapper: Further docs updates

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -12,7 +12,7 @@ into an Ajax-powered autocomplete smart UI control (leveraging `Tom Select`_):
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Then install the bundle using Composer and Symfony Flex:
 
@@ -20,12 +20,11 @@ Then install the bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-autocomplete
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -585,7 +584,7 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework: https://symfony.com/doc/current/contributing/code/bc.html
 
 .. _`Tom Select`: https://tom-select.js.org/
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`Tom Select Options`: https://tom-select.js.org/docs/#general-configuration
 .. _`controller.ts`: https://github.com/symfony/ux/blob/2.x/src/Autocomplete/assets/src/controller.ts
 .. _`Tom Select Render Templates`: https://tom-select.js.org/docs/#render-templates

--- a/src/Chartjs/doc/index.rst
+++ b/src/Chartjs/doc/index.rst
@@ -8,20 +8,19 @@ It is part of `the Symfony UX initiative`_.
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
-Then, install this bundle using Composer and Symfony Flex:
+Then install the bundle using Composer and Symfony Flex:
 
 .. code-block:: terminal
 
     $ composer require symfony/ux-chartjs
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -244,7 +243,7 @@ the Symfony framework: https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Chart.js`: https://www.chartjs.org
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`Chart.js documentation`: https://www.chartjs.org/docs/latest/
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`a lot of plugins`: https://github.com/chartjs/awesome#plugins
 .. _`zoom plugin`: https://www.chartjs.org/chartjs-plugin-zoom/latest/
 .. _`zoom plugin documentation`: https://www.chartjs.org/chartjs-plugin-zoom/latest/guide/integration.html

--- a/src/Cropperjs/doc/index.rst
+++ b/src/Cropperjs/doc/index.rst
@@ -8,7 +8,7 @@ Symfony UX Cropper.js is a Symfony bundle integrating the
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Then, install this bundle using Composer and Symfony Flex:
 
@@ -16,12 +16,11 @@ Then, install this bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-cropperjs
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -151,4 +150,4 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Cropper.js`: https://fengyuanchen.github.io/cropperjs/
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`the Cropper.js options`: https://github.com/fengyuanchen/cropperjs/blob/main/README.md#options
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/Dropzone/doc/index.rst
+++ b/src/Dropzone/doc/index.rst
@@ -10,7 +10,7 @@ having to browse their computer for a file.
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Then, install this bundle using Composer and Symfony Flex:
 
@@ -18,12 +18,11 @@ Then, install this bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-dropzone
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -157,4 +156,4 @@ the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
 .. _`the Symfony UX initiative`: https://symfony.com/ux
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/LazyImage/doc/index.rst
+++ b/src/LazyImage/doc/index.rst
@@ -12,7 +12,7 @@ It provides two key features:
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Then install this bundle using Composer and Symfony Flex:
 
@@ -20,12 +20,11 @@ Then install this bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-lazy-image
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -174,4 +173,4 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`BlurHash implementation`: https://blurha.sh
 .. _`StimulusBundle`: https://symfony.com/bundles/StimulusBundle/current/index.html
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -4,10 +4,13 @@ Live Components
 **EXPERIMENTAL** This component is currently experimental and is likely
 to change, or even change drastically.
 
-Live components work with the `TwigComponent`_ library
+Live components builds on top of the `TwigComponent`_ library
 to give you the power to automatically update your Twig components on
 the frontend as the user interacts with them. Inspired by
 `Livewire`_ and `Phoenix LiveView`_.
+
+If you're not familiar with Twig components yet, it's worth taking a few minutes
+to familiarize yourself in the `TwigComponent documentation`_.
 
 A real-time product search component might look like this::
 
@@ -55,16 +58,6 @@ A real-time product search component might look like this::
         </ul>
     </div>
 
-.. versionadded:: 2.1
-
-    The ability to reference local variables in the template (e.g. ``query``) was added in TwigComponents 2.1.
-    Previously, all data needed to be referenced through ``this`` (e.g. ``this.query``).
-
-.. versionadded:: 2.1
-
-    The ability to initialize live component with the ``attributes`` twig variable was added in LiveComponents
-    2.1. Previously, the ``init_live_component()`` function was required (this function was removed in 2.1).
-
 Done! Now render it wherever you want:
 
 .. code-block:: twig
@@ -79,7 +72,7 @@ Want some demos? Check out https://ux.symfony.com/live-component#demo
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Now install the library with:
 
@@ -87,12 +80,11 @@ Now install the library with:
 
     $ composer require symfony/ux-live-component
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -411,7 +403,8 @@ In this case, the model (e.g. ``publishAt``) will probably *not*
 update correctly because JavaScript doesn't trigger the normal
 ``change`` event. To fix this, you'll need to "hook" into the
 JavaScript library and set the model directly (or trigger a
-``change`` event on the ``data-model`` field). See :ref:`working-in-javascript`.
+``change`` event on the ``data-model`` field). See
+:ref:`manually trigger an element change <javascript-manual-element-change>`.
 
 .. _hydration:
 
@@ -788,6 +781,8 @@ initialized:
 
     const component = document.getElementById('id-of-your-element').__component;
     component.mode = 'editing';
+
+.. _javascript-manual-element-change:
 
 Finally, you can also set the value of a model field directly. However,
 be sure to *also* trigger a ``change`` event so that live components is notified
@@ -2949,6 +2944,7 @@ However it is currently considered `experimental`_, meaning it is not
 bound to Symfony's BC policy for the moment.
 
 .. _`TwigComponent`: https://symfony.com/bundles/ux-twig-component/current/index.html
+.. _TwigComponent documentation: https://symfony.com/bundles/ux-twig-component/current/index.html
 .. _`Livewire`: https://laravel-livewire.com
 .. _`Phoenix LiveView`: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html
 .. _`Twig Component`: https://symfony.com/bundles/ux-twig-component/current/index.html
@@ -2956,7 +2952,7 @@ bound to Symfony's BC policy for the moment.
 .. _`Symfony form`: https://symfony.com/doc/current/forms.html
 .. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`dependent form fields`: https://ux.symfony.com/live-component/demos/dependent-form-fields
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`localizes its URLs`: https://symfony.com/doc/current/translation/locale.html#translation-locale-url
 .. _`attributes variable`: https://symfony.com/bundles/ux-twig-component/current/index.html#component-attributes
 .. _`CollectionType`: https://symfony.com/doc/current/form/form_collections.html

--- a/src/Notify/doc/index.rst
+++ b/src/Notify/doc/index.rst
@@ -7,7 +7,7 @@ in Symfony applications using `Mercure`_. It is part of `the Symfony UX initiati
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Then, install this bundle using Composer and Symfony Flex:
 
@@ -15,12 +15,11 @@ Then, install this bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-notify
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -153,7 +152,7 @@ the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
 .. _`the Symfony UX initiative`: https://symfony.com/ux
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`Mercure`: https://mercure.rocks
 .. _`running Mercure server`: https://symfony.com/doc/current/mercure.html#running-a-mercure-hub
 .. _`native notifications`: https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API

--- a/src/React/doc/index.rst
+++ b/src/React/doc/index.rst
@@ -13,7 +13,12 @@ Symfony UX React supports React 18+.
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+.. note::
+
+    This package works best with WebpackEncore. To use it with AssetMapper, see
+    :ref:`Using with AssetMapper <using-with-asset-mapper>`.
+
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 Then install the bundle using Composer and Symfony Flex:
 
 .. code-block:: terminal
@@ -40,7 +45,6 @@ Install a package to help React:
     $ npm run watch
 
     # or use yarn
-    
     $ yarn add @babel/preset-react --dev --force
     $ yarn watch
 
@@ -98,10 +102,39 @@ For example:
         <div {{ react_component('MyComponent', { 'fullName': number }) }}>
             Loading... <i class="fas fa-cog fa-spin fa-3x"></i>
         </div>
-        
+
         {# Component living in a subdirectory: "assets/react/controllers/Admin/OtherComponent" #}
         <div {{ react_component('Admin/OtherComponent') }}></div>
     {% endblock %}
+
+.. _using-with-asset-mapper:
+
+Using with AssetMapper
+----------------------
+
+Because the JSX format isn't pure JavaScript, using this library with AssetMapper
+requires some extra steps.
+
+#. Compile your ``.jsx`` files to pure JavaScript files. This can be done by
+   installing Babel and the ``@babel/preset-react`` preset. Example:
+   https://github.com/symfony/ux/blob/2.x/ux.symfony.com/package.json
+
+#. Point this library at the "built" controllers directory that contains the final
+   JavaScript files:
+
+.. code-block:: yaml
+
+    # config/packages/react.yaml
+    react:
+        controllers_path: '%kernel.project_dir%/assets/build/react/controllers'
+
+Also, inside of your ``.jsx`` files, when importing another component, use the
+``.js`` extension:
+
+.. code-block:: javascript
+
+    // use PackageList.js even though the file is named PackageList.jsx
+    import PackageList from '../components/PackageList.js';
 
 Backward Compatibility promise
 ------------------------------
@@ -112,4 +145,4 @@ https://symfony.com/doc/current/contributing/code/bc.html
 
 .. _`React`: https://reactjs.org/
 .. _`the Symfony UX initiative`: https://symfony.com/ux
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -1,11 +1,17 @@
 StimulusBundle: Symfony integration with Stimulus
 =================================================
 
-This bundle adds integration between Symfony, `Stimulus`_ and Symfony UX:
+.. tip::
 
-A) Twig ``stimulus_*`` functions & filters to add Stimulus controllers, actions & targets in your templates;
-B) Integration with Symfony UX & AssetMapper (this integration is `experimental`_)
-C) A helper service to build the Stimulus data attributes and use them in your services.
+    Check out live demos of Symfony UX at https://ux.symfony.com!
+
+This bundle adds integration between Symfony, `Stimulus`_ and the Symfony UX packages:
+
+A) Twig ``stimulus_`` functions & filters to add Stimulus controllers,
+   actions & targets in your templates;
+
+B) Integration to load :ref:`UX Packages <ux-packages>` (extra Stimulus controllers)
+   (if you're using AssetMapper, this integration is `experimental`_)
 
 Installation
 ------------
@@ -15,18 +21,13 @@ both work great with StimulusBundle:
 
 * A) `Webpack Encore`_ Node-based packaging system:
 
-  .. code-block:: terminal
-
-      $ composer require symfony/webpack-encore-bundle
 or
 
 * B) `AssetMapper`_: PHP-based system for handling assets:
 
-  .. code-block:: terminal
+See `Encore vs AssetMapper`_ to learn which is best for your project.
 
-      $ composer require symfony/asset-mapper
-
-Then, install the bundle:
+Next, install the bundle:
 
 .. code-block:: terminal
 
@@ -35,11 +36,26 @@ Then, install the bundle:
 If you're using `Symfony Flex`_, you're done! The recipe will update the
 necessary files. If not, or you're curious, see :ref:`Manual Setup <manual-installation>`.
 
+.. tip::
+
+    If you're using Encore, be sure to install your assets (e.g. ``npm install``)
+    and restart Encore.
+
 Usage
 -----
 
 You can now create custom Stimulus controllers inside of the ``assets/controllers.``
-directory. In fact, you should have an example controller there already: ``hello_controller.js``.
+directory. In fact, you should have an example controller there already: ``hello_controller.js``:
+
+.. code-block:: javascript
+
+    import { Controller } from '@hotwired/stimulus';
+
+    export default class extends Controller {
+        connect() {
+            this.element.textContent = 'Hello Stimulus! Edit me in assets/controllers/hello_controller.js';
+        }
+    }
 
 Use the Twig functions from this bundle to activate your controllers:
 
@@ -49,13 +65,97 @@ Use the Twig functions from this bundle to activate your controllers:
         ...
     </div>
 
-Your app will also activate any 3rd party controllers (installed by UX bundles)
-mentioned in your ``assets/controllers.json`` file.
+That's it! Whenever this element appears on the page, the ``hello`` controller
+will activate.
 
-For a *ton* more details, see the `Symfony UX documentation`_.
+There's a *lot* more to learn about Stimulus. See the `Stimulus Documentation`_
+for all the goodies.
+
+.. _ux-packages:
+
+The UX Packages
+~~~~~~~~~~~~~~~
+
+Symfony provides a set of UX packages that add extra Stimulus controllers to solve
+common problems. StimulusBundle activates any 3rd party Stimulus controllers
+that are mentioned in your ``assets/controllers.json`` file. This file is updated
+whenever you install a UX package.
+
+The official UX packages are:
+
+* `ux-autocomplete`_: Transform ``EntityType``, ``ChoiceType`` or *any*
+  ``<select>`` element into an Ajax-powered autocomplete field
+  (`see demo <https://ux.symfony.com/autocomplete>`_)
+* `ux-chartjs`_: Easy charts with `Chart.js`_ (`see demo <https://ux.symfony.com/chartjs>`_)
+* `ux-cropperjs`_: Form Type and tools for cropping images (`see demo <https://ux.symfony.com/cropperjs>`_)
+* `ux-dropzone`_: Form Type for stylized "drop zone" for file uploads
+  (`see demo <https://ux.symfony.com/dropzone>`_)
+* `ux-lazy-image`_: Optimize Image Loading with BlurHash
+  (`see demo <https://ux.symfony.com/lazy-image>`_)
+* `ux-live-component`_: Build Dynamic Interfaces with Zero JavaScript
+  (`see demo <https://ux.symfony.com/live-component>`_)
+* `ux-notify`_: Send server-sent native notification with Mercure
+  (`see demo <https://ux.symfony.com/notify>`_)
+* `ux-react`_: Render `React`_ component from Twig (`see demo <https://ux.symfony.com/react>`_)
+* `ux-svelte`_: Render `Svelte`_ component from Twig (`see demo <https://ux.symfony.com/svelte>`_)
+* `ux-swup`_: Integration with `Swup`_ (`see demo <https://ux.symfony.com/swup>`_)
+* `ux-translator`_: Use your Symfony translations in JavaScript `Swup`_ (`see demo <https://ux.symfony.com/translator>`_)
+* `ux-turbo`_: Integration with `Turbo Drive`_ for a single-page-app experience
+  (`see demo <https://ux.symfony.com/turbo>`_)
+* `ux-twig-component`_: Build Twig Components Backed by a PHP Class
+  (`see demo <https://ux.symfony.com/twig-component>`_)
+* `ux-typed`_: Integration with `Typed`_ (`see demo <https://ux.symfony.com/typed>`_)
+* `ux-vue`_: Render `Vue`_ component from Twig (`see demo <https://ux.symfony.com/vue>`_)
+
+Lazy Stimulus Controllers
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, all of your controllers (i.e. files in ``assets/controllers/`` +
+controllers in ``assets/controllers.json``) will be downloaded and loaded on
+every page.
+
+Sometimes you may have a controller that's only used on some pages. In that case,
+you can make the controller "lazy". In this case, will *not be downloaded on
+initial page load. Instead, as soon as an element appears on the page matching
+the controller (e.g. ``<div data-controller="hello">``), the controller - and anything
+else it imports - will be lazily-loaded via Ajax.
+
+To make one of your custom controllers lazy, add a special comment on top:
+
+.. code-block:: javascript
+
+    import { Controller } from '@hotwired/stimulus';
+
+    /* stimulusFetch: 'lazy' */
+    export default class extends Controller {
+        // ...
+    }
+
+To make a third-party controller lazy, in ``assets/controllers.json``, set
+``fetch`` to ``lazy``.
+
+.. note::
+
+    If you write your controllers using TypeScript, make sure
+    ``removeComments`` is not set to ``true`` in your TypeScript config.
+
+Stimulus Tools around the World
+-------------------------------
+
+Because Stimulus is used by developers outside of Symfony, many tools
+exist beyond the UX packages:
+
+* `stimulus-use`_: Add composable behaviors to your Stimulus controllers, like
+  debouncing, detecting outside clicks and many other things.
+
+* `stimulus-components`_ A large number of pre-made Stimulus controllers, like for
+  Copying to clipboard, Sortable, Popover (similar to tooltips) and much more.
 
 Stimulus Twig Helpers
 ---------------------
+
+This bundle adds 3 Twig functions/filters to help add Stimulus controllers,
+actions & targets in your templates.
 
 stimulus_controller
 ~~~~~~~~~~~~~~~~~~~
@@ -203,6 +303,8 @@ You can also retrieve the generated attributes as an array, which can be helpful
 
     {{ form_row(form.password, { attr: stimulus_target('hello-controller', 'a-target').toArray() }) }}
 
+.. _configuration:
+
 Configuration
 -------------
 
@@ -303,10 +405,77 @@ will import all your custom controllers as well as those from ``controllers.json
 It will also dynamically enable "debug" mode in Stimulus when your application
 is running in debug mode.
 
+How are the Stimulus Controllers Loaded?
+----------------------------------------
+
+When you install a UX PHP package, Symfony Flex will automatically update your
+``package.json`` file (not done or needed if using AssetMapper) to point to a
+"virtual package" that lives inside that PHP package. For example:
+
+.. code-block:: json
+
+    {
+        "devDependencies": {
+            "...": "",
+            "@symfony/ux-chartjs": "file:vendor/symfony/ux-chartjs/assets"
+        }
+    }
+
+This gives you a *real* Node package (e.g. ``@symfony/ux-chartjs``) that, instead
+of being downloaded, points directly to files that already live in your ``vendor/``
+directory.
+
+The Flex recipe will usually also update your ``assets/controllers.json`` file
+to add a new Stimulus controller to your app. For example:
+
+.. code-block:: json
+
+    {
+        "controllers": {
+            "@symfony/ux-chartjs": {
+                "chart": {
+                    "enabled": true,
+                    "fetch": "eager"
+                }
+            }
+        },
+        "entrypoints": []
+    }
+
+Finally, your ``assets/bootstrap.js`` file will automatically register:
+
+* All files in ``assets/controllers/`` as Stimulus controllers;
+* And all controllers described in ``assets/controllers.json`` as Stimulus controllers.
+
+.. note::
+
+    If you're using WebpackEncore, the ``bootstrap.js`` file works in partnership
+    with `@symfony/stimulus-bridge`_. With AssetMapper, the ``bootstrap.js`` file
+    works directly with this bundle: a ``@symfony/stimulus-bundle`` entry is added
+    to your ``importmap.php`` file via Flex, which points to a file that is dynamically
+    built to find and load your controllers (see :ref:`Configuration <configuration>`).
+
+The end result: you install a package, and you instantly have a Stimulus
+controller available! In this example, it's called
+``@symfony/ux-chartjs/chart``. Well, technically, it will be called
+``symfony--ux-chartjs--chart``. However, you can pass the original name
+into the ``{{ stimulus_controller() }}`` function from WebpackEncoreBundle, and
+it will normalize it:
+
+.. code-block:: html+twig
+
+    <div {{ stimulus_controller('@symfony/ux-chartjs/chart') }}>
+
+    <!-- will render as: -->
+    <div data-controller="symfony--ux-chartjs--chart">
+
+.. _Encore vs AssetMapper: https://symfony.com/doc/current/frontend.html
+.. _Symfony Flex: https://symfony.com/doc/current/setup/flex.html
+.. _Stimulus Documentation: https://stimulus.hotwired.dev/
+.. _`@symfony/stimulus-bridge`: https://github.com/symfony/stimulus-bridge
 .. _`Stimulus`: https://stimulus.hotwired.dev/
 .. _`Webpack Encore`: https://symfony.com/doc/current/frontend.html
 .. _`AssetMapper`: https://symfony.com/doc/current/frontend/asset-mapper.html
-.. _`Symfony UX documentation`: https://symfony.com/doc/current/frontend/ux.html
 .. _`Stimulus Controllers & Values`: https://stimulus.hotwired.dev/reference/values
 .. _`CSS Classes`: https://stimulus.hotwired.dev/reference/css-classes
 .. _`Stimulus Actions`: https://stimulus.hotwired.dev/reference/actions
@@ -314,3 +483,27 @@ is running in debug mode.
 .. _`Stimulus Targets`: https://stimulus.hotwired.dev/reference/targets
 .. _`StimulusBundle Flex recipe`: https://github.com/symfony/recipes/tree/main/symfony/stimulus-bundle
 .. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
+.. _`ux-autocomplete`: https://symfony.com/bundles/ux-autocomplete/current/index.html
+.. _`ux-chartjs`: https://symfony.com/bundles/ux-chartjs/current/index.html
+.. _`ux-cropperjs`: https://symfony.com/bundles/ux-cropperjs/current/index.html
+.. _`ux-dropzone`: https://symfony.com/bundles/ux-dropzone/current/index.html
+.. _`ux-lazy-image`: https://symfony.com/bundles/ux-lazy-image/current/index.html
+.. _`ux-live-component`: https://symfony.com/bundles/ux-live-component/current/index.html
+.. _`ux-notify`: https://symfony.com/bundles/ux-notify/current/index.html
+.. _`ux-react`: https://symfony.com/bundles/ux-react/current/index.html
+.. _ux-translator: https://symfony.com/bundles/ux-translator/current/index.html
+.. _`ux-swup`: https://symfony.com/bundles/ux-swup/current/index.html
+.. _`ux-turbo`: https://symfony.com/bundles/ux-turbo/current/index.html
+.. _`ux-twig-component`: https://symfony.com/bundles/ux-twig-component/current/index.html
+.. _`ux-typed`: https://symfony.com/bundles/ux-typed/current/index.html
+.. _`ux-vue`: https://symfony.com/bundles/ux-vue/current/index.html
+.. _`ux-svelte`: https://symfony.com/bundles/ux-svelte/current/index.html
+.. _`Chart.js`: https://www.chartjs.org/
+.. _`Swup`: https://swup.js.org/
+.. _`React`: https://reactjs.org/
+.. _`Svelte`: https://svelte.dev/
+.. _`Turbo Drive`: https://turbo.hotwired.dev/
+.. _`Typed`: https://github.com/mattboldt/typed.js/
+.. _`Vue`: https://vuejs.org/
+.. _`stimulus-use`: https://stimulus-use.github.io/stimulus-use
+.. _`stimulus-components`: https://stimulus-components.netlify.app/

--- a/src/Svelte/doc/index.rst
+++ b/src/Svelte/doc/index.rst
@@ -13,7 +13,12 @@ Symfony UX Svelte supports Svelte 3 only.
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+.. note::
+
+    This package works best with WebpackEncore. To use it with AssetMapper, see
+    :ref:`Using with AssetMapper <using-with-asset-mapper>`.
+
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Then install the bundle using Composer and Symfony Flex:
 
@@ -21,7 +26,6 @@ Then install the bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-svelte
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -115,6 +119,35 @@ Svelte client-side component API:
     {# templates/home.html.twig #}
     <div {{ svelte_component('MyAnimatedComponent', { 'name': app.user.fullName }, true) }}></div>
 
+.. _using-with-asset-mapper:
+
+Using with AssetMapper
+----------------------
+
+Because the ``.svelte`` file format isn't pure JavaScript, using this library with
+AssetMapper requires some extra steps.
+
+#. Compile your ``.svelte`` files to pure JavaScript files. This can be done by
+   using the ``svelte/compiler`` library, but is a bit of a non-standard process.
+   For an example, see https://github.com/symfony/ux/blob/2.x/ux.symfony.com/bin/compile_svelte.js.
+
+#. Point this library at the "built" controllers directory that contains the final
+   JavaScript files:
+
+.. code-block:: yaml
+
+    # config/packages/svelte.yaml
+    svelte:
+        controllers_path: '%kernel.project_dir%/assets/build/svelte/controllers'
+
+Also, inside of your ``.svelte`` files, when importing another component, use the
+``.js`` extension:
+
+.. code-block:: javascript
+
+    // use PackageList.js even though the file is named PackageList.svelte
+    import PackageList from '../components/PackageList.js';
+
 Backward Compatibility promise
 ------------------------------
 
@@ -125,4 +158,4 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Svelte`: https://svelte.dev/
 .. _`svelte-loader`: https://github.com/sveltejs/svelte-loader/blob/master/README.md
 .. _`the Symfony UX initiative`: https://symfony.com/ux
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/Swup/doc/index.rst
+++ b/src/Swup/doc/index.rst
@@ -12,7 +12,7 @@ bringing the complexity of a React/Vue/Angular application.
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Then install the bundle using Composer and Symfony Flex:
 
@@ -20,12 +20,11 @@ Then install the bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-swup
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -203,4 +202,4 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`StimulusBundle`: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`Swup Options`: https://swup.js.org/options
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -12,7 +12,12 @@ The `ICU Message Format`_ is also supported.
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+.. note::
+
+    This package works best with WebpackEncore. To use it with AssetMapper, see
+    :ref:`Using with AssetMapper <using-with-asset-mapper>`.
+
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Install this bundle using Composer and Symfony Flex:
 
@@ -20,12 +25,11 @@ Install this bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-translator
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -114,6 +118,31 @@ so you can import them like this:
     // Same as above, but uses the "it" locale
     trans(TRANSLATION_MULTI_LOCALES, {}, 'messages', 'it');
 
+.. _using-with-asset-mapper:
+
+Using with AssetMapper
+----------------------
+
+Using this library with AssetMapper is possible, but is currently experimental
+and may not be ready yet for production.
+
+When installing with AssetMapper, Flex will add a few new items to your ``importmap.php``
+file. 2 of the new items are::
+
+    '@app/translations' => [
+        'path' => 'var/translations/index.js',
+    ],
+    '@app/translations/configuration' => [
+        'path' => 'var/translations/configuration.js',
+    ],
+
+These are then imported in your ``assets/translator.js`` file. This setup is
+very similar to working with WebpackEncore. However, the ``var/translations/index.js``
+file contains *every* translation in your app, which is not ideal for production
+and may even leak translations only meant for admin areas. Encore solves this via
+tree-shaking, but the AssetMapper component does not. There is not, yet, a way to
+solve this properly with the AssetMapper component.
+
 Backward Compatibility promise
 ------------------------------
 
@@ -123,5 +152,5 @@ https://symfony.com/doc/current/contributing/code/bc.html
 
 .. _`Symfony Translator`: https://symfony.com/doc/current/translation.html
 .. _`the Symfony UX initiative`: https://symfony.com/ux
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`ICU Message Format`: https://symfony.com/doc/current/translation/message_format.html

--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -19,7 +19,7 @@ Or watch the `Turbo Screencast on SymfonyCasts`_.
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Install this bundle using Composer and Symfony Flex:
 
@@ -27,12 +27,11 @@ Install this bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-turbo
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -902,6 +901,6 @@ Symfony UX Turbo has been created by `Kévin Dunglas`_. It has been inspired by
 .. _`Kévin Dunglas`: https://dunglas.fr
 .. _`hotwired/turbo-rails`: https://github.com/hotwired/turbo-rails
 .. _`sroze/live-twig`: https://github.com/sroze/live-twig
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`Moving <script> inside <head> and the "defer" Attribute`: https://symfony.com/blog/moving-script-inside-head-and-the-defer-attribute
 .. _`Expression Language`: https://symfony.com/doc/current/components/expression_language.html

--- a/src/Typed/doc/index.rst
+++ b/src/Typed/doc/index.rst
@@ -13,7 +13,7 @@ Just enter the strings you want to see typed, and it goes live without complexit
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 
 Then install the bundle using Composer and Symfony Flex:
 
@@ -21,12 +21,11 @@ Then install the bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-typed
 
-If you're using WebpackEncore, install your assets and restart Encore. This is
-not needed if you're using AssetMapper:
+If you're using WebpackEncore, install your assets and restart Encore (not
+needed if you're using AssetMapper):
 
 .. code-block:: terminal
 
-    # Don't forget to install the JavaScript dependencies as well and compile
     $ npm install --force
     $ npm run watch
 
@@ -156,4 +155,4 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Typed`: https://github.com/mattboldt/typed.js/blob/master/README.md
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _`typed library`: https://github.com/mattboldt/typed.js/blob/master/README.md
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/Vue/doc/index.rst
+++ b/src/Vue/doc/index.rst
@@ -13,7 +13,12 @@ Symfony UX Vue.js supports Vue.js v3 only.
 Installation
 ------------
 
-Before you start, make sure you have `Symfony UX configured in your app`_.
+.. note::
+
+    This package works best with WebpackEncore. To use it with AssetMapper, see
+    :ref:`Using with AssetMapper <using-with-asset-mapper>`.
+
+Before you start, make sure you have `StimulusBundle configured in your app`_.
 Then install the bundle using Composer and Symfony Flex:
 
 .. code-block:: terminal
@@ -34,17 +39,12 @@ Next, in ``webpack.config.js``, enable Vue.js support:
 
 Install a package to help Vue:
 
-With NPM:
-
 .. code-block:: terminal
 
     $ npm install -D vue-loader --force
     $ npm run watch
-    
-With Yarn:
 
-.. code-block:: terminal
-
+    # or with yarn
     $ yarn add vue-loader --dev --force
     $ yarn watch
 
@@ -70,7 +70,7 @@ Finally, to load your Vue components, add the following lines to ``assets/app.js
     // and improve performance, you can use the following line instead:
     //registerVueControllerComponents(require.context('./vue/controllers', true, /\.vue$/, 'lazy'));
 
-That's it! Create an `assets/vue/controllers/` directory and start creating your
+That's it! Create an ``assets/vue/controllers/`` directory and start creating your
 Vue components.
 
 Usage
@@ -83,9 +83,6 @@ from Twig.
 When using the ``registerVueControllerComponents`` configuration shown previously, all
 Vue.js components located in the directory ``assets/vue/controllers`` are registered as
 Vue.js controller components.
-
-To make sure those components can be loaded by Webpack Encore, you need to configure
-it by following the instructions in `the related section of the documentation`_.
 
 You can then render any Vue.js controller component in Twig using the ``vue_component``.
 For example:
@@ -194,6 +191,19 @@ used for all the Vue routes:
 
     app.use(router);
 
+.. _using-with-asset-mapper:
+
+Using with AssetMapper
+----------------------
+
+The Vue single-file component (i.e. ``.vue``) file format is not pure JavaScript
+and cannot currently be converted to pure JavaScript outside of a bundler like
+Webpack Encore or Vite. This means that the ``.vue`` file format cannot be used
+with AssetMapper.
+
+If you *do* still want to use Vue with AssetMapper, you can do so by avoiding
+the ``.vue`` file format. For example, https://github.com/symfony/ux/blob/2.x/ux.symfony.com/assets/vue/controllers/PackageSearch.js.
+
 Backward Compatibility promise
 ------------------------------
 
@@ -204,4 +214,4 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Vue.js`: https://vuejs.org/
 .. _`the Symfony UX initiative`: https://symfony.com/ux
 .. _ `the related section of the documentation`: https://symfony.com/doc/current/frontend/encore/vuejs.html
-.. _`Symfony UX configured in your app`: https://symfony.com/doc/current/frontend/ux.html
+.. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/ux.symfony.com/src/Service/LiveDemoRepository.php
+++ b/ux.symfony.com/src/Service/LiveDemoRepository.php
@@ -86,9 +86,9 @@ EOF
                 description: 'Create an invoice + line items that updates as you type.',
                 route: 'app_live_components_invoice',
                 longDescription: <<<EOF
-A parent component with children components for each line item.
+Create or edit an `Invoice` entity along with child components for each related `InvoiceItem` entity.
 <br>
-Children emit events to communicate to the parent.
+Children components emit events to communicate to the parent and everything is saved in a `saveInvoice` LiveAction method.
 EOF
             ),
             new LiveDemo(

--- a/ux.symfony.com/templates/liveDemoBase.html.twig
+++ b/ux.symfony.com/templates/liveDemoBase.html.twig
@@ -18,7 +18,7 @@
     <div class="container-fluid container-xxl px-5 pt-5">
 
         <section style="color: rgb(100 116 139); font-size: 14px; line-height: 1.75rem;" class="mb-2">
-            {{ demo.longDescription|raw }}
+            {{ demo.longDescription|markdown_to_html }}
         </section>
 
         <div class="mb-3" style="position: relative;">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

Further updates for smooth documentation now that the AssetMapper component exists. The biggest change is that the docs for installing UX (which really just means installing StimulusBundle at this point) have moved into that bundle.

Cheers!
