### PR TITLE
[Live] add `TestLiveComponent::actingAs()`

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3123,6 +3123,20 @@ uses Symfony's test client to render and make requests to your components::
             $response = $testComponent->call('redirect')->response(); // Symfony\Component\HttpFoundation\Response
 
             $this->assertSame(302, $response->getStatusCode());
+
+            // authenticate a user ($user is instance of UserInterface)
+            $testComponent->actingAs($user);
+
+            // customize the test client
+            $client = self::getContainer()->get('test.client');
+
+            // do some stuff with the client (ie login user via form)
+
+            $testComponent = $this->createLiveComponent(
+                name: 'MyComponent',
+                data: ['foo' => 'bar'],
+                client: $client,
+            );
         }
     }
 

--- a/src/LiveComponent/src/Test/InteractsWithLiveComponents.php
+++ b/src/LiveComponent/src/Test/InteractsWithLiveComponents.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\LiveComponent\Test;
 
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\TwigComponent\ComponentFactory;
 
@@ -19,7 +20,7 @@ use Symfony\UX\TwigComponent\ComponentFactory;
  */
 trait InteractsWithLiveComponents
 {
-    protected function createLiveComponent(string $name, array $data = []): TestLiveComponent
+    protected function createLiveComponent(string $name, array $data = [], KernelBrowser $client = null): TestLiveComponent
     {
         if (!$this instanceof KernelTestCase) {
             throw new \LogicException(sprintf('The "%s" trait can only be used on "%s" classes.', __TRAIT__, KernelTestCase::class));
@@ -37,7 +38,7 @@ trait InteractsWithLiveComponents
             $metadata,
             $data,
             $factory,
-            self::getContainer()->get('test.client'),
+            $client ?? self::getContainer()->get('test.client'),
             self::getContainer()->get('ux.live_component.component_hydrator'),
             self::getContainer()->get('ux.live_component.metadata_factory'),
             self::getContainer()->get('router'),

--- a/src/LiveComponent/src/Test/TestLiveComponent.php
+++ b/src/LiveComponent/src/Test/TestLiveComponent.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\LiveComponent\Test;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadataFactory;
 use Symfony\UX\TwigComponent\ComponentFactory;
@@ -74,6 +75,16 @@ final class TestLiveComponent
         );
 
         return (new MountedComponent($this->metadata->getName(), $component, $componentAttributes))->getComponent();
+    }
+
+    /**
+     * @param UserInterface $user
+     */
+    public function actingAs(object $user, string $firewallContext = 'main'): self
+    {
+        $this->client->loginUser($user, $firewallContext);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | (slack discussion)
| License       | MIT

```php
$this->createLiveComponent('my_component')
    ->actingAs($user) // UserInterface
    ->...
;
```

Additionally, the test client can be passed to `InteractsWithLiveComponents::createLiveComponent()`:

```php
// customize the test client
$client = self::getContainer()->get('test.client');

// do some stuff with the client (ie login user via form)

$testComponent = $this->createLiveComponent(
    name: 'MyComponent',
    data: ['foo' => 'bar'],
    client: $client,
);
```
