### PR TITLE
fix(live): fix testing events

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Component/Component2.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component2.php
@@ -14,6 +14,8 @@ namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveListener;
 use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -49,6 +51,18 @@ final class Component2
     public function redirect(UrlGeneratorInterface $urlGenerator): RedirectResponse
     {
         return new RedirectResponse($urlGenerator->generate('homepage'), 302, ['X-Custom-Header' => '1']);
+    }
+
+    #[LiveListener('triggerIncrease')]
+    public function increaseEvent1(#[LiveArg] int $amount = 1): void
+    {
+        $this->count += $amount;
+    }
+
+    #[LiveListener('triggerIncrease')]
+    public function increaseEvent2(#[LiveArg] int $amount = 1): void
+    {
+        $this->count += $amount;
     }
 
     #[PreDehydrate]

--- a/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
+++ b/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
@@ -63,6 +63,28 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertSame(33.3, $testComponent->component()->arg3);
     }
 
+    public function testCanEmitEvent(): void
+    {
+        $testComponent = $this->createLiveComponent('component2');
+
+        $this->assertStringContainsString('Count: 1', $testComponent->render());
+        $this->assertSame(1, $testComponent->component()->count);
+
+        $testComponent->emit('triggerIncrease', ['amount' => 2]);
+
+        $this->assertStringContainsString('Count: 5', $testComponent->render());
+        $this->assertSame(5, $testComponent->component()->count);
+    }
+
+    public function testInvalidEventName(): void
+    {
+        $testComponent = $this->createLiveComponent('component2');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $testComponent->emit('invalid');
+    }
+
     public function testCanSetLiveProp(): void
     {
         $testComponent = $this->createLiveComponent('component_with_writable_props');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #1110
| License       | MIT

When implementing #823, I made the wrong assumption that events were identical to actions. This fixes that.
