### PR TITLE
[TogglePasswordComponent] Update documentation example for usage without Symfony Forms

### DIFF
--- a/src/TogglePassword/doc/index.rst
+++ b/src/TogglePassword/doc/index.rst
@@ -275,6 +275,10 @@ You can also use the TogglePassword with native HTML inputs:
             name="password"
             type="password"
             {{ stimulus_controller('symfony/ux-toggle-password/toggle-password', {
+                    {# visibleLabel: 'Show password', // If you want to modify this label. #}
+                    {# visibleIcon: 'Some svg icon', // If you want to modify this icon. #}
+                    {# hiddenLabel: 'Hide password', // If you want to modify this label. #}
+                    {# hiddenIcon: 'Some svg icon', // If you want to modify this icon. #}
                     buttonClasses: ['toggle-password-button'], // Add as many classes as you wish. "toggle-password-button" is needed to activate the default CSS.
             }) }}
         >


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Tickets       | n/a
| License       | MIT

Update the example to use the component without Symfony Forms
before : 
```html
    <div class="toggle-password-container"> // Add "toggle-password-container" or a class that applies position: relative to this container.
        <label for="password">Password</label>
        <input
            id="password"
            name="password"
            type="password"
            {{ stimulus_controller('symfony/ux-toggle-password/toggle-password', {
                    buttonClasses: ['toggle-password-button'], // Add as many classes as you wish. "toggle-password-button" is needed to activate the default CSS.
            }) }}
        >
    </div>
```

after:
```html
    <div class="toggle-password-container"> // Add "toggle-password-container" or a class that applies position: relative to this container.
        <label for="password">Password</label>
        <input
            id="password"
            name="password"
            type="password"
            {{ stimulus_controller('symfony/ux-toggle-password/toggle-password', {
                    {# visibleLabel: 'Show password', // If you want to modify this label. #}
                    {# visibleIcon: 'Some svg icon', // If you want to modify this icon. #}
                    {# hiddenLabel: 'Hide password', // If you want to modify this label. #}
                    {# hiddenIcon: 'Some svg icon', // If you want to modify this icon. #}
                    buttonClasses: ['toggle-password-button'], // Add as many classes as you wish. "toggle-password-button" is needed to activate the default CSS.
            }) }}
        >
    </div>
```
