### PR TITLE
[Twig Components]ExposeInTemplate Attribute update

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -167,11 +167,10 @@ them as a 2nd argument to the ``component()`` function when rendering:
         message: 'Danger Will Robinson!'
     }) }}
 
-Behind the scenes, a new ``Alert`` will be instantiated and the
-``message`` key (and ``type`` if passed) will be set onto the
-``$message`` property of the object. Then, the component is rendered! If
-a property has a setter method (e.g. ``setMessage()``), that will be
-called instead of setting the property directly.
+Behind the scenes, a new ``Alert`` will be instantiated and the ``message`` key (and
+``type`` if passed) will be set onto the ``$message`` property of the object. This works
+as long as the ``$message`` property is writable (i.e. it is public or there is a
+``setMessage()`` method).
 
 .. note::
 
@@ -365,10 +364,6 @@ All public component properties are available directly in your component
 template. You can use the ``ExposeInTemplate`` attribute to expose
 private/protected properties and public methods directly in a component
 template (``someProp`` vs ``this.someProp``, ``someMethod`` vs ``this.someMethod``).
-/* update this part to Properties must be *accessible* (have a getter and setter). Methods *cannot have* 
-*  because if i have a getter without a setter and the prop is private as an example so how can i get a prop that is not setted 
-*  from the start
-*/
 Properties must be *accessible* (have a getter). Methods *cannot have*
 required parameters::
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -365,6 +365,10 @@ All public component properties are available directly in your component
 template. You can use the ``ExposeInTemplate`` attribute to expose
 private/protected properties and public methods directly in a component
 template (``someProp`` vs ``this.someProp``, ``someMethod`` vs ``this.someMethod``).
+/* update this part to Properties must be *accessible* (have a getter and setter). Methods *cannot have* 
+*  because if i have a getter without a setter and the prop is private as an example so how can i get a prop that is not setted 
+*  from the start
+*/
 Properties must be *accessible* (have a getter). Methods *cannot have*
 required parameters::
 


### PR DESCRIPTION
update this part to Properties must be *accessible* (have a getter and setter). Methods *cannot have* 
 because if i have a getter without a setter and the prop is private as an example so how can i get a prop that is not setted 
from the start

https://symfony.com/bundles/ux-twig-component/current/index.html#exposeintemplate-attribute

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

need to change this part at the documentation
[ExposeInTemplate Attribute](https://symfony.com/bundles/ux-twig-component/current/index.html#exposeintemplate-attribute)
```
All public component properties are available directly in your component template. 
You can use the ExposeInTemplate attribute to expose private/protected properties and public methods directly in a component template (someProp vs this.someProp, someMethod vs this.someMethod). Properties must be accessible (have a getter). Methods cannot have required parameters:
```
to 
```
All public component properties are available directly in your component template. 
You can use the ExposeInTemplate attribute to expose private/protected properties and public methods directly in a component template (someProp vs this.someProp, someMethod vs this.someMethod). Properties must be accessible (have a getter and setter). Methods cannot have required parameters:
```
tried to use it with only getter and got an error that the title cant be reached 
![Screenshot from 2023-06-20 23-14-13](https://github.com/symfony/ux/assets/39167278/c94bcd9b-ccb4-4308-9efc-f9f3ff62b033)

component class
```
<?php

namespace App\Twig\Components;

use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;

#[AsTwigComponent()]
final class LinksComponent
{
    #[ExposeInTemplate]
    private string $title;


    /**
     * @param string $title
     */
/*    public function setTitle(string $title): void
    {
        $this->title = $title;
    }*/
    public function getTitle(): string
    {
        return $this->title;
    }

}
```
