### PR TITLE
fix(live): ensure non-class service id can be used

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/Compiler/ComponentDefaultActionPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/ComponentDefaultActionPass.php
@@ -25,9 +25,13 @@ final class ComponentDefaultActionPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        foreach ($container->findTaggedServiceIds('twig.component') as $class => $component) {
+        foreach ($container->findTaggedServiceIds('twig.component') as $id => $component) {
             if (!($component[0]['live'] ?? false)) {
                 continue;
+            }
+
+            if (!$class = $container->getDefinition($id)->getClass()) {
+                throw new \LogicException(sprintf('Live component service "%s" must have a class.', $id));
             }
 
             $defaultAction = trim($component[0]['default_action'] ?? '__invoke', '()');

--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\UX\LiveComponent\LiveComponentBundle;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Component\Component1;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Serializer\Entity2Normalizer;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Serializer\MoneyNormalizer;
 use Symfony\UX\TwigComponent\TwigComponentBundle;
@@ -129,7 +130,10 @@ final class Kernel extends BaseKernel
             ->set(Entity2Normalizer::class)->autoconfigure()->autowire()
             ->load(__NAMESPACE__.'\\Component\\', __DIR__.'/Component')
             ->set(TestingDeterministicIdTwigExtension::class)
-            ->args([service('ux.live_component.deterministic_id_calculator')]);
+            ->args([service('ux.live_component.deterministic_id_calculator')])
+            ->set('some_service_id', Component1::class)
+                ->tag('twig.component', ['live' => true])
+        ;
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | n/a
| License       | MIT

Without this fix, you cannot register live components with a non-class service id.
