### PR TITLE
[TwigComponent][WebProfiler] Add profile + StopWatch + WDT

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.13.0
+
+-   Add profiler integration: `TwigComponentDataCollector` and debug toolbar templates
+
 ## 2.12.0
 
 -   Added a `debug:twig-component` command.

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -40,6 +40,7 @@
         "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/phpunit-bridge": "^6.0|^7.0",
         "symfony/stimulus-bundle": "^2.9.1",
+        "symfony/stopwatch": "^5.4|^6.0|^7.0",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",
         "symfony/webpack-encore-bundle": "^1.15"
     },

--- a/src/TwigComponent/config/debug.php
+++ b/src/TwigComponent/config/debug.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\UX\TwigComponent\DataCollector\TwigComponentDataCollector;
+use Symfony\UX\TwigComponent\EventListener\TwigComponentLoggerListener;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+
+        ->set('ux.twig_component.component_logger_listener', TwigComponentLoggerListener::class)
+        ->args([
+            service('debug.stopwatch')->ignoreOnInvalid(),
+        ])
+        ->tag('kernel.event_subscriber')
+
+        ->set('ux.twig_component.data_collector', TwigComponentDataCollector::class)
+        ->args([
+            service('ux.twig_component.component_logger_listener'),
+            service('twig'),
+        ])
+        ->tag('data_collector', [
+            'template' => '@TwigComponent/Collector/twig_component.html.twig',
+            'id' => 'twig_component',
+            'priority' => 256,
+        ]);
+};

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -76,7 +76,7 @@ final class ComponentRenderer implements ComponentRendererInterface
                 $event->getTemplateIndex(),
             )->render($event->getVariables());
         } finally {
-            $this->componentStack->pop();
+            $mounted = $this->componentStack->pop();
 
             $event = new PostRenderEvent($mounted);
             $this->dispatcher->dispatch($event);

--- a/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
+++ b/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\DataCollector;
+
+use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+use Symfony\Component\VarDumper\Caster\ClassStub;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\UX\TwigComponent\Event\PostRenderEvent;
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
+use Symfony\UX\TwigComponent\EventListener\TwigComponentLoggerListener;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+class TwigComponentDataCollector extends AbstractDataCollector implements LateDataCollectorInterface
+{
+    private bool $hasStub;
+
+    public function __construct(
+        private readonly TwigComponentLoggerListener $logger,
+        private readonly Environment $twig,
+    ) {
+        $this->hasStub = class_exists(ClassStub::class);
+    }
+
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    {
+    }
+
+    public function lateCollect(): void
+    {
+        $this->collectDataFromLogger();
+        $this->data = $this->cloneVar($this->data);
+    }
+
+    public function getData(): array|Data
+    {
+        return $this->data;
+    }
+
+    public function getName(): string
+    {
+        return 'twig_component';
+    }
+
+    public function reset(): void
+    {
+        $this->logger->reset();
+        parent::reset();
+    }
+
+    public function getComponents(): array|Data
+    {
+        return $this->data['components'] ?? [];
+    }
+
+    public function getComponentCount(): int
+    {
+        return $this->data['component_count'] ?? 0;
+    }
+
+    public function getPeakMemoryUsage(): int
+    {
+        return $this->data['peak_memory_usage'] ?? 0;
+    }
+
+    public function getRenders(): array|Data
+    {
+        return $this->data['renders'] ?? [];
+    }
+
+    public function getRenderCount(): int
+    {
+        return $this->data['render_count'] ?? 0;
+    }
+
+    public function getRenderTime(): int
+    {
+        return $this->data['render_time'] ?? 0;
+    }
+
+    private function collectDataFromLogger(): void
+    {
+        $components = [];
+        $renders = [];
+        $ongoingRenders = [];
+
+        foreach ($this->logger->getEvents() as [$event, $profile]) {
+            if ($event instanceof PreRenderEvent) {
+                $mountedComponent = $event->getMountedComponent();
+
+                $metadata = $event->getMetadata();
+                $componentName = $metadata->getName();
+                $componentClass = $mountedComponent->getComponent()::class;
+
+                $components[$componentName] ??= [
+                    'name' => $componentName,
+                    'class' => $componentClass,
+                    'class_stub' => $this->hasStub ? new ClassStub($componentClass) : $componentClass,
+                    'template' => $metadata->getTemplate(),
+                    'template_path' => $this->resolveTemplatePath($metadata->getTemplate()), // defer ? lazy ?
+                    'render_count' => 0,
+                    'render_time' => 0,
+                ];
+
+                $renderId = spl_object_id($mountedComponent);
+                $renders[$renderId] = [
+                    'name' => $componentName,
+                    'class' => $componentClass,
+                    'is_embed' => $event->isEmbedded(),
+                    'input_props' => $mountedComponent->getInputProps(),
+                    'attributes' => $mountedComponent->getAttributes()->all(),
+                    'variables' => $event->getVariables(),
+                    'template_index' => $event->getTemplateIndex(),
+                    'component' => $mountedComponent->getComponent(),
+                    'depth' => \count($ongoingRenders),
+                    'children' => [],
+                    'render_start' => $profile[0],
+                ];
+
+                if ($parentId = end($ongoingRenders)) {
+                    $renders[$parentId]['children'][] = $renderId;
+                }
+
+                $ongoingRenders[$renderId] = $renderId;
+                continue;
+            }
+
+            if ($event instanceof PostRenderEvent) {
+                $mountedComponent = $event->getMountedComponent();
+                $componentName = $mountedComponent->getName();
+                $renderId = spl_object_id($mountedComponent);
+
+                $renderTime = ($profile[0] - $renders[$renderId]['render_start']) * 1000;
+                $renders[$renderId] += [
+                    'render_end' => $profile[0],
+                    'render_time' => $renderTime,
+                    'render_memory' => $profile[1],
+                ];
+
+                ++$components[$componentName]['render_count'];
+                $components[$componentName]['render_time'] += $renderTime;
+
+                unset($ongoingRenders[$renderId]);
+            }
+        }
+
+        // Sort by render count DESC
+        uasort($components, fn ($a, $b) => $b['render_count'] <=> $a['render_count']);
+
+        $this->data['components'] = $components;
+        $this->data['component_count'] = \count($components);
+
+        $this->data['renders'] = $renders;
+        $this->data['render_count'] = \count($renders);
+        $rootRenders = array_filter($renders, fn (array $r) => 0 === $r['depth']);
+        $this->data['render_time'] = array_sum(array_column($rootRenders, 'render_time'));
+
+        $this->data['peak_memory_usage'] = max([0, ...array_column($renders, 'render_memory')]);
+    }
+
+    private function resolveTemplatePath(string $logicalName): ?string
+    {
+        try {
+            $source = $this->twig->getLoader()->getSourceContext($logicalName);
+        } catch (LoaderError) {
+            return null;
+        }
+
+        return $source->getPath();
+    }
+}

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -11,13 +11,16 @@
 
 namespace Symfony\UX\TwigComponent\DependencyInjection;
 
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Command\ComponentDebugCommand;
 use Symfony\UX\TwigComponent\ComponentFactory;
@@ -41,6 +44,8 @@ final class TwigComponentExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
+
         if (!isset($container->getParameter('kernel.bundles')['TwigBundle'])) {
             throw new LogicException('The TwigBundle is not registered in your application. Try running "composer require symfony/twig-bundle".');
         }
@@ -105,5 +110,9 @@ final class TwigComponentExtension extends Extension
             ])
             ->addTag('console.command')
         ;
