### PR TITLE
[LiveComponent] Workaround for bad behavior with Chrome's translation feature

### DIFF
--- a/src/LiveComponent/assets/dist/Rendering/ExternalMutationTracker.d.ts
+++ b/src/LiveComponent/assets/dist/Rendering/ExternalMutationTracker.d.ts
@@ -22,4 +22,5 @@ export default class {
     private handleStyleAttributeMutation;
     private handleGenericAttributeMutation;
     private extractStyles;
+    private isElementAddedByTranslation;
 }

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1565,6 +1565,9 @@ class ExternalMutationTracker {
             if (!this.shouldTrackChangeCallback(element)) {
                 continue;
             }
+            if (this.isElementAddedByTranslation(element)) {
+                continue;
+            }
             let isChangeInAddedElement = false;
             for (const addedElement of this.addedElements) {
                 if (addedElement.contains(element)) {
@@ -1601,6 +1604,9 @@ class ExternalMutationTracker {
             }
             if (this.removedElements.includes(node)) {
                 this.removedElements.splice(this.removedElements.indexOf(node), 1);
+                return;
+            }
+            if (this.isElementAddedByTranslation(node)) {
                 return;
             }
             this.addedElements.push(node);
@@ -1710,6 +1716,9 @@ class ExternalMutationTracker {
             styleObject[property] = parts.slice(1).join(':').trim();
         });
         return styleObject;
+    }
+    isElementAddedByTranslation(element) {
+        return element.tagName === 'FONT' && element.getAttribute('style') === 'vertical-align: inherit;';
     }
 }
 

--- a/src/LiveComponent/assets/src/Rendering/ExternalMutationTracker.ts
+++ b/src/LiveComponent/assets/src/Rendering/ExternalMutationTracker.ts
@@ -75,6 +75,10 @@ export default class {
                 continue;
             }
 
+            if (this.isElementAddedByTranslation(element)) {
+                continue;
+            }
+
             // ignore changes in elements that were externally-added
             let isChangeInAddedElement = false;
             for (const addedElement of this.addedElements) {
@@ -130,6 +134,10 @@ export default class {
                 // this node was removed then added back, so no net change
                 this.removedElements.splice(this.removedElements.indexOf(node), 1);
 
+                return;
+            }
+
+            if (this.isElementAddedByTranslation(node)) {
                 return;
             }
 
@@ -292,5 +300,17 @@ export default class {
         });
 
         return styleObject;
+    }
+
+    /**
+     * Helps avoid tracking changes by Chrome's translation feature.
+     *
+     * When Chrome translates, it mutates the dom in a way that triggers MutationObserver.
+     * This includes adding new elements wrapped in a <font> tag. This causes live
+     * components to incorrectly think that these new elements should persist through
+     * re-renders, causing duplicate text.
+     */
+    private isElementAddedByTranslation(element: Element): boolean {
+        return element.tagName === 'FONT' && element.getAttribute('style') === 'vertical-align: inherit;'
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #1120
| License       | MIT

A bit of a hack, but works nicely locally. As @smnandre mentioned, Firefox and Safari are already ok, as they modify the page without triggering the MutationObserver or adding any ugly `font` tags ;).

Cheers!