### PR TITLE
LiveComponents: nested dependent fields example

### DIFF
--- a/ux.symfony.com/composer.json
+++ b/ux.symfony.com/composer.json
@@ -20,6 +20,7 @@
         "symfony/asset-mapper": "6.3.x-dev",
         "symfony/console": "6.3.*",
         "symfony/dotenv": "6.3.*",
+        "symfony/expression-language": "6.3.*",
         "symfony/flex": "^2",
         "symfony/form": "6.3.*",
         "symfony/framework-bundle": "6.3.x-dev",

--- a/ux.symfony.com/composer.lock
+++ b/ux.symfony.com/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05956e4265f74a999ad8d37d391a38d2",
+    "content-hash": "010dcf4fa2bd13ee6460beba23043d3b",
     "packages": [
         {
             "name": "babdev/pagerfanta-bundle",
@@ -4052,6 +4052,70 @@
                 }
             ],
             "time": "2023-03-01T10:32:47+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "6d560c4c80e7e328708efd923f93ad67e6a0c1c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/6d560c4c80e7e328708efd923f93ad67e6a0c1c0",
+                "reference": "6d560c4c80e7e328708efd923f93ad67e6a0c1c0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ExpressionLanguage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an engine that can compile and evaluate expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/expression-language/tree/v6.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-04-28T16:05:33+00:00"
         },
         {
             "name": "symfony/filesystem",

--- a/ux.symfony.com/src/Enum/Food.php
+++ b/ux.symfony.com/src/Enum/Food.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Enum;
+
+enum Food: string
+{
+    case Eggs = 'eggs';
+    case Bacon = 'bacon';
+    case Strawberries = 'strawberries';
+    case Croissant = 'croissant';
+    case Bagel = 'bagel';
+    case Kiwi = 'kiwi';
+    case Avocado = 'avocado';
+    case Waffles = 'waffles';
+    case Pancakes = 'pancakes';
+    case Salad = 'salad';
+    case Tea = 'tea️';
+    case Sandwich = 'sandwich';
+    case Cheese = 'cheese';
+    case Sushi = 'sushi';
+    case Pizza = 'pizza';
+    case Pint = 'pint';
+    case Pasta = 'pasta';
+
+    public function getReadable(): string
+    {
+        return match ($this) {
+            self::Eggs => 'Eggs 🍳',
+            self::Bacon => 'Bacon 🥓',
+            self::Strawberries => 'Strawberries 🍓',
+            self::Croissant => 'Croissant 🥐',
+            self::Bagel => 'Bagel 🥯',
+            self::Kiwi => 'Kiwi 🥝',
+            self::Avocado => 'Avocado 🥑',
+            self::Waffles => 'Waffles 🧇',
+            self::Pancakes => 'Pancakes 🥞',
+            self::Salad => 'Salad 🥙',
+            self::Tea => 'Tea ☕️',
+            self::Sandwich => 'Sandwich 🥪',
+            self::Cheese => 'Cheese 🧀',
+            self::Sushi => 'Sushi 🍱',
+            self::Pizza => 'Pizza 🍕',
+            self::Pint => 'A Pint 🍺',
+            self::Pasta => 'Pasta 🍝',
+        };
+    }
+}

--- a/ux.symfony.com/src/Enum/Meal.php
+++ b/ux.symfony.com/src/Enum/Meal.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Enum;
+
+enum Meal: string
+{
+    case Breakfast = 'breakfast';
+    case SecondBreakfast = 'second_breakfast';
+    case Elevenses = 'elevenses';
+    case Lunch = 'lunch';
+    case Dinner = 'dinner';
+
+    public function getReadable(): string
+    {
+        return match ($this) {
+            self::Breakfast => 'Breakfast',
+            self::SecondBreakfast => 'Second Breakfast',
+            self::Elevenses => 'Elevenses',
+            self::Lunch => 'Lunch',
+            self::Dinner => 'Dinner',
+        };
+    }
+
+    /**
+     * @return list<Food>
+     */
+    public function getFoodChoices(): array
+    {
+        return match ($this) {
+            self::Breakfast => [Food::Eggs, Food::Bacon, Food::Strawberries, Food::Croissant],
+            self::SecondBreakfast => [Food::Bagel, Food::Kiwi, Food::Avocado, Food::Waffles],
+            self::Elevenses => [Food::Pancakes, Food::Strawberries, Food::Tea],
+            self::Lunch => [Food::Sandwich, Food::Cheese, Food::Sushi],
+            self::Dinner => [Food::Pizza, Food::Pint, Food::Pasta],
+        };
+    }
+}

--- a/ux.symfony.com/src/Enum/PizzaSize.php
+++ b/ux.symfony.com/src/Enum/PizzaSize.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enum;
+
+enum PizzaSize: int
+{
+    case Small = 12;
+    case Medium = 14;
+    case Large = 16;
+
+    public function getReadable(): string
+    {
+        return match ($this) {
+            self::Small => '12 inch',
+            self::Medium => '14 inch',
+            self::Large => '16 inch',
+        };
+    }
+}

--- a/ux.symfony.com/src/Model/MealPlan.php
+++ b/ux.symfony.com/src/Model/MealPlan.php
@@ -2,33 +2,54 @@
 
 namespace App\Model;
 
-use Symfony\Component\Validator\Constraints\NotBlank;
+use App\Enum\Food;
+use App\Enum\Meal;
+use App\Enum\PizzaSize;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MealPlan
 {
-    #[NotBlank]
-    private ?string $meal = null;
+    #[Assert\NotNull]
+    private ?Meal $meal = null;
 
-    #[NotBlank]
-    private ?string $mainFood = null;
+    #[Assert\NotNull]
+    private ?Food $mainFood = null;
 
-    public function getMeal(): ?string
+    #[Assert\When(
+        expression: 'this.getMainFood() === enum("App\\\Enum\\\Food::Pizza")',
+        constraints: [
+            new Assert\NotNull(message: 'Please select a Pizza Size.'),
+        ],
+    )]
+    private ?PizzaSize $pizzaSize = null;
+
+    public function getMeal(): ?Meal
     {
         return $this->meal;
     }
 
