### PR TITLE
[LiveComponent] LiveCollectionType documentation

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1798,7 +1798,7 @@ via the ``LiveCollectionType``::
 
 Now, create a Twig component to render the form::
 
-    namespace App\Twig;
+    namespace App\Components;
 
     use App\Entity\BlogPost;
     use App\Form\BlogPostFormType;
@@ -1809,7 +1809,7 @@ Now, create a Twig component to render the form::
     use Symfony\UX\LiveComponent\DefaultActionTrait;
     use Symfony\UX\LiveComponent\LiveCollectionTrait;
 
-    #[AsLiveComponent]
+    #[AsLiveComponent('blog-post-collection-type')]
     class BlogPostCollectionType extends AbstractController
     {
         use LiveCollectionTrait;
@@ -1824,13 +1824,23 @@ Now, create a Twig component to render the form::
         }
     }
 
-There is no need for a custom template just render the form as usual:
+Create a custom template for the component :
 
 .. code-block:: html+twig
 
+    {# templates/components/blog-post-collection-type.html.twig #}
     <div {{ attributes }}>
         {{ form(form) }}
     </div>
+
+Render the component : 
+
+.. code-block:: html+twig
+
+    {# templates/blog-post/edit.html.twig #}
+    {{ component('BlogPostCollectionType', {
+          initialFormData: post,
+    }) }}
 
 This automatically renders add and delete buttons that are connected to the live component.
 If you want to customize how the buttons and the collection rows are rendered, you can use


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | 
| License       | MIT

Hi,

I've tried to follow the documentation of [LiveCollectionType](https://symfony.com/bundles/ux-live-component/current/index.html#using-livecollectiontype) and I had some trouble at the end with

> There is no need for a custom template just render the form as usual:
```twig
<div {{ attributes }}>
    {{ form(form) }}
</div>
```

Doing so, I had an error 

> Variable "attributes" does not exist.

If you remove the attributes, there is the Add button, but nothing is happening when you click it.

Was I doing something wrong and the documentation was right ? Or is the documentation incomplete ? 

I finally manage to make it work.

Instead of 

> just render the form as usual

I rendered the component :

```twig
    {{ component('BlogPostCollectionType', {
          initialFormData: post,
    }) }}
```

I created the html file of the component : 
```twig
{# templates/components/BlogPostCollectionType.html.twig #}
<div {{ attributes }}>
    {{ form_start(form) }}
    {{ form_end(form) }}
</div>
```

If you tell me the documentation is right, then it is fine.

If not, here's the PR.

Edit: I would love to fix the check that failed, but I don't know how to add another commit...

Thanks.
