### PR TITLE
[LiveComponent] Only consider Live components in InterceptChildComponentRenderSubscriber

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -41,6 +41,7 @@ use Symfony\UX\LiveComponent\Twig\TemplateCacheWarmer;
 use Symfony\UX\LiveComponent\Twig\TemplateMap;
 use Symfony\UX\LiveComponent\Util\ChildComponentPartialRenderer;
 use Symfony\UX\LiveComponent\Util\FingerprintCalculator;
+use Symfony\UX\LiveComponent\Util\LiveComponentStack;
 use Symfony\UX\LiveComponent\Util\LiveControllerAttributesCreator;
 use Symfony\UX\LiveComponent\Util\TwigAttributeHelperFactory;
 use Symfony\UX\TwigComponent\ComponentFactory;
@@ -113,7 +114,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
         $container->register('ux.live_component.event_listener.data_model_props_subscriber', DataModelPropsSubscriber::class)
             ->addTag('kernel.event_subscriber')
             ->setArguments([
-                new Reference('ux.twig_component.component_stack'),
+                new Reference('ux.twig_component.live_component_stack'),
                 new Reference('property_accessor'),
             ])
         ;
@@ -130,9 +131,15 @@ final class LiveComponentExtension extends Extension implements PrependExtension
         $container->register('ux.live_component.live_responder', LiveResponder::class);
         $container->setAlias(LiveResponder::class, 'ux.live_component.live_responder');
 
-        $container->register('ux.live_component.intercept_child_component_render_subscriber', InterceptChildComponentRenderSubscriber::class)
+        $container->register('ux.twig_component.live_component_stack', LiveComponentStack::class)
             ->setArguments([
                 new Reference('ux.twig_component.component_stack'),
+            ])
+        ;
+
+        $container->register('ux.live_component.intercept_child_component_render_subscriber', InterceptChildComponentRenderSubscriber::class)
+            ->setArguments([
+                new Reference('ux.twig_component.live_component_stack'),
             ])
             ->addTag('container.service_subscriber', ['key' => DeterministicTwigIdCalculator::class, 'id' => 'ux.live_component.deterministic_id_calculator'])
             ->addTag('container.service_subscriber', ['key' => ChildComponentPartialRenderer::class, 'id' => 'ux.live_component.child_component_partial_renderer'])

--- a/src/LiveComponent/src/EventListener/DataModelPropsSubscriber.php
+++ b/src/LiveComponent/src/EventListener/DataModelPropsSubscriber.php
@@ -13,11 +13,9 @@ namespace Symfony\UX\LiveComponent\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
-use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Util\LiveComponentStack;
 use Symfony\UX\LiveComponent\Util\ModelBindingParser;
-use Symfony\UX\TwigComponent\ComponentStack;
 use Symfony\UX\TwigComponent\Event\PreMountEvent;
