### PR TITLE
Fix missing double dash in namespaced Stimulus outlets

### DIFF
--- a/src/StimulusBundle/src/Dto/StimulusAttributes.php
+++ b/src/StimulusBundle/src/Dto/StimulusAttributes.php
@@ -58,7 +58,7 @@ class StimulusAttributes implements \Stringable, \IteratorAggregate
         }
 
         foreach ($controllerOutlets as $outlet => $selector) {
-            $outlet = $this->normalizeKeyName($outlet);
+            $outlet = $this->normalizeControllerName($outlet);
 
             $this->attributes['data-'.$controllerName.'-'.$outlet.'-outlet'] = $selector;
         }

--- a/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
+++ b/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
@@ -119,6 +119,15 @@ final class StimulusTwigExtensionTest extends TestCase
             'expectedString' => 'data-controller="my-controller" data-my-controller-other-controller-outlet=".target"',
             'expectedArray' => ['data-controller' => 'my-controller', 'data-my-controller-other-controller-outlet' => '.target'],
         ];
+
+        yield 'short-single-controller-no-data-with-namespaced-outlet' => [
+            'controllerName' => 'my-controller',
+            'controllerValues' => [],
+            'controllerClasses' => [],
+            'controllerOutlets' => ['namespaced--other-controller' => '.target'],
+            'expectedString' => 'data-controller="my-controller" data-my-controller-namespaced--other-controller-outlet=".target"',
+            'expectedArray' => ['data-controller' => 'my-controller', 'data-my-controller-namespaced--other-controller-outlet' => '.target'],
+        ];
     }
 
     public function testAppendStimulusController(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?     |  yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       |  /
| License       | MIT


In `StimulusTwigExtension`, namespaced (ie: in sub directories) stimulus controllers didn't work as the regex in `StimulusAttribute::normalizeKeyName` removes the double-dash needed to mark 
namespace separations. 

As the outlet value is the name of a controller, I suggest to use `normalizeControllerName` from the same class, instead.

