### PR TITLE
[Site] Use monospace system font

### DIFF
--- a/ux.symfony.com/assets/styles/_variables.scss
+++ b/ux.symfony.com/assets/styles/_variables.scss
@@ -16,3 +16,5 @@ $green: #84DE2C;
 $primary: #222 !default;
 
 $size-unit: calc(8px + 1.5625vw);
+
+$font-family-monospace: var(--font-family-code);

--- a/ux.symfony.com/assets/styles/app/_root.scss
+++ b/ux.symfony.com/assets/styles/app/_root.scss
@@ -14,7 +14,9 @@
   --space-larger: 2rem;
 
   // Fonts
+  //  --font-family-title: "Ubuntu";
   --font-family-text: system-ui, sans-serif;
+  --font-family-code: ui-monospace, "SF Mono", SFMono-Regular, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 
   // Colors
   --color-primary: var(--bs-body-color);

--- a/ux.symfony.com/assets/styles/components/_Terminal.scss
+++ b/ux.symfony.com/assets/styles/components/_Terminal.scss
@@ -76,7 +76,7 @@
 .Terminal_body {
     background-color: $n-800;
     height: 100%;
-    font-family: 'Space Mono', monospace;
+    font-family: var(--font-family-code);
     font-size: 14px;
     line-height: 160%;
     color: #FFF;

--- a/ux.symfony.com/assets/styles/components/_TerminalCommand.scss
+++ b/ux.symfony.com/assets/styles/components/_TerminalCommand.scss
@@ -34,7 +34,7 @@
   background: transparent;
   z-index: 4;
   outline: none;
-  font-family: var(--bs-font-monospace);
+  font-family: var(--font-family-code);
   font-size: .9rem;
   padding: 0 .5rem;
   width: inherit;

--- a/ux.symfony.com/templates/base.html.twig
+++ b/ux.symfony.com/templates/base.html.twig
@@ -12,7 +12,7 @@
         <meta name="color-scheme" content="light dark">
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         {% block stylesheets %}
-            <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Playfair+Display:400,700i|Space+Mono|Ubuntu:400,700&display=swap">
+            <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Playfair+Display:400,700i|Ubuntu:400,700&display=swap">
             {{ ux_controller_link_tags() }}
             <link rel="stylesheet" href="{{ asset('styles/app.scss') }}">
         {% endblock %}


### PR DESCRIPTION
TL;DR; i suggest to use native system fonts instead of webfont.

Follow https://github.com/symfony/ux/pull/1119, this time for the `monospace` font, with the same reasons.

Again, I put online some before/after captures*  with a slider tool to compare.
(* made on macOS Ventura / Firefox)

Captures here: https://smnand.re/w/b68eda/ 

<img width="1565" alt="slider-comparaison" src="https://github.com/symfony/ux/assets/1359581/c1fd99cd-bc38-4279-9e5f-46f175903d0b">

I made two separate PR because developpers tend to be a little more sensible about code fonts :) 