+
+        if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
+            $loader->load('debug.php');
+        }
     }
 }

--- a/src/TwigComponent/src/EventListener/TwigComponentLoggerListener.php
+++ b/src/TwigComponent/src/EventListener/TwigComponentLoggerListener.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Contracts\Service\ResetInterface;
+use Symfony\UX\TwigComponent\Event\PostMountEvent;
+use Symfony\UX\TwigComponent\Event\PostRenderEvent;
+use Symfony\UX\TwigComponent\Event\PreCreateForRenderEvent;
+use Symfony\UX\TwigComponent\Event\PreMountEvent;
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+class TwigComponentLoggerListener implements EventSubscriberInterface, ResetInterface
+{
+    private array $events = [];
+
+    public function __construct(private ?Stopwatch $stopwatch = null)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PreCreateForRenderEvent::class => [
+                // High priority: start the stopwatch as soon as possible
+                ['onPreCreateForRender', 255],
+                // Low priority: check `event::getRenderedString()` as late as possible
+                ['onPostCreateForRender', -255],
+            ],
+            PreMountEvent::class => ['onPreMount', 255],
+            PostMountEvent::class => ['onPostMount', -255],
+            PreRenderEvent::class => ['onPreRender', 255],
+            PostRenderEvent::class => ['onPostRender', -255],
+        ];
+    }
+
+    public function getEvents(): array
+    {
+        return $this->events;
+    }
+
+    public function onPreCreateForRender(PreCreateForRenderEvent $event): void
+    {
+        $this->stopwatch?->start($event->getName(), 'twig_component');
+        $this->logEvent($event);
+    }
+
+    private function logEvent(object $event): void
+    {
+        $this->events[] = [$event, [microtime(true), memory_get_usage(true)]];
+    }
+
+    public function onPostCreateForRender(PreCreateForRenderEvent $event): void
+    {
+        if (\is_string($event->getRenderedString())) {
+            $this->stopwatch?->stop($event->getName());
+            $this->logEvent($event);
+        }
+    }
+
+    public function onPreMount(PreMountEvent $event): void
+    {
+        $this->logEvent($event);
+    }
+
+    public function onPostMount(PostMountEvent $event): void
+    {
+        $this->logEvent($event);
+    }
+
+    public function onPreRender(PreRenderEvent $event): void
+    {
+        $this->logEvent($event);
+    }
+
+    public function onPostRender(PostRenderEvent $event): void
+    {
+        if ($this->stopwatch?->isStarted($name = $event->getMountedComponent()->getName())) {
+            $this->stopwatch->stop($name);
+        }
+        $this->logEvent($event);
+    }
+
+    public function reset(): void
+    {
+        $this->events = [];
+    }
+}

