### PR TITLE
[TwigComponent] Remove undefined var $name in ComponentExtension

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -82,11 +82,7 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
 
     public function finishEmbeddedComponentRender(): void
     {
-        try {
-            $this->container->get(ComponentRenderer::class)->finishEmbeddedComponentRender();
-        } catch (\Throwable $e) {
-            $this->throwRuntimeError($name, $e);
-        }
+        $this->container->get(ComponentRenderer::class)->finishEmbeddedComponentRender();
     }
 
     private function throwRuntimeError(string $name, \Throwable $e): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #1115 
| License       | MIT

Implement the solution suggested by @kbond  here:  https://github.com/symfony/ux/issues/1115#issuecomment-1719726445 
