### PR TITLE
[Site] Use `system-ui` font family

### DIFF
--- a/ux.symfony.com/assets/styles/app/_html.scss
+++ b/ux.symfony.com/assets/styles/app/_html.scss
@@ -1,5 +1,5 @@
 body {
-  font-family: Inter;
+  font-family: var(--font-family-text);
   font-size: 16px;
   font-weight: 400;
   line-height: 26px;

--- a/ux.symfony.com/assets/styles/app/_root.scss
+++ b/ux.symfony.com/assets/styles/app/_root.scss
@@ -14,9 +14,7 @@
   --space-larger: 2rem;
 
   // Fonts
-  //  --font-family-title: "Inter";
-  --font-family-text: "Inter";
-  // --font-family-code: "Inter";
+  --font-family-text: system-ui, sans-serif;
 
   // Colors
   --color-primary: var(--bs-body-color);

--- a/ux.symfony.com/assets/styles/app/_typography.scss
+++ b/ux.symfony.com/assets/styles/app/_typography.scss
@@ -5,14 +5,6 @@ h1 {
   letter-spacing: -0.035em;
 }
 
-h1.inter {
-  font-family: Inter;
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 26px;
-  letter-spacing: 0px;
-}
-
 h1.ubuntu {
   line-height: 60px;
 }
@@ -89,7 +81,7 @@ h4.ubuntu {
 
 .eyebrows {
   text-transform: uppercase;
-  font-family: Inter;
+  font-family: var(--font-family-text);
   font-size: 0.7rem;
   font-weight: 600;
   line-height: 1.6;

--- a/ux.symfony.com/assets/styles/utilities/_info-tooltips.scss
+++ b/ux.symfony.com/assets/styles/utilities/_info-tooltips.scss
@@ -1,5 +1,5 @@
 .info-tooltips {
-  font-family: Inter;
+  font-family: var(--font-family-text);
   font-size: 12px;
   font-weight: 400;
   line-height: 19px;

--- a/ux.symfony.com/templates/base.html.twig
+++ b/ux.symfony.com/templates/base.html.twig
@@ -12,7 +12,7 @@
         <meta name="color-scheme" content="light dark">
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         {% block stylesheets %}
-            <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter:200,400,600|Playfair+Display:400,700i|Space+Mono|Ubuntu:400,700&display=swap">
+            <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Playfair+Display:400,700i|Space+Mono|Ubuntu:400,700&display=swap">
             {{ ux_controller_link_tags() }}
             <link rel="stylesheet" href="{{ asset('styles/app.scss') }}">
         {% endblock %}


### PR DESCRIPTION
### TL;DR;

I suggest we use "system-ui" (native/OS font) instead of "Inter" on the website.

--- 

### What ? 
* System font are the default font used in every OS 
* They can be used instead of webfont .. and are excellent fonts.
* This article is a great overview on system fonts: https://woorkup.com/system-font/ 
* Already used by Github, bootstrap, web.dev, apple, Stripe, and many more

### Why ? 
* better web performance (good for seo, greater for accessibility & UX)
* less bandwidth used (good for 💰, greater for 🌍)
* the system fonts will allow us more things than Inter 
* Allow the user to get the standard font used in the OS

### How does it look ?

The difference is subtile... at least. 
And i'm pretty sure only a very, very low part of the visitors will notice the difference.

### Test it

I made some captures for you to see the "before/after" on our main pages.. 
They are available on a page if you want to test yourself the slider and see the differences
-> https://smnand.re/w/ab4e91/ 

| All demos | Invoice demo |
| - | - |
| ![all-demos](https://github.com/symfony/ux/assets/1359581/4151f2ac-e094-4b7c-9729-6c2437cf9a1b) | ![demo-invoice](https://github.com/symfony/ux/assets/1359581/bf6e84f8-289d-4008-856b-51d7f954da53) |

| [Test it yourself (external link)](https://smnand.re/w/ab4e91/) | 
| - | 
| ![comparaison-tool](https://github.com/symfony/ux/assets/1359581/3370b32d-fe8b-4758-a895-364bdfe24d08) |












