### PR TITLE
Don't store ux_live_component URLs in setTargetPath of the security component

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2154,6 +2154,7 @@ class RequestBuilder {
         const fetchOptions = {};
         fetchOptions.headers = {
             Accept: 'application/vnd.live-component+html',
+            'X-Requested-With': 'XMLHttpRequest',
         };
         const totalFiles = Object.entries(files).reduce((total, current) => total + current.length, 0);
         const hasFingerprints = Object.keys(children).length > 0;

--- a/src/LiveComponent/assets/src/Backend/RequestBuilder.ts
+++ b/src/LiveComponent/assets/src/Backend/RequestBuilder.ts
@@ -25,6 +25,7 @@ export default class {
         const fetchOptions: RequestInit = {};
         fetchOptions.headers = {
             Accept: 'application/vnd.live-component+html',
+            'X-Requested-With': 'XMLHttpRequest',
         };
 
         const totalFiles = Object.entries(files).reduce(

--- a/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
+++ b/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
@@ -16,6 +16,7 @@ describe('buildRequest', () => {
         expect(fetchOptions.method).toEqual('GET');
         expect(fetchOptions.headers).toEqual({
             Accept: 'application/vnd.live-component+html',
+            'X-Requested-With': 'XMLHttpRequest',
         });
     });
 
@@ -38,6 +39,7 @@ describe('buildRequest', () => {
         expect(fetchOptions.headers).toEqual({
             Accept: 'application/vnd.live-component+html',
             'X-CSRF-TOKEN': '_the_csrf_token',
+            'X-Requested-With': 'XMLHttpRequest',
         });
         const body = <FormData>fetchOptions.body;
         expect(body).toBeInstanceOf(FormData);
@@ -100,6 +102,7 @@ describe('buildRequest', () => {
         expect(fetchOptions.headers).toEqual({
             // no token
             Accept: 'application/vnd.live-component+html',
+            'X-Requested-With': 'XMLHttpRequest',
         });
         const body = <FormData>fetchOptions.body;
         expect(body).toBeInstanceOf(FormData);
@@ -180,6 +183,7 @@ describe('buildRequest', () => {
         expect(fetchOptions.headers).toEqual({
             Accept: 'application/vnd.live-component+html',
             'X-CSRF-TOKEN': '_the_csrf_token',
+            'X-Requested-With': 'XMLHttpRequest',
         });
         const body = <FormData>fetchOptions.body;
         expect(body).toBeInstanceOf(FormData);
@@ -204,6 +208,7 @@ describe('buildRequest', () => {
         expect(fetchOptions.headers).toEqual({
             Accept: 'application/vnd.live-component+html',
             'X-CSRF-TOKEN': '_the_csrf_token',
+            'X-Requested-With': 'XMLHttpRequest',
         });
         const body = <FormData>fetchOptions.body;
         expect(body).toBeInstanceOf(FormData);


### PR DESCRIPTION
Solves issue #1095

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #1095
| License       | MIT

Prevent to redirect to ux_live_component URL after login
