### PR TITLE
bump to php >=8.1 everywhere

### DIFF
--- a/.github/workflows/test-turbo.yml
+++ b/.github/workflows/test-turbo.yml
@@ -29,13 +29,13 @@ jobs:
               working-directory: src/Turbo
               run: vendor/bin/phpstan analyse --no-progress
 
-    tests-php-high-deps:
+    tests:
         runs-on: ubuntu-latest
         strategy:
-            matrix:
-                php-versions: ['8.1']
-            fail-fast: false
-        name: PHP ${{ matrix.php-versions }} Test on ubuntu-latest
+           fail-fast: false
+           matrix:
+               php-version: ['8.1']
+               dependency-version: ['lowest', 'highest']
 
         services:
             mercure:
@@ -57,12 +57,13 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ matrix.php-versions }}
-                  extensions: zip, pdo_sqlite
+                  php-version: ${{ matrix.php-version }}
 
-            - uses: ramsey/composer-install@v2
+            - name: Install Turbo packages
+              uses: ramsey/composer-install@v2
               with:
-                  working-directory: src/Turbo
+                working-directory: src/Turbo
+                dependency-versions: ${{ matrix.dependency-version }}
 
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
@@ -90,68 +91,4 @@ jobs:
 
             - name: Run tests
               working-directory: src/Turbo
-              env:
-                  SYMFONY_DEPRECATIONS_HELPER: max[direct]=0
-              run: vendor/bin/simple-phpunit
-
-    tests-php-low-deps:
-        runs-on: ubuntu-latest
-        name: PHP 8.1 (lowest) Test on ubuntu-latest
-
-        services:
-            mercure:
-                image: dunglas/mercure
-                env:
-                    SERVER_NAME: :3000
-                    MERCURE_PUBLISHER_JWT_KEY: '!ChangeMe!'
-                    MERCURE_SUBSCRIBER_JWT_KEY: '!ChangeMe!'
-                    MERCURE_EXTRA_DIRECTIVES: |
-                        anonymous
-                        cors_origins *
-                ports:
-                    - 3000:3000
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.1'
-                  extensions: zip, pdo_sqlite
-
-            - uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Turbo
-                  dependency-versions: lowest
-
-            - name: Get yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
-
-            - name: Install JavaScript dependencies
-              working-directory: src/Turbo/tests/app
-              run: yarn install
-
-            - name: Build JavaScript
-              working-directory: src/Turbo/tests/app
-              run: yarn build
-
-            - name: Create DB
-              working-directory: src/Turbo/tests/app
-              run: php public/index.php doctrine:schema:create
-
-            - name: Run tests
-              working-directory: src/Turbo
-              env:
-                  SYMFONY_DEPRECATIONS_HELPER: max[total]=9223372036854775807 # PHP_INT_MAX
               run: vendor/bin/simple-phpunit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
             - uses: actions/checkout@master
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                  php-version: '8.1'
             - uses: ramsey/composer-install@v2
             - name: php-cs-fixer
               run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
@@ -67,280 +67,59 @@ jobs:
                 echo "${{ steps.changes.outputs.STATUS }}"
                 exit 1
 
-    tests-php72-low-deps:
+    tests-php-components:
         runs-on: ubuntu-latest
+        outputs:
+            components: ${{ steps.components.outputs.components }}
         steps:
-            - uses: actions/checkout@master
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '7.2'
+            - uses: actions/checkout@v3
 
-            - name: Cropperjs Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Cropperjs
-                  dependency-versions: lowest
-            - name: Cropperjs Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/Cropperjs
+            - id: components
+              run: |
+                components=$(tree src -J -d -L 1 | jq -c '.[0].contents | map(.name)')
+                echo "$components"
+                echo "components=$components" >> $GITHUB_OUTPUT
 
-            - name: Dropzone Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Dropzone
-                  dependency-versions: lowest
-            - name: Dropzone Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/Dropzone
-
-            - name: LazyImage Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/LazyImage
-                  dependency-versions: lowest
-            - name: LazyImage Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/LazyImage
-
-    tests-php80-low-deps:
+    tests-php:
         runs-on: ubuntu-latest
