### PR TITLE
Avoiding double-wrapping of Twig RuntimeError

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -87,9 +87,15 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
 
     private function throwRuntimeError(string $name, \Throwable $e): void
     {
+        // if it's already a Twig RuntimeError, just rethrow it
+        if ($e instanceof RuntimeError) {
+            throw $e;
+        }
+
         if (!($e instanceof \Exception)) {
             $e = new \Exception($e->getMessage(), $e->getCode(), $e->getPrevious());
         }
+
         throw new RuntimeError(sprintf('Error rendering "%s" component: %s', $name, $e->getMessage()), previous: $e);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Tickets       | None
| License       | MIT

I had noticed that, when making a typo in my Twig file, the true error was hidden inside a nested exception.

**Before (left top of page, right, further down the page)**
<img width="400" alt="Screenshot 2023-09-22 at 8 21 05 AM" src="https://github.com/symfony/ux/assets/121003/5f17b58e-a9fe-40e9-a85b-90aadec5b1cd"><img width="400" alt="Screenshot 2023-09-22 at 8 21 16 AM" src="https://github.com/symfony/ux/assets/121003/e5d38f99-adca-44a6-b845-276348623da4">

**After**

<img width="400" alt="Screenshot 2023-09-22 at 8 18 24 AM" src="https://github.com/symfony/ux/assets/121003/ad18117f-1b78-4fdc-80e3-d1550859ebf6">

So, you see the exact error now. You lose that the error happened when rendering the `InvoiceCreator` component, but I think that's not important. And you can find that actually if you look up the stacktrace a bit.

Btw, the reason we want to throw a `RuntimeError` from Twig is if, when rendering, if you have an error in your PHP code (not template), it makes it look nicer. Without wrapping your PHP error in a `RuntimeError`, you get:

> An exception has been thrown during the rendering of a template ("AHhhh").

After, it is:

> Error rendering "Icon" component: AHhhh

So the `RuntimeError` is 👍 ... but we don't need to create a 2nd one if we already have one.

Cheers!