### PR TITLE
[LiveComponent] fix: respect `data-turbo="false"` when performing redirects

### DIFF
--- a/src/LiveComponent/assets/dist/Component/index.d.ts
+++ b/src/LiveComponent/assets/dist/Component/index.d.ts
@@ -55,6 +55,7 @@ export default class Component {
     private doEmit;
     updateFromNewElementFromParentRender(toEl: HTMLElement): void;
     onChildComponentModelUpdate(modelName: string, value: any, childComponent: Component): void;
+    private isTurboEnabled;
     private tryStartingRequest;
     private performRequest;
     private processRerender;

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1893,6 +1893,9 @@ class Component {
             this.set(modelBinding.modelName, value, modelBinding.shouldRender, modelBinding.debounce);
         });
     }
+    isTurboEnabled() {
+        return typeof Turbo !== 'undefined' && !this.element.closest('[data-turbo="false"]');
+    }
     tryStartingRequest() {
         if (!this.backendRequest) {
             this.performRequest();
@@ -1949,7 +1952,7 @@ class Component {
             return;
         }
         if (backendResponse.response.headers.get('Location')) {
-            if (typeof Turbo !== 'undefined') {
+            if (this.isTurboEnabled()) {
                 Turbo.visit(backendResponse.response.headers.get('Location'));
             }
             else {

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -337,6 +337,10 @@ export default class Component {
         });
     }
 
+    private isTurboEnabled(): boolean {
+        return typeof Turbo !== 'undefined' && !this.element.closest('[data-turbo="false"]');
+    }
+
     private tryStartingRequest(): void {
         if (!this.backendRequest) {
             this.performRequest()
@@ -430,7 +434,7 @@ export default class Component {
 
         if (backendResponse.response.headers.get('Location')) {
             // action returned a redirect
-            if (typeof Turbo !== 'undefined') {
+            if (this.isTurboEnabled()) {
                 Turbo.visit(backendResponse.response.headers.get('Location'));
             } else {
                 window.location.href = backendResponse.response.headers.get('Location') || '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Tickets       | no
| License       | MIT

Any redirect response from the backend will trigger a `Turbo.visit()` regardless if the frontend component lives within a `data-turbo="false"` context.

This might lead to several problems when it comes to cross-site redirects since they will be dispatched via javascript `fetch()` where stricter rule apply (e.g. CORS etc).
