### PR TITLE
Fix javascript error - 2 extra closing brackets in _onPreConnect

### DIFF
--- a/src/Typed/doc/index.rst
+++ b/src/Typed/doc/index.rst
@@ -108,10 +108,10 @@ Stimulus controller:
             console.log(event.detail.options); // Options that will be used to initialize Typed
             event.detail.options.onBegin = (typed) => {
                 console.log("Typed is ready to type cool messages!");
-            });
+            };
             event.detail.options.onStop = (typed) => {
                 console.log("OK. Enough is enough.");
-            });
+            };
         }
 
         _onConnect(event) {


### PR DESCRIPTION
Code was not valid due to extra closing brackets.

Removed extra ")", run code and tested.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Tickets       | No ticket
| License       | MIT

README
Fixed an error in _onPreConnect – javascript code was not actually valid. It has an extra closing bracket.

