### PR TITLE
[TwigComponent] Support for SubDirectory-named components via namespace config

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -83,18 +83,40 @@ final class Kernel extends BaseKernel
 
     protected function configureContainer(ContainerConfigurator $c): void
     {
-        $c->extension('framework', [
+        $frameworkConfig = [
             'secret' => 'S3CRET',
             'test' => true,
             'router' => ['utf8' => true],
             'secrets' => false,
-            'session' => ['storage_factory_id' => 'session.storage.factory.mock_file'],
+            'session' => [
+                'storage_factory_id' => 'session.storage.factory.mock_file',
+                'handler_id' => null,
+                'cookie_secure' => 'auto',
+                'cookie_samesite' => 'lax',
+            ],
+            'validation' => [
+                'email_validation_mode' => 'html5',
+            ],
+            'php_errors' => [
+                'log' => false,
+            ],
             'http_method_override' => false,
             'property_info' => ['enabled' => true],
-        ]);
+        ];
+        if (self::VERSION_ID >= 60200) {
+            $frameworkConfig['handle_all_throwables'] = true;
+        }
+
+        $c->extension('framework', $frameworkConfig);
 
         $c->extension('twig', [
             'default_path' => '%kernel.project_dir%/tests/Fixtures/templates',
+        ]);
+
+        $c->extension('twig_component', [
+            'defaults' => [
+                'Symfony\UX\LiveComponent\Tests\Fixtures\Component\\' => 'components/',
+            ],
         ]);
 
         $c->extension('zenstruck_foundry', [

--- a/src/LiveComponent/tests/Fixtures/Serializer/Entity2Normalizer.php
+++ b/src/LiveComponent/tests/Fixtures/Serializer/Entity2Normalizer.php
@@ -25,24 +25,24 @@ final class Entity2Normalizer implements NormalizerInterface, DenormalizerInterf
     {
     }
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
         [, $id] = \explode(':', $data);
 
         return $this->doctrine->getRepository(Entity2::class)->find($id);
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = [])
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return Entity2::class === $type;
     }
 
-    public function normalize(mixed $object, string $format = null, array $context = [])
+    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return 'entity2:'.$object->id;
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = [])
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof Entity2;
     }

--- a/src/LiveComponent/tests/Fixtures/Serializer/MoneyNormalizer.php
+++ b/src/LiveComponent/tests/Fixtures/Serializer/MoneyNormalizer.php
@@ -17,22 +17,22 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Money;
 
 final class MoneyNormalizer implements NormalizerInterface, DenormalizerInterface
 {
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
         return new Money(...\explode('|', $data));
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = [])
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return Money::class === $type;
     }
 
-    public function normalize(mixed $object, string $format = null, array $context = [])
+    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return \implode('|', [$object->amount, $object->currency]);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = [])
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof Money;
     }

--- a/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
+++ b/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
@@ -32,8 +32,7 @@ final class StimulusExtension extends Extension implements PrependExtensionInter
         $loader = new Loader\PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
         $loader->load('services.php');
 
-        $configuration = $this->getConfiguration($configs, $container);
-        $config = $this->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($this, $configs);
 
         $container->findDefinition('stimulus.asset_mapper.controllers_map_generator')
             ->replaceArgument(2, $config['controller_paths'])
@@ -62,11 +61,6 @@ final class StimulusExtension extends Extension implements PrependExtensionInter
                 ],
             ],
         ]);
-    }
-
-    public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface
-    {
-        return $this;
     }
 
     public function getConfigTreeBuilder(): TreeBuilder

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1204,6 +1204,44 @@ independently. If you're using `Live Components`_, then there
 *are* some guidelines related to how the re-rendering of parent and
 child components works. Read `Live Nested Components`_.
 
+Configuration
+-------------
+
+To see the full list of configuration options, run:
+
+.. code-block:: terminal
+
+    $ php bin/console config:dump twig_component
+
+The most important configuration is the ``defaults`` key, which allows
+you to define options for different namespaces of your components. This
+controls how components are named and where their templates live:
+
+.. code-block:: yaml
+
+    # config/packages/twig_component.yaml
+    twig_component:
+        defaults:
+            # short form: components under this namespace:
+            #    - name will be the class name that comes after the prefix
+            #        App\Twig\Components\Alert => Alert
+            #        App\Twig\Components\Button\Primary => Button:Primary
+            #    - templates will live in "components/"
+            #        Alert => templates/components/Alert.html.twig
+            #        Button:Primary => templates/components/Button/Primary.html.twig
+            App\Twig\Components: components/
+
+            # long form
+            App\Pizza\Components:
+                template_directory: components/pizza
+                # component names will have an extra "Pizza:" prefix
+                #    App\Pizza\Components\Alert => Pizza:Alert
+                #    App\Pizza\Components\Button\Primary => Pizza:Button:Primary
+                name_prefix: Pizza
+
+If a component class matches multiple namespaces, the first matched will
+be used.
+
 Debugging Components
 --------------------
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -7,8 +7,8 @@ making it easier to render and re-use small template "units" - like an
 
 Every component consists of (1) a class::
 
-    // src/Components/Alert.php
-    namespace App\Components;
+    // src/Twig/Components/Alert.php
+    namespace App\Twig\Components;
 
     use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -19,7 +19,7 @@ Every component consists of (1) a class::
         public string $message;
     }
 
-And (2) a corresponding template:
+And (2) a template:
 
 .. code-block:: html+twig
 
@@ -33,6 +33,8 @@ Done! Now render it wherever you want:
 .. code-block:: twig
 
     {{ component('Alert', { message: 'Hello Twig Components!' }) }}
+
+    <twig:Alert message="Or use the fun HTML syntax!" />
 
 Enjoy your new component!
 
@@ -56,18 +58,28 @@ Let's get this thing installed! Run:
 
     $ composer require symfony/ux-twig-component
 
-That's it! We're ready to go!
+That's it! We're ready to go! If you're not using Symfony Flex, add a config
+file to control the template directory for your components:
 
-Creating a Basic Component
---------------------------
+.. _default_config:
+
+```
+# config/packages/twig_component.yaml
+twig_component:
+    defaults:
+        # default component template directory
+        App\Twig\Components\: 'components/'
+```
+
+Component Basics
+----------------
 
 Let's create a reusable "alert" element that we can use to show success
-or error messages across our site. Step 1 is always to create a
-component that has an ``AsTwigComponent`` class attribute. Let's start
-as simple as possible::
+or error messages across our site. Step 1 is to create a component class
+and give it the ``AsTwigComponent`` attribute::
 
-    // src/Components/Alert.php
-    namespace App\Components;
+    // src/Twig/Components/Alert.php
+    namespace App\Twig\Components;
 
     use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -76,7 +88,12 @@ as simple as possible::
     {
     }
 
-Step 2 is to create a template for this component. By default, templates
+This class can technically live anywhere, but in practice, you'll put it
+somewhere under the namespace configured in :ref:`config/packages/twig_component.yaml <default_config>`.
+This helps TwigComponent :ref:`name <naming>` your component and know where its
+template lives.
+
+Step 2 is to create the template. By default, templates
 live in ``templates/components/{component_name}.html.twig``, where
 ``{component_name}`` matches the class name of the component:
 
@@ -87,7 +104,7 @@ live in ``templates/components/{component_name}.html.twig``, where
         Success! You've created a Twig component!
     </div>
 
-This isn't very interesting yet… since the message is hardcoded into the
+This isn't very interesting yet… since the message is hardcoded in the
 template. But it's enough! Celebrate by rendering your component from
 any other Twig template:
 
@@ -95,36 +112,56 @@ any other Twig template:
 
     {{ component('Alert') }}
 
-Done! You've just rendered your first Twig Component! Take a moment to
-fist pump - then come back!
+Done! You've just rendered your first Twig Component! You can see it
+and any other components by running:
+
+.. code-block:: terminal
+
+    $ php bin/console debug:twig-component --dir=bar
+
+Take a moment to fist pump - then come back!
+
+.. _naming:
 
 Naming Your Component
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 2.8
 
     Before 2.8, passing a name to ``AsTwigComponent`` was required. Now, the
     name is optional and defaults to the class name.
 
-The name of your component is the class name by default. But you can
-customize it by passing an argument to ``AsTwigComponent``::
+To give your component a name, TwigComponent looks at the namespace(s)
+configured in :ref:`twig_component.yaml <default_config>` and finds the
+first match. If your have the recommended ``App\Twig\\Components\\``, then:
+
+=========================================  ==================
+Component Class                            Component Name
+=========================================  ==================
+``App\\Twig\\Components\\Alert``           ``Alert``
+``App\\Twig\\Components\\Button\\Primary`` ``Button:Primary``
+=========================================  ==================
+
+The ``:`` character is used in the name instead of ``\``. See
+:ref:`Configuration <configuration>` for more info.
+
+Instead of letting TwigComponent choose a name, you can also set on yourself::
 
     #[AsTwigComponent('alert')]
     class Alert
     {
     }
 
-Passing Data into your Component
---------------------------------
+Passing Data (Props) into your Component
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Good start: but this isn't very interesting yet! To make our ``Alert``
-component reusable, we need to make the message and type
-(e.g. ``success``, ``danger``, etc) configurable. To do that, create a
+To make our ``Alert`` component reusable, we need the message and type
+(e.g. ``success``, ``danger``, etc) to be configurable. To do that, create a
 public property for each:
 
 .. code-block:: diff
 
-      // src/Components/Alert.php
+      // src/Twig/Components/Alert.php
       // ...
 
       #[AsTwigComponent]
@@ -141,11 +178,6 @@ In the template, the ``Alert`` instance is available via
 the ``this`` variable and public properties are available directly.
 Use them to render the two new properties:
 
