### PR TITLE
Add "dev" keyword to symfony/ux package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "symfony/ux",
     "license": "MIT",
+    "keywords": ["dev"],
     "require-dev": {
         "symfony/filesystem": "^5.2|^6.0",
         "symfony/finder": "^5.4|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | -
| License       | MIT

Same as https://github.com/symfony/symfony/pull/51811

Even if symfony/ux is not registered on packagist, I'm doing this for completeness and consistency among all our meta-repositories.