### PR TITLE
[TwigComponent] Fix escaping stimulus attributes

### DIFF
--- a/src/StimulusBundle/src/Dto/StimulusAttributes.php
+++ b/src/StimulusBundle/src/Dto/StimulusAttributes.php
@@ -179,6 +179,16 @@ class StimulusAttributes implements \Stringable, \IteratorAggregate
         return array_merge($attributes, $this->attributes);
     }
 
+    public function toEscapedArray(): array
+    {
+        $escaped = [];
+        foreach ($this->toArray() as $key => $value) {
+            $escaped[$key] = $this->escapeAsHtmlAttr($value);
+        }
+
+        return $escaped;
+    }
+
     private function getFormattedValue(mixed $value): string
     {
         if ($value instanceof \Stringable || (\is_object($value) && \is_callable([$value, '__toString']))) {

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -69,6 +69,10 @@ final class ComponentAttributes
      */
     public function defaults(iterable $attributes): self
     {
+        if ($attributes instanceof StimulusAttributes) {
+            $attributes = $attributes->toEscapedArray();
+        }
+
         if ($attributes instanceof \Traversable) {
             $attributes = iterator_to_array($attributes);
         }

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -134,7 +134,7 @@ final class ComponentAttributesTest extends TestCase
         ]);
 
         $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
-        $stimulusAttributes->addController('foo', ['name' => 'ryan']);
+        $stimulusAttributes->addController('foo', ['name' => 'ryan', 'some_array' => ['a', 'b']]);
         $attributes = $attributes->defaults($stimulusAttributes);
 
         $this->assertEquals([
@@ -142,6 +142,7 @@ final class ComponentAttributesTest extends TestCase
             'data-controller' => 'foo live',
             'data-live-data-value' => '{}',
             'data-foo-name-value' => 'ryan',
+            'data-foo-some-array-value' => '&#x5B;&quot;a&quot;,&quot;b&quot;&#x5D;',
         ], $attributes->all());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #968
| License       | MIT

I think we should do this as late as possible, e.g. in `__toString` or only in twig and maybe for all the attributes.
So this feels like a naive solution, but it works for now.
