### PR TITLE
[TwigComponent][LiveComponent] Fix DataModelPropsSubscriber for embedded components

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Component/InputComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/InputComponent.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsTwigComponent('input_component')]
+final class InputComponent
+{
+}

--- a/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModel.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModel.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsLiveComponent('parent_component_data_model')]
+final class ParentComponentDataModel
+{
+    use DefaultActionTrait;
+}

--- a/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModel2.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModel2.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ */
+#[AsLiveComponent('parent_component_data_model_2')]
+final class ParentComponentDataModel2
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)] public string $content;
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/input_component.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/input_component.html.twig
@@ -1,0 +1,1 @@
+<input{{ attributes }} />

--- a/src/LiveComponent/tests/Fixtures/templates/components/parent_component_data_model.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/parent_component_data_model.html.twig
@@ -1,0 +1,2 @@
+{% component parent_component_data_model_2 with { content: 'default content on mount' } %}
+{% endcomponent %}

--- a/src/LiveComponent/tests/Fixtures/templates/components/parent_component_data_model_2.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/parent_component_data_model_2.html.twig
@@ -1,0 +1,2 @@
+{{ component('textarea_component', { dataModel: 'content' }) }}
+{% component input_component with { dataModel: 'content' } %}{% endcomponent %}

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -93,17 +93,18 @@ final class ComponentRenderer implements ComponentRendererInterface
 
         $this->componentStack->push($mounted);
 
-        try {
-            $embeddedContext = $this->preRender($mounted, $context)->getVariables();
+        $embeddedContext = $this->preRender($mounted, $context)->getVariables();
 
-            if (!isset($embeddedContext['outerBlocks'])) {
-                $embeddedContext['outerBlocks'] = new BlockStack();
-            }
-
-            return $embeddedContext;
-        } finally {
-            $this->componentStack->pop();
+        if (!isset($embeddedContext['outerBlocks'])) {
+            $embeddedContext['outerBlocks'] = new BlockStack();
         }
+
+        return $embeddedContext;
+    }
+
+    public function finishEmbeddedComponentRender(): void
+    {
+        $this->componentStack->pop();
     }
 
     private function preRender(MountedComponent $mounted, array $context = []): PreRenderEvent

--- a/src/TwigComponent/src/ComponentStack.php
+++ b/src/TwigComponent/src/ComponentStack.php
@@ -16,7 +16,7 @@ namespace Symfony\UX\TwigComponent;
  *
  * @internal
  */
-class ComponentStack
+class ComponentStack implements \IteratorAggregate
 {
     /**
      * @var MountedComponent[]
@@ -59,5 +59,13 @@ class ComponentStack
     public function hasParentComponent(): bool
     {
         return (bool) $this->getParentComponent();
+    }
+
+    /**
+     * @return MountedComponent[]|\ArrayIterator
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator(array_reverse($this->components));
     }
 }

--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -80,6 +80,15 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
         }
     }
 
+    public function finishEmbeddedComponentRender(): void
+    {
+        try {
+            $this->container->get(ComponentRenderer::class)->finishEmbeddedComponentRender();
+        } catch (\Throwable $e) {
+            $this->throwRuntimeError($name, $e);
+        }
+    }
+
     private function throwRuntimeError(string $name, \Throwable $e): void
     {
         if (!($e instanceof \Exception)) {

--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -85,6 +85,12 @@ final class ComponentNode extends EmbedNode
         $compiler->raw('->display($embeddedContext, $embeddedBlocks);');
         $compiler->raw("\n");
 
+        $compiler->write('$this->extensions[')
+            ->string(ComponentExtension::class)
+            ->raw(']->finishEmbeddedComponentRender()')
+            ->raw(";\n")
+        ;
+
         $compiler
             ->outdent()
             ->write('}')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | 
| License       | MIT

### Reproduce

```
{# components/A.html.twig #}

<B>
  {# content doesn't matter, as long as it's an embedded component #}
</B>
```
```
{# components/B.html.twig #}

<C data-model="X"/>
```
(given a component B with a prop X)

With this setup the `DataModelPropsSubscriber::preMount()`  would result in an error "_Can't get a way to read the property "X" in class "A"_".

An even simpler setup

```
{# anyTemplate.html.twig #}

<A>
{# A is already embedded #}
</A>
```
Will result in "_You can only pass "data-model" when rendering a component when you're rendering inside of a parent component._"
Whether the data-model attribute is deep inside template B or already in template A doesn't matter. The thing is that during rendering of A, which is now embedded, there's no component on the stack.

### Problem

Self-closing component are rendered via `ComponentRenderer::createAndRender()`.
Embedded components are rendered via `ComponentRenderer::embeddedContext()` + `Template::display()`.

Both push the component being rendered on the `ComponentStack`, and pop it again at the end of the `ComponentRender` functions. During the rendering of C, B is already been popped from the stack, and therefore the `DataModelPropsSubscriber` doesn't have a way to find the parent component context. And it incorrectly uses component A, which is still on the component stack (while it should be linked to B).

### Solution
The rendering of an embedded component is only really done after the `Template::display()` execution. Therefore the component can only be removed when BOTH are done.