### PR TITLE
Fixing old stimulus_controller() syntax for multiple controllers

### DIFF
--- a/src/LazyImage/doc/index.rst
+++ b/src/LazyImage/doc/index.rst
@@ -145,11 +145,8 @@ Then in your template, add your controller to the HTML attribute:
 
     <img
         src="{{ data_uri_thumbnail('public/image/large.png', 100, 75) }}"
-        {{ stimulus_controller({
-            mylazyimage: {},
-            'symfony/ux-lazy-image/lazy-image': {
-                src: asset('image/large.png')
-            }
+        {{ stimulus_controller('mylazyimage')|stimulus_controller('symfony/ux-lazy-image/lazy-image', {
+            src: asset('image/large.png')
         }) }}
 
         {# Using BlurHash, the size is required #}

--- a/src/Swup/doc/index.rst
+++ b/src/Swup/doc/index.rst
@@ -178,9 +178,8 @@ Then in your template, add your controller to the HTML attribute:
             <title>Swup</title>
             {# ... #}
         </head>
-        <body {{ stimulus_controller({
-            myswup: {},
-            'symfony/ux-swup/swup': {}
+        <body {{ stimulus_controller('myswup')|stimulus_controller('symfony/ux-swup/swup', {
+            // ... options
         }) }}>
             {# ... #}
         </body>

--- a/src/Typed/doc/index.rst
+++ b/src/Typed/doc/index.rst
@@ -132,9 +132,8 @@ Then in your template, add your controller to the HTML attribute:
             <title>Typed</title>
             {# ... #}
         </head>
-        <body {{ stimulus_controller({
-            mytyped: {},
-            'symfony/ux-typed': {}
+        <body {{ stimulus_controller('mytyped')|stimulus_controller('symfony/ux-typed', {
+            strings: ['...'],
         }) }}>
             {# ... #}
         </body>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | #937
| License       | MIT

I believe all other usages I'm aware of are ok.

Cheers!
