### PR TITLE
Add deferred live components

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.13.0
+
+-   Add deferred rendering of Live Components
+
 ## 2.12.0
 
 -   Add `onUpdated` hook for `LiveProp`

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2175,6 +2175,32 @@ To validate only on "change", use the ``on(change)`` modifier:
         class="{{ _errors.has('post.content') ? 'is-invalid' : '' }}"
     >
 
+Deferring the Loading
+---------------------
+
+Certain components might be heavy to load. You can defer the loading of these components
+until after the rest of the page has loaded. To do this, use the ``defer`` attribute:
+
+.. code-block:: twig
+
+    {{ component('SomeHeavyComponent', { defer: true }) }}
+
+Doing so will render an empty "placeholder" tag with the live attributes. Once the ``live:connect`` event is triggered,
+the component will be rendered asynchronously.
+
+By default the rendered tag is a ``div``. You can change this by specifying the ``loading-tag`` attribute:
+
+.. code-block:: twig
+
+    {{ component('SomeHeavyComponent', { defer: true, loading-tag: 'span' }) }}
+
+If you need to signify that the component is loading, use the ``loading-template`` attribute.
+This lets you provide a Twig template that will render inside the "placeholder" tag:
+
+.. code-block:: twig
+
+    {{ component('SomeHeavyComponent', { defer: true, loading-template: 'spinning-wheel.html.twig' }) }}
+
 Polling
 -------
 

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -25,6 +25,7 @@ use Symfony\UX\LiveComponent\ComponentValidatorInterface;
 use Symfony\UX\LiveComponent\Controller\BatchActionController;
 use Symfony\UX\LiveComponent\EventListener\AddLiveAttributesSubscriber;
 use Symfony\UX\LiveComponent\EventListener\DataModelPropsSubscriber;
+use Symfony\UX\LiveComponent\EventListener\DeferLiveComponentSubscriber;
 use Symfony\UX\LiveComponent\EventListener\InterceptChildComponentRenderSubscriber;
 use Symfony\UX\LiveComponent\EventListener\LiveComponentSubscriber;
 use Symfony\UX\LiveComponent\EventListener\ResetDeterministicIdSubscriber;
@@ -212,6 +213,14 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             ])
             ->addTag('kernel.event_subscriber')
             ->addTag('container.service_subscriber', ['key' => LiveControllerAttributesCreator::class, 'id' => 'ux.live_component.live_controller_attributes_creator'])
+        ;
+
+        $container->register('ux.live_component.defer_live_component_subscriber', DeferLiveComponentSubscriber::class)
+            ->setArguments([
+                new Reference('ux.twig_component.component_stack'),
+                new Reference('ux.live_component.live_controller_attributes_creator'),
+            ])
+            ->addTag('kernel.event_subscriber')
         ;
 
         $container->register('ux.live_component.deterministic_id_calculator', DeterministicTwigIdCalculator::class);

