### PR TITLE
[Twig] Fix min Stimulus Bundle version

### DIFF
--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -36,7 +36,7 @@
     "require-dev": {
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/stimulus-bundle": "^2.9.1",
+        "symfony/stimulus-bundle": "^2.9.2",
         "symfony/twig-bundle": "^5.4|^6.0",
         "symfony/webpack-encore-bundle": "^1.15"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | -
| License       | MIT

A follow up for https://github.com/symfony/ux/pull/969 to ensure when 
someone updates gets the correct version.

Since 2.9.2 was not released yet, I'm not sure how to do this properly.

