### PR TITLE
[TwigComponent] Fix debug:twig-component duplicates

### DIFF
--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -130,7 +130,7 @@ EOF
     private function findComponents(): array
     {
         $components = [];
-        foreach ($this->componentClassMap as $name => $class) {
+        foreach ($this->componentClassMap as $class => $name) {
             $components[$name] ??= $this->componentFactory->metadataFor($name);
         }
         foreach ($this->findAnonymousComponents() as $name => $template) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| License       | MIT

The debug:twig-components commands displayed duplicate results.
