### PR TITLE
[StimulusBundle] Adding missing not about ux_controller_link_tags

### DIFF
--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -430,6 +430,17 @@ will import all your custom controllers as well as those from ``controllers.json
 It will also dynamically enable "debug" mode in Stimulus when your application
 is running in debug mode.
 
+Finally, to output any ``autoimport`` CSS files in your ``controllers.json`` file,
+include the ``ux_controller_link_tags()`` function in your base template:
+
+.. code-block:: html+twig
+
+    {% block stylesheets %}
+        {{ ux_controller_link_tags() }}
+
+        <!-- ... -->
+    {% endblock %}
+
 How are the Stimulus Controllers Loaded?
 ----------------------------------------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

This is in the recipe - https://github.com/symfony/recipes/blob/2cf7ec6e8e08f9d9dfa2e21ab7438092b1a69902/symfony/stimulus-bundle/2.9/manifest.json#L40 - but wasn't mentioned here.