--- a/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\UX\LiveComponent\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\UX\TwigComponent\Event\PostMountEvent;
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
+
+final class DeferLiveComponentSubscriber implements EventSubscriberInterface
+{
+    private const DEFAULT_LOADING_TAG = 'div';
+
+    private const DEFAULT_LOADING_TEMPLATE = null;
+
+    public function onPostMount(PostMountEvent $event): void
+    {
+        $data = $event->getData();
+        if (\array_key_exists('defer', $data)) {
+            $event->addExtraMetadata('defer', true);
+            unset($event->getData()['defer']);
+        }
+
+        if (\array_key_exists('loading-template', $data)) {
+            $event->addExtraMetadata('loading-template', $data['loading-template']);
+            unset($event->getData()['loading-template']);
+        }
+
+        if (\array_key_exists('loading-tag', $data)) {
+            $event->addExtraMetadata('loading-tag', $data['loading-tag']);
+            unset($event->getData()['loading-tag']);
+        }
+
+        $event->setData($data);
+    }
+
+    public function onPreRender(PreRenderEvent $event): void
+    {
+        $mountedComponent = $event->getMountedComponent();
+
+        if (!$mountedComponent->hasExtraMetadata('defer')) {
+            return;
+        }
+
+        $event->setTemplate('@LiveComponent/deferred.html.twig');
+
+        $variables = $event->getVariables();
+        $variables['loadingTemplate'] = self::DEFAULT_LOADING_TEMPLATE;
+        $variables['loadingTag'] = self::DEFAULT_LOADING_TAG;
+
+        if ($mountedComponent->hasExtraMetadata('loading-template')) {
+            $variables['loadingTemplate'] = $mountedComponent->getExtraMetadata('loading-template');
+        }
+
+        if ($mountedComponent->hasExtraMetadata('loading-tag')) {
+            $variables['loadingTag'] = $mountedComponent->getExtraMetadata('loading-tag');
+        }
+
+        $event->setVariables($variables);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PostMountEvent::class => ['onPostMount'],
+            PreRenderEvent::class => ['onPreRender'],
+        ];
+    }
+}

--- a/src/LiveComponent/templates/deferred.html.twig
+++ b/src/LiveComponent/templates/deferred.html.twig
@@ -1,0 +1,7 @@
+<{{ loadingTag }} {{ attributes }} data-action="live:connect->live#$render">
+    {% block loadingContent %}
+        {% if loadingTemplate != null %}
+            {{ include(loadingTemplate) }}
+        {% endif %}
+    {% endblock %}
+</{{ loadingTag }}>

