### PR TITLE
[StimulusBundle] Fixing bug where new custom controllers were not seen due to cache

### DIFF
--- a/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
+++ b/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
@@ -48,6 +48,11 @@ class ControllersMapGenerator
         return $this->controllersJsonPath;
     }
 
+    public function getControllerPaths(): array
+    {
+        return $this->controllerPaths;
+    }
+
     /**
      * @return array<string, MappedControllerAsset>
      */

--- a/src/StimulusBundle/src/AssetMapper/StimulusLoaderJavaScriptCompiler.php
+++ b/src/StimulusBundle/src/AssetMapper/StimulusLoaderJavaScriptCompiler.php
@@ -43,7 +43,13 @@ class StimulusLoaderJavaScriptCompiler implements AssetCompilerInterface
         $eagerControllerParts = [];
         $lazyControllers = [];
         $loaderPublicPath = $asset->publicPathWithoutDigest;
+
+        // add file dependencies so the cache rebuilds
         $asset->addFileDependency($this->controllersMapGenerator->getControllersJsonPath());
+        foreach ($this->controllersMapGenerator->getControllerPaths() as $controllerDir) {
+            $asset->addFileDependency($controllerDir);
+        }
+
         foreach ($this->controllersMapGenerator->getControllersMap() as $name => $mappedControllerAsset) {
             $controllerPublicPath = $mappedControllerAsset->asset->publicPathWithoutDigest;
             $relativeImportPath = $this->createRelativePath($loaderPublicPath, $controllerPublicPath);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #961 
| License       | MIT

This requires https://github.com/symfony/symfony/pull/50749

Cheers!
