### PR TITLE
[LiveComponent] Dependent Form Fields documentation

### DIFF
--- a/ux.symfony.com/src/Form/MealPlannerForm.php
+++ b/ux.symfony.com/src/Form/MealPlannerForm.php
@@ -53,7 +53,7 @@ class MealPlannerForm extends AbstractType
         /** @var ?MealPlan $data */
         $data = $event->getData();
 
-        $this->addFoodField($event->getForm(), $data?->getMeal());
+        $this->addFoodField($event->getForm(), $data?->getMeal(), $data?->getFood());
         $this->addPizzaSizeField($event->getForm(), $data?->getPizzaSize());
     }
 
@@ -83,10 +83,10 @@ class MealPlannerForm extends AbstractType
         );
     }
 
-    public function addFoodField(FormInterface $form, ?Meal $meal): void
+    public function addFoodField(FormInterface $form, ?Meal $meal, ?Food $food = null): void
     {
         $mainFood = $this->factory
-            ->createNamedBuilder('mainFood', EnumType::class, $meal, [
+            ->createNamedBuilder('mainFood', EnumType::class, $food, [
                 'class' => Food::class,
                 'placeholder' => null === $meal ? 'Select a meal first' : sprintf('What\'s for %s?', $meal->getReadable()),
                 'choices' => $meal?->getFoodChoices(),

--- a/ux.symfony.com/src/Form/MealPlannerForm.php
+++ b/ux.symfony.com/src/Form/MealPlannerForm.php
@@ -83,7 +83,7 @@ class MealPlannerForm extends AbstractType
         );
     }
 
-    public function addFoodField(FormInterface $form, ?Meal $meal, ?Food $food = null): void
+    public function addFoodField(FormInterface $form, ?Meal $meal, Food $food = null): void
     {
         $mainFood = $this->factory
             ->createNamedBuilder('mainFood', EnumType::class, $food, [

--- a/ux.symfony.com/src/Twig/MealPlanner.php
+++ b/ux.symfony.com/src/Twig/MealPlanner.php
@@ -15,8 +15,11 @@ class MealPlanner extends AbstractController
     use ComponentWithFormTrait;
     use DefaultActionTrait;
 
+    #[LiveProp(fieldName: 'formData')]
+    public ?MealPlan $mealPlan;
+
     protected function instantiateForm(): FormInterface
     {
-        return $this->createForm(MealPlannerForm::class);
+        return $this->createForm(MealPlannerForm::class, $this->mealPlan);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| License       | MIT

Hi, 

I followed the documentation and I had trouble using the same form when editing my object.

Since the third attributes `$data` of `createNamedBuilder()` is `@param mixed $data The initial data`,
should we not give him a Food instead of meal ?
Check my PR.

-----

In order to handle edition using the same form, I also edited the LiveComponent. 
With this, to call the component we need to pass attributes (but it's not on this page of the documentation).
```twig
{{ component('MealPlanner', {
    form: form,
    mealPlan: mealPlan.id ? mealPlan : null,
}) }}
```
Imho, this might be a good idea to add it to the documentation too (I found `mealPlan: mealPlan.id ? mealPlan : null` in an issue...)

Thanks