+        needs: tests-php-components
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version: ['8.1']
+                dependency-version: ['lowest', 'highest']
+                component: ${{ fromJson(needs.tests-php-components.outputs.components )}}
+                exclude:
+                  - component: Swup  # has no tests
+                  - component: Turbo # has its own workflow (test-turbo.yml)
+                  - component: Typed  # has no tests
+
         steps:
-            - uses: actions/checkout@master
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.0'
-
-            - name: TwigComponent Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/TwigComponent
-                  dependency-versions: lowest
-                  # needed for php 8.0 to skip symfony/stimulus-bundle
-                  composer-options: "--ignore-platform-reqs"
-            - name: TwigComponent Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/TwigComponent
-
-            - name: LiveComponent Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/LiveComponent
-                  dependency-versions: lowest
-            - name: LiveComponent Tests
-              working-directory: src/LiveComponent
-              run: php vendor/bin/simple-phpunit
-
-            - name: Autocomplete Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                working-directory: src/Autocomplete
-                dependency-versions: lowest
-            - name: Autocomplete Tests
-              working-directory: src/Autocomplete
-              run: php vendor/bin/simple-phpunit
-
-            - name: Translator Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                working-directory: src/Translator
-                dependency-versions: lowest
-            - name: Translator Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/Translator
-    tests-php80-high-deps:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v3
 
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                php-version: ${{ matrix.php-version }}
 
-            - name: Install root Dependencies
-              uses: ramsey/composer-install@v2
-
-            - run: php .github/build-packages.php
-
-            - name: Cropperjs Dependencies
+            - name: Install root packages
               uses: ramsey/composer-install@v2
               with:
-                  working-directory: src/Cropperjs
-            - name: Cropperjs Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/Cropperjs
+                working-directory: ${{ github.workspace }}
+                dependency-versions: ${{ matrix.dependency-version }}
 
-            - name: Dropzone Dependencies
+            - name: Build root packages
+              run: php .github/build-packages.php
+              working-directory: ${{ github.workspace }}
+
+            - name: Install ${{ matrix.component }} packages
               uses: ramsey/composer-install@v2
               with:
-                  working-directory: src/Dropzone
-            - name: Dropzone Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/Dropzone
+                working-directory: "src/${{ matrix.component }}"
+                dependency-versions: ${{ matrix.dependency-version }}
 