-    public function setMeal(?string $meal): void
+    public function setMeal(?Meal $meal): void
     {
         $this->meal = $meal;
     }
 
-    public function getMainFood(): ?string
+    public function getMainFood(): ?Food
     {
         return $this->mainFood;
     }
 
-    public function setMainFood(?string $mainFood): void
+    public function setMainFood(?Food $mainFood): void
     {
         $this->mainFood = $mainFood;
+    }
+
+    public function getPizzaSize(): ?PizzaSize
+    {
+        return $this->pizzaSize;
+    }
+
+    public function setPizzaSize(?PizzaSize $pizzaSize): void
+    {
+        $this->pizzaSize = $pizzaSize;
     }
 }

--- a/ux.symfony.com/templates/components/MealPlanner.html.twig
+++ b/ux.symfony.com/templates/components/MealPlanner.html.twig
@@ -5,5 +5,8 @@
     {{ form_start(form) }}
         {{ form_row(form.meal) }}
         {{ form_row(form.mainFood) }}
+        {% if form.pizzaSize is defined %}
+            {{ form_row(form.pizzaSize) }}
+        {% endif %}
     {{ form_end(form) }}
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | instead -->
| License       | MIT

This PR update the LiveComponents dependant form fields example to include a 3rd dependent field which is dependent on the 2nd.

Here, we need to use `FormFactoryInterface::createNamedBuilder()` to get access to `addEventListener()`,
as that method is not available on `FormInterface`.

Some refactoring was done to introduce enums to make this a bit more managable.

![pizza-size](https://github.com/symfony/ux/assets/625392/20b1a2bd-8e25-4eed-9100-f800ae6f0e77)