### PR TITLE
[Turbo] Fixing a bug where saving a proxy would not trigger Broadcasts

### DIFF
--- a/src/Turbo/src/Bridge/Mercure/Broadcaster.php
+++ b/src/Turbo/src/Bridge/Mercure/Broadcaster.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\UX\Turbo\Bridge\Mercure;
 
+use Doctrine\Common\Util\ClassUtils;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
 
 /**
@@ -61,7 +63,14 @@ final class Broadcaster implements BroadcasterInterface
             return;
         }
 
-        $entityClass = $entity::class;
+        if ($entity instanceof LazyObjectInterface) {
+            $entityClass = get_parent_class($entity);
+            if (false === $entityClass) {
+                throw new \LogicException('Parent class missing');
+            }
+        } else {
+            $entityClass = ClassUtils::getClass($entity);
+        }
 
         if (!isset($options['rendered_action'])) {
             throw new \InvalidArgumentException(sprintf('Cannot broadcast entity of class "%s" as option "rendered_action" is missing.', $entityClass));

--- a/src/Turbo/src/Broadcaster/TwigBroadcaster.php
+++ b/src/Turbo/src/Broadcaster/TwigBroadcaster.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\UX\Turbo\Broadcaster;
 
+use Doctrine\Common\Util\ClassUtils;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 use Twig\Environment;
 
 /**
@@ -42,8 +44,18 @@ final class TwigBroadcaster implements BroadcasterInterface
             $options['id'] = $id;
         }
 
+        // handle proxies (both styles)
+        if ($entity instanceof LazyObjectInterface) {
+            $class = get_parent_class($entity);
+            if (false === $class) {
+                throw new \LogicException('Parent class missing');
+            }
+        } else {
+            $class = ClassUtils::getClass($entity);
+        }
+
         if (null === $template = $options['template'] ?? null) {
-            $template = $entity::class;
+            $template = $class;
             foreach ($this->templatePrefixes as $namespace => $prefix) {
                 if (str_starts_with($template, $namespace)) {
                     $template = substr_replace($template, $prefix, 0, \strlen($namespace));

--- a/src/Turbo/tests/BroadcastTest.php
+++ b/src/Turbo/tests/BroadcastTest.php
@@ -33,7 +33,7 @@ class BroadcastTest extends PantherTestCase
         parent::setUp();
     }
 
-    public function testBroadcast(): void
+    public function testBroadcastBasic(): void
     {
         ($client = self::createPantherClient())->request('GET', '/books');
 
@@ -87,5 +87,21 @@ class BroadcastTest extends PantherTestCase
             $songsElement->getText(),
             'Artist 2 shows a song that does not belong to them'
         );
+    }
+
+    public function testBroadcastWithProxy(): void
+    {
+        // testing that Artist is updated, even though it's saved as Proxy
+        ($client = self::createPantherClient())->request('GET', '/artistFromSong');
+
+        // submit first time to create the artist
+        $client->submitForm('Submit');
+        $this->assertSelectorWillContain('#artists', 'testing artist');
+
+        // submit again to update the artist
+        $client->submitForm('Submit');
+        $this->assertSelectorWillContain('#artists', 'testing artist after change');
+        // this part is from the stream template
+        $this->assertSelectorWillContain('#artists', ', updated)');
     }
 }

--- a/src/Turbo/tests/app/templates/artist_from_song.html.twig
+++ b/src/Turbo/tests/app/templates/artist_from_song.html.twig
@@ -1,0 +1,14 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <h1>Update Artist Via Song</h1>
+
+    <div id="artists" {{ turbo_stream_listen('App\\Entity\\Artist') }}></div>
+
+    <turbo-frame id="api">
+        <form method="post" enctype="application/x-www-form-urlencoded">
+            <input name="id" value="{{ song ? song.id }}">
+            <button>Submit</button>
+        </form>
+    </turbo-frame>
+{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

If the object you're updating, for example, happens to be wrapped in a Proxy object, then `BroadcastListener` would fail to find the `#[Broadcast]` attribute and no broadcasting would happen.

Cheers!
