### PR TITLE
[CI] Fix deprecations

### DIFF
--- a/.github/workflows/doctor-rst.yaml
+++ b/.github/workflows/doctor-rst.yaml
@@ -16,7 +16,7 @@ jobs:
               run: mkdir .cache
 
             - name: Extract base branch name
-              run: echo "##[set-output name=branch;]$(echo ${GITHUB_BASE_REF:=${GITHUB_REF##*/}})"
+              run: echo "branch=$(echo ${GITHUB_BASE_REF:=${GITHUB_REF##*/}})" >> $GITHUB_OUTPUT
               id: extract_base_branch
 
             - name: Cache DOCtor-RST

--- a/.github/workflows/test-turbo.yml
+++ b/.github/workflows/test-turbo.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -52,7 +52,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -69,7 +69,7 @@ jobs:
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                   path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     coding-style-php:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v3
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.1'
@@ -20,11 +20,11 @@ jobs:
         name: JavaScript Coding Style
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v3
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                   path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -39,11 +39,11 @@ jobs:
         name: Check for UnBuilt JS Dist Files
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v3
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                   path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -124,11 +124,11 @@ jobs:
     tests-js:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v3
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                   path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -291,7 +291,7 @@ class Kernel extends BaseKernel
                 if (!$artist) {
                     throw new NotFoundHttpException();
                 }
-                $artist->name = $artist->name.' after change';
+                $artist->name .= ' after change';
 
                 $doctrine->flush();
             }


### PR DESCRIPTION
Fix multiple deprecations in CI workflows.


### [doctor-rst.yaml](https://github.com/symfony/ux/actions/workflows/doctor-rst.yaml)

```
DOCtor-RST
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. [...]
```


### [test.yaml](https://github.com/symfony/ux/actions/runs/6209833130/workflow)

Note: ~~the failing php-cs-fixer test is unrelated (cause: new rule in php-cs-fixer)~~
Update: fixed the cs problem, another CI bug appears... not sure if random (does not seem related at all)

```
JavaScript Coding Style
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/cache@v2. [...]
```

```
Check for UnBuilt JS Dist Files
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/cache@v2 [...]
```

```
tests-js
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/cache@v2. [...]
```

### [test_turbo.yaml](https://github.com/symfony/ux/actions/runs/6209833129)

```
phpstan
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. [...]
```

```
tests (8.1, highest)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. [...]
```

```
tests (8.1, lowest)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. [...]
```



