### PR TITLE
[LiveComponent] Add missing typehints to HydrationExtensionInterface

### DIFF
--- a/src/LiveComponent/src/Hydration/HydrationExtensionInterface.php
+++ b/src/LiveComponent/src/Hydration/HydrationExtensionInterface.php
@@ -13,8 +13,14 @@ namespace Symfony\UX\LiveComponent\Hydration;
 
 interface HydrationExtensionInterface
 {
+    /**
+     * @param class-string $className
+     */
     public function supports(string $className): bool;
 
+    /**
+     * @param class-string $className
+     */
     public function hydrate(mixed $value, string $className): ?object;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no /not sure
| New feature?  | no /not sure
| Tickets       | N/A
| License       | MIT

I have a custom hydration extension that in `supports` method checks if the provided class has my custom marker attribute through Reflection, but SA complains:

> Parameter `#1` $objectOrClass of class ReflectionClass constructor expects class-string<T of object>|T of object, string given.