--- a/src/LiveComponent/tests/Fixtures/Component/DeferredComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/DeferredComponent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('deferred_component')]
+final class DeferredComponent
+{
+    use DefaultActionTrait;
+
+    public function getLongAwaitedData(): string
+    {
+        return 'Long awaited data';
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/deferred_component.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/deferred_component.html.twig
@@ -1,0 +1,1 @@
+<div {{ attributes }}>{{ computed.longAwaitedData }}</div>

--- a/src/LiveComponent/tests/Fixtures/templates/dummy/loading.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/dummy/loading.html.twig
@@ -1,0 +1,1 @@
+I'm loading a reaaaally slow live component

--- a/src/LiveComponent/tests/Fixtures/templates/render_deferred_component.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/render_deferred_component.html.twig
@@ -1,0 +1,1 @@
+<twig:deferred_component defer />

--- a/src/LiveComponent/tests/Fixtures/templates/render_deferred_component_with_li_tag.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/render_deferred_component_with_li_tag.html.twig
@@ -1,0 +1,1 @@
+<twig:deferred_component defer loading-tag='li' />

--- a/src/LiveComponent/tests/Fixtures/templates/render_deferred_component_with_template.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/render_deferred_component_with_template.html.twig
@@ -1,0 +1,1 @@
+<twig:deferred_component defer loading-template='dummy/loading.html.twig' />

--- a/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\UX\LiveComponent\Tests\Functional\EventListener;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\LiveComponent\Tests\LiveComponentTestHelper;
+use Zenstruck\Browser\Test\HasBrowser;
+
+final class DeferLiveComponentSubscriberTest extends KernelTestCase
+{
+    use HasBrowser;
+    use LiveComponentTestHelper;
+
+    public function testItSetsDeferredTemplateIfLiveIdNotPassed(): void
+    {
+        $div = $this->browser()
+            ->visit('/render-template/render_deferred_component')
+            ->assertSuccessful()
+            ->crawler()
+            ->filter('div')
+        ;
+
+        $this->assertSame('', trim($div->html()));
+        $this->assertSame('live:connect->live#$render', $div->attr('data-action'));
+
+        $component = $this->mountComponent('deferred_component', [
+            'data-live-id' => $div->attr('data-live-id'),
+        ]);
+
+        $dehydrated = $this->dehydrateComponent($component);
+
+        $div = $this->browser()
+            ->visit('/_components/deferred_component?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->assertSuccessful()
+            ->crawler()
+            ->filter('div')
+        ;
+
+        $this->assertSame('Long awaited data', $div->html());
+    }
+
+    public function testItIncludesGivenTemplateWhileLoadingDeferredComponent(): void
+    {
+        $div = $this->browser()
+            ->visit('/render-template/render_deferred_component_with_template')
+            ->assertSuccessful()
+            ->crawler()
+            ->filter('div')
+        ;
+
+        $this->assertSame('I\'m loading a reaaaally slow live component', trim($div->html()));
+
+        $component = $this->mountComponent('deferred_component', [
+            'data-live-id' => $div->attr('data-live-id'),
+        ]);
+
+        $dehydrated = $this->dehydrateComponent($component);
+
+        $div = $this->browser()
+            ->visit('/_components/deferred_component?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->assertSuccessful()
+            ->crawler()
+            ->filter('div')
+        ;
+
+        $this->assertStringContainsString('Long awaited data', $div->html());
+    }
+
+    public function testItAllowsToSetCustomLoadingHtmlTag(): void
+    {
+        $crawler = $this->browser()
+            ->visit('/render-template/render_deferred_component_with_li_tag')
+            ->assertSuccessful()
+            ->crawler()
+        ;
+
+        $this->assertSame(0, $crawler->filter('div')->count());
+        $this->assertSame(1, $crawler->filter('li')->count());
+    }
+}

--- a/src/TwigComponent/src/Event/PostMountEvent.php
+++ b/src/TwigComponent/src/Event/PostMountEvent.php
@@ -18,8 +18,11 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class PostMountEvent extends Event
 {
-    public function __construct(private object $component, private array $data)
-    {
+    public function __construct(
+        private object $component,
+        private array $data,
+        private array $extraMetadata = [],
+    ) {
     }
 
     public function getComponent(): object
@@ -35,5 +38,20 @@ final class PostMountEvent extends Event
     public function setData(array $data): void
     {
         $this->data = $data;
+    }
+
+    public function getExtraMetadata(): array
+    {
+        return $this->extraMetadata;
+    }
+
+    public function addExtraMetadata(string $key, mixed $value): void
+    {
+        $this->extraMetadata[$key] = $value;
+    }
+
+    public function removeExtraMetadata(string $key): void
+    {
+        unset($this->extraMetadata[$key]);
     }
 }

--- a/src/TwigComponent/src/MountedComponent.php
+++ b/src/TwigComponent/src/MountedComponent.php
@@ -19,13 +19,6 @@ namespace Symfony\UX\TwigComponent;
 final class MountedComponent
 {
     /**
-     * Any extra metadata that might be useful to set.
-     *
-     * @var array<string, mixed>
-     */
-    private array $extraMetadata = [];
-
-    /**
      * @param array|null $inputProps if the component was just originally created,
      *                               (not hydrated from a request), this is the
      *                               array of initial props used to create the component
@@ -34,7 +27,8 @@ final class MountedComponent
         private string $name,
         private object $component,
         private ComponentAttributes $attributes,
-        private ?array $inputProps = []
+        private ?array $inputProps = [],
+        private array $extraMetadata = [],
     ) {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #994
| License       | MIT

Initially this feature was called `lazy loading`, but this name could be misleading, as my solution doesn't provide **real** lazy loading. So, I named it `deferred live components`, I guess this name fits better.

How to use it?

```twig
<twig:MyComponent defer />
```

In such case we'll get an empty div. Once `live:connect` event called, it'll load the component in the background. We can also define a template to be rendered while loading (e.g. a cool spinner or some text).

```twig
<twig:MyComponent defer defer-loading-template="my_cool_spinner.html.twig" />
```

I'm open for any suggestions 🙌🏼!