### PR TITLE
Allow removing options that `EntityType` can't accept

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Next
+
+-   Allow not passing custom options to the nested `EntityType` by passing a list through another custom option
+    called `autocomplete_excluded_options` - #420
+
 ## 2.9.0
 
 -   Add support for symfony/asset-mapper

--- a/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
+++ b/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
@@ -82,6 +82,8 @@ final class ParentEntityAutocompleteType extends AbstractType implements DataMap
             'security' => false,
             // set the max results number that a query on automatic endpoint return.
             'max_results' => 10,
+            /* @see AutocompleteEntityTypeSubscriber::withoutExcludedOptions() */
+            'autocomplete_excluded_options' => [],
         ]);
 
         $resolver->setRequired(['class']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #420
| License       | MIT

If you implement a custom Autocompleter class as [described in the docs](https://symfony.com/bundles/ux-autocomplete/current/index.html#usage-in-a-form-with-ajax) and happen to require some non-standard options for your custom field, the Autocompleter (currently) tries to pass your custom option to the internal `EntityType` field. 

This PR adds the ability to list the options that should NOT be passed to that `EntityType`. 