### PR TITLE
[LiveComponent] Fix tests now that a live id is always added, even for embedded components

### DIFF
--- a/src/LiveComponent/src/Test/TestLiveComponent.php
+++ b/src/LiveComponent/src/Test/TestLiveComponent.php
@@ -40,6 +40,8 @@ final class TestLiveComponent
     ) {
         $this->client->catchExceptions(false);
 
+        $data['attributes']['data-live-id'] ??= 'in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed';
+
         $mounted = $this->factory->create($this->metadata->getName(), $data);
         $props = $this->hydrator->dehydrate(
             $mounted->getComponent(),

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -290,7 +290,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             })
             ->post('/_components/component2/increase', [
                 'headers' => ['X-CSRF-TOKEN' => $token],
-                'body' => json_encode(['props' => $dehydrated->getProps()]),
+                'body' => ['data' => json_encode(['props' => $dehydrated->getProps()])],
             ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | 
| License       | MIT

Embedded components can also be live now, so they also need a live-id.

The `TestLiveComponent` trait was added after the live-id change had been introduced in the embedded live components branch, so it now needed to be synced with those changes.

The conflicting change: https://github.com/symfony/ux/pull/913/files#diff-c1c2695c57da687bdba39e2b9e5285f30e9b87f50886bf645a048545575f6659