### PR TITLE
[LiveComponent] Use `display:revert` for `data-loading` style

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2380,7 +2380,7 @@ class LoadingPlugin {
         return loadingDirectives;
     }
     showElement(element) {
-        element.style.display = 'inline-block';
+        element.style.display = 'revert';
     }
     hideElement(element) {
         element.style.display = 'none';

--- a/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
@@ -173,7 +173,7 @@ export default class implements PluginInterface {
     }
 
     private showElement(element: HTMLElement|SVGElement) {
-        element.style.display = 'inline-block';
+        element.style.display = 'revert';
     }
 
     private hideElement(element: HTMLElement|SVGElement) {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | N/A
| License       | MIT

Using `display:inline-block` breaks the inner workings if for example `data-loading` was used on `<tr>` element, so the table row contents are incorrectly displayed.
