### PR TITLE
Docs: Fix Vue usage code sample

### DIFF
--- a/src/Vue/doc/index.rst
+++ b/src/Vue/doc/index.rst
@@ -54,7 +54,7 @@ code to your ``assets/app.js`` file:
     // assets/app.js
     import { registerVueControllerComponents } from '@symfony/ux-vue';
 
-    registerVueControllerComponents(require.context('./vue/controllers', true, /\\.(j|t)sx?$/));
+    registerVueControllerComponents(require.context('./vue/controllers', true, /\.vue$/));
 
 This will load all Vue components located in the ``assets/vue/controllers``
 directory. These are known as **Vue controller components**: top-level


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | 
| License       | MIT

Aligning this wrong statement with the [current recipe](https://github.com/symfony/recipes/blob/d866fda4b41fada955ff2048d18aba16c00b8260/symfony/ux-vue/2.9/manifest.json#L27).

Especially the double `\\` took me some time to catch, it is only necessary in the recipe manifest to be a valid JSON string.