### PR TITLE
[Site] Avoid sass files from being exported publicly

### DIFF
--- a/ux.symfony.com/config/packages/asset_mapper.yaml
+++ b/ux.symfony.com/config/packages/asset_mapper.yaml
@@ -3,6 +3,9 @@ framework:
         # The paths to make available to the asset mapper.
         paths:
             - assets/
+        excluded_patterns:
+            - '*/assets/styles/_*.scss'
+            - '*/assets/styles/**/_*.scss'
 
 react:
     controllers_path: '%kernel.project_dir%/assets/build/react/controllers'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | None
| License       | MIT

This doesn't matter much for an OSS project anyway, but this prevents the `.scss` files from being exported to the `public/assets` directory on deploy. 

Cheers!
