### PR TITLE
[CI] Fix tests

### DIFF
--- a/src/Cropperjs/tests/Form/CropperTypeTest.php
+++ b/src/Cropperjs/tests/Form/CropperTypeTest.php
@@ -52,7 +52,7 @@ class CropperTypeTest extends TestCase
                             '<input type="hidden" id="form_photo_options" name="form[photo][options]" '.
                                 'data-controller="mycropper symfony--ux-cropperjs--cropper" '.
                                 'data-symfony--ux-cropperjs--cropper-public-url-value="/public/url.jpg" '.
-                                'data-symfony--ux-cropperjs--cropper-options-value="{&quot;viewMode&quot;:1,&quot;dragMode&quot;:&quot;move&quot;}" />'.
+                                'data-symfony--ux-cropperjs--cropper-options-value="{&quot;viewMode&quot;:1,&quot;dragMode&quot;:&quot;move&quot;}">'.
                         '</div>'.
                     '</div>'.
                 '</div>'.
@@ -86,7 +86,7 @@ class CropperTypeTest extends TestCase
                             '<input type="hidden" id="form_photo_options" name="form[photo][options]" '.
                                 'data-controller="mycropper symfony--ux-cropperjs--cropper" '.
                                 'data-symfony--ux-cropperjs--cropper-public-url-value="/public/url.jpg" '.
-                                'data-symfony--ux-cropperjs--cropper-options-value="[]" />'.
+                                'data-symfony--ux-cropperjs--cropper-options-value="[]">'.
                         '</div>'.
                     '</div>'.
                 '</div>'.

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -199,10 +199,10 @@ class ComponentWithFormTest extends KernelTestCase
             ->throwExceptions()
             ->get($getUrl($dehydratedProps))
             ->assertSuccessful()
-            ->assertContains('<input type="checkbox" id="form_choice_multiple_1" name="form[choice_multiple][]" value="2" checked="checked" />')
-            ->assertContains('<input type="checkbox" id="form_choice_multiple_0" name="form[choice_multiple][]" value="1" />')
-            ->assertContains('<input type="checkbox" id="form_checkbox" name="form[checkbox]" required="required" value="1" />')
-            ->assertContains('<input type="checkbox" id="form_checkbox_checked" name="form[checkbox_checked]" required="required" value="1" checked="checked" />')
+            ->assertContains('<input type="checkbox" id="form_choice_multiple_1" name="form[choice_multiple][]" value="2" checked="checked">')
+            ->assertContains('<input type="checkbox" id="form_choice_multiple_0" name="form[choice_multiple][]" value="1">')
+            ->assertContains('<input type="checkbox" id="form_checkbox" name="form[checkbox]" required="required" value="1">')
+            ->assertContains('<input type="checkbox" id="form_checkbox_checked" name="form[checkbox_checked]" required="required" value="1" checked="checked">')
         ;
 
         // check both multiple fields
@@ -210,8 +210,8 @@ class ComponentWithFormTest extends KernelTestCase
 
         $crawler = $browser
             ->get($getUrl($dehydratedProps, $updatedProps))
