### PR TITLE
[LiveComponents] OnUpdate hook for LiveProp

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## ...
+## 2.12.0
 
 -   Add `onUpdated` hook for `LiveProp`
 

--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## ...
+
+-   Add `onUpdated` hook for `LiveProp`
+
 ## 2.11.0
 
 -   Add helper for testing live components.

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3070,9 +3070,9 @@ Add a Hook on LiveProp Update
 
     The ``onUpdated`` option was added in LiveComponents 2.12.
 
-If you want to run a custom code after a specific LiveProp was updated,
-you can do it by adding a ``onUpdated`` option. Specify a method name
-that will be called. The method should be public and created on the Component:
+If you want to run custom code after a specific LiveProp is updated,
+you can do it by adding an ``onUpdated`` option set to a public method name
+on the component:
 
 .. code-block:: diff
 
@@ -3098,8 +3098,8 @@ that will be called. The method should be public and created on the Component:
 As soon as the `query` LiveProp is updated, the ``onQueryUpdated()`` method
 will be called. The previous value is passed there as the first argument.
 
-It also works with non-scalar types, expand ``onUpdated`` configuration
-to an array with format ``['field_name' => 'function_name']``:
+If you're allowing object properties to be writable, you can also listen to
+the change of one specific key:
 
 .. code-block::
 
@@ -3108,34 +3108,12 @@ to an array with format ``['field_name' => 'function_name']``:
     #[AsLiveComponent]
     class EditPost
     {
-        #[LiveProp(writable: [LiveProp::IDENTITY, 'title', 'content'], onUpdated: ['title' => 'onTitleUpdated'])]
+        #[LiveProp(writable: ['title', 'content'], onUpdated: ['title' => 'onTitleUpdated'])]
         public Post $post;
 
         // ...
 
         public function onTitleUpdated($previousValue): void
-        {
-            // ...
-        }
-    }
-
-You can iterate more fields with corresponding function names if you want.
-Also, you can even create a hook for the entire entity identity change - use
-``LiveProp::IDENTITY`` as a key for the function name:
-
-.. code-block::
-
-    // ...
-
-    #[AsLiveComponent]
-    class EditPost
-    {
-        #[LiveProp(writable: [LiveProp::IDENTITY, 'title', 'content'], onUpdated: [LiveProp::IDENTITY => 'onEntirePostChanged'])]
-        public Post $post;
-
-        // ...
-
-        public function onEntirePostChanged($previousValue): void
         {
             // ...
         }

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3101,7 +3101,7 @@ will be called. The previous value is passed there as the first argument.
 It also works with non-scalar types, expand ``onUpdated`` configuration
 to an array with format ``['field_name' => 'function_name']``:
 
-.. code-block:: php
+.. code-block::
 
     // ...
 
@@ -3123,7 +3123,7 @@ You can iterate more fields with corresponding function names if you want.
 Also, you can even create a hook for the entire entity identity change - use
 ``LiveProp::IDENTITY`` as a key for the function name:
 
-.. code-block:: php
+.. code-block::
 
     // ...
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3063,6 +3063,84 @@ Then specify this new route on your component:
           use DefaultActionTrait;
       }
 
+Add a Hook on LiveProp Update
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.12
+
+    The ``onUpdated`` option was added in LiveComponents 2.12.
+
+If you want to run a custom code after a specific LiveProp was updated,
+you can do it by adding a ``onUpdated`` option. Specify a method name
+that will be called. The method should be public and created on the Component:
+
+.. code-block:: diff
+
+    // ...
+
+    #[AsLiveComponent]
+    class ProductSearch
+    {
+      - #[LiveProp(writable: true)]
+      + #[LiveProp(writable: true, onUpdated: 'onQueryUpdated')]
+        public string $query = '';
+
+        // ...
+
+        public function onQueryUpdated($previousValue): void
+        {
+            // $this->query already contains a new value
+            // and its previous value is passed as an argument
+        }
+    }
+}
+
+As soon as the `query` LiveProp is updated, the ``onQueryUpdated()`` method
+will be called. The previous value is passed there as the first argument.
+
+It also works with non-scalar types, expand ``onUpdated`` configuration
+to an array with format ``['field_name' => 'function_name']``:
+
+.. code-block:: php
+
+    // ...
+
+    #[AsLiveComponent]
+    class EditPost
+    {
+        #[LiveProp(writable: [LiveProp::IDENTITY, 'title', 'content'], onUpdated: ['title' => 'onTitleUpdated'])]
+        public Post $post;
+
+        // ...
+
+        public function onTitleUpdated($previousValue): void
+        {
+            // ...
+        }
+    }
+
+You can iterate more fields with corresponding function names if you want.
+Also, you can even create a hook for the entire entity identity change - use
+``LiveProp::IDENTITY`` as a key for the function name:
+
+.. code-block:: php
+
+    // ...
+
+    #[AsLiveComponent]
+    class EditPost
+    {
+        #[LiveProp(writable: [LiveProp::IDENTITY, 'title', 'content'], onUpdated: [LiveProp::IDENTITY => 'onEntirePostChanged'])]
+        public Post $post;
+
+        // ...
+
+        public function onEntirePostChanged($previousValue): void
+        {
+            // ...
+        }
+    }
+
 Test Helper
 -----------
 

