### PR TITLE
Fix typo in outerBlocks doc

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -865,7 +865,7 @@ imagine we want to create a ``SuccessAlert`` component that's usable like this:
 
     {# templates/some_page.html.twig #}
     {% component SuccessAlert %}
-        {% content %}We will successfully <em>forward</em> this block content!{% endblock %}
+        {% block content %}We will successfully <em>forward</em> this block content!{% endblock %}
     {% endcomponent %}
 
 But we already have a generic ``Alert`` component, and we want to re-use it:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | 
| License       | MIT

I noticed the recently merged doc from #985 had a small typo in one of the snippets.