-            ->assertContains('<input type="checkbox" id="form_choice_multiple_1" name="form[choice_multiple][]" value="2" checked="checked" />')
-            ->assertContains('<input type="checkbox" id="form_choice_multiple_0" name="form[choice_multiple][]" value="1" checked="checked" />')
+            ->assertContains('<input type="checkbox" id="form_choice_multiple_1" name="form[choice_multiple][]" value="2" checked="checked">')
+            ->assertContains('<input type="checkbox" id="form_choice_multiple_0" name="form[choice_multiple][]" value="1" checked="checked">')
             ->crawler()
         ;
         $dehydratedProps = json_decode(
@@ -228,10 +228,10 @@ class ComponentWithFormTest extends KernelTestCase
 
         $crawler = $browser
             ->get($getUrl($dehydratedProps, $updatedProps))
-            ->assertContains('<input type="checkbox" id="form_choice_multiple_1" name="form[choice_multiple][]" value="2" />')
-            ->assertContains('<input type="checkbox" id="form_choice_multiple_0" name="form[choice_multiple][]" value="1" />')
-            ->assertContains('<input type="checkbox" id="form_checkbox" name="form[checkbox]" required="required" value="1" checked="checked" />')
-            ->assertContains('<input type="checkbox" id="form_checkbox_checked" name="form[checkbox_checked]" required="required" value="1" />')
+            ->assertContains('<input type="checkbox" id="form_choice_multiple_1" name="form[choice_multiple][]" value="2">')
+            ->assertContains('<input type="checkbox" id="form_choice_multiple_0" name="form[choice_multiple][]" value="1">')
+            ->assertContains('<input type="checkbox" id="form_checkbox" name="form[checkbox]" required="required" value="1" checked="checked">')
+            ->assertContains('<input type="checkbox" id="form_checkbox_checked" name="form[checkbox_checked]" required="required" value="1">')
             ->crawler()
         ;
         $dehydratedProps = json_decode(

--- a/src/TogglePassword/tests/Form/TogglePasswordTypeTest.php
+++ b/src/TogglePassword/tests/Form/TogglePasswordTypeTest.php
@@ -22,7 +22,7 @@ class TogglePasswordTypeTest extends TestCase
 
         $rendered = $container->get(Environment::class)->render('toggle_password_form.html.twig', ['form' => $form->createView()]);
 
-        self::assertSame('<form name="form" method="post"><div id="form"><div><label for="form_password" class="required">Password</label><div class="toggle-password-container"><input type="password" id="form_password" name="form[password]" required="required" data-controller="symfony--ux-toggle-password--toggle-password" data-symfony--ux-toggle-password--toggle-password-hidden-label-value="Hide" data-symfony--ux-toggle-password--toggle-password-visible-label-value="Show" data-symfony--ux-toggle-password--toggle-password-hidden-icon-value="Default" data-symfony--ux-toggle-password--toggle-password-visible-icon-value="Default" data-symfony--ux-toggle-password--toggle-password-button-classes-value="[&quot;toggle-password-button&quot;]" /></div></div></div></form>
+        self::assertSame('<form name="form" method="post"><div id="form"><div><label for="form_password" class="required">Password</label><div class="toggle-password-container"><input type="password" id="form_password" name="form[password]" required="required" data-controller="symfony--ux-toggle-password--toggle-password" data-symfony--ux-toggle-password--toggle-password-hidden-label-value="Hide" data-symfony--ux-toggle-password--toggle-password-visible-label-value="Show" data-symfony--ux-toggle-password--toggle-password-hidden-icon-value="Default" data-symfony--ux-toggle-password--toggle-password-visible-icon-value="Default" data-symfony--ux-toggle-password--toggle-password-button-classes-value="[&quot;toggle-password-button&quot;]"></div></div></div></form>
 ', $rendered);
     }
 
@@ -36,7 +36,7 @@ class TogglePasswordTypeTest extends TestCase
 
         $rendered = $container->get(Environment::class)->render('toggle_password_form.html.twig', ['form' => $form->createView()]);
 
-        self::assertSame('<form name="form" method="post"><div id="form"><div><label for="form_password" class="required">Password</label><input type="password" id="form_password" name="form[password]" required="required" /></div></div></form>
+        self::assertSame('<form name="form" method="post"><div id="form"><div><label for="form_password" class="required">Password</label><input type="password" id="form_password" name="form[password]" required="required"></div></div></form>
 ', $rendered);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | N/A
| License       | MIT

Expected markup for tests in Cropperjs, LiveComponent, and TogglePassword aren't matching because of a missing self closing tag on `input`.
It seems a little odd and i didn't manage to find the reason why but this PR propose a fix for those failing tests
