### PR TITLE
[TwigComponent] Add support for namespaced templates in TemplateMap

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -29,6 +29,7 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Serializer\Entity2Normalizer;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Serializer\MoneyNormalizer;
 use Symfony\UX\TwigComponent\TwigComponentBundle;
 use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 use Zenstruck\Foundry\ZenstruckFoundryBundle;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -50,6 +51,13 @@ final class Kernel extends BaseKernel
         $twig ??= $this->container->get('twig');
 
         return new Response($twig->render("{$template}.html.twig"));
+    }
+
+    public function renderNamespacedTemplate(string $template, Environment $twig = null): Response
+    {
+        $twig ??= $this->container->get('twig');
+
+        return new Response($twig->render('@'.FilesystemLoader::MAIN_NAMESPACE.'/'.$template.'.html.twig'));
     }
 
     public function registerBundles(): iterable
@@ -142,6 +150,7 @@ final class Kernel extends BaseKernel
             ->prefix('/_components');
 
         $routes->add('template', '/render-template/{template}')->controller('kernel::renderTemplate');
+        $routes->add('render_namespaced_template', '/render-namespaced-template/{template}')->controller('kernel::renderNamespacedTemplate');
         $routes->add('homepage', '/')->controller('kernel::index');
         $routes->add('alternate_live_route', '/alt/{_live_component}/{_live_action}')->defaults(['_live_action' => 'get']);
     }

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -259,6 +259,19 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
+    public function testItWorksWithNamespacedTemplateNamesForEmbeddedComponents(): void
+    {
+        $templateName = 'render_embedded_with_blocks.html.twig';
+        $obscuredName = 'fb7992f74bbb43c08e47b7cf5c880edb';
+        $this->addTemplateMap($obscuredName, $templateName);
+
+        $this->browser()
+            ->visit('/render-namespaced-template/render_embedded_with_blocks')
+            ->assertSuccessful()
+            ->assertElementAttributeContains('.component2', 'data-live-props-value', '"data-host-template":"'.$obscuredName.'"')
+        ;
+    }
+
     public function testItUseBlocksFromEmbeddedContextUsingMultipleComponents(): void
     {
         $templateName = 'render_multiple_embedded_with_blocks.html.twig';

--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -68,7 +68,7 @@ final class ComponentNode extends EmbedNode
             ->raw('), ')
             ->raw($this->getAttribute('only') ? '[]' : '$context')
             ->raw(', ')
-            ->string($this->getAttribute('name'))
+            ->string($this->parseTemplateName($this->getAttribute('name')))
             ->raw(', ')
             ->raw($this->getAttribute('index'))
             ->raw(");\n")
@@ -90,5 +90,21 @@ final class ComponentNode extends EmbedNode
             ->write('}')
             ->raw("\n")
         ;
+    }
+
+    /**
+     * Copied from Twig\Loader\FilesystemLoader, and adjusted to needs for this class.
+     */
+    private function parseTemplateName(string $name): mixed
+    {
+        if (isset($name[0]) && '@' == $name[0]) {
+            if (false === $pos = strpos($name, '/')) {
+                throw new \LogicException(sprintf('Malformed namespaced template name "%s" (expecting "@namespace/template_name").', $name));
+            }
+
+            return substr($name, $pos + 1);
+        }
+
+        return $name;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | 
| License       | MIT

## Problem
If a template is rendered as "_@MyNamespace/some/template.html.twig_", and it contains an embedded live component, then that name is used for the host template attribute. When obscuring this name, an error is thrown, because it cannot be found in the template map (which consists of real file paths).

## Solution
Parse the name when compiling a ComponentNode, just like the FilesystemLoader would, so it becomes "_some/template.html.twig_"