### PR TITLE
fix(twig-component): fix <twig> syntax with empty attribute, close #925

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -233,7 +233,7 @@ class TwigPreLexer
                 $attributeValue = $this->consumeAttributeValue($quote);
             }
 
-            $attributes[] = sprintf('%s: %s', preg_match('/[-:]/', $key) ? "'$key'" : $key, $attributeValue);
+            $attributes[] = sprintf('%s: %s', preg_match('/[-:]/', $key) ? "'$key'" : $key, '' === $attributeValue ? "''" : $attributeValue);
 
             $this->expectAndConsumeChar($quote);
             $this->consumeWhitespace();

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -192,6 +192,11 @@ final class TwigPreLexerTest extends TestCase
             '{% component \'foobar\' with { \'data-turbo-stream\': true } %}{% endcomponent %}',
         ];
 
+        yield 'component_with_empty_attributes' => [
+            '<twig:foobar data-turbo-stream="" my-attribute=\'\'></twig:foobar>',
+            '{% component \'foobar\' with { \'data-turbo-stream\': \'\', \'my-attribute\': \'\' } %}{% endcomponent %}',
+        ];
+
         yield 'ignore_twig_comment' => [
             '{# <twig:Alert/> #} <twig:Alert/>',
             '{# <twig:Alert/> #} {{ component(\'Alert\') }}',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #925 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR is a proposal for fixing the issue with Twig Components when using the `<twig:Component>` syntax with empty attributes.