### PR TITLE
Update index.rst regex matching file extensions fix

### DIFF
--- a/src/React/doc/index.rst
+++ b/src/React/doc/index.rst
@@ -54,7 +54,7 @@ code to your ``assets/app.js`` file:
     // assets/app.js
     import { registerReactControllerComponents } from '@symfony/ux-react';
 
-    registerReactControllerComponents(require.context('./react/controllers', true, /\\.(j|t)sx?$/));
+    registerReactControllerComponents(require.context('./react/controllers', true, /\.(j|t)sx?$/));
 
 This will load all React components located in the ``assets/react/controllers``
 directory. These are known as **React controller components**: top-level


### PR DESCRIPTION
 /\\.(j|t)sx?$/. It seems to be using double backslashes (\\) to escape the dot (.) character, which is not necessary. The correct way to escape the dot character in a regular expression is by using a single backslash (\), like this: /\.(j|t)sx?$/.
