### PR TITLE
Fix AssetMapper link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ to build the chart in PHP. The JavaScript is handled for you automatically.
 Symfony UX leverages [Stimulus](https://stimulus.hotwired.dev/) for JavaScript
 and can integrate with [Webpack Encore](https://github.com/symfony/webpack-encore)
 (with the help of [Stimulus Bridge](https://github.com/symfony/stimulus-bridge))
-or with [AssetMapper](https://symfony.com/doc/current/frontend/asset-mapper.html)
+or with [AssetMapper](https://symfony.com/doc/current/frontend/asset_mapper.html)
 
 ## Resources
 


### PR DESCRIPTION
Fix the AssetMapper documentation link (the url used `asset-mapper` instead of `asset_mapper`)