### PR TITLE
[LiveComponent] Working around issue where FormView is passed to the component

### DIFF
--- a/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
+++ b/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
@@ -56,7 +56,11 @@ final class ParentEntityAutocompleteType extends AbstractType implements DataMap
         array_splice($view['autocomplete']->vars['block_prefixes'], -1, 0, 'ux_entity_autocomplete_inner');
         // this IS A compound (i.e. has children) field
         // however, we only render the child "autocomplete" field. So for rendering, fake NOT compound
+        // This is a hack and we should check into removing it in the future
         $view->vars['compound'] = false;
+        // the above, unfortunately, can also trick other things that might use
+        // "compound" for other reasons. This, at least, leaves a hint.
+        $view->vars['compound_data'] = true;
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -92,7 +92,7 @@ trait ComponentWithFormTrait
         }
 
         // set the formValues from the initial form view's data
-        $this->formValues = $this->extractFormValues($this->getForm(), $this->getFormInstance());
+        $this->formValues = $this->extractFormValues($this->getForm());
 
         return $data;
     }
@@ -145,7 +145,7 @@ trait ComponentWithFormTrait
         $this->shouldAutoSubmitForm = false;
         $this->formInstance = null;
         $this->formView = null;
-        $this->formValues = $this->extractFormValues($this->getForm(), $this->getFormInstance());
+        $this->formValues = $this->extractFormValues($this->getForm());
     }
 
     private function submitForm(bool $validateAll = true): void
@@ -172,7 +172,7 @@ trait ComponentWithFormTrait
 
         // re-extract the "view" values in case the submitted data
         // changed the underlying data or structure of the form
-        $this->formValues = $this->extractFormValues($this->getForm(), $form);
+        $this->formValues = $this->extractFormValues($this->getForm());
 
         // remove any validatedFields that do not exist in data anymore
         $this->validatedFields = LiveFormUtility::removePathsNotInData(
@@ -238,7 +238,7 @@ trait ComponentWithFormTrait
      * frontend, and it's meant to equal the raw POST data that would
      * be sent if the form were submitted without modification.
      */
-    private function extractFormValues(FormView $formView, FormInterface $form): array
+    private function extractFormValues(FormView $formView): array
     {
         $values = [];
 
@@ -250,10 +250,12 @@ trait ComponentWithFormTrait
             // is already correct. For example, an expanded ChoiceType with
             // options "text" and "phone" would already have a value in the format
             // ["text"] (assuming "text" is checked and "phone" is not).
-            //
-            $isCompound = $form->has($name) && $form->get($name)->getConfig()->getOption('compound', false);
+            // "compound" is how we know if a field holds children. The extra
+            // "compound_data" is a special flag to workaround the fact that
+            // the "autocomplete" library fakes their compound fake incorrectly.
+            $isCompound = $child->vars['compound_data'] ?? $child->vars['compound'] ?? false;
             if ($isCompound && !($child->vars['expanded'] ?? false)) {
-                $values[$name] = $this->extractFormValues($child, $form->get($name));
+                $values[$name] = $this->extractFormValues($child);
 
                 continue;
             }

--- a/src/LiveComponent/tests/Fixtures/Form/ComplexFieldType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/ComplexFieldType.php
@@ -19,6 +19,8 @@ class ComplexFieldType extends AbstractType
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
         // try to confuse ComponentWithFormTrait
+        // mimics what autocomplete does
         $view->vars['compound'] = false;
+        $view->vars['compound_data'] = true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Conversation with @1ed on Slack
| License       | MIT

In this case, the FormView will likely be initialized with certain data and, in the case of something like a CollectionType, it will have certain children fields. If we try to get the "form instance", that will be created "fresh" with different data and different fields, which causes the "compound" check to fail.

Getting the "compound" from the form instance was always a workaround for autocomplete, which tricks us by changing their compound flag. This goes back to the original logic, with a workaround for autocomplete.

Cheers!