-.. versionadded:: 2.1
-
-    The ability to reference local variables in the template (e.g. ``message``) was added in TwigComponents 2.1.
-    Previously, all data needed to be referenced through ``this`` (e.g. ``this.message``).
-
 .. code-block:: html+twig
 
     <div class="alert alert-{{ type }}">
@@ -156,7 +188,7 @@ Use them to render the two new properties:
     </div>
 
 How can we populate the ``message`` and ``type`` properties? By passing
-them as a 2nd argument to the ``component()`` function when rendering:
+them as "props" via the a 2nd argument to ``component()``:
 
 .. code-block:: twig
 
@@ -184,264 +216,144 @@ called instead of setting the property directly.
             // ...
         }
 
-Customize the Twig Template
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing & Rendering Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can customize the template used to render the component by passing it
-as the second argument to the ``AsTwigComponent`` attribute:
+If you pass extra props that are *not* settable on your component class,
+those can be rendered as attributes:
+
+.. code-block:: twig
+
+    {{ component('Alert', {
+        id: 'custom-alert-id',
+        message: 'Danger Will Robinson!'
+    }) }}
+
+To render the attributes, use the special ``attributes`` variable that's
+available in every component template:
+
+.. code-block:: html+twig
+
+    <div {{ attributes.defaults({ class: 'alert alert'~ type }) }}">
+        {{ message }}
+    </div>
+
+See :ref:`Component Attributes <attributes>` to learn more.
+
+Component Template Path
+~~~~~~~~~~~~~~~~~~~~~~~
+
+If you're using the :ref:`default config <default_config>`, the template
+name will be: ``templates/components/{component_name}.html.twig``, where
+``{component_name}`` matches the component *name*.
+
+===================  ==================================================
+Component Name       Template Path
+===================  ==================================================
+``Alert``            ``templates/components/Alert.html.twig``
+``Button:Primary``   ``templates/components/Button/Primary.html.twig``
+===================  ==================================================
+
+Any `:` in the name are changed to subdirectories.s
+
+You can control the template used via the ``AsTwigComponent`` attribute:
 
 .. code-block:: diff
 
-      // src/Components/Alert.php
+      // src/Twig/Components/Alert.php
       // ...
 
     - #[AsTwigComponent]
     + #[AsTwigComponent(template: 'my/custom/template.html.twig')]
       class Alert
-      {
-          // ...
-      }
 
-Twig Template Namespaces
-~~~~~~~~~~~~~~~~~~~~~~~~
+You can also configure the default template directory for an entire
+namespace. See :ref:`Configuration <configuration>`.
 
-You can use a ``:`` in your component's name to indicate a namespace. The default
-template will replace the ``:`` with ``/``. For example, a component with the name
-``form:input`` will look for a template in ``templates/components/form/input.html.twig``.
+Component HTML Syntax
+~~~~~~~~~~~~~~~~~~~~~
 
-The mount() Method
-~~~~~~~~~~~~~~~~~~
+.. versionadded:: 2.8
 
-If, for some reason, you don't want an option to the ``component()``
-function to be set directly onto a property, you can, instead, create a
-``mount()`` method in your component::
+    This syntax was been introduced in 2.8 and is still experimental.
 
-    // src/Components/Alert.php
-    // ...
+So far so good! To make it *really* nice to work with Twig Components, it
+comes with an HTML-like syntax where props are passed as attributes:
 
-    #[AsTwigComponent]
-    class Alert
-    {
-        public string $message;
-        public string $type = 'success';
+.. code-block:: html+twig
 
-        public function mount(bool $isSuccess = true)
-        {
-            $this->type = $isSuccess ? 'success' : 'danger';
-        }
+    <twig:Alert message="This is really cool!" withCloseButton />
 
-        // ...
-    }
+This would pass a ``message`` and ``withCloseButton`` (``true``) props
+to the ``Alert`` component and render it! If an attribute is dynamic,
+prefix the attribute with ``:`` or use the normal ``{{ }}`` syntax:
 
-The ``mount()`` method is called just one time immediately after your
-component is instantiated. Because the method has an ``$isSuccess``
-argument, we can pass an ``isSuccess`` option when rendering the
-component:
+.. code-block:: html+twig
 
-.. code-block:: twig
+    <twig:Alert message="hello!" :user="user.id" />
 
-    {{ component('alert', {
-        isSuccess: false,
-        message: 'Danger Will Robinson!'
-    }) }}
+    // equal to
+    <twig:Alert message="hello!" user="{{ user.id }}" />
 
-If an option name matches an argument name in ``mount()``, the option is
-passed as that argument and the component system will *not* try to set
-it directly on a property.
+    // pass object, array, or anything you imagine
+    <twig:Alert :foo="['col' => ['foo', 'oof']]" />
 
-PreMount Hook
-~~~~~~~~~~~~~
+Don't forget that you can mix and match props with attributes that you
+want to render on the root element:
 
-If you need to modify/validate data before it's *mounted* on the
-component use a ``PreMount`` hook::
+.. code-block:: html+twig
 
-    // src/Components/Alert.php
-    use Symfony\UX\TwigComponent\Attribute\PreMount;
-    // ...
+    <twig:Alert message="hello!" id="custom-alert-id" />
 
-    #[AsTwigComponent]
-    class Alert
-    {
-        public string $message;
-        public string $type = 'success';
+To pass an array of attributes, use `{{...}}` spread operator syntax.
+This requires Twig 3.7.0 or higher:
 
-        #[PreMount]
-        public function preMount(array $data): array
-        {
-            // validate data
-            $resolver = new OptionsResolver();
-            $resolver->setDefaults(['type' => 'success']);
-            $resolver->setAllowedValues('type', ['success', 'danger']);
-            $resolver->setRequired('message');
-            $resolver->setAllowedTypes('message', 'string');
+.. code-block:: html+twig
 
-            return $resolver->resolve($data);
-        }
+    <twig:Alert{{ ...myAttributes }} />
 
-        // ...
-    }
+We'll use the HTML syntax for the rest of the guide.
 
-.. note::
-
-    If your component has multiple ``PreMount`` hooks, and you'd like to control
-    the order in which they're called, use the ``priority`` attribute parameter:
-    ``PreMount(priority: 10)`` (higher called earlier).
-
-PostMount Hook
-~~~~~~~~~~~~~~
-
-.. versionadded:: 2.1
-
-    The ``PostMount`` hook was added in TwigComponents 2.1.
-
-After a component is instantiated and its data mounted, you can run extra
-code via the ``PostMount`` hook::
-
-    // src/Components/Alert.php
-    use Symfony\UX\TwigComponent\Attribute\PostMount;
-    // ...
-
-    #[AsTwigComponent]
-    class Alert
-    {
-        #[PostMount]
-        public function postMount(): array
-        {
-            if (str_contains($this->message, 'danger')) {
-                $this->type = 'danger';
-            }
-        }
-        // ...
-    }
-
-A ``PostMount`` method can also receive an array ``$data`` argument, which
-will contain any props passed to the component that have *not* yet been processed,
-i.e. because they don't correspond to any property. You can handle these props,
-remove them from the ``$data`` and return the array::
-
-    // src/Components/Alert.php
-    #[AsTwigComponent]
-    class Alert
-    {
-        public string $message;
-        public string $type = 'success';
-
-        #[PostMount]
-        public function processAutoChooseType(array $data): array
-        {
-            if ($data['autoChooseType'] ?? false) {
-                if (str_contains($this->message, 'danger')) {
-                    $this->type = 'danger';
-                }
-
-                // remove the autoChooseType prop from the data array
-                unset($data['autoChooseType']);
-            }
-
-            // any remaining data will become attributes on the component
-            return $data;
-        }
-        // ...
-    }
-
-.. note::
-
-    If your component has multiple ``PostMount`` hooks, and you'd like to control
-    the order in which they're called, use the ``priority`` attribute parameter:
-    ``PostMount(priority: 10)`` (higher called earlier).
-
-ExposeInTemplate Attribute
+Passing HTML to Components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.1
+Instead of passing a ``message`` prop to the ``Alert`` component, what if we
+could do this?
 
-    The ``ExposeInTemplate`` attribute was added in TwigComponents 2.1.
+.. code-block:: html+twig
 
-.. versionadded:: 2.3
+    <twig:Alert>
+        I'm writing <strong>HTML</strong> right here!
+    </twig:Alert>
 
-    The ``ExposeInTemplate`` attribute can now be used on public methods.
+We can! When you add content between the the ``<twig:Alert>`` open and
+close tag, it's passed to your component template as the block called
+``content``. You can render it like any normal block:
 
-All public component properties are available directly in your component
-template. You can use the ``ExposeInTemplate`` attribute to expose
-private/protected properties and public methods directly in a component
-template (``someProp`` vs ``this.someProp``, ``someMethod`` vs ``this.someMethod``).
-Properties must be *accessible* (have a getter). Methods *cannot have*
-required parameters::
+.. code-block:: html+twig
 
-    // ...
-    use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+    <div {{ attributes.defaults({ class: 'alert alert'~ type }) }}">
+        {% block content %}{% endblock %}
+    </div>
 
-    #[AsTwigComponent]
-    class Alert
-    {
-        #[ExposeInTemplate]
-        private string $message; // available as `{{ message }}` in the template
-
-        #[ExposeInTemplate('alert_type')]
-        private string $type = 'success'; // available as `{{ alert_type }}` in the template
-
-        #[ExposeInTemplate(name: 'ico', getter: 'fetchIcon')]
-        private string $icon = 'ico-warning'; // available as `{{ ico }}` in the template using `fetchIcon()` as the getter
-
-        /**
-         * Required to access $this->message
-         */
-        public function getMessage(): string
-        {
-            return $this->message;
-        }
-
-        /**
-         * Required to access $this->type
-         */
-        public function getType(): string
-        {
-            return $this->type;
-        }
-
-        /**
-         * Required to access $this->icon
-         */
-        public function fetchIcon(): string
-        {
-            return $this->icon;
-        }
-
-        #[ExposeInTemplate]
-        public function getActions(): array // available as `{{ actions }}` in the template
-        {
-            // ...
-        }
-
-        #[ExposeInTemplate('dismissable')]
-        public function canBeDismissed(): bool // available as `{{ dismissable }}` in the template
-        {
-            // ...
-        }
-
-        // ...
-    }
-
-.. note::
-
-    When using ``ExposeInTemplate`` on a method the value is fetched eagerly
-    before rendering.
+You can even give the block default content. See
+:ref:`Passing HTML to Components via Block <embedded-components>`
+for more info.
 
 Fetching Services
 -----------------
 
 Let's create a more complex example: a "featured products" component.
