### PR TITLE
Add hosting link to platform.sh

### DIFF
--- a/ux.symfony.com/templates/base.html.twig
+++ b/ux.symfony.com/templates/base.html.twig
@@ -28,16 +28,23 @@
                 <div class="col-12 col-md-4 text-center text-md-start">
                     <p style="font-size: 14px;">&copy; {{ 'now'|date('Y')}} Symfony Inc. All rights reserved.</p>
                 </div>
-                <div class="col-12 col-md-4 order-md-3 text-center text-md-end">
+                <div class="col-12 col-md-2 order-md-3 text-center text-md-end">
                     <a href="https://github.com/symfony/ux" rel="external noopener noreferrer" style="color: #0A0A0A;">
                         <i class="fab fa-github"></i>
                     </a>
                 </div>
-                <div class="col-12 col-md-4 order-md-2">
-                    <p class="mt-3 mt-md-0 text-center" style="font-size: 11px; text-transform: uppercase;">crafted by <span style="font-weight: 700;">
-                        <a href="https://symfonycasts.com" rel="external noopener noreferrer">SymfonyCasts</a> &amp;
-                        <a href="https://locastic.com" rel="external noopener noreferrer">Locastic</a>
-                    </span></p>
+                <div class="col-12 col-md-6 order-md-2">
+                    <p class="mt-3 mt-md-0 text-center" style="font-size: 11px; text-transform: uppercase;">
+                        crafted by
+                        <span style="font-weight: 700;">
+                            <a href="https://symfonycasts.com" rel="external noopener noreferrer">SymfonyCasts</a> &amp;
+                            <a href="https://locastic.com" rel="external noopener noreferrer">Locastic</a>,
+                        </span>
+                        hosted with
+                        <span style="font-weight: 700;">
+                            <a href="https://platform.sh" rel="external noopener noreferrer">Platform.sh</a>
+                        </span>
+                    </p>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

It looks like platform.sh will graciously offer free hosting (the hosting has been sponsored by SymfonyCasts until now). This adds a link to mention that :).

<img width="1277" alt="Screenshot 2023-06-28 at 3 43 09 PM" src="https://github.com/symfony/ux/assets/121003/c8ef0af1-8db2-45d7-ba09-728e4485ee22">

 