### PR TITLE
Fix ComponentAttributes constructor typehint and remove `@internal`

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -22,9 +22,7 @@ use Symfony\WebpackEncoreBundle\Dto\AbstractStimulusDto;
 final class ComponentAttributes
 {
     /**
-     * @internal
-     *
-     * @param array<string, string> $attributes
+     * @param array<string, string|bool> $attributes
      */
     public function __construct(private array $attributes)
     {
@@ -53,7 +51,7 @@ final class ComponentAttributes
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, string|bool>
      */
     public function all(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #304
| License       | MIT

I heavily rely on ComponentAttributes instantiation in components to be able to use same logic on all component elements, for example:

```twig
<div{{ attributes.defaults({ ... })>
  <img{{ imageAttributes.defaults({ ... })>
</div>
```

In the issue it was proposed to rename ComponentAttributes but I don't see the point to break the code for people now :slightly_smiling_face: 