### PR TITLE
[Live] array return on cache warmer

### DIFF
--- a/src/LiveComponent/src/Twig/TemplateCacheWarmer.php
+++ b/src/LiveComponent/src/Twig/TemplateCacheWarmer.php
@@ -26,7 +26,7 @@ final class TemplateCacheWarmer implements CacheWarmerInterface
     {
     }
 
-    public function warmUp(string $cacheDir): void
+    public function warmUp(string $cacheDir): array
     {
         $map = [];
         foreach ($this->templateIterator as $item) {
@@ -34,6 +34,8 @@ final class TemplateCacheWarmer implements CacheWarmerInterface
         }
 
         (new PhpArrayAdapter($cacheDir.'/'.$this->cacheFilename, new NullAdapter()))->warmUp(['map' => $map]);
+
+        return [];
     }
 
     public function isOptional(): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | None
| License       | MIT

`warmUp` has a documented array return type, which will become a true return type in Symfony 7.
