### PR TITLE
[LiveComponent][Docs] Fix version added for file uploads support

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1158,9 +1158,9 @@ shortcuts. We even added a flash message!
 Uploading files
 ---------------
 
-.. versionadded:: 2.9
+.. versionadded:: 2.11
 
-    The ability to upload files to actions was added in version 2.9.
+    The ability to upload files to actions was added in version 2.11.
 
 Files aren't sent to the component by default. You need to use a live action
 to handle the files and tell the component when the file should be sent:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | N/A
| License       | MIT

File uploads support for Live Components was introduced with v2.11, however the docs mention v2.9 instead.

See https://github.com/symfony/ux/pull/834#issuecomment-1701452041