### PR TITLE
[LiveComponent] Add priority to PreReRender hook

### DIFF
--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -65,9 +65,15 @@ final class AsLiveComponent extends AsTwigComponent
      *
      * @return \ReflectionMethod[]
      */
-    public static function preReRenderMethods(object $component): \Traversable
+    public static function preReRenderMethods(object $component): iterable
     {
-        yield from self::attributeMethodsFor(PreReRender::class, $component);
+        $methods = iterator_to_array(self::attributeMethodsFor(PreReRender::class, $component));
+
+        usort($methods, static function (\ReflectionMethod $a, \ReflectionMethod $b) {
+            return $a->getAttributes(PreReRender::class)[0]->newInstance()->priority <=> $b->getAttributes(PreReRender::class)[0]->newInstance()->priority;
+        });
+
+        return array_reverse($methods);
     }
 
     /**

--- a/src/LiveComponent/src/Attribute/PreReRender.php
+++ b/src/LiveComponent/src/Attribute/PreReRender.php
@@ -22,4 +22,11 @@ namespace Symfony\UX\LiveComponent\Attribute;
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class PreReRender
 {
+    /**
+     * @param int $priority If multiple hooks are registered in a component, use to configure
+     *                      the order in which they are called (higher called earlier)
+     */
+    public function __construct(public int $priority = 0)
+    {
+    }
 }

--- a/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\LiveComponent\Tests\Unit\Attribute;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Component\Component5;
 
 /**
@@ -36,12 +37,31 @@ final class AsLiveComponentTest extends TestCase
         $this->assertSame('method5', $methods[0]->getName());
     }
 
-    public function testCanGetPreReRenderMethods(): void
+    public function testPreMountHooksAreOrderedByPriority(): void
     {
-        $methods = iterator_to_array(AsLiveComponent::preReRenderMethods(new Component5()));
+        $hooks = AsLiveComponent::preReRenderMethods(
+            new class() {
+                #[PreReRender(priority: -10)]
+                public function hook1()
+                {
+                }
 
-        $this->assertCount(1, $methods);
-        $this->assertSame('method3', $methods[0]->getName());
+                #[PreReRender(priority: 10)]
+                public function hook2()
+                {
+                }
+
+                #[PreReRender]
+                public function hook3()
+                {
+                }
+            }
+        );
+
+        $this->assertCount(3, $hooks);
+        $this->assertSame('hook2', $hooks[0]->name);
+        $this->assertSame('hook3', $hooks[1]->name);
+        $this->assertSame('hook1', $hooks[2]->name);
     }
 
     public function testCanGetLiveListeners(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | 
| License       | MIT

Analogue with Pre- & PostMount hooks in AsTwigComponent, if you have multiple PreReRender methods, some may have to be run first.