-use Symfony\UX\TwigComponent\MountedComponent;
 
 /**
  * Parses the "data-model" key, which triggers extra props to be passed in.
@@ -33,7 +31,7 @@ final class DataModelPropsSubscriber implements EventSubscriberInterface
 {
     private ModelBindingParser $modelBindingParser;
 
-    public function __construct(private ComponentStack $componentStack, private PropertyAccessorInterface $propertyAccessor)
+    public function __construct(private LiveComponentStack $componentStack, private PropertyAccessorInterface $propertyAccessor)
     {
         $this->modelBindingParser = new ModelBindingParser();
     }
@@ -58,7 +56,7 @@ final class DataModelPropsSubscriber implements EventSubscriberInterface
 
         // find the first parent of the component about to be rendered that is a Live Component
         // only those can have properties controlled via the data-model attribute
-        $parentMountedComponent = $this->getCurrentLiveComponent($this->componentStack);
+        $parentMountedComponent = $this->componentStack->getCurrentLiveComponent();
         if (null === $parentMountedComponent) {
             throw new \LogicException('You can only pass "data-model" when rendering a component when you\'re rendering inside of a parent component.');
         }
@@ -78,21 +76,5 @@ final class DataModelPropsSubscriber implements EventSubscriberInterface
         return [
             PreMountEvent::class => 'onPreMount',
         ];
-    }
-
-    private function getCurrentLiveComponent(ComponentStack $componentStack): ?MountedComponent
-    {
-        foreach ($componentStack as $mountedComponent) {
-            if ($this->isLiveComponent($mountedComponent->getComponent()::class)) {
-                return $mountedComponent;
-            }
-        }
-
-        return null;
-    }
-
-    private function isLiveComponent(string $classname): bool
-    {
-        return [] !== (new \ReflectionClass($classname))->getAttributes(AsLiveComponent::class);
     }
 }

--- a/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
+++ b/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
@@ -16,8 +16,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\UX\LiveComponent\Twig\DeterministicTwigIdCalculator;
 use Symfony\UX\LiveComponent\Util\ChildComponentPartialRenderer;
+use Symfony\UX\LiveComponent\Util\LiveComponentStack;
 use Symfony\UX\LiveComponent\Util\LiveControllerAttributesCreator;
-use Symfony\UX\TwigComponent\ComponentStack;
 use Symfony\UX\TwigComponent\Event\PreCreateForRenderEvent;
 
 /**
@@ -34,7 +34,7 @@ class InterceptChildComponentRenderSubscriber implements EventSubscriberInterfac
     public const CHILDREN_FINGERPRINTS_METADATA_KEY = 'children_fingerprints';
 
     public function __construct(
-        private ComponentStack $componentStack,
+        private LiveComponentStack $componentStack,
         private ContainerInterface $container,
     ) {
     }
@@ -42,7 +42,7 @@ class InterceptChildComponentRenderSubscriber implements EventSubscriberInterfac
     public function preComponentCreated(PreCreateForRenderEvent $event): void
     {
         // if there is already a component, that's a parent. Else, this is not a child.
-        if (null === $parentComponent = $this->componentStack->getCurrentComponent()) {
+        if (null === $parentComponent = $this->componentStack->getCurrentLiveComponent()) {
             return;
         }
 

--- a/src/LiveComponent/src/Util/LiveComponentStack.php
+++ b/src/LiveComponent/src/Util/LiveComponentStack.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\UX\LiveComponent\Util;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\TwigComponent\ComponentStack;
+use Symfony\UX\TwigComponent\MountedComponent;
+
+/**
+ * This class decorates the TwigComponent\ComponentStack adding specific Live component functionalities.
+ *
+ * @author Bart Vanderstukken <bart.vanderstukken@gmail.com>
+ *
+ * @internal
+ */
+final class LiveComponentStack extends ComponentStack
+{
+    public function __construct(private readonly ComponentStack $componentStack)
+    {
+    }
+
+    public function getCurrentLiveComponent(): ?MountedComponent
+    {
+        foreach ($this->componentStack as $mountedComponent) {
+            if ($this->isLiveComponent($mountedComponent->getComponent()::class)) {
+                return $mountedComponent;
+            }
+        }
+
+        return null;
+    }
+
+    private function isLiveComponent(string $classname): bool
+    {
+        return [] !== (new \ReflectionClass($classname))->getAttributes(AsLiveComponent::class);
+    }
+
+    public function getCurrentComponent(): ?MountedComponent
+    {
+        return $this->componentStack->getCurrentComponent();
+    }
+
+    public function getParentComponent(): ?MountedComponent
+    {
+        return $this->componentStack->getParentComponent();
+    }
+
+    public function hasParentComponent(): bool
+    {
+        return $this->componentStack->hasParentComponent();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | 
| License       | MIT

This PR is related to the change of #1093.

### Problem
The component stack now also contains embedded Components until they are fully rendered, which is good. But, that also means that with this setup

```
{# someTemplate #}

<twig:aLiveComponent>
    <twig:aTwigComponent>
        <twig:anotherLiveComponent>
            {# ... #}
        </twig:anotherLiveComponent>
    </twig:aTwigComponent>
</twig:aLiveComponent>
```
when re-rendering the `anotherLiveComponent` the `InterceptChildComponentRenderSubscriber` would look at the parent component's `childrenFingerprints` to determine if it can short-circuit the rendering process for `anotherLiveComponent` and return an empty html element causing the FE to not do a callback to re-render it. However since that parent is a non-live component it will never short-circuit.

### Solution

Only take live components into account. 