### PR TITLE
[TwigComponent] Fix typo in docs

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -884,7 +884,7 @@ via the ``outerBlocks`` variable and forward it into ``Alert``:
 
     {# templates/SuccessAlert.html.twig #}
     {% component Alert with { type: 'success' } %}
-        {% block content %}{{ blocks(outerBlocks.content) }}{% endblock %}
+        {% block content %}{{ block(outerBlocks.content) }}{% endblock %}
     {% endcomponent %}
 
 Note that to pass a block multiple components down, each component needs to pass it.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | Fix #...
| License       | MIT

There is no function named `blocks`