-You *could* choose to pass an array of Product objects into the
-``component()`` function and set those on a ``$products`` property. But
-instead, let's allow the component to do the work of executing the
-query.
+You *could* choose to pass an array of Product objects to the component
+and set those on a ``$products`` property. But instead, let's let the
+*component* to do the work of executing the query.
 
 How? Components are *services*, which means autowiring works like
 normal. This example assumes you have a ``Product`` Doctrine entity and
 ``ProductRepository``::
 
-    // src/Components/FeaturedProducts.php
-    namespace App\Components;
+    // src/Twig/Components/FeaturedProducts.php
+    namespace App\Twig\Components;
 
     use App\Repository\ProductRepository;
     use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
@@ -482,7 +394,7 @@ need to populate, you can render it with:
 
 .. code-block:: twig
 
-    {{ component('FeaturedProducts') }}
+    <twig:FeaturedProducts />
 
 .. note::
 
@@ -491,69 +403,417 @@ need to populate, you can render it with:
     means that you can safely render the same component multiple times with
     different data because each component will be an independent instance.
 
-Computed Properties
-~~~~~~~~~~~~~~~~~~~
+Mounting Data
+-------------
 
-.. versionadded:: 2.1
+Most of the time, you will create public properties and then pass values
+to those as "props" when rendering. But there are several hooks in case
+you need to do something more complex.
 
-    Computed Properties were added in TwigComponents 2.1.
+The mount() Method
+~~~~~~~~~~~~~~~~~~
 
-In the previous example, instead of querying for the featured products
-immediately (e.g. in ``__construct()``), we created a ``getProducts()``
-method and called that from the template via ``this.products``.
+For more control over how your "props" are handled, you can create a method
+called ``mount()``::
 
-This was done because, as a general rule, you should make your
-components as *lazy* as possible and store only the information you need
-on its properties (this also helps if you convert your component to a
-`live component`_ later). With this setup, the query is only executed if and
-when the ``getProducts()`` method is actually called. This is very similar
-to the idea of "computed properties" in frameworks like `Vue`_.
+    // src/Twig/Components/Alert.php
+    // ...
 
-But there's no magic with the ``getProducts()`` method: if you call
-``this.products`` multiple times in your template, the query would be
-executed multiple times.
+    #[AsTwigComponent]
+    class Alert
+    {
+        public string $message;
+        public string $type = 'success';
 
-To make your ``getProducts()`` method act like a true computed property,
-call ``computed.products`` in your template. ``computed`` is a proxy
-that wraps your component and caches the return of methods. If they
-are called additional times, the cached value is used.
+        public function mount(bool $isSuccess = true)
+        {
+            $this->type = $isSuccess ? 'success' : 'danger';
+        }
 
-.. code-block:: html+twig
+        // ...
+    }
 
