### PR TITLE
[TwigComponent] Remove 3 futures deprecations (minor)

### DIFF
--- a/src/TwigComponent/tests/Fixtures/Kernel.php
+++ b/src/TwigComponent/tests/Fixtures/Kernel.php
@@ -35,13 +35,19 @@ final class Kernel extends BaseKernel
 
     protected function configureContainer(ContainerConfigurator $c): void
     {
-        $c->extension('framework', [
+        $frameworkConfig = [
             'secret' => 'S3CRET',
             'test' => true,
             'router' => ['utf8' => true],
             'secrets' => false,
             'http_method_override' => false,
-        ]);
+            'php_errors' => ['log' => true],
+        ];
+        if (self::VERSION_ID >= 60200) {
+            $frameworkConfig['handle_all_throwables'] = true;
+        }
+        $c->extension('framework', $frameworkConfig);
+
         $c->extension('twig', [
             'default_path' => '%kernel.project_dir%/tests/Fixtures/templates',
         ]);

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -25,7 +25,7 @@ final class TwigPreLexerTest extends TestCase
         $this->assertSame($expectedOutput, $lexer->preLexComponents($input));
     }
 
-    public function getLexTests(): iterable
+    public static function getLexTests(): iterable
     {
         yield 'simple_component' => [
             '<twig:foo />',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| License       | MIT

Fix deprecations

Framework
```
1x: Since symfony/framework-bundle 6.4: Not setting the "framework.handle_all_throwables" config option is deprecated. It will default to "true" in 7.0.
1x in ComponentFactoryTest::testTwigComponentServiceTagWithoutKeyButCollissionCausesAnException from Symfony\UX\TwigComponent\Tests\Integration

1x: Since symfony/framework-bundle 6.4: Not setting the "framework.php_errors.log" config option is deprecated. It will default to "true" in 7.0.
1x in ComponentFactoryTest::testTwigComponentServiceTagWithoutKeyButCollissionCausesAnException from Symfony\UX\TwigComponent\Tests\Integration
```

PHPUnit
```
1) Symfony\UX\TwigComponent\Tests\Unit\TwigPreLexerTest::testPreLex
Data Provider method Symfony\UX\TwigComponent\Tests\Unit\TwigPreLexerTest::getLexTests() is not static
```