-            - name: LazyImage Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/LazyImage
-            - name: LazyImage Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/LazyImage
-
-            - name: LiveComponent Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/LiveComponent
-            - name: LiveComponent Tests
-              working-directory: src/LiveComponent
-              run: php vendor/bin/simple-phpunit
-
-            - name: Autocomplete Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                working-directory: src/Autocomplete
-            - name: Autocomplete Tests
-              working-directory: src/Autocomplete
-              run: php vendor/bin/simple-phpunit
-
-    tests-php81-high-deps:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@master
-
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.1'
-
-            - name: Install root Dependencies
-              uses: ramsey/composer-install@v2
-
-            - run: php .github/build-packages.php
-
-            - name: Chartjs Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Chartjs
-            - name: Chartjs Tests
-              working-directory: src/Chartjs
-              run: php vendor/bin/simple-phpunit
-
-            - name: Notify Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Notify
-            - name: Notify Tests
-              working-directory: src/Notify
-              run: php vendor/bin/simple-phpunit
-
-            - name: React Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/React
-            - name: React Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/React
-
-            - name: StimulusBundle Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                working-directory: src/StimulusBundle
-            - name: StimulusBundle Tests
-              working-directory: src/StimulusBundle
-              run: php vendor/bin/simple-phpunit
-
-            - name: Svelte Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Svelte
-            - name: Svelte Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/Svelte
-
-            - name: Translator Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Translator
-            - name: Translator Tests
-              working-directory: src/Translator
-              run: php vendor/bin/simple-phpunit
-
-            - name: TwigComponent Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/TwigComponent
-            - name: TwigComponent Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/TwigComponent
-
-            - name: Vue Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Vue
-            - name: Vue Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/Vue
-
-    tests-php81-low-deps:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@master
-
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.1'
-
-            - name: Chartjs Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Chartjs
-                  dependency-versions: lowest
-            - name: Chartjs Tests
-              working-directory: src/Chartjs
-              run: php vendor/bin/simple-phpunit
-
-            - name: Notify Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Notify
-                  dependency-versions: lowest
-            - name: Notify Tests
-              working-directory: src/Notify
-              run: php vendor/bin/simple-phpunit
-
-            - name: React Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/React
-                  dependency-versions: lowest
-            - name: React Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/React
-
-            - name: StimulusBundle Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                working-directory: src/StimulusBundle
-                dependency-versions: lowest
-            - name: StimulusBundle Tests
-              working-directory: src/StimulusBundle
-              run: php vendor/bin/simple-phpunit
-
-            - name: Svelte Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Svelte
-                  dependency-versions: lowest
-            - name: Svelte Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/Svelte
-
-            - name: Vue Dependencies
-              uses: ramsey/composer-install@v2
-              with:
-                  working-directory: src/Vue
-                  dependency-versions: lowest
-            - name: Vue Tests
-              run: php vendor/bin/simple-phpunit
-              working-directory: src/Vue
+            - name: ${{ matrix.component }} Tests
+              working-directory: "src/${{ matrix.component }}"
+              run: vendor/bin/simple-phpunit
 
     tests-js:
         runs-on: ubuntu-latest

--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
@@ -32,11 +32,13 @@
         "symfony/string": "^5.4|^6.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^2.4",
-        "doctrine/orm": "^2.9",
+        "doctrine/collections": "^1.6.8|^2.0",
+        "doctrine/doctrine-bundle": "^2.4.3",
+        "doctrine/orm": "^2.9.4",
         "fakerphp/faker": "^1.22",
         "mtdowling/jmespath.php": "^2.6",
         "symfony/form": "^5.4|^6.0",
+        "symfony/options-resolver": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/maker-bundle": "^1.40",
         "symfony/phpunit-bridge": "^5.4|^6.0",
@@ -45,8 +47,9 @@
         "symfony/security-csrf": "^5.4|^6.0",
         "symfony/twig-bundle": "^5.4|^6.0",
         "symfony/uid": "^5.4|^6.0",
+        "twig/twig": "^2.14.7|^3.0.4",
         "zenstruck/browser": "^1.1",