-    {# templates/components/FeaturedProducts.html.twig #}
-    <div>
-        <h3>Featured Products</h3>
+The ``mount()`` method is called just one time: immediately after your
+component is instantiated. Because the method has an ``$isSuccess``
+argument, if we pass an ``isSuccess`` prop when rendering, it will be
+passed to ``mount()``.
 
-        {% for product in computed.products %}
-            ...
-        {% endfor %}
+.. code-block:: twig
 
-        ...
-        {% for product in computed.products %} {# use cache, does not result in a second query #}
-            ...
-        {% endfor %}
-    </div>
+    <twig:Alert
+        :isSuccess="false"
+        message="Danger Will Robinson!"
+    />
+
+If a prop name (e.g. ``isSuccess``) matches an argument name in ``mount()``,
+the prop will be passed as that argument and the component system will
+**not** try to set it directly on a property or use it for the component
+``attributes``.
+
+PreMount Hook
+~~~~~~~~~~~~~
+
+If you need to modify/validate data before it's *mounted* on the
+component use a ``PreMount`` hook::
+
+    // src/Twig/Components/Alert.php
+    use Symfony\UX\TwigComponent\Attribute\PreMount;
+    // ...
+
+    #[AsTwigComponent]
+    class Alert
+    {
+        public string $message;
+        public string $type = 'success';
+
+        #[PreMount]
+        public function preMount(array $data): array
+        {
+            // validate data
+            $resolver = new OptionsResolver();
+            $resolver->setDefaults(['type' => 'success']);
+            $resolver->setAllowedValues('type', ['success', 'danger']);
+            $resolver->setRequired('message');
+            $resolver->setAllowedTypes('message', 'string');
+
+            return $resolver->resolve($data);
+        }
+
+        // ...
+    }
+
+The data returned from ``preMount()`` will be used as the props for mounting.
 
 .. note::
 
-    Computed methods only work for component methods with no required
-    arguments.
+    If your component has multiple ``PreMount`` hooks, and you'd like to control
+    the order in which they're called, use the ``priority`` attribute parameter:
+    ``PreMount(priority: 10)`` (higher called earlier).
+
+PostMount Hook
+~~~~~~~~~~~~~~
+
+.. versionadded:: 2.1
+
+    The ``PostMount`` hook was added in TwigComponents 2.1.
+
+After a component is instantiated and its data mounted, you can run extra
+code via the ``PostMount`` hook::
+
+    // src/Twig/Components/Alert.php
+    use Symfony\UX\TwigComponent\Attribute\PostMount;
+    // ...
+
+    #[AsTwigComponent]
+    class Alert
+    {
+        #[PostMount]
+        public function postMount(): void
+        {
+            if (str_contains($this->message, 'danger')) {
+                $this->type = 'danger';
+            }
+        }
+        // ...
+    }
+
+A ``PostMount`` method can also receive an array ``$data`` argument, which
+will contain any props passed to the component that have *not* yet been processed,
+(i.e. they don't correspond to any property and weren't an argument to the
+``mount()`` method). You can handle these props, remove them from the ``$data``
+and return the array::
+
+    // src/Twig/Components/Alert.php
+    #[AsTwigComponent]
+    class Alert
+    {
+        public string $message;
+        public string $type = 'success';
+
+        #[PostMount]
+        public function processAutoChooseType(array $data): array
+        {
+            if ($data['autoChooseType'] ?? false) {
+                if (str_contains($this->message, 'danger')) {
+                    $this->type = 'danger';
+                }
+
+                // remove the autoChooseType prop from the data array
+                unset($data['autoChooseType']);
+            }
+
+            // any remaining data will become attributes on the component
+            return $data;
+        }
+        // ...
+    }
+
+.. note::
+
+    If your component has multiple ``PostMount`` hooks, and you'd like to control
+    the order in which they're called, use the ``priority`` attribute parameter:
+    ``PostMount(priority: 10)`` (higher called earlier).
+
+Anonymous Components
+--------------------
+
+Sometimes a component is simple enough that it doesn't need a PHP class.
+In this case, you can skip the class and only create the template. The component
+name is determined by the location of the template:
+
+.. code-block:: html+twig
+
+    {# templates/components/Button/Primary.html.twig #}
+    <button {{ attributes.defaults({ class: 'primary' }) }}>
+        {% block content %}{% endblock %}
+    </button>
+
+The name for this component will be ``Button:Primary`` because of
+the subdirectory:
+
+.. code-block:: html+twig
+
+    {# index.html.twig #}
+    ...
+    <div>
+       <twig:Button:Primary>Click Me!</twig:Button:Primary>
+    </div>
+
+    {# renders as: #}
+    <button class="primary">Click Me!</button>
+
+Like normal, you can pass extra attributes that will be rendered on the element:
+
+.. code-block:: html+twig
+
+    {# index.html.twig #}
+    ...
+    <div>
+       <twig:Button:Primary type="button" name="foo">Click Me!</twig:Button:Primary>
+    </div>
+
+    {# renders as: #}
+    <button class="primary" type="button" name="foo">Click Me!</button>
+
+You can also pass a variable (prop) into your template:
+
+.. code-block:: html+twig
+
+    {# index.html.twig #}
+    ...
+    <div>
+        <twig:Button icon="fa-plus" type="primary" role="button">Click Me!</twig:Button>
+    </div>
+
+To tell the system that ``icon`` and ``type`` are props and not attributes, use the
+``{% props %}`` tag at the top of your template.
+
+.. code-block:: html+twig
+
+    {# templates/components/Button.html.twig #}
+    {% props icon = null, type = 'primary' %}
+
+    <button {{ attributes.defaults({ class: 'btn btn-'~type }) }}>
+        {% block content %}{% endblock %}
+        {% if icon %}
+            <span class="fa-solid fa-{{ icon }}"></span>
+        {% endif %}
+    </button>
+
+.. _embedded-components:
+
+Passing HTML to Components Via Blocks
+-------------------------------------
+
+Props aren't the only way you can pass something to your component. You can
+also pass content:
+
+.. code-block:: html+twig
+
+    <twig:Alert type="success">
+        <div>Congratulations! You've won a free puppy!</div>
+    </twig:Alert>
+
+In your component template, this becomes a block named ``content``:
+
+.. code-block:: html+twig
+
+    <div class="alert alert-{{ type }}">
+        {% block content %}
+            // the content will appear in here
+        {% endblock %}
+     </div>
+
+You can also add more, named blocks:
+
+.. code-block:: html+twig
+
+    <twig:Alert type="success">
+        <div>Congrats on winning a free puppy!</div>
+
+        <twig:block name="footer">
+            {{ parent() }} {# render the default content if needed #}
+            <button class="btn btn-primary">Claim your prize</button>
+        </twig:block>
+    </twig:Alert>
+
+Render these in the normal way.
+
+.. code-block:: html+twig
+
+    <div class="alert alert-{{ type }}">
+        {% block content %}{% endblock %}
+        {% block footer %}
+            <div>Default Footer content</div>
+        {% endblock %}
+     </div>
+
+Passing content into your template can also be done with LiveComponents
+though there are some caveats to know related to variable scope.
+See `Passing Blocks to Live Components`_.
+
+There is also a non-HTML syntax that can be used:
+
+.. code-block:: html+twig
+
+    {% component Alert with {type: 'success'} %}
+        {% block content %}<div>Congrats!</div>{% endblock %}
+        {% block footer %}... footer content{% endblock %}
+    {% endcomponent %}
+
+Context / Variables Inside of Blocks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The content inside of the ``<twig:{Component}>`` should be viewed as living in its own,
+independent template, which extends the component's template. This has a few interesting
+consequences.
+
+First, inside of ``<twig:{Component}>``, the ``this`` variable represents
+the component you're *now* rendering *and* you have access to all of *that*
+component's variables:
+
+.. code-block:: twig
+
+    {# templates/components/SuccessAlert.html.twig #}
+    {{ this.someFunction }} {# this === SuccessAlert #}
+
+    <twig:Alert type="success">
+        {{ this.someFunction }} {# this === Alert #}
+
+        {{ type }} {# references a "type" prop from Alert #}
+    </twig:Alert>
+
+Conveniently, in addition to the variables from the ``Alert`` component, you
+*also* have access to whatever variables are available in the original template:
+
+.. code-block:: twig
+
+    {# templates/components/SuccessAlert.html.twig #}
+
+    {% set name = 'Fabien' %}
+    <twig:Alert type="success">
+        Hello {{ name }}
+    </twig:Alert>
+
+ALL variables from the upper component (e.g. ``SuccessAlert``) are available
+inside the content of the lower component (e.g. ``Alert``). However, because variables
+are merged, any variables with the same name are overridden by the lower component
+(e.g. ``Alert``). That's why ``this`` refers to the embedded, or "current" component
+``Alert``.
+
+There is also one special superpower when passing content to a component: your
+code executes as if it is "copy-and-pasted" into the block of the target template.
+This means you can **access variables from the block you're overriding**! For example:
+
+.. code-block:: twig
+
+    {# templates/component/SuccessAlert.html.twig #}
+    {% for message in messages %}
+        {% block alert_message %}
+            A default {{ message }}
+        {% endblock %}
+    {% endfor %}
+
+When overriding the ``alert_message`` block, you have access to the ``message`` variable:
+
+.. code-block:: twig
+
+    {# templates/some_page.html.twig #}
+    <twig:SuccessAlert>
+        <twig:block name="alert_message">
+            I can override the alert_message block and access the {{ message }} too!
+        </twig:block>
+    </twig:SuccessAlert>
+
+Inheritance & Forwarding "Outer Blocks"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.10`
+
+    The ``outerBlocks`` variable was added in 2.10.
+
+The content inside a ``<twig:{Component}>`` tag should be viewed as living in
+its own, independent template, which *extends* the component's template. This means that
+any blocks that live in the "outer" template are not available. However, you
+*can* access these via a special ``outerBlocks`` variable:
+
+.. code-block:: html+twig
+
+  {% extends 'base.html.twig' %}
+
+  {% block call_to_action %}<strong>Attention! Free Puppies!</strong>{% endblock %}
+
+  {% block body %}
+    <twig:Alert>
+        {# block('call_to_action') #} would not work #}
+
+        {{ block(outerBlocks.call_to_action) }}
+    </twig:Alert>
+  {% endblock %}
+
+The ``outerBlocks`` variable becomes especially useful with nested components.
+For example, imagine we want to create a ``SuccessAlert`` component:
+
+.. code-block:: html+twig
+
+    {# templates/some_page.html.twig #}
+    <twig:SuccessAlert>
+        We will successfully <em>forward</em> this block content!
+    <twig:SuccessAlert>
+
+We already have a generic ``Alert`` component, so let's re-use it:
+
+.. code-block:: html+twig
+
+    {# templates/components/Alert.html.twig #}
+    <div {{ attributes.defaults({ class: 'alert alert'~ type }) }}">
+        {% block content %}{% endblock %}
+    </div>
+
+To do this, the ``SuccessAlert`` component can grab the ``content`` block
+that's passed to it via the ``outerBlocks`` variable and forward it into ``Alert``:
+
+.. code-block:: twig
+
+    {# templates/components/SuccessAlert.html.twig #}
+    <twig:Alert type="success">
+    {% component Alert with { type: 'success' } %}
+        {{ block(outerBlocks.content) }}
+    </twig:Alert>
+
+By passing the original ``content`` block into the `content` block of ``Alert``,
+this will work perfectly.
+
+.. _attributes:
 
 Component Attributes
 --------------------
 
-.. versionadded:: 2.1
-
-    Component attributes were added in TwigComponents 2.1.
-
 A common need for components is to configure/render attributes for the
-root node. Attributes are any data passed to ``component()`` that cannot be
-mounted on the component itself. This extra data is added to a
-``ComponentAttributes`` that is available as ``attributes`` in your
-component's template.
-
-To use, in your component's template, render the ``attributes`` variable in
-the root element:
+root node. Attributes are any props that are passed when rendering that
+cannot be mounted on the component itself. This extra data is added to a
+``ComponentAttributes`` object that'ss available as ``attributes`` in your
+component's template:
 
 .. code-block:: html+twig
 
@@ -566,7 +826,7 @@ When rendering the component, you can pass an array of html attributes to add:
 
 .. code-block:: html+twig
 
-    {{ component('MyComponent', { class: 'foo', style: 'color:red' }) }}
+    <twig:MyComponent class="foo" style="color: red" />
 
     {# renders as: #}
     <div class="foo" style="color:red">
@@ -577,11 +837,11 @@ Set an attribute's value to ``true`` to render just the attribute name:
 
 .. code-block:: html+twig
 
-    {# templates/components/MyComponent.html.twig #}
+    {# templates/components/Input.html.twig #}
     <input{{ attributes }}/>
 
     {# render component #}
-    {{ component('MyComponent', { type: 'text', value: '', autofocus: true }) }}
+    <twig:Input type="text" value="" :autofocus="true" />
 
     {# renders as: #}
     <input type="text" value="" autofocus/>
@@ -590,16 +850,20 @@ Set an attribute's value to ``false`` to exclude the attribute:
 
 .. code-block:: html+twig
 
-    {# templates/components/MyComponent.html.twig #}
+    {# templates/components/Input.html.twig #}
     <input{{ attributes }}/>
 
     {# render component #}
-    {{ component('MyComponent', { type: 'text', value: '', autofocus: false }) }}
+    <twig:Input type="text" value="" :autofocus="false" />
 
     {# renders as: #}
     <input type="text" value=""/>
 
 To add a custom `Stimulus controller`_ to your root component element:
+
+.. code-block:: html+twig
+
+    <div {{ attributes.defaults(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
 
 .. versionadded:: 2.9
 
@@ -607,10 +871,6 @@ To add a custom `Stimulus controller`_ to your root component element:
     was added in TwigComponents 2.9 and requires ``symfony/stimulus-bundle``.
     Previously, ``stimulus_controller()`` was passed to an ``attributes.add()``
     method.
-
-.. code-block:: html+twig
-
-    <div {{ attributes.defaults(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
 
 .. note::
 
@@ -686,497 +946,6 @@ Exclude specific attributes:
       My Component!
     </div>
 
-PreRenderEvent
---------------
-
-.. versionadded:: 2.1
-
-    The ``PreRenderEvent`` was added in TwigComponents 2.1.
-
-Subscribing to the ``PreRenderEvent`` gives the ability to modify
-the twig template and twig variables before components are rendered::
-
-    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-    use Symfony\UX\TwigComponent\Event\PreRenderEvent;
-
-    class HookIntoTwigPreRenderSubscriber implements EventSubscriberInterface
-    {
-        public function onPreRender(PreRenderEvent $event): void
-        {
-            $event->getComponent(); // the component object
-            $event->getTemplate(); // the twig template name that will be rendered
-            $event->getVariables(); // the variables that will be available in the template
-
-            $event->setTemplate('some_other_template.html.twig'); // change the template used
-
-            // manipulate the variables:
-            $variables = $event->getVariables();
-            $variables['custom'] = 'value';
-
-            $event->setVariables($variables); // {{ custom }} will be available in your template
-        }
-
-        public static function getSubscribedEvents(): array
-        {
-            return [PreRenderEvent::class => 'onPreRender'];
-        }
-    }
-
-PostRenderEvent
----------------
-
-.. versionadded:: 2.5
-
-    The ``PostRenderEvent`` was added in TwigComponents 2.5.
-
-The ``PostRenderEvent`` is called after a component has finished
-rendering and contains the ``MountedComponent`` that was just
-rendered.
-
-PreCreateForRenderEvent
------------------------
-
-.. versionadded:: 2.5
-
-    The ``PreCreateForRenderEvent`` was added in TwigComponents 2.5.
-
-Subscribing to the ``PreCreateForRenderEvent`` gives the ability to be
-notified before a component object is created or hydrated, at the
-very start of the rendering process. You have access to the component
-name, input props and can interrupt the process by setting HTML. This
-event is not triggered during a re-render.
-
-PreMountEvent and PostMountEvent
---------------------------------
-
-.. versionadded:: 2.1
-
-    The ``PreMountEvent`` and ``PostMountEvent`` ere added in TwigComponents 2.5.
-
-To run code just before or after a component's data is mounted, you can
-listen to ``PreMountEvent`` or ``PostMountEvent``.
-
-Nested Components
------------------
-
-It's totally possible to nest one component into another. When you do
-this, there's nothing special to know: both components render
-independently. If you're using `Live Components`_, then there
-*are* some guidelines related to how the re-rendering of parent and
-child components works. Read `Live Nested Components`_.
-
-.. _embedded-components:
-
-Passing Blocks to Components
-----------------------------
-
-.. tip::
-
-    The `Component HTML Syntax`_ allows you to pass blocks to components in an
-    even more readable way.
-
-You can write your component's Twig template with blocks that can be overridden
-when rendering using the ``{% component %}`` syntax. These blocks can be thought of as
-*slots* which you may be familiar with from Vue. The ``component`` tag is very
-similar to Twig's native `embed tag`_.
-
-Consider a data table component. You pass it headers and rows but can expose
-blocks for the cells and an optional footer:
-
-.. code-block:: html+twig
-
-    {# templates/components/DataTable.html.twig #}
-    <div{{ attributes.defaults({class: 'data-table'}) }}>
-        <table>
-            <thead>
-                <tr>
-                    {% for header in this.headers %}
-                        <th class="{% block th_class %}data-table-header{% endblock %}">
-                            {{ header }}
-                        </th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for row in this.data %}
-                    <tr>
-                        {% for cell in row %}
-                            <td class="{% block td_class %}data-table-cell{% endblock %}">
-                                {{ cell }}
-                            </td>
-                        {% endfor %}
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-        {% block footer %}{% endblock %}
-    </div>
-
-When rendering, you can override the ``th_class``, ``td_class``, and ``footer`` blocks.
-The ``with`` data is what's mounted on the component object.
-
-.. code-block:: html+twig
-
-    {# templates/some_page.html.twig #}
-    {% component DataTable with {headers: ['key', 'value'], data: [[1, 2], [3, 4]]} %}
-        {% block th_class %}{{ parent() }} text-bold{% endblock %}
-
-        {% block td_class %}{{ parent() }} text-italic{% endblock %}
-
-        {% block footer %}
-            <div class="data-table-footer">
-                My footer
-            </div>
-        {% endblock %}
-    {% endcomponent %}
-
-.. versionadded:: 2.11
-
-    The ``{% component %}`` syntax can also be used with LiveComponents since 2.11.
-    However, there are some caveats related to the context between parent and child
-    components during re-rending. Read `Passing Blocks to Live Components`_.
-
-Inheritance & Forwarding "Outer Blocks"
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 2.10
-
-    The ``outerBlocks`` variable was added in 2.10.
-
-The content inside a ``{% component ... %}`` tag should be viewed as living in
-its own, independent template, which extends the component's template. This means that
-any blocks that live in the "outer" template are not available inside the ``{% component %}`` tag.
-However, a special ``outerBlocks`` variable is added as a way to refer to those blocks:
-
-.. code-block:: html+twig
-
-  {% extends 'base.html.twig' %}
-
-  {% block call_to_action %}<strong>Attention! Free Puppies!</strong>{% endblock %}
-
-  {% block body %}
-    {% component Alert %}
-      {% block content %}{{ block(outerBlocks.call_to_action) }}{% endblock %}
-    {% endcomponent %}
-  {% endblock %}
-
-The ``outerBlocks`` variable becomes specially useful with nested components. For example,
-imagine we want to create a ``SuccessAlert`` component that's usable like this:
-
-.. code-block:: html+twig
-
-    {# templates/some_page.html.twig #}
-    {% component SuccessAlert %}
-        {% block content %}We will successfully <em>forward</em> this block content!{% endblock %}
-    {% endcomponent %}
-
-But we already have a generic ``Alert`` component, and we want to re-use it:
-
-.. code-block:: html+twig
-
-    {# templates/Alert.html.twig #}
-    <div class="alert alert-{{ type }}">
-        {% block content %}{% endblock %}
-    </div>
-
-To do this, the ``SuccessAlert`` component can grab the ``content`` block that's passed to it
-via the ``outerBlocks`` variable and forward it into ``Alert``:
-
-.. code-block:: twig
-
-    {# templates/SuccessAlert.html.twig #}
-    {% component Alert with { type: 'success' } %}
-        {% block content %}{{ block(outerBlocks.content) }}{% endblock %}
-    {% endcomponent %}
-
-Note that to pass a block multiple components down, each component needs to pass it.
-
-Context / Variables Inside of Blocks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The content inside of the ``{% component ... %}`` should be viewed as living in its own,
-independent template, which extends the component's template. This has a few interesting consequences.
-
-First, once you're inside of ``{% component ... %}``, the ``this`` variable represents
-the component you're now rendering *and* you have access to all of that component's variables:
-
-.. code-block:: twig
-
-    {# templates/SuccessAlert.html.twig #}
-    {{ this.someFunction }} {# this refers to SuccessAlert #}
-
-    {% component Alert with { type: 'success' } %}
-        {% block content %}
-            {{ this.someFunction }} {# this refers to Alert! #}
-
-            {{ type }} {# references a "type" prop from Alert #}
-        {% endblock %}
-    {% endcomponent %}
-
-Conveniently, in addition to the variables from the ``Alert`` component, you still have
-access to whatever variables are available in the original template:
-
-.. code-block:: twig
-
-    {# templates/SuccessAlert.html.twig #}
-    {% set name = 'Fabien' %}
-    {% component Alert with { type: 'success' } %}
-        {% block content %}
-            Hello {{ name }}
-        {% endblock %}
-    {% endcomponent %}
-
-Note that ALL variables from upper components (e.g. ``SuccessAlert``) are available to lower
-components (e.g. ``Alert``). However, because variables are merged, variables with the same name
-are overridden by lower components (that's also why ``this`` refers to the embedded, or
-"current" component).
-
-The most interesting thing is that the content inside of ``{% component ... %}`` is
-executed as if it is "copy-and-pasted" into the block of the target template. This means
-you can access variables from the block you're overriding! For example:
-
-.. code-block:: twig
-
-    {# templates/SuccessAlert.html.twig #}
-    {% for message in messages %}
-        {% block alert_message %}
-            A default {{ message }}
-        {% endblock %}
-    {% endfor %}
-
-When overriding the ``alert_message`` block, you have access to the ``message`` variable:
-
-.. code-block:: twig
-
-    {# templates/some_page.html.twig #}
-    {% component SuccessAlert %}
-        {% block alert_message %}
-            I can override the alert_message block and access the {{ message }} too!
-        {% endblock %}
-    {% endcomponent %}
-
-Component HTML Syntax
----------------------
-
-.. versionadded:: 2.8
-
-    This syntax was been introduced in 2.8 and is still experimental: it may change in the future.
-
-Twig Components come with an HTML-like syntax to ease the readability of your template:
-
-.. code-block:: html+twig
-
-    <twig:Alert></twig:Alert>
-    // or use a self-closing tag
-    <twig:Alert />
-
-Passing Props as HTML Attributes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Passing props is done with HTML attributes. For example if you have this component::
-
-    #[AsTwigComponent]
-    class Alert
-    {
-        public string $message = '';
-        public bool $withActions = false;
-        public string $type = 'success';
-    }
-
-You can pass the ``message``, ``withActions`` or ``type`` props as attributes:
-
-.. code-block:: html+twig
-
-    // withActions will be set to true
-    <twig:Alert type="info" message="hello!" withActions />
-
-To pass in a dynamic value, prefix the attribute with ``:`` or use the
-normal ``{{ }}`` syntax:
-
-.. code-block:: html+twig
-
-    <twig:Alert message="hello!" :user="user.id" />
-
-    // equal to
-    <twig:Alert message="hello!" user="{{ user.id }}" />
-
-    // and pass object, or table, or anything you imagine
-    <twig:Alert :foo="['col' => ['foo', 'oof']]" />
-
-To forward attributes to another component, use `{{...}}` spread operator syntax.
-This requires Twig 3.7.0 or higher:
-
-.. code-block:: html+twig
-
-    <twig:Alert{{ ...myAttributes }} />
-
-.. _passing-blocks:
-
-Passing Content (Blocks) to Components
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can also pass content directly to your component:
-
-.. code-block:: html+twig
-
-    <twig:Alert type="success">
-        <div>Congratulations! You've won a free puppy!</div>
-    </twig:Alert>
-
-In your component template, this becomes a block named ``content``:
-
-.. code-block:: html+twig
-
-    <div class="alert alert-{{ type }}">
-        {% block content %}
-            // the content will appear in here
-        {% endblock %}
-     </div>
-
-In addition to the default block, you can also add named blocks:
-
-.. code-block:: html+twig
-
-    <twig:Alert type="success">
-        <div>Congrats on winning a free puppy!</div>
-
-        <twig:block name="footer">
-            <button class="btn btn-primary">Claim your prize</button>
-        </twig:block>
-    </twig:Alert>
-
-And in your component template you can access your embedded block
-
-.. code-block:: html+twig
-
-    <div class="alert alert-{{ type }}">
-        {% block content %}{% endblock %}
-        {% block footer %}{% endblock %}
-     </div>
-
-Anonymous Components
---------------------
-
-Sometimes a component is simple enough that it doesn't have any complex logic or injected services.
-In this case, you can skip the class and only create the template. The component name is determined
-by the location of the template (see `Twig Template Namespaces`_):
-
-.. code-block:: html+twig
-
-    {# templates/components/Button/Primary.html.twig #}
-    <button {{ attributes.defaults({ class: 'primary' }) }}>
-        {% block content %}{% endblock %}
-    </button>
-
-Then use your component with ``:`` to navigate through sub-directories (if there are any):
-
-.. code-block:: html+twig
-
-    {# index.html.twig #}
-    ...
-    <div>
-       <twig:Button:Primary>Click Me!</twig:Button:Primary>
-    </div>
-
-    {# renders as: #}
-    <button class="primary">Click Me!</button>
-
-Like normal, you can pass extra attributes that will be rendered on the element:
-
-.. code-block:: html+twig
-
-    {# index.html.twig #}
-    ...
-    <div>
-       <twig:Button:Primary type="button" name="foo">Click Me!</twig:Button:Primary>
-    </div>
-
-    {# renders as: #}
-    <button class="primary" type="button" name="foo">Click Me!</button>
-
-You can also pass a variable (prop) into your template:
-
-.. code-block:: html+twig
-
-    {# index.html.twig #}
-    ...
-    <div>
-        <twig:Button icon="fa-plus" type="primary" role="button">Click Me!</twig:Button>
-    </div>
-
-To tell the system that ``icon`` and ``type`` are props and not attributes, use the ``{% props %}`` tag at the top of your template.
-
-.. code-block:: html+twig
-
-    {# templates/components/Button.html.twig #}
-    {% props icon = null, type = 'primary' %}
-
-    <button {{ attributes.defaults({ class: 'btn btn-'~type }) }}>
-        {% block content %}{% endblock %}
-        {% if icon %}
-            <span class="fa-solid fa-{{ icon }}"></span>
-        {% endif %}
-    </button>
-
-Debugging Components
---------------------
-
-As your application grows, you'll eventually have a lot of components.
-This command will help you to debug some components issues.
-First, the debug:twig-component command lists all your application components
-who live in ``templates/components``:
-
-.. code-block:: terminal
-
-    $ php bin/console debug:component
-
-    +---------------+-----------------------------+------------------------------------+------+
-    | Component     | Class                       | Template                           | Live |
-    +---------------+-----------------------------+------------------------------------+------+
-    | Coucou        | App\Components\Alert        | components/Coucou.html.twig        |      |
-    | RandomNumber  | App\Components\RandomNumber | components/RandomNumber.html.twig  | X    |
-    | Test          | App\Components\foo\Test     | components/foo/Test.html.twig      |      |
-    | Button        | Anonymous component         | components/Button.html.twig        |      |
-    | foo:Anonymous | Anonymous component         | components/foo/Anonymous.html.twig |      |
-    +---------------+-----------------------------+------------------------------------+------+
-
-.. tip::
-
-    The Live column show you which component is a LiveComponent.
-
-If you have some components who doesn't live in ``templates/components``,
-but in ``templates/bar`` for example you can pass an option:
-
-.. code-block:: terminal
-
-    $ php bin/console debug:twig-component --dir=bar
-
-    +----------------+-------------------------------+------------------------------+------+
-    | Component      | Class                         | Template                     | Live |
-    +----------------+-------------------------------+------------------------------+------+
-    | OtherDirectory | App\Components\OtherDirectory | bar/OtherDirectory.html.twig |      |
-    +----------------+-------------------------------+------------------------------+------+
-
-And the name of some component to this argument to print the
-component details:
-
-.. code-block:: terminal
-
-    $ php bin/console debug:component RandomNumber
-
-    +---------------------------------------------------+-----------------------------------+
-    | Property                                          | Value                             |
-    +---------------------------------------------------+-----------------------------------+
-    | Component                                         | RandomNumber                      |
-    | Live                                              | X                                 |
-    | Class                                             | App\Components\RandomNumber       |
-    | Template                                          | components/RandomNumber.html.twig |
-    | Properties (type / name / default value if exist) | string $name = toto               |
-    |                                                   | string $type = test               |
-    | Live Properties                                   | int $max = 1000                   |
-    |                                                   | int $min = 10                     |
-    +---------------------------------------------------+-----------------------------------+
-
 Test Helpers
 ------------
 
@@ -1234,6 +1003,256 @@ You can test how your component is mounted and rendered using the
 
     The ``InteractsWithTwigComponents`` trait can only be used in tests that extend
     ``Symfony\Bundle\FrameworkBundle\Test\KernelTestCase``.
+
+Special Component Variables
+---------------------------
+
+By default, your template will have access to the following variables:
+
+* ``this``
+* ``attributes``
+* ... and all public properties on your component
+
+There are also a few other special ways you can control the variables.
+
+ExposeInTemplate Attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All public component properties are available directly in your component
+template. You can use the ``ExposeInTemplate`` attribute to expose
+private/protected properties and public methods directly in a component
+template (``someProp`` vs ``this.someProp``, ``someMethod`` vs ``this.someMethod``).
+Properties must be *accessible* (have a getter). Methods *cannot have*
+required parameters::
+
+    // ...
+    use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+
+    #[AsTwigComponent]
+    class Alert
+    {
+        #[ExposeInTemplate]
+        private string $message; // available as `{{ message }}` in the template
+
+        #[ExposeInTemplate('alert_type')]
+        private string $type = 'success'; // available as `{{ alert_type }}` in the template
+
+        #[ExposeInTemplate(name: 'ico', getter: 'fetchIcon')]
+        private string $icon = 'ico-warning'; // available as `{{ ico }}` in the template using `fetchIcon()` as the getter
+
+        /**
+         * Required to access $this->message
+         */
+        public function getMessage(): string
+        {
+            return $this->message;
+        }
+
+        /**
+         * Required to access $this->type
+         */
+        public function getType(): string
+        {
+            return $this->type;
+        }
+
+        /**
+         * Required to access $this->icon
+         */
+        public function fetchIcon(): string
+        {
+            return $this->icon;
+        }
+
+        #[ExposeInTemplate]
+        public function getActions(): array // available as `{{ actions }}` in the template
+        {
+            // ...
+        }
+
+        #[ExposeInTemplate('dismissable')]
+        public function canBeDismissed(): bool // available as `{{ dismissable }}` in the template
+        {
+            // ...
+        }
+
+        // ...
+    }
+
+.. note::
+
+    When using ``ExposeInTemplate`` on a method the value is fetched eagerly
+    before rendering.
+
+Computed Properties
+~~~~~~~~~~~~~~~~~~~
+
+In the previous example, instead of querying for the featured products
+immediately (e.g. in ``__construct()``), we created a ``getProducts()``
+method and called that from the template via ``this.products``.
+
+This was done because, as a general rule, you should make your
+components as *lazy* as possible and store only the information you need
+on its properties (this also helps if you convert your component to a
+`live component`_ later). With this setup, the query is only executed if and
+when the ``getProducts()`` method is actually called. This is very similar
+to the idea of "computed properties" in frameworks like `Vue`_.
+
+But there's no magic with the ``getProducts()`` method: if you call
+``this.products`` multiple times in your template, the query would be
+executed multiple times.
+
+To make your ``getProducts()`` method act like a true computed property,
+call ``computed.products`` in your template. ``computed`` is a proxy
+that wraps your component and caches the return of methods. If they
+are called additional times, the cached value is used.
+
+.. code-block:: html+twig
+
+    {# templates/components/FeaturedProducts.html.twig #}
+    <div>
+        <h3>Featured Products</h3>
+
+        {% for product in computed.products %}
+            ...
+        {% endfor %}
+
+        ...
+        {% for product in computed.products %} {# use cache, does not result in a second query #}
+            ...
+        {% endfor %}
+    </div>
+
+.. note::
+
+    Computed methods only work for component methods with no required
+    arguments.
+
+Events
+------
+
+Twig Components dispatches various events throughout the lifecycle
+of instantiating, mounting and rendering a component.
+
+PreRenderEvent
+~~~~~~~~~~~~~~
+
+Subscribing to the ``PreRenderEvent`` gives the ability to modify
+the twig template and twig variables before components are rendered::
+
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+    use Symfony\UX\TwigComponent\Event\PreRenderEvent;
+
+    class HookIntoTwigPreRenderSubscriber implements EventSubscriberInterface
+    {
+        public function onPreRender(PreRenderEvent $event): void
+        {
+            $event->getComponent(); // the component object
+            $event->getTemplate(); // the twig template name that will be rendered
+            $event->getVariables(); // the variables that will be available in the template
+
+            $event->setTemplate('some_other_template.html.twig'); // change the template used
+
+            // manipulate the variables:
+            $variables = $event->getVariables();
+            $variables['custom'] = 'value';
+
+            $event->setVariables($variables); // {{ custom }} will be available in your template
+        }
+
+        public static function getSubscribedEvents(): array
+        {
+            return [PreRenderEvent::class => 'onPreRender'];
+        }
+    }
+
+PostRenderEvent
+~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.5
+
+    The ``PostRenderEvent`` was added in TwigComponents 2.5.
+
+The ``PostRenderEvent`` is called after a component has finished
+rendering and contains the ``MountedComponent`` that was just
+rendered.
+
+PreCreateForRenderEvent
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.5
+
+    The ``PreCreateForRenderEvent`` was added in TwigComponents 2.5.
+
+Subscribing to the ``PreCreateForRenderEvent`` gives the ability to be
+notified before a component object is created or hydrated, at the
+very start of the rendering process. You have access to the component
+name, input props and can interrupt the process by setting HTML. This
+event is not triggered during a re-render.
+
+PreMountEvent and PostMountEvent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To run code just before or after a component's data is mounted, you can
+listen to ``PreMountEvent`` or ``PostMountEvent``.
+
+Nested Components
+-----------------
+
+It's totally possible to nest one component into another. When you do
+this, there's nothing special to know: both components render
+independently. If you're using `Live Components`_, then there
+*are* some guidelines related to how the re-rendering of parent and
+child components works. Read `Live Nested Components`_.
+
+Debugging Components
+--------------------
+
+As your application grows, you'll eventually have a lot of components.
+This command will help you to debug some components issues.
+First, the debug:twig-component command lists all your application components
+who live in ``templates/components``:
+
+.. code-block:: terminal
+
+    $ php bin/console debug:component
+
+    +---------------+-----------------------------+------------------------------------+------+
+    | Component     | Class                       | Template                           | Live |
+    +---------------+-----------------------------+------------------------------------+------+
+    | Coucou        | App\Components\Alert        | components/Coucou.html.twig        |      |
+    | RandomNumber  | App\Components\RandomNumber | components/RandomNumber.html.twig  | X    |
+    | Test          | App\Components\foo\Test     | components/foo/Test.html.twig      |      |
+    | Button        | Anonymous component         | components/Button.html.twig        |      |
+    | foo:Anonymous | Anonymous component         | components/foo/Anonymous.html.twig |      |
+    +---------------+-----------------------------+------------------------------------+------+
+
+If you have some components that don't live in ``templates/components/``,
+but in ``templates/bar`` for example, you can pass an option:
+
+.. code-block:: terminal
+
+    $ php bin/console debug:twig-component --dir=bar
+
+And the name of some component to this argument to print the
+component details:
+
+.. code-block:: terminal
+
+    $ php bin/console debug:component RandomNumber
+
+    +---------------------------------------------------+-----------------------------------+
+    | Property                                          | Value                             |
+    +---------------------------------------------------+-----------------------------------+
+    | Component                                         | RandomNumber                      |
+    | Live                                              | X                                 |
+    | Class                                             | App\Components\RandomNumber       |
+    | Template                                          | components/RandomNumber.html.twig |
+    | Properties (type / name / default value if exist) | string $name = toto               |
+    |                                                   | string $type = test               |
+    | Live Properties                                   | int $max = 1000                   |
+    |                                                   | int $min = 10                     |
+    +---------------------------------------------------+-----------------------------------+
 
 Contributing
 ------------

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -30,7 +30,7 @@ And (2) a template:
 
 Done! Now render it wherever you want:
 
-.. code-block:: twig
+.. code-block:: html+twig
 
     {{ component('Alert', { message: 'Hello Twig Components!' }) }}
 
@@ -133,14 +133,14 @@ Naming Your Component
 
 To give your component a name, TwigComponent looks at the namespace(s)
 configured in :ref:`twig_component.yaml <default_config>` and finds the
-first match. If your have the recommended ``App\Twig\\Components\\``, then:
+first match. If your have the recommended ``App\Twig\Components\``, then:
 
-=========================================  ==================
+========================================  ===================
 Component Class                            Component Name
-=========================================  ==================
-``App\\Twig\\Components\\Alert``           ``Alert``
-``App\\Twig\\Components\\Button\\Primary`` ``Button:Primary``
-=========================================  ==================
+========================================  ===================
+``App\Twig\Components\Alert``              ``Alert``
+``App\Twig\Components\Button\Primary``     ``Button:Primary``
+========================================  ===================
 
 The ``:`` character is used in the name instead of ``\``. See
 :ref:`Configuration <configuration>` for more info.
@@ -326,7 +326,7 @@ could do this?
         I'm writing <strong>HTML</strong> right here!
     </twig:Alert>
 
-We can! When you add content between the the ``<twig:Alert>`` open and
+We can! When you add content between the ``<twig:Alert>`` open and
 close tag, it's passed to your component template as the block called
 ``content``. You can render it like any normal block:
 
@@ -392,7 +392,7 @@ In the template, the ``getProducts()`` method can be accessed via
 And because this component doesn't have any public properties that we
 need to populate, you can render it with:
 
-.. code-block:: twig
+.. code-block:: html+twig
 
     <twig:FeaturedProducts />
 
@@ -438,7 +438,7 @@ component is instantiated. Because the method has an ``$isSuccess``
 argument, if we pass an ``isSuccess`` prop when rendering, it will be
 passed to ``mount()``.
 
-.. code-block:: twig
+.. code-block:: html+twig
 
     <twig:Alert
         :isSuccess="false"
@@ -692,7 +692,7 @@ First, inside of ``<twig:{Component}>``, the ``this`` variable represents
 the component you're *now* rendering *and* you have access to all of *that*
 component's variables:
 
-.. code-block:: twig
+.. code-block:: html+twig
 
     {# templates/components/SuccessAlert.html.twig #}
     {{ this.someFunction }} {# this === SuccessAlert #}
@@ -706,10 +706,9 @@ component's variables:
 Conveniently, in addition to the variables from the ``Alert`` component, you
 *also* have access to whatever variables are available in the original template:
 
-.. code-block:: twig
+.. code-block:: html+twig
 
     {# templates/components/SuccessAlert.html.twig #}
-
     {% set name = 'Fabien' %}
     <twig:Alert type="success">
         Hello {{ name }}
@@ -736,7 +735,7 @@ This means you can **access variables from the block you're overriding**! For ex
 
 When overriding the ``alert_message`` block, you have access to the ``message`` variable:
 
-.. code-block:: twig
+.. code-block:: html+twig
 
     {# templates/some_page.html.twig #}
     <twig:SuccessAlert>
@@ -748,7 +747,7 @@ When overriding the ``alert_message`` block, you have access to the ``message`` 
 Inheritance & Forwarding "Outer Blocks"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.10`
+.. versionadded:: 2.10
 
     The ``outerBlocks`` variable was added in 2.10.
 
@@ -793,7 +792,7 @@ We already have a generic ``Alert`` component, so let's re-use it:
 To do this, the ``SuccessAlert`` component can grab the ``content`` block
 that's passed to it via the ``outerBlocks`` variable and forward it into ``Alert``:
 
-.. code-block:: twig
+.. code-block:: html+twig
 
     {# templates/components/SuccessAlert.html.twig #}
     <twig:Alert type="success">
@@ -1272,5 +1271,4 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Vue`: https://v3.vuejs.org/guide/computed.html
 .. _`Live Nested Components`: https://symfony.com/bundles/ux-live-component/current/index.html#nested-components
 .. _`Passing Blocks to Live Components`: https://symfony.com/bundles/ux-live-component/current/index.html#passing-blocks
-.. _`embed tag`: https://twig.symfony.com/doc/3.x/tags/embed.html
 .. _`Stimulus controller`: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
+++ b/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
@@ -31,25 +31,43 @@ final class TwigComponentPass implements CompilerPassInterface
         $componentReferences = [];
         $componentClassMap = [];
         $componentNames = [];
+        $componentDefaults = $container->getParameter('ux.twig_component.component_defaults');
+        $container->getParameterBag()->remove('ux.twig_component.component_defaults');
+        $legacyAutoNaming = $container->hasParameter('ux.twig_component.legacy_autonaming');
+        $container->getParameterBag()->remove('ux.twig_component.legacy_autonaming');
+
         foreach ($container->findTaggedServiceIds('twig.component') as $id => $tags) {
             $definition = $container->findDefinition($id);
 
             // component services must not be shared
             $definition->setShared(false);
+            $fqcn = $definition->getClass();
+            $defaults = $this->findMatchingDefaults($fqcn, $componentDefaults);
 
             foreach ($tags as $tag) {
                 if (!\array_key_exists('key', $tag)) {
-                    $fqcn = $definition->getClass();
-                    $name = substr($fqcn, strrpos($fqcn, '\\') + 1);
+                    if ($legacyAutoNaming) {
+                        $name = substr($fqcn, strrpos($fqcn, '\\') + 1);
+                    } else {
+                        if (null === $defaults) {
+                            throw new LogicException(sprintf('Could not generate a component name for class "%s": no matching namespace found under the "twig_component.defaults" to use as a root. Check the config or give your component an explicit name.', $fqcn));
+                        }
+
+                        $name = str_replace('\\', ':', substr($fqcn, \strlen($defaults['namespace'])));
+                        if ($defaults['name_prefix']) {
+                            $name = sprintf('%s:%s', $defaults['name_prefix'], $name);
+                        }
+                    }
                     if (\in_array($name, $componentNames, true)) {
                         throw new LogicException(sprintf('Failed creating the "%s" component with the automatic name "%s": another component already has this name. To fix this, give the component an explicit name (hint: using "%s" will override the existing component).', $fqcn, $name, $name));
                     }
+
                     $tag['key'] = $name;
                 }
 
                 $tag['service_id'] = $id;
                 $tag['class'] = $definition->getClass();
-                $tag['template'] = $tag['template'] ?? sprintf('components/%s.html.twig', str_replace(':', '/', $tag['key']));
+                $tag['template'] = $tag['template'] ?? $this->calculateTemplate($tag['key'], $defaults);
                 $componentConfig[$tag['key']] = $tag;
                 $componentReferences[$tag['key']] = new Reference($id);
                 $componentNames[] = $tag['key'];
@@ -61,5 +79,28 @@ final class TwigComponentPass implements CompilerPassInterface
         $factoryDefinition->setArgument(1, ServiceLocatorTagPass::register($container, $componentReferences));
         $factoryDefinition->setArgument(4, $componentConfig);
         $factoryDefinition->setArgument(5, $componentClassMap);
+    }
+
+    private function findMatchingDefaults(string $className, array $componentDefaults): ?array
+    {
+        foreach ($componentDefaults as $namespace => $defaults) {
+            if (str_starts_with($className, $namespace)) {
+                return array_merge(['namespace' => $namespace], $defaults);
+            }
+        }
+
+        return null;
+    }
+
+    private function calculateTemplate(string $componentName, ?array $defaults): string
+    {
+        $directory = $defaults && isset($defaults['template_directory']) ? $defaults['template_directory'] : 'components';
+
+        // if a name_prefix was added to the name, don't include it in the template path
+        if ($defaults && $defaults['name_prefix'] ?? null) {
+            $componentName = substr($componentName, \strlen($defaults['name_prefix']) + 1);
+        }
+
+        return sprintf('%s/%s.html.twig', $directory, str_replace(':', '/', $componentName));
     }
 }

--- a/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
+++ b/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
@@ -101,6 +101,6 @@ final class TwigComponentPass implements CompilerPassInterface
             $componentName = substr($componentName, \strlen($defaults['name_prefix']) + 1);
         }
 
-        return sprintf('%s/%s.html.twig', $directory, str_replace(':', '/', $componentName));
+        return sprintf('%s/%s.html.twig', rtrim($directory, '/'), str_replace(':', '/', $componentName));
     }
 }

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -43,7 +43,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_it
  */
 final class TwigComponentExtension extends Extension implements ConfigurationInterface
 {
-    const DEPRECATED_DEFAULT_KEY = '__deprecated__use_old_naming_behavior';
+    private const DEPRECATED_DEFAULT_KEY = '__deprecated__use_old_naming_behavior';
 
     public function load(array $configs, ContainerBuilder $container): void
     {
@@ -135,7 +135,7 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                     ->defaultValue([self::DEPRECATED_DEFAULT_KEY])
                     ->useAttributeAsKey('namespace')
                     ->validate()
-                        ->always(function($v) {
+                        ->always(function ($v) {
                             foreach ($v as $namespace => $defaults) {
                                 if (!str_ends_with($namespace, '\\')) {
                                     throw new InvalidConfigurationException(sprintf('The twig_component.defaults namespace "%s" is invalid: it must end in a "\"', $namespace));
@@ -147,6 +147,12 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                     ->end()
                     // validate that namespace ends in \
                     ->arrayPrototype()
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->then(function (string $v) {
+                                return ['template_directory' => $v];
+                            })
+                        ->end()
                         ->children()
                             ->scalarNode('template_directory')
                                 ->defaultValue('components')

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\TwigComponent\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -42,11 +43,23 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_it
  */
 final class TwigComponentExtension extends Extension implements ConfigurationInterface
 {
+    const DEPRECATED_DEFAULT_KEY = '__deprecated__use_old_naming_behavior';
+
     public function load(array $configs, ContainerBuilder $container): void
     {
         if (!isset($container->getParameter('kernel.bundles')['TwigBundle'])) {
             throw new LogicException('The TwigBundle is not registered in your application. Try running "composer require symfony/twig-bundle".');
         }
+
+        $config = $this->processConfiguration($this, $configs);
+        $defaults = $config['defaults'];
+        if ($defaults === [self::DEPRECATED_DEFAULT_KEY]) {
+            trigger_deprecation('symfony/ux-twig-component', '2.13', 'Not setting the "twig_component.defaults" config option is deprecated. Check the documentation for an example configuration.');
+            $container->setParameter('ux.twig_component.legacy_autonaming', true);
+
+            $defaults = [];
+        }
+        $container->setParameter('ux.twig_component.component_defaults', $defaults);
 
         $container->register('ux.twig_component.component_template_finder', ComponentTemplateFinder::class)
             ->setArguments([
@@ -118,9 +131,31 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
 
         $rootNode
             ->children()
-                ->arrayNode('controller_paths')
-                    ->defaultValue(['%kernel.project_dir%/assets/controllers'])
-                    ->scalarPrototype()->end()
+                ->arrayNode('defaults')
+                    ->defaultValue([self::DEPRECATED_DEFAULT_KEY])
+                    ->useAttributeAsKey('namespace')
+                    ->validate()
+                        ->always(function($v) {
+                            foreach ($v as $namespace => $defaults) {
+                                if (!str_ends_with($namespace, '\\')) {
+                                    throw new InvalidConfigurationException(sprintf('The twig_component.defaults namespace "%s" is invalid: it must end in a "\"', $namespace));
+                                }
+                            }
+
+                            return $v;
+                        })
+                    ->end()
+                    // validate that namespace ends in \
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('template_directory')
+                                ->defaultValue('components')
+                            ->end()
+                            ->scalarNode('name_prefix')
+                                ->defaultValue('')
+                            ->end()
+                        ->end()
+                    ->end()
                 ->end()
                 ->scalarNode('controllers_json')
                     ->defaultValue('%kernel.project_dir%/assets/controllers.json')

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\UX\TwigComponent\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -37,7 +40,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_it
  *
  * @internal
  */
-final class TwigComponentExtension extends Extension
+final class TwigComponentExtension extends Extension implements ConfigurationInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
@@ -105,5 +108,25 @@ final class TwigComponentExtension extends Extension
             ])
             ->addTag('console.command')
         ;
+    }
+
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('twig_component');
+        $rootNode = $treeBuilder->getRootNode();
+        \assert($rootNode instanceof ArrayNodeDefinition);
+
+        $rootNode
+            ->children()
+                ->arrayNode('controller_paths')
+                    ->defaultValue(['%kernel.project_dir%/assets/controllers'])
+                    ->scalarPrototype()->end()
+                ->end()
+                ->scalarNode('controllers_json')
+                    ->defaultValue('%kernel.project_dir%/assets/controllers.json')
+                ->end()
+            ->end();
+
+        return $treeBuilder;
     }
 }

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -123,7 +123,7 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
         ;
     }
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('twig_component');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/TwigComponent/tests/Fixtures/AcmeComponent/AcmeRootComponent.php
+++ b/src/TwigComponent/tests/Fixtures/AcmeComponent/AcmeRootComponent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\AcmeComponent;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent]
+class AcmeRootComponent
+{
+
+}

--- a/src/TwigComponent/tests/Fixtures/AcmeComponent/AcmeSubDir/AcmeOtherComponent.php
+++ b/src/TwigComponent/tests/Fixtures/AcmeComponent/AcmeSubDir/AcmeOtherComponent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\AcmeComponent\AcmeSubDir;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent]
+class AcmeOtherComponent
+{
+
+}

--- a/src/TwigComponent/tests/Fixtures/Component/SubDirectory/ComponentInSubDirectory.php
+++ b/src/TwigComponent/tests/Fixtures/Component/SubDirectory/ComponentInSubDirectory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component\SubDirectory;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent]
+class ComponentInSubDirectory
+{
+
+}

--- a/src/TwigComponent/tests/Fixtures/Kernel.php
+++ b/src/TwigComponent/tests/Fixtures/Kernel.php
@@ -52,6 +52,21 @@ final class Kernel extends BaseKernel
             'default_path' => '%kernel.project_dir%/tests/Fixtures/templates',
         ]);
 
+        if ('legacy_autonaming' != $this->environment) {
+            $acmeDefaults = [
+                'name_prefix' => 'AcmePrefix',
+            ];
+            if ('no_template_directory' !== $this->environment) {
+                $acmeDefaults['template_directory'] = 'acme_components';
+            }
+            $c->extension('twig_component', [
+                'defaults' => [
+                    'Symfony\UX\TwigComponent\Tests\Fixtures\Component\\' => [],
+                    'Symfony\UX\TwigComponent\Tests\Fixtures\AcmeComponent\\' => $acmeDefaults,
+                ],
+            ]);
+        }
+
         $services = $c->services()
             ->defaults()
                 ->autowire()

--- a/src/TwigComponent/tests/Fixtures/Kernel.php
+++ b/src/TwigComponent/tests/Fixtures/Kernel.php
@@ -61,7 +61,7 @@ final class Kernel extends BaseKernel
             }
             $c->extension('twig_component', [
                 'defaults' => [
-                    'Symfony\UX\TwigComponent\Tests\Fixtures\Component\\' => [],
+                    'Symfony\UX\TwigComponent\Tests\Fixtures\Component\\' => 'components/',
                     'Symfony\UX\TwigComponent\Tests\Fixtures\AcmeComponent\\' => $acmeDefaults,
                 ],
             ]);

--- a/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
@@ -18,7 +18,6 @@ use Symfony\UX\TwigComponent\Tests\Fixtures\Component\BasicComponent;
 use Symfony\UX\TwigComponent\Tests\Fixtures\Component\ComponentA;
 use Symfony\UX\TwigComponent\Tests\Fixtures\Component\ComponentB;
 use Symfony\UX\TwigComponent\Tests\Fixtures\Component\ComponentC;
-use Symfony\UX\TwigComponent\Tests\Fixtures\Component\SubDirectory\ComponentInSubDirectory;
 use Symfony\UX\TwigComponent\Tests\Fixtures\Component\WithSlots;
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Ref: https://github.com/symfony/demo/pull/1426#discussion_r1319791664
| License       | MIT

Recipes PR: https://github.com/symfony/recipes/pull/1243

Currently, you can render an anonymous component with a `:` syntax, which becomes a subdirectory:

```
<twig:Button:Primary /> -> templates/components/Button/Primary.html.twig
```

But if you want to add a class for this component later, you now *must* use the `name: 'Button:Primary'` key. That's because, even if the component lives in `App\Twig\Components\Button\Primary`, the automatic component name will just be `Primary`.

## New Features & Conventions from this PR

A) **New Config**

You configure the "namespace root" and templates directory for your components. Default will be:

```yaml
# config/packages/twig_component.yaml
twig_component:
    defaults:
        # default component template directory
        App\Twig\Components\: 'components/'
```

If you don't have this config, you will get the same "class name === component name" behavior of today, but with a deprecation notice.

B) **SubDirectory Naming**

Thanks to the above, component names now take into account "subdirectories":

| Component Class                          | Component Name    |
| --------------------------------------- | ----------------- |
| `App\Twig\Components\Alert`             | `Alert`           |
| `App\Twig\Components\Button\Primary`     | `Button:Primary`  |


## Best-Practices / Conventions

1) `App\Twig\Components\` as the default namespace/directory for components.

What do people think? What are you doing in your apps today?

2) Upper-camel case for component names

You can do whatever you want, but I'm proposing that we continue to use the convention where component name, class and template all use UpperCamelCase naming:

```
<twig:Alert> -> App\Twig\Components\Alert -> templates/components/Alert.html.twig
```

I've also updated and reorganized the TwigComponent docs quite a lot - we had some great sections that, over time, were not in the ideal order.

Also, the TwigComponent docs now use the `<twig:HTML>` syntax almost exclusively.

Cheers!

### TODO

* [X] Recipe update for config file
* [ ] Add Configuration section to docs