--- a/src/TwigComponent/templates/Collector/chevron-down.svg
+++ b/src/TwigComponent/templates/Collector/chevron-down.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-chevron-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <path d="M6 9l6 6l6 -6"></path>
+</svg>

--- a/src/TwigComponent/templates/Collector/icon.svg
+++ b/src/TwigComponent/templates/Collector/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+     stroke-width="1.5" viewBox="0 0 24 24">
+    <path d="M12 8.29c0-1.37-.55-2.68-1.54-3.64a5.3 5.3 0 0 0-3.71-1.5H4.12v1.7a5.1 5.1 0 0 0 1.54 3.64A5.3 5.3 0 0 0 9.37 10H12m0 1.47c0-1.3.55-2.55 1.54-3.46a5.45 5.45 0 0 1 3.71-1.44h2.63v.82c0 1.3-.56 2.54-1.54 3.46a5.45 5.45 0 0 1-3.71 1.44H12m0 4.57V7.7M7.11 15 4 18l3.11 3M17 15l3.11 3L17 21"/>
+</svg>

--- a/src/TwigComponent/templates/Collector/twig_component.html.twig
+++ b/src/TwigComponent/templates/Collector/twig_component.html.twig
@@ -1,0 +1,304 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block page_title 'Twig Components' %}
+
+{% block head %}
+    {{ parent() }}
+    <style>
+        .twig-component-dump {
+            display: block;
+            background: rgba(0, 0, 0, .15);
+            --font-size-monospace: 12px;
+            font-weight: 400;
+            border-radius: 4px;
+            padding: 5px;
+        }
+        .twig-component-metrics {
+            margin-block-end: 3rem;
+        }
+
+        .twig-component-component {
+            margin-block-end: 3rem;
+        }
+        .twig-component-component th:first-child,
+        .twig-component-component td:first-child {
+            width: 25%;
+        }
+        .twig-component-component thead th {
+            font-weight: 200;
+            vertical-align: middle;
+            padding: .75rem 1rem;
+        }
+        .twig-component-component thead strong {
+            font-weight: 600;
+            display: block;
+        }
+        .twig-component-component td {
+            vertical-align: middle;
+            padding: .75rem 1rem;
+        }
+        .twig-component-component tbody td.metric {
+            text-align: right;
+        }
+        .twig-component-component thead small,
+        .twig-component-component thead strong {
+            display: block;
+        }
+        .twig-component-component .cell-right {
+            width: 4rem;
+            text-align: right;
+        }
+
+        .twig-component-renders {
+            margin-bottom: 2rem;
+        }
+        .twig-component-render {
+            margin-left: calc(var(--render-depth) * .5rem);
+            width: calc(100% - calc(var(--render-depth) * .5rem));
+        }
+        .twig-component-render thead th {
+            text-align: left;
+            border-bottom: none;
+            vertical-align: middle;
+        }
+        .twig-component-render thead tr {
+            vertical-align: middle;
+            opacity: .9;
+        }
+        .twig-component-render thead tr:hover {
+            opacity: 1;
+            cursor: pointer;
+        }
+        .twig-component-render .sf-toggle .toggle-button {
+            color: inherit;
+        }
+        .twig-component-render .sf-toggle-on .toggle-button {
+            transform: rotate(0deg);
+            opacity: 1;
+            transition: all 150ms ease-in-out;
+        }
+        .twig-component-render .sf-toggle-off .toggle-button {
+            transform: rotate(90deg);
+            opacity: .85;
+            transition: all 250ms ease-in-out;
+        }
+        .twig-component-render th:first-child,
+        .twig-component-render tr:first-child {
+            width: 25%;
+        }
+        .twig-component-render th,
+        .twig-component-render tbody th {
+            font-weight: normal;
+        }
+        .twig-component-render th:first-child {
+            font-weight: bolder;
+        }
+        .twig-component-render th:first-child svg {
+            transform: rotate(45deg);
+            transform-origin: inherit;
+            transform-style: initial;
+            width: 1.25rem;
+            vertical-align: inherit;
+        }
+        .twig-component-render th:last-child {
+            width: 2rem;
+        }
+        .twig-component-render th.renderTime {
+            width: 4rem;
+            font-weight: initial;
+        }
+        .twig-component-render tbody.sf-toggle-visible {
+            display: table-row-group;
+            width: inherit;
+        }
+        .twig-component-render tbody th {
+            font-weight: normal !important;
+        }
+    </style>
+{% endblock %}
+
+{% block toolbar %}
+    {% if collector.renderCount %}
+
+        {% set icon %}
+            {{ source('@TwigComponent/Collector/icon.svg') }}
+            <span class="sf-toolbar-value">{{ collector.renderCount }}</span>
+            <span class="sf-toolbar-info-piece-additional-detail">
+                <span class="sf-toolbar-label">in</span>
+                <span class="sf-toolbar-value">{{ collector.renderTime }}</span>
+                <span class="sf-toolbar-label">ms</span>
+            </span>
+        {% endset %}
+
+        {% set text %}
+            {% for _component in collector.components %}
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">{{ _component.name }}</b>
+                    <span class="sf-toolbar-status">{{ _component.render_count }}</span>
+                </div>
+            {% endfor %}
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}
+
+    {% endif %}
+{% endblock %}
+
+{% block menu %}
+    <span class="label{{ collector.components is empty ? ' disabled' }}">
+        <span class="icon">{{ source('@TwigComponent/Collector/icon.svg') }}</span>
+        <strong>Twig Components</strong>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h2>Components</h2>
+    {% if not collector.componentCount|default %}
+        <div class="empty empty-panel">
+            <p>No component were rendered for this request.</p>
+        </div>
+    {% else %}
+        <section class="twig-component-metrics metrics">
+            <div class="metric-group">
+                {{ _self.metric(collector.componentCount, "Twig Components") }}
+            </div>
+            <div class="metric-divider"></div>
+            <div class="metric-group">
+                {{ _self.metric(collector.renderCount, "Render Count") }}
+                {{ _self.metric(collector.renderTime, "Render Time", "ms") }}
+            </div>
+            <div class="metric-divider"></div>
+            <div class="metric-group">
+                {{ _self.metric((collector.peakMemoryUsage / 1024 / 1024)|number_format(1), "Memory Usage", "MiB") }}
+            </div>
+        </section>
+        <section class="twig-component-components">
+            <h3>Components</h3>
+            {{ block('table_components') }}
+        </section>
+        <section class="twig-component-renders">
+            <h3>Render calls</h3>
+            {{ block('table_renders') }}
+        </section>
+    {% endif %}
+{% endblock %}
+
+{% macro metric(value, label, unit = '') %}
+    <div class="metric">
+        <span class="value">
+            {{ value }}
+            {% if unit %}
+                <span class="unit text-small">{{ unit }}</span>
+            {% endif %}
+        </span>
+        <span class="label">
+            {{- label -}}
+        </span>
+    </div>
+{% endmacro %}
+
+{% block table_components %}
+    <table class="twig-component-component">
+        <thead>
+        <tr>
+            <th class="key">
+                <strong>Name</strong>
+            </th>
+            <th>
+                <strong>Metadata</strong>
+            </th>
+            <th class="cell-right">
+                <small>Render</small>
+                <strong>Count</strong>
+            </th>
+            <th class="cell-right">
+                <small>Render</small>
+                <strong>Time</strong>
+            </th>
+        </tr>
+        </thead>
+        <tbody>
+            {% for component in collector.components %}
+                <tr>
+                    <td>{{ component.name }}</td>
+                    <td>
+                        {% if component.class == 'Symfony\\UX\\TwigComponent\\AnonymousComponent' %}
+                            <pre class="sf-dump"><span class="text-muted">[Anonymous]</span></pre>
+                        {% else %}
+                            {{ profiler_dump(component.class_stub) }}
+                        {% endif %}
+                        {% if component.template_path %}
+                            <a class=text-muted" href="{{ component.template_path|file_link(1) }}">
+                                {{- component.template -}}
+                            </a>
+                        {% else %}
+                            <span class=text-muted">{{ component.template }}</span>
+                        {% endif %}
+                    </td>
+                    <td class="cell-right">{{ component.render_count }}</td>
+                    <td class="cell-right">
+                        {{- component.render_time|number_format(2) -}}
+                        <span class="text-muted text-small">ms</span>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}
+
+{% block table_renders %}
+    <div class="twig-component-renders">
+        {% set _memory = null %}
+        {% for render in collector.renders %}
+            <table class="twig-component-render" style="--render-depth:{{ render.depth }};">
+                <thead
+                    class="sf-toggle {{ loop.index == 1 ? 'sf-toggle-on' : 'sf-toggle-off' }}"
+                   data-toggle-selector="#render-{{ loop.index }}--details"
+                   data-toggle-initial="{{ loop.index == 1 ? 'display' }}"
+                >
+                    <tr>
+                        <th class="key">{{ render.depth ? source('@TwigComponent/Collector/chevron-down.svg') }}{{ render.name }}</th>
+                        <th>
+                            {% if render.class == 'Symfony\\UX\\TwigComponent\\AnonymousComponent' %}
+                                <pre class="sf-dump"><span class="text-muted">[Anonymous]</span></pre>
+                            {% else %}
+                                {{ render.class }}
+                            {% endif %}
+                        </th>
+                        <th class="cell-right renderTime">
+                            {% set _render_memory = render.render_memory|default(0) / 1024 / 1024 %}
+                            <span class="{{ _render_memory == _memory ? 'text-muted' }}">
+                                {{- _render_memory|number_format(1) -}}
+                            </span>
+                            <span class="text-muted text-small">MiB</span>
+                            {% set _memory = _render_memory %}
+                        </th>
+                        <th class="cell-right renderTime">
+                            {{ render.render_time|number_format(2) }}
+                            <span class="text-muted text-small">ms</span>
+                        </th>
+                        <th class="cell-right">
+                            <button class="btn btn-link toggle-button" type="button" aria-label="Toggle details">
+                                {{ source('@TwigComponent/Collector/chevron-down.svg') }}
+                            </button>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody id="render-{{ loop.index }}--details">
+                    <tr class="{{ not render.input_props|default ? 'opacity-50' }}">
+                        <th scope="row">Input props</th>
+                        <td colspan="3">{{ profiler_dump(render.input_props) }}</td>
+                    </tr>
+                    <tr class="{{ not render.attributes|default ? 'opacity-50' }}">
+                        <th scope="row">Attributes</th>
+                        <td colspan="3">{{ profiler_dump(render.attributes) }}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Component</th>
+                        <td colspan="3">{{ profiler_dump(render.component) }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/src/TwigComponent/tests/Fixtures/User.php
+++ b/src/TwigComponent/tests/Fixtures/User.php
@@ -7,7 +7,8 @@ class User
     public function __construct(
         private readonly string $name,
         private readonly string $email,
-    ) {}
+    ) {
+    }
 
     public function getName(): string
     {

--- a/src/TwigComponent/tests/Unit/DataCollector/TwigComponentDataCollectorTest.php
+++ b/src/TwigComponent/tests/Unit/DataCollector/TwigComponentDataCollectorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit\DataCollector;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\UX\TwigComponent\DataCollector\TwigComponentDataCollector;
+use Symfony\UX\TwigComponent\EventListener\TwigComponentLoggerListener;
+use Twig\Environment;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+class TwigComponentDataCollectorTest extends TestCase
+{
+    public function testCollectDoesNothing(): void
+    {
+        $logger = new TwigComponentLoggerListener();
+        $twig = $this->createMock(Environment::class);
+        $dataCollector = new TwigComponentDataCollector($logger, $twig);
+
+        $this->assertSame([], $dataCollector->getData());
+
+        $dataCollector->collect(new Request(), new Response());
+        $this->assertSame([], $dataCollector->getData());
+    }
+
+    public function testLateCollect(): void
+    {
+        $logger = new TwigComponentLoggerListener();
+        $twig = $this->createMock(Environment::class);
+        $dataCollector = new TwigComponentDataCollector($logger, $twig);
+
+        $dataCollector->lateCollect();
+
+        $this->assertSame(0, $dataCollector->getComponentCount());
+        $this->assertIsIterable($dataCollector->getComponents());
+        $this->assertEmpty($dataCollector->getComponents());
+
+        $this->assertSame(0, $dataCollector->getRenderCount());
+        $this->assertIsIterable($dataCollector->getRenders());
+        $this->assertEmpty($dataCollector->getRenders());
+
+        $this->assertSame(0, $dataCollector->getRenderTime());
+    }
+
+    public function testReset(): void
+    {
+        $logger = new TwigComponentLoggerListener();
+        $twig = $this->createMock(Environment::class);
+        $dataCollector = new TwigComponentDataCollector($logger, $twig);
+
+        $dataCollector->lateCollect();
+        $this->assertNotSame([], $dataCollector->getData());
+
+        $dataCollector->reset();
+        $this->assertSame([], $dataCollector->getData());
+    }
+
+    public function testGetName(): void
+    {
+        $logger = new TwigComponentLoggerListener();
+        $twig = $this->createMock(Environment::class);
+        $dataCollector = new TwigComponentDataCollector($logger, $twig);
+
+        $this->assertEquals('twig_component', $dataCollector->getName());
+    }
+}

--- a/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Test\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\UX\TwigComponent\DependencyInjection\TwigComponentExtension;
+use Symfony\UX\TwigComponent\TwigComponentBundle;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+class TwigComponentExtensionTest extends TestCase
+{
+    public function testDataCollectorWithDebugMode()
+    {
+        $container = $this->createContainer();
+        $container->registerExtension(new TwigComponentExtension());
+        $container->loadFromExtension('twig_component', []);
+        $this->compileContainer($container);
+
+        $this->assertTrue($container->hasDefinition('ux.twig_component.data_collector'));
+    }
+
+    public function testDataCollectorWithoutDebugMode()
+    {
+        $container = $this->createContainer();
+        $container->setParameter('kernel.debug', false);
+        $container->registerExtension(new TwigComponentExtension());
+        $container->loadFromExtension('twig_component', []);
+        $this->compileContainer($container);
+
+        $this->assertFalse($container->hasDefinition('ux.twig_component.data_collector'));
+    }
+
+    private function createContainer()
+    {
+        $container = new ContainerBuilder(new ParameterBag([
+            'kernel.cache_dir' => __DIR__,
+            'kernel.build_dir' => __DIR__,
+            'kernel.charset' => 'UTF-8',
+            'kernel.debug' => true,
+            'kernel.project_dir' => __DIR__,
+            'kernel.bundles' => [
+                'TwigBundle' => new class() {},
+                'TwigComponentBundle' => TwigComponentBundle::class,
+            ],
+        ]));
+
+        return $container;
+    }
+
+    private function compileContainer(ContainerBuilder $container)
+    {
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+        $container->compile();
+    }
+}

--- a/src/TwigComponent/tests/Unit/EventListener/TwigComponentLoggerListenerTest.php
+++ b/src/TwigComponent/tests/Unit/EventListener/TwigComponentLoggerListenerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\TwigComponent\ComponentAttributes;
+use Symfony\UX\TwigComponent\ComponentMetadata;
+use Symfony\UX\TwigComponent\Event\PostMountEvent;
+use Symfony\UX\TwigComponent\Event\PostRenderEvent;
+use Symfony\UX\TwigComponent\Event\PreCreateForRenderEvent;
+use Symfony\UX\TwigComponent\Event\PreMountEvent;
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
+use Symfony\UX\TwigComponent\EventListener\TwigComponentLoggerListener;
+use Symfony\UX\TwigComponent\MountedComponent;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+class TwigComponentLoggerListenerTest extends TestCase
+{
+    public function testLoggerStoreEvents(): void
+    {
+        $logger = new TwigComponentLoggerListener();
+        $this->assertSame([], $logger->getEvents());
+
+        $eventA = new PreCreateForRenderEvent('a');
+        $logger->onPreCreateForRender($eventA);
+
+        $eventB = new PreCreateForRenderEvent('b');
+        $logger->onPreCreateForRender($eventB);
+
+        $eventC = new PreMountEvent(new \stdClass(), []);
+        $logger->onPreMount($eventC);
+        $eventD = new PostMountEvent(new \stdClass(), []);
+        $logger->onPostMount($eventD);
+
+        $mounted = new MountedComponent('foo', new \stdClass(), new ComponentAttributes([]));
+        $eventE = new PreRenderEvent($mounted, new ComponentMetadata(['template' => 'bar']), []);
+        $logger->onPreRender($eventE);
+        $eventF = new PostRenderEvent($mounted);
+        $logger->onPostRender($eventF);
+
+        $this->assertSame([$eventA, $eventB, $eventC, $eventD, $eventE, $eventF], array_column($logger->getEvents(), 0));
+    }
+
+    public function testLoggerReset(): void
+    {
+        $logger = new TwigComponentLoggerListener();
+
+        $logger->onPreCreateForRender(new PreCreateForRenderEvent('foo'));
+        $this->assertNotSame([], $logger->getEvents());
+
+        $logger->reset();
+        $this->assertSame([], $logger->getEvents());
+    }
+}


### PR DESCRIPTION
Add a DataCollector to add data in the web debug toolpar and a profiler pane.

Based on the events (`PreRender` / `PostRender`) triggerd during the request.

| Overview | Details | 
| - | - | 
| ![overview](https://github.com/symfony/ux/assets/1359581/9237e924-ba3d-47b6-970a-8b8cabbb4e8f) | ![details](https://github.com/symfony/ux/assets/1359581/6f78431e-e4a3-41a0-a0b1-2084b17bce19) | 

| Anonymous components | Stopwatch + performance | 
| - | - | 
| ![anonymous-timing](https://github.com/symfony/ux/assets/1359581/e4899dfc-f716-4164-8377-4f617bf6bde6) | ![perforlmance](https://github.com/symfony/ux/assets/1359581/6356858e-c3fe-426a-ae95-c7475cd192fd) | 