-        "zenstruck/foundry": "^1.32"
+        "zenstruck/foundry": "^1.33"
     },
     "conflict": {
         "doctrine/orm": "2.9.0 || 2.9.1"

--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -18,6 +18,9 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -64,6 +67,17 @@ final class Kernel extends BaseKernel
         yield new SecurityBundle();
         yield new MakerBundle();
         yield new ZenstruckFoundryBundle();
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        // workaround https://github.com/symfony/symfony/issues/50322
+        $container->addCompilerPass(new class() implements CompilerPassInterface {
+            public function process(ContainerBuilder $container): void
+            {
+                $container->removeDefinition('doctrine.orm.listeners.pdo_session_handler_schema_listener');
+            }
+        }, PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 
     protected function configureContainer(ContainerConfigurator $c): void

--- a/src/Chartjs/phpunit.xml.dist
+++ b/src/Chartjs/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -28,19 +28,21 @@
         }
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "intervention/image": "^2.5",
         "symfony/config": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/form": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
+        "symfony/options-resolver": "^5.4|^6.0",
         "symfony/validator": "^5.4|^6.0"
     },
     "require-dev": {
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^5.4|^6.0",
         "symfony/twig-bundle": "^5.4|^6.0",
-        "symfony/var-dumper": "^5.4|^6.0"
+        "symfony/var-dumper": "^5.4|^6.0",
+        "twig/twig": "^2.14.7|^3.0.4"
     },
     "conflict": {
         "symfony/flex": "<1.13"

--- a/src/Cropperjs/phpunit.xml.dist
+++ b/src/Cropperjs/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/src/Dropzone/composer.json
+++ b/src/Dropzone/composer.json
@@ -28,17 +28,19 @@
         }
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "symfony/config": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/form": "^5.4|^6.0",
-        "symfony/http-kernel": "^5.4|^6.0"
+        "symfony/http-kernel": "^5.4|^6.0",
+        "symfony/options-resolver": "^5.4|^6.0"
     },
     "require-dev": {
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^5.4|^6.0",
         "symfony/twig-bundle": "^5.4|^6.0",
-        "symfony/var-dumper": "^5.4|^6.0"
+        "symfony/var-dumper": "^5.4|^6.0",
+        "twig/twig": "^2.14.7|^3.0.4"
     },
     "extra": {
         "thanks": {

--- a/src/Dropzone/phpunit.xml.dist
+++ b/src/Dropzone/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/src/LazyImage/composer.json
+++ b/src/LazyImage/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "symfony/config": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0"

--- a/src/LazyImage/phpunit.xml.dist
+++ b/src/LazyImage/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -26,19 +26,22 @@
         }
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "symfony/property-access": "^5.4.5|^6.0",
         "symfony/serializer": "^5.4|^6.0",
-        "symfony/ux-twig-component": "^2.8"
+        "symfony/ux-twig-component": "^2.8",
+        "twig/twig": "^2.14.7|^3.0.4"
     },
     "require-dev": {
         "doctrine/annotations": "^1.0",
-        "doctrine/doctrine-bundle": "^2.0",
-        "doctrine/orm": "^2.7",
+        "doctrine/collections": "^1.6.8|^2.0",
+        "doctrine/doctrine-bundle": "^2.4.3",
+        "doctrine/orm": "^2.9.4",
         "doctrine/persistence": "^2.5.2|^3.0",
         "phpdocumentor/reflection-docblock": "5.x-dev",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/form": "^5.4|^6.0",
+        "symfony/options-resolver": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^6.0",
         "symfony/property-info": "^5.4|^6.0",
@@ -46,7 +49,7 @@
         "symfony/twig-bundle": "^5.4|^6.0",
         "symfony/validator": "^5.4|^6.0",
         "zenstruck/browser": "^1.2.0",
-        "zenstruck/foundry": "^1.10"
+        "zenstruck/foundry": "^1.33"
     },
     "conflict": {
         "symfony/config": "<5.4.0"

--- a/src/LiveComponent/tests/Fixtures/Entity/CategoryFixtureEntity.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/CategoryFixtureEntity.php
@@ -13,21 +13,15 @@ namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class CategoryFixtureEntity
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private ?int $id = null;
 
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     private ?string $name = null;
 
     public function getId(): ?int

--- a/src/LiveComponent/tests/Fixtures/Entity/Embeddable1.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/Embeddable1.php
@@ -13,14 +13,10 @@ namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Embeddable
- */
+#[ORM\Embeddable]
 final class Embeddable1
 {
-    /**
-     * @ORM\Column
-     */
+    #[ORM\Column]
     public string $name;
 
     public function __construct(string $name)

--- a/src/LiveComponent/tests/Fixtures/Entity/Entity1.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/Entity1.php
@@ -13,15 +13,11 @@ namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Entity1
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     public $id;
 }

--- a/src/LiveComponent/tests/Fixtures/Entity/Entity2.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/Entity2.php
@@ -14,25 +14,17 @@ namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Embeddable2;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Entity2
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     public $id;
 
-    /**
-     * @ORM\Embedded(Embeddable1::class)
-     */
+    #[ORM\Embedded(Embeddable1::class)]
     public Embeddable1 $embedded1;
 
-    /**
-     * @ORM\Embedded(Embeddable2::class)
-     */
+    #[ORM\Embedded(Embeddable2::class)]
     public Embeddable2 $embedded2;
 }

