### PR TITLE
[TwigComponent][LiveComponent] Fix Live embedded component within namespaced template

### DIFF
--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -311,6 +311,45 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
+    public function testItUseBlocksFromEmbeddedContextUsingMultipleComponentsWithNamespacedTemplate(): void
+    {
+        $templateName = 'render_multiple_embedded_with_blocks.html.twig';
+        $obscuredName = '5c474b02358c46cca3da7340cc79cc2e';
+
+        $this->addTemplateMap($obscuredName, $templateName);
+
+        $dehydrated = $this->dehydrateComponent(
+            $this->mountComponent(
+                'component2',
+                [
+                    'data-host-template' => $obscuredName,
+                    'data-embedded-template-index' => self::DETERMINISTIC_ID_MULTI_2,
+                ]
+            )
+        );
+
+        $token = null;
+
+        $this->browser()
+            ->visit('/render-namespaced-template/render_multiple_embedded_with_blocks')
+            ->assertSuccessful()
+            ->assertSeeIn('#component1', 'Overridden content from component 1')
+            ->assertSeeIn('#component2', 'Overridden content from component 2 on same line - count: 1')
+            ->assertSeeIn('#component3', 'PreReRenderCalled: No')
+            ->use(function (Crawler $crawler) use (&$token) {
+                // get a valid token to use for actions
+                $token = $crawler->filter('div')->eq(1)->attr('data-live-csrf-value');
+            })
+            ->post('/_components/component2/increase', [
+                'headers' => ['X-CSRF-TOKEN' => $token],
+                'body' => ['data' => json_encode(['props' => $dehydrated->getProps()])],
+            ])
+            ->assertSuccessful()
+            ->assertHeaderContains('Content-Type', 'html')
+            ->assertSee('Overridden content from component 2 on same line - count: 2')
+        ;
+    }
+
     public function testCanRedirectFromComponentAction(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('component2'));

--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -68,7 +68,7 @@ final class ComponentNode extends EmbedNode
             ->raw('), ')
             ->raw($this->getAttribute('only') ? '[]' : '$context')
             ->raw(', ')
-            ->string($this->parseTemplateName($this->getAttribute('name')))
+            ->string(TemplateNameParser::parse($this->getAttribute('name')))
             ->raw(', ')
             ->raw($this->getAttribute('index'))
             ->raw(");\n")
@@ -90,21 +90,5 @@ final class ComponentNode extends EmbedNode
             ->write('}')
             ->raw("\n")
         ;
-    }
-
-    /**
-     * Copied from Twig\Loader\FilesystemLoader, and adjusted to needs for this class.
-     */
-    private function parseTemplateName(string $name): mixed
-    {
-        if (isset($name[0]) && '@' == $name[0]) {
-            if (false === $pos = strpos($name, '/')) {
-                throw new \LogicException(sprintf('Malformed namespaced template name "%s" (expecting "@namespace/template_name").', $name));
-            }
-
-            return substr($name, $pos + 1);
-        }
-
-        return $name;
     }
 }

--- a/src/TwigComponent/src/Twig/ComponentTokenParser.php
+++ b/src/TwigComponent/src/Twig/ComponentTokenParser.php
@@ -87,7 +87,7 @@ final class ComponentTokenParser extends AbstractTokenParser
         $this->parser->embedTemplate($module);
 
         // use deterministic index for the embedded template, so it can be loaded in a controlled manner
-        $module->setAttribute('index', $this->generateEmbeddedTemplateIndex($stream->getSourceContext()->getName(), $token->getLine()));
+        $module->setAttribute('index', $this->generateEmbeddedTemplateIndex(TemplateNameParser::parse($stream->getSourceContext()->getName()), $token->getLine()));
 
         $stream->expect(Token::BLOCK_END_TYPE);
 

--- a/src/TwigComponent/src/Twig/TemplateNameParser.php
+++ b/src/TwigComponent/src/Twig/TemplateNameParser.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\UX\TwigComponent\Twig;
+
+final class TemplateNameParser
+{
+    /**
+     * Copied from Twig\Loader\FilesystemLoader, and adjusted to needs for this class (no namespace returned).
+     *
+     * @see \Twig\Loader\FilesystemLoader::parseName
+     */
+    public static function parse(string $name): mixed
+    {
+        if (isset($name[0]) && '@' == $name[0]) {
+            if (false === $pos = strpos($name, '/')) {
+                throw new \LogicException(sprintf('Malformed namespaced template name "%s" (expecting "@namespace/template_name").', $name));
+            }
+
+            return substr($name, $pos + 1);
+        }
+
+        return $name;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | 
| License       | MIT

This fix is related to #1070 .
That PR made sure that a namespaced template could also be found in the TemplateMap, which contains paths without the namespace, so that the right template name (or actually obscuring hash) is used for the host template reference for live embedded components within such a template (which is used to find the right blocks during a re-render). 

However, because the Parser was still using the namespaced template name to calculate the deterministic index number for an embedded template, it would not match with the index of the stripped / namespace-less template name, causing it to have a different index for the embedded template during re-render then during parsing, resulting in a template not found error.

This PR now also strips namespaces from template names during parsing.

