### PR TITLE
[Chart.js] Restricting version users will get

### DIFF
--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -21,7 +21,7 @@
     },
     "peerDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "chart.js": "^3.4.1"
+        "chart.js": "^3.4.1 <3.9"
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #1013
| License       | MIT

Until we properly support 3.9, we need to show that here. Without this, users would start their app with ^3.4.1 thanks to flex, they might get 3.9.1, and then npm may install 2 copies of chart.js: 3.9.1 and 3.8.* for symfony/ux-chartjs