--- a/src/LiveComponent/tests/Fixtures/Entity/ProductFixtureEntity.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/ProductFixtureEntity.php
@@ -13,25 +13,17 @@ namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class ProductFixtureEntity
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     public ?int $id = null;
 
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     public string $name = '';
 
-    /**
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Column(type: 'integer')]
     public int $price = 0;
 }

--- a/src/LiveComponent/tests/Fixtures/Entity/TodoItemFixtureEntity.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/TodoItemFixtureEntity.php
@@ -15,26 +15,18 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class TodoItemFixtureEntity
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     public $id;
 
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     private ?string $name = null;
 
-    /**
-     * @ORM\ManyToOne(targetEntity=TodoListFixtureEntity::class, inversedBy="todoItems")
-     */
+    #[ORM\ManyToOne(targetEntity: TodoListFixtureEntity::class, inversedBy: 'todoItems')]
     private TodoListFixtureEntity $todoList;
 
     /**

--- a/src/LiveComponent/tests/Fixtures/Entity/TodoListFixtureEntity.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/TodoListFixtureEntity.php
@@ -15,26 +15,18 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class TodoListFixtureEntity
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     public $id;
 
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     public string $listTitle = '';
 
-    /**
-     * @ORM\OneToMany(targetEntity=TodoItemFixtureEntity::class, mappedBy="todoList")
-     */
+    #[ORM\OneToMany(targetEntity: TodoItemFixtureEntity::class, mappedBy: 'todoList')]
     private Collection $todoItems;
 
     public function __construct(string $listTitle = '')

--- a/src/Notify/phpunit.xml.dist
+++ b/src/Notify/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/src/React/phpunit.xml.dist
+++ b/src/React/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/src/Svelte/phpunit.xml.dist
+++ b/src/Svelte/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/src/Translator/composer.json
+++ b/src/Translator/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "symfony/console": "^5.4|^6.0",
         "symfony/filesystem": "^5.4|^6.0",
         "symfony/string": "^5.4|^6.0",

--- a/src/Translator/phpunit.xml.dist
+++ b/src/Translator/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/src/Turbo/phpunit.xml.dist
+++ b/src/Turbo/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="KERNEL_CLASS" value="App\Kernel" />
         <server name="PANTHER_WEB_SERVER_DIR" value="./tests/app/public" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -26,12 +26,12 @@
         }
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/property-access": "^5.4|^6.0",
-        "twig/twig": "^2.0|^3.0"
+        "twig/twig": "^2.14.7|^3.0.4"
     },
     "require-dev": {
         "symfony/framework-bundle": "^5.4|^6.0",

--- a/src/Vue/phpunit.xml.dist
+++ b/src/Vue/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>

--- a/ux.symfony.com/composer.json
+++ b/ux.symfony.com/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "RC",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.0.2",
+        "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "babdev/pagerfanta-bundle": "^3.7",

--- a/ux.symfony.com/src/Repository/CategoryRepository.php
+++ b/ux.symfony.com/src/Repository/CategoryRepository.php
@@ -38,29 +38,4 @@ class CategoryRepository extends ServiceEntityRepository
             $this->getEntityManager()->flush();
         }
     }
-
-//    /**
-//     * @return Category[] Returns an array of Category objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('c')
-//            ->andWhere('c.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('c.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
-
-//    public function findOneBySomeField($value): ?Category
-//    {
-//        return $this->createQueryBuilder('c')
-//            ->andWhere('c.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
 }

--- a/ux.symfony.com/src/Repository/ChatRepository.php
+++ b/ux.symfony.com/src/Repository/ChatRepository.php
@@ -38,29 +38,4 @@ class ChatRepository extends ServiceEntityRepository
             $this->getEntityManager()->flush();
         }
     }
-
-//    /**
-//     * @return Chat[] Returns an array of Chat objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('c')
-//            ->andWhere('c.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('c.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
-
-//    public function findOneBySomeField($value): ?Chat
-//    {
-//        return $this->createQueryBuilder('c')
-//            ->andWhere('c.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
 }