--- a/src/LiveComponent/src/Attribute/LiveProp.php
+++ b/src/LiveComponent/src/Attribute/LiveProp.php
@@ -50,6 +50,15 @@ final class LiveProp
     private bool $acceptUpdatesFromParent;
 
     /**
+     * @var string|string[]|null
+     *
+     * A hook that will be called after the property is updated.
+     * Set it to a method name on the Live Component that should be called.
+     * The old value of the property will be passed as an argument to it.
+     */
+    private null|string|array $onUpdated;
+
+    /**
      * @param bool|array  $writable                  If true, this property can be changed by the frontend.
      *                                               Or set to an array of paths within this object/array
      *                                               that are writable.
@@ -73,7 +82,8 @@ final class LiveProp
         array $serializationContext = [],
         string $fieldName = null,
         string $format = null,
-        bool $updateFromParent = false
+        bool $updateFromParent = false,
+        string|array $onUpdated = null,
     ) {
         $this->writable = $writable;
         $this->hydrateWith = $hydrateWith;
@@ -83,6 +93,7 @@ final class LiveProp
         $this->fieldName = $fieldName;
         $this->format = $format;
         $this->acceptUpdatesFromParent = $updateFromParent;
+        $this->onUpdated = $onUpdated;
 
         if ($this->useSerializerForHydration && ($this->hydrateWith || $this->dehydrateWith)) {
             throw new \InvalidArgumentException('Cannot use useSerializerForHydration with hydrateWith or dehydrateWith.');
@@ -171,5 +182,10 @@ final class LiveProp
     public function acceptUpdatesFromParent(): bool
     {
         return $this->acceptUpdatesFromParent;
+    }
+
+    public function onUpdated(): null|string|array
+    {
+        return $this->onUpdated;
     }
 }

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -225,9 +225,7 @@ final class LiveComponentHydrator
                         $this->ensureOnUpdatedMethodExists($component, $funcName);
 
                         if (LiveProp::IDENTITY === $propName) {
-                            if ($dehydratedUpdatedProps->hasPropValue($frontendName)
-                                && $dehydratedOriginalProps->getPropValue($frontendName) !== $dehydratedUpdatedProps->getPropValue($frontendName)
-                            ) {
+                            if ($dehydratedUpdatedProps->hasPropValue($frontendName)) {
                                 $propertyOldValue = $this->hydrateValue(
                                     $dehydratedOriginalProps->getPropValue($frontendName),
                                     $propMetadata,

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -603,6 +603,6 @@ final class LiveComponentHydrator
             return;
         }
 
-        throw new \Exception(sprintf('Method "%s:%s()" specified as LiveProp "onUpdated" hook does not exist', $component::class, $methodName));
+        throw new \Exception(sprintf('Method "%s:%s()" specified as LiveProp "onUpdated" hook does not exist.', $component::class, $methodName));
     }
 }

--- a/src/LiveComponent/src/Metadata/LivePropMetadata.php
+++ b/src/LiveComponent/src/Metadata/LivePropMetadata.php
@@ -105,4 +105,9 @@ final class LivePropMetadata
     {
         return $this->liveProp->format();
     }
+
+    public function onUpdated(): null|string|array
+    {
+        return $this->liveProp->onUpdated();
+    }
 }

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -192,7 +192,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 });
         }];
 
-        yield 'onUpdated: with object value' => [function () {
+        yield 'onUpdated: set to an array' => [function () {
             $product = create(ProductFixtureEntity::class, [
                 'name' => 'Chicken',
             ])->object();

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -228,37 +228,6 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 });
         }];
 
-        yield 'onUpdated: with IDENTITY to null' => [function () {
-            $entity1 = create(Entity1::class)->object();
-            \assert($entity1 instanceof Entity1);
-
-            return HydrationTest::create(new class() {
-                #[LiveProp(writable: [LiveProp::IDENTITY], onUpdated: [LiveProp::IDENTITY => 'onEntireEntityUpdated'])]
-                public ?Entity1 $entity1;
-
-                public function onEntireEntityUpdated($oldValue)
-                {
-                    // Sanity check
-                    if ($this->entity1 === $oldValue) {
-                        throw new \Exception('Old value is the same entity?!');
-                    }
-                    if (null === $this->entity1) {
-                        // Revert the value
-                        $this->entity1 = $oldValue;
-                    }
-                }
-            })
-                ->mountWith(['entity1' => $entity1])
-                ->userUpdatesProps(['entity1' => null])
-                ->assertObjectAfterHydration(function (object $object) use ($entity1) {
-                    $this->assertNotNull($object->entity1);
-                    $this->assertSame(
-                        $entity1->id,
-                        $object->entity1->id
-                    );
-                });
-        }];
-
         yield 'string: (de)hydrates correctly' => [function () {
             return HydrationTest::create(new class() {
                 #[LiveProp()]

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -144,6 +144,140 @@ final class LiveComponentHydratorTest extends KernelTestCase
 
     public function provideDehydrationHydrationTests(): iterable
     {
+        yield 'onUpdated: exception if method not exists' => [function () {
+            return HydrationTest::create(new class() {
+                #[LiveProp(writable: true, onUpdated: 'onFirstNameUpdated')]
+                public string $firstName;
+            })
+                ->mountWith(['firstName' => 'Ryan'])
+                ->userUpdatesProps(['firstName' => 'Victor'])
+                ->expectsExceptionDuringHydration(\Exception::class, '/onFirstNameUpdated\(\)" specified as LiveProp "onUpdated" hook does not exist/');
+        }];
+
+        yield 'onUpdated: with string value' => [function () {
+            return HydrationTest::create(new class() {
+                #[LiveProp(writable: true, onUpdated: 'onFirstNameUpdated')]
+                public string $firstName;
+
+                public function onFirstNameUpdated($oldValue)
+                {
+                    if ('Victor' === $this->firstName) {
+                        $this->firstName = 'Revert to '.$oldValue;
+                    }
+                }
+            })
+                ->mountWith(['firstName' => 'Ryan'])
+                ->userUpdatesProps(['firstName' => 'Victor'])
+                ->assertObjectAfterHydration(function (object $object) {
+                    $this->assertSame('Revert to Ryan', $object->firstName);
+                });
+        }];
+
+        yield 'onUpdated: with integer value' => [function () {
+            return HydrationTest::create(new class() {
+                #[LiveProp(writable: true, onUpdated: 'onNumberUpdated')]
+                public int $number;
+
+                public function onNumberUpdated($oldValue)
+                {
+                    if (9 === $this->number) {
+                        $this->number = $oldValue;
+                    }
+                }
+            })
+                ->mountWith(['number' => 10])
+                ->userUpdatesProps(['number' => 9])
+                ->assertObjectAfterHydration(function (object $object) {
+                    $this->assertSame(10, $object->number);
+                });
+        }];
+
+        yield 'onUpdated: with object value' => [function () {
+            $product = create(ProductFixtureEntity::class, [
+                'name' => 'Chicken',
+            ])->object();
+
+            return HydrationTest::create(new class() {
+                #[LiveProp(writable: ['name'], onUpdated: ['name' => 'onNameUpdated'])]
+                public ProductFixtureEntity $product;
+
+                public function onNameUpdated($oldValue)
+                {
+                    if ('Rabbit' === $this->product->name) {
+                        $this->product->name = 'Revert to '.$oldValue;
+                    }
+                }
+            })
+                ->mountWith(['product' => $product])
+                ->userUpdatesProps(['product.name' => 'Rabbit'])
+                ->assertObjectAfterHydration(function (object $object) {
+                    $this->assertSame('Revert to Chicken', $object->product->name);
+                });
+        }];
+
+        yield 'onUpdated: with IDENTITY' => [function () {
+            $entityOriginal = create(Entity1::class)->object();
+            $entityNext = create(Entity1::class)->object();
+            \assert($entityOriginal instanceof Entity1);
+            \assert($entityNext instanceof Entity1);
+
+            return HydrationTest::create(new class() {
+                #[LiveProp(writable: [LiveProp::IDENTITY], onUpdated: [LiveProp::IDENTITY => 'onEntireEntityUpdated'])]
+                public Entity1 $entity1;
+
+                public function onEntireEntityUpdated($oldValue)
+                {
+                    // Sanity check
+                    if ($this->entity1 === $oldValue) {
+                        throw new \Exception('Old value is the same entity?!');
+                    }
+                    if (2 === $this->entity1->id) {
+                        // Revert the value
+                        $this->entity1 = $oldValue;
+                    }
+                }
+            })
+                ->mountWith(['entity1' => $entityOriginal])
+                ->userUpdatesProps(['entity1' => $entityNext->id])
+                ->assertObjectAfterHydration(function (object $object) use ($entityOriginal) {
+                    $this->assertSame(
+                        $entityOriginal->id,
+                        $object->entity1->id
+                    );
+                });
+        }];
+
+        yield 'onUpdated: with IDENTITY to null' => [function () {
+            $entity1 = create(Entity1::class)->object();
+            \assert($entity1 instanceof Entity1);
+
+            return HydrationTest::create(new class() {
+                #[LiveProp(writable: [LiveProp::IDENTITY], onUpdated: [LiveProp::IDENTITY => 'onEntireEntityUpdated'])]
+                public ?Entity1 $entity1;
+
+                public function onEntireEntityUpdated($oldValue)
+                {
+                    // Sanity check
+                    if ($this->entity1 === $oldValue) {
+                        throw new \Exception('Old value is the same entity?!');
+                    }
+                    if (null === $this->entity1) {
+                        // Revert the value
+                        $this->entity1 = $oldValue;
+                    }
+                }
+            })
+                ->mountWith(['entity1' => $entity1])
+                ->userUpdatesProps(['entity1' => null])
+                ->assertObjectAfterHydration(function (object $object) use ($entity1) {
+                    $this->assertNotNull($object->entity1);
+                    $this->assertSame(
+                        $entity1->id,
+                        $object->entity1->id
+                    );
+                });
+        }];
+
         yield 'string: (de)hydrates correctly' => [function () {
             return HydrationTest::create(new class() {
                 #[LiveProp()]

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -154,7 +154,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 ->expectsExceptionDuringHydration(\Exception::class, '/onFirstNameUpdated\(\)" specified as LiveProp "onUpdated" hook does not exist/');
         }];
 
-        yield 'onUpdated: with string value' => [function () {
+        yield 'onUpdated: with scalar value' => [function () {
             return HydrationTest::create(new class() {
                 #[LiveProp(writable: true, onUpdated: 'onFirstNameUpdated')]
                 public string $firstName;
@@ -170,25 +170,6 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 ->userUpdatesProps(['firstName' => 'Victor'])
                 ->assertObjectAfterHydration(function (object $object) {
                     $this->assertSame('Revert to Ryan', $object->firstName);
-                });
-        }];
-
-        yield 'onUpdated: with integer value' => [function () {
-            return HydrationTest::create(new class() {
-                #[LiveProp(writable: true, onUpdated: 'onNumberUpdated')]
-                public int $number;
-
-                public function onNumberUpdated($oldValue)
-                {
-                    if (9 === $this->number) {
-                        $this->number = $oldValue;
-                    }
-                }
-            })
-                ->mountWith(['number' => 10])
-                ->userUpdatesProps(['number' => 9])
-                ->assertObjectAfterHydration(function (object $object) {
-                    $this->assertSame(10, $object->number);
                 });
         }];
 

--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -291,7 +291,7 @@ class Kernel extends BaseKernel
                 if (!$artist) {
                     throw new NotFoundHttpException();
                 }
-                $artist->name = $artist->name.' after change';
+                $artist->name .= ' after change';
 
                 $doctrine->flush();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->

Feature allows to add a hook on LiveProp changed, providing the "previous value" for convenience:

```php
    #[LiveProp(writable: true, onUpdated: 'onTitleUpdated')]
    public string $title = 'Test';

    #[LiveProp(writable: ['customerName', 'customerEmail', 'taxRate'], onUpdated: ['customerName' => 'onCustomerNameUpdated'])]
    public Invoice $invoice;

    #[LiveProp(writable: LiveProp::IDENTITY, onUpdated: [LiveProp::IDENTITY => 'onEntireInvoiceChange'])]
    public Invoice $invoice;

    public function onTitleUpdated($oldValue)
    {
        // ...
    }

    public function onCustomerNameUpdated($oldValue)
    {
        // ...
    }

    public function onEntireInvoiceChange($oldValue)
    {
        // ...
    }
```