### PR TITLE
[Live] Method Name changes in ComponentWithFormTrait + expanded docs

### DIFF
--- a/src/LiveComponent/tests/Fixtures/templates/components/form_with_many_different_fields_type.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/form_with_many_different_fields_type.html.twig
@@ -1,12 +1,12 @@
 <div {{ attributes }}>
-    {{ form_start(this.form) }}
+    {{ form_start(form) }}
         {#
             This is a compound field, but to be tricky, we change its compound
             view value to false. This causes the rendering system (correctly) to
             choke on it. So, we render it manually. This imitates the behavior
             of the UX autocomplete form type.
         #}
-        {{ form_row(this.form.complexType.sub_field) }}
-        {{ form_widget(this.form) }}
-    {{ form_end(this.form) }}
+        {{ form_row(form.complexType.sub_field) }}
+        {{ form_widget(form) }}
+    {{ form_end(form) }}
 </div>

--- a/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
+++ b/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
@@ -215,13 +215,13 @@ final class LiveCollectionTraitTest extends TestCase
             use LiveCollectionTrait;
 
             public function __construct(
-                private FormInterface $form,
+                private FormInterface $theForm,
             ) {
             }
 
             protected function instantiateForm(): FormInterface
             {
-                return $this->form;
+                return $this->theForm;
             }
         };
         $component->formName = array_key_first($postedFormData);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes (the method name changes)
| Tickets       | None
| License       | MIT

Using live components to render a dynamic form is turning out to be a very popular thing to do. The downside is that, in some ways, the form system doesn't "play well" when used so dynamically, which can cause confusion. In this PR:

A) In the docs, I've renamed the property that is bound to your form class to `initialFormData` to *really* emphasize that this is the ORIGINAL data used to create the form. It will not represent the *new* data until the form is submitted. I've also clarified this further in the docs.

B) Updated the docs to talk more about `$this->formValues` and when data is and isn't updated during the lifecycle. 

C) Renamed some methods in `ComponentWithFormTrait`: `getFormInstance()` -> `getForm()` and `getForm()` -> `getFormView()`. That's a BC break, and it's going to be annoying... which gives me hesitation. But these are currently named incorrectly (the reason goes back to an old version of live components to help name the variable `form` in the template).

Cheers!