--- a/ux.symfony.com/src/Repository/FoodRepository.php
+++ b/ux.symfony.com/src/Repository/FoodRepository.php
@@ -46,29 +46,4 @@ class FoodRepository extends ServiceEntityRepository
             $this->_em->flush();
         }
     }
-
-//    /**
-//     * @return Food[] Returns an array of Food objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('c')
-//            ->andWhere('c.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('c.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
-
-//    public function findOneBySomeField($value): ?Food
-//    {
-//        return $this->createQueryBuilder('c')
-//            ->andWhere('c.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
 }

--- a/ux.symfony.com/src/Repository/InvoiceItemRepository.php
+++ b/ux.symfony.com/src/Repository/InvoiceItemRepository.php
@@ -38,29 +38,4 @@ class InvoiceItemRepository extends ServiceEntityRepository
             $this->getEntityManager()->flush();
         }
     }
-
-//    /**
-//     * @return InvoiceItem[] Returns an array of InvoiceItem objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('i')
-//            ->andWhere('i.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('i.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
-
-//    public function findOneBySomeField($value): ?InvoiceItem
-//    {
-//        return $this->createQueryBuilder('i')
-//            ->andWhere('i.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
 }

--- a/ux.symfony.com/src/Repository/InvoiceRepository.php
+++ b/ux.symfony.com/src/Repository/InvoiceRepository.php
@@ -38,29 +38,4 @@ class InvoiceRepository extends ServiceEntityRepository
             $this->getEntityManager()->flush();
         }
     }
-
-//    /**
-//     * @return Invoice[] Returns an array of Invoice objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('i')
-//            ->andWhere('i.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('i.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
-
-//    public function findOneBySomeField($value): ?Invoice
-//    {
-//        return $this->createQueryBuilder('i')
-//            ->andWhere('i.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
 }

--- a/ux.symfony.com/src/Repository/ProductRepository.php
+++ b/ux.symfony.com/src/Repository/ProductRepository.php
@@ -38,29 +38,4 @@ class ProductRepository extends ServiceEntityRepository
             $this->getEntityManager()->flush();
         }
     }
-
-//    /**
-//     * @return Product[] Returns an array of Product objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('p')
-//            ->andWhere('p.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('p.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
-
-//    public function findOneBySomeField($value): ?Product
-//    {
-//        return $this->createQueryBuilder('p')
-//            ->andWhere('p.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
 }

--- a/ux.symfony.com/src/Repository/TodoItemRepository.php
+++ b/ux.symfony.com/src/Repository/TodoItemRepository.php
@@ -38,29 +38,4 @@ class TodoItemRepository extends ServiceEntityRepository
             $this->getEntityManager()->flush();
         }
     }
-
-//    /**
-//     * @return TodoItem[] Returns an array of TodoItem objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('t')
-//            ->andWhere('t.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('t.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
-
-//    public function findOneBySomeField($value): ?TodoItem
-//    {
-//        return $this->createQueryBuilder('t')
-//            ->andWhere('t.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
 }

--- a/ux.symfony.com/src/Repository/TodoListRepository.php
+++ b/ux.symfony.com/src/Repository/TodoListRepository.php
@@ -38,29 +38,4 @@ class TodoListRepository extends ServiceEntityRepository
             $this->getEntityManager()->flush();
         }
     }
-
-//    /**
-//     * @return TodoList[] Returns an array of TodoList objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('t')
-//            ->andWhere('t.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('t.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
-
-//    public function findOneBySomeField($value): ?TodoList
-//    {
-//        return $this->createQueryBuilder('t')
-//            ->andWhere('t.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
-//    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no
| Tickets       | 
| License       |

The versions of php were a bit disparate. they should be the same everywhere.

workflows for for 7.2 and 8.0 removed.

testing for php 8.2 should probably be added