### PR TITLE
Change Vue reference to Svelte in docs

### DIFF
--- a/src/Svelte/doc/index.rst
+++ b/src/Svelte/doc/index.rst
@@ -35,7 +35,7 @@ Then install the bundle using Composer and Symfony Flex:
 
 The Flex recipe will automatically set things up for you, like adding
 ``.enableSvelte()`` to your ``webpack.config.js`` file and adding code
-to load your Vue components inside ``assets/app.js``.
+to load your Svelte components inside ``assets/app.js``.
 
 Next, install a package to help Svelte:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT

Symfony UX Svelte docs refer to Vue components. I'm assuming this is because the initial docs were based on the Vue bundle. This PR changes the reference to Svelte.
