### PR TITLE
Fix custom controller scale documentation

### DIFF
--- a/src/Chartjs/doc/index.rst
+++ b/src/Chartjs/doc/index.rst
@@ -184,15 +184,13 @@ custom Stimulus controller:
 
             // For instance you can format Y axis
             event.detail.config.options.scales = {
-                yAxes: [
-                    {
-                        ticks: {
-                            callback: function (value, index, values) {
-                                /* ... */
-                            },
+                y: {
+                    ticks: {
+                        callback: function (value, index, values) {
+                            /* ... */
                         },
                     },
-                ],
+                },
             };
         }
 


### PR DESCRIPTION
In a custom stimulus controller to update the configuration for the scales it is not an array but just an object, if not you get the following error : 

Invalid scale configuration for scale

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| License       | MIT
