### PR TITLE
[StimulusBundle] Fix controller name conversion

### DIFF
--- a/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
+++ b/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
@@ -62,7 +62,7 @@ class ControllersMapGenerator
         foreach ($finder as $file) {
             $name = $file->getRelativePathname();
             $name = str_replace(['_controller.js', '-controller.js'], '', $name);
-            $name = str_replace('/', '--', $name);
+            $name = str_replace(['_', '/'], ['-', '--'], $name);
 
             $asset = $this->assetMapper->getAssetFromSourcePath($file->getRealPath());
             $isLazy = preg_match('/\/\*\s*stimulusFetch:\s*\'lazy\'\s*\*\//i', $asset->content);

--- a/src/StimulusBundle/tests/AssetMapper/ControllerMapGeneratorTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/ControllerMapGeneratorTest.php
@@ -54,8 +54,8 @@ class ControllerMapGeneratorTest extends TestCase
         $map = $generator->getControllersMap();
         // + 3 controller.json UX controllers
         // - 1 controllers.json UX controller is disabled
-        // + 4 custom controllers (1 file is not a controller & 1 is overridden)
-        $this->assertCount(6, $map);
+        // + 8 custom controllers (1 file is not a controller & 1 is overridden)
+        $this->assertCount(10, $map);
         $packageNames = array_keys($map);
         sort($packageNames);
         $this->assertSame([
@@ -63,8 +63,12 @@ class ControllerMapGeneratorTest extends TestCase
             'fake-vendor--ux-package1--controller-second',
             'fake-vendor--ux-package2--hello-controller',
             'hello',
+            'hello-with-dashes',
+            'hello-with-underscores',
             'other',
             'subdir--deeper',
+            'subdir--deeper-with-dashes',
+            'subdir--deeper-with-underscores',
         ], $packageNames);
 
         $controllerSecond = $map['fake-vendor--ux-package1--controller-second'];

--- a/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
@@ -40,9 +40,13 @@ class StimulusControllerLoaderFunctionalTest extends WebTestCase
         $this->assertSame([
             // 1x import from loader.js (which is aliased to @symfony/stimulus-bundle via importmap)
             '/assets/@symfony/stimulus-bundle/controllers.js',
-            // 2x from "controllers" (hello is overridden)
+            // 6x from "controllers" (hello is overridden)
             '/assets/controllers/bye_controller.js',
+            '/assets/controllers/hello-with-dashes-controller.js',
+            '/assets/controllers/hello_with_underscores-controller.js',
             '/assets/controllers/subdir/deeper-controller.js',
+            '/assets/controllers/subdir/deeper-with-dashes-controller.js',
+            '/assets/controllers/subdir/deeper_with_underscores-controller.js',
             // 2x from UX packages, which are enabled in controllers.json
             '/assets/fake-vendor/ux-package1/package-controller-second.js',
             '/assets/fake-vendor/ux-package2/package-hello-controller.js',
@@ -61,14 +65,18 @@ class StimulusControllerLoaderFunctionalTest extends WebTestCase
         $preLoadHrefs = $crawler->filter('link[rel="modulepreload"]')->each(function ($link) {
             return $link->attr('href');
         });
-        $this->assertCount(6, $preLoadHrefs);
+        $this->assertCount(10, $preLoadHrefs);
         sort($preLoadHrefs);
         $this->assertStringStartsWith('/assets/@symfony/stimulus-bundle/controllers-', $preLoadHrefs[0]);
         $this->assertStringStartsWith('/assets/@symfony/stimulus-bundle/loader-', $preLoadHrefs[1]);
         $this->assertStringStartsWith('/assets/app-', $preLoadHrefs[2]);
-        $this->assertStringStartsWith('/assets/controllers/subdir/deeper-controller-', $preLoadHrefs[3]);
-        $this->assertStringStartsWith('/assets/fake-vendor/ux-package2/package-hello-controller-', $preLoadHrefs[4]);
-        $this->assertStringStartsWith('/assets/more-controllers/hello-controller-', $preLoadHrefs[5]);
+        $this->assertStringStartsWith('/assets/controllers/hello-with-dashes-controller-', $preLoadHrefs[3]);
+        $this->assertStringStartsWith('/assets/controllers/hello_with_underscores-controller-', $preLoadHrefs[4]);
+        $this->assertStringStartsWith('/assets/controllers/subdir/deeper-controller-', $preLoadHrefs[5]);
+        $this->assertStringStartsWith('/assets/controllers/subdir/deeper-with-dashes-controller-', $preLoadHrefs[6]);
+        $this->assertStringStartsWith('/assets/controllers/subdir/deeper_with_underscores-controller-', $preLoadHrefs[7]);
+        $this->assertStringStartsWith('/assets/fake-vendor/ux-package2/package-hello-controller-', $preLoadHrefs[8]);
+        $this->assertStringStartsWith('/assets/more-controllers/hello-controller-', $preLoadHrefs[9]);
     }
 
     protected static function getKernelClass(): string

--- a/src/StimulusBundle/tests/fixtures/assets/controllers/hello-with-dashes-controller.js
+++ b/src/StimulusBundle/tests/fixtures/assets/controllers/hello-with-dashes-controller.js
@@ -1,4 +1,4 @@
-// hello-controller.js
+// hello--with-dashes-controller.js
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {

--- a/src/StimulusBundle/tests/fixtures/assets/controllers/hello_with_underscores-controller.js
+++ b/src/StimulusBundle/tests/fixtures/assets/controllers/hello_with_underscores-controller.js
@@ -1,4 +1,4 @@
-// hello-controller.js
+// hello_with_underscores-controller.js
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {

--- a/src/StimulusBundle/tests/fixtures/assets/controllers/subdir/deeper-with-dashes-controller.js
+++ b/src/StimulusBundle/tests/fixtures/assets/controllers/subdir/deeper-with-dashes-controller.js
@@ -1,4 +1,4 @@
-// hello-controller.js
+// subdir/deeper-with-dashes-controller.js
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {

--- a/src/StimulusBundle/tests/fixtures/assets/controllers/subdir/deeper_with_underscores-controller.js
+++ b/src/StimulusBundle/tests/fixtures/assets/controllers/subdir/deeper_with_underscores-controller.js
@@ -1,4 +1,4 @@
-// hello-controller.js
+// subdir/deeper_with_underscores-controller.js
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | N/A
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->

Stimulus controllers must follow some naming convention/normalization according to https://stimulus.hotwired.dev/reference/controllers#identifiers

There was a case when controllers file with underscores in their name would not be a valid entry for Stimulus.

I wasn't sure about using `Symfony\UX\StimulusBundle\Dto\StimulusAttributes::normalizeControllerName` because it seems related to Twig (due to its `private Environment $env` in construct)