### PR TITLE
[Site] Use <twig: HTML syntax in demos

### DIFF
--- a/ux.symfony.com/src/Twig/NewProductForm.php
+++ b/ux.symfony.com/src/Twig/NewProductForm.php
@@ -73,6 +73,6 @@ class NewProductForm extends AbstractController
 
         $this->addFlash('live_demo_success', 'Product created! Add another one!');
 
-        return $this->redirectToRoute('app_live_components_product_form');
+        return $this->redirectToRoute('app_demo_live_component_product_form');
     }
 }

--- a/ux.symfony.com/templates/components/InvoiceCreator.html.twig
+++ b/ux.symfony.com/templates/components/InvoiceCreator.html.twig
@@ -44,12 +44,12 @@
                     </thead>
                     <tbody>
                         {% for key, line in lineItems %}
-                            {{ component('InvoiceCreatorLineItem', {
-                                key: key,
-                                productId: line.productId,
-                                quantity: line.quantity,
-                                isEditing: line.isEditing,
-                            }) }}
+                            <twig:InvoiceCreatorLineItem
+                                key="{{ key }}"
+                                productId="{{ line.productId }}"
+                                quantity="{{ line.quantity }}"
+                                isEditing="{{ line.isEditing }}"
+                            />
                         {% endfor %}
                     </tbody>
                 </table>

--- a/ux.symfony.com/templates/components/NewProductForm.html.twig
+++ b/ux.symfony.com/templates/components/NewProductForm.html.twig
@@ -85,7 +85,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         {% endblock %}
         {% block modal_body %}
-            {{ component('NewCategoryForm') }}
+            <twig:NewCategoryForm />
         {% endblock %}
     {% endcomponent %}
 </div>

--- a/ux.symfony.com/templates/demos/live_component/auto_validating_form.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/auto_validating_form.html.twig
@@ -9,5 +9,5 @@
 {% endblock %}
 
 {% block demo_content %}
-    {{ component('RegistrationForm') }}
+    <twig:RegistrationForm />
 {% endblock %}

--- a/ux.symfony.com/templates/demos/live_component/chartjs.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/chartjs.html.twig
@@ -9,5 +9,5 @@
 {% endblock %}
 
 {% block demo_content %}
-    {{ component('DinoChart') }}
+    <twig:DinoChart />
 {% endblock %}

--- a/ux.symfony.com/templates/demos/live_component/dependent_form_fields.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/dependent_form_fields.html.twig
@@ -9,5 +9,5 @@
 {% endblock %}
 
 {% block demo_content %}
-    {{ component('MealPlanner') }}
+    <twig:MealPlanner />
 {% endblock %}

--- a/ux.symfony.com/templates/demos/live_component/form_collection_type.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/form_collection_type.html.twig
@@ -9,9 +9,6 @@
 {% endblock %}
 
 {% block demo_content %}
-    {{ component('TodoListForm', {
-        form: form,
-        todoList: todoList
-    }) }}
+    <twig:TodoListForm :form="form" :todoList="todoList" />
 {% endblock %}
 

--- a/ux.symfony.com/templates/demos/live_component/inline_edit.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/inline_edit.html.twig
@@ -9,7 +9,5 @@
 {% endblock %}
 
 {% block demo_content %}
-    {{ component('InlineEditFood', {
-        food: food
-    }) }}
+    <twig:InlineEditFood :food="food" />
 {% endblock %}

--- a/ux.symfony.com/templates/demos/live_component/invoice.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/invoice.html.twig
@@ -55,9 +55,7 @@ we emit the event directly.
 {% block demo_content %}
     <div class="row">
         <div class="col-8">
-            {{ component('InvoiceCreator', {
-                invoice: invoice
-            }) }}
+            <twig:InvoiceCreator :invoice="invoice"/>
         </div>
     </div>
     <div class="mt-3">

--- a/ux.symfony.com/templates/demos/live_component/product_form.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/product_form.html.twig
@@ -1,7 +1,7 @@
 {% extends 'liveDemoBase.html.twig' %}
 
 {% block demo_content %}
-    {{ component('NewProductForm') }}
+    <twig:NewProductForm />
 {% endblock %}
 
 {% block code_block_full %}

--- a/ux.symfony.com/templates/demos/live_component/upload.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/upload.html.twig
@@ -9,5 +9,5 @@
 {% endblock %}
 
 {% block demo_content %}
-    {{ component('UploadFiles') }}
+    <twig:UploadFiles />
 {% endblock %}

--- a/ux.symfony.com/templates/demos/live_component/voting.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/voting.html.twig
@@ -11,9 +11,7 @@
 {% block demo_content %}
     <table class="table">
         {% for food in foods %}
-            {{ component('FoodVote', {
-                food: food
-            }) }}
+            <twig:FoodVote :food="food" />
         {% endfor %}
     </table>
 {% endblock %}

--- a/ux.symfony.com/templates/main/homepage.html.twig
+++ b/ux.symfony.com/templates/main/homepage.html.twig
@@ -11,7 +11,7 @@
             <p>A set of PHP &amp; JavaScript packages to solve every day frontend problems featuring Stimulus and Turbo.</p>
           </div>
           <div class="col-12 col-sm-10 col-md-8 col-lg-6">
-              {{ component('HomepageTerminalSwapper', {class: 'shadow-blur shadow-blur--rainbow', style: '--shadow-bottom: 2rem;'}) }}
+              <twig:HomepageTerminalSwapper class="shadow-blur shadow-blur--rainbow" style="--shadow-bottom: 2rem;" />
           </div>
         </div>
     </div>
@@ -24,13 +24,11 @@
 
     <div class="row">
         <div class="col-12 col-md-6">
-            {% component Terminal %}
-                {% block content %}
-                    composer require symfony/webpack-encore-bundle symfony/stimulus-bundle
-                    npm install
-                    npm run watch
-                {% endblock %}
-            {% endcomponent %}
+            <twig:Terminal>
+                composer require symfony/webpack-encore-bundle symfony/stimulus-bundle
+                npm install
+                npm run watch
+            </twig:Terminal>
         </div>
 
         <div class="col-12 col-md-6 mt-3 mt-md-0">

--- a/ux.symfony.com/templates/main/packages.html.twig
+++ b/ux.symfony.com/templates/main/packages.html.twig
@@ -25,16 +25,16 @@
     <div style="background-color: var(--bs-secondary-bg);" class="mt-5">
         <div class="container-fluid container-xxl p-5">
             <div style="display: grid; gap: 2rem; grid-template-columns: repeat(auto-fit, minmax(min(100%, 380px), 1fr));">
-                {{ component('DocsLink', {
-                    url: 'https://symfonycasts.com/screencast/stimulus',
-                    title: 'Screencasts',
-                    text: 'Jump right into with the Symfony UX & Stimulus screencast.'
-                }) }}
-                {{ component('DocsLink', {
-                    url: 'https://symfony.com/doc/current/frontend/ux.html',
-                    title: 'Documentation',
-                    text: 'Ready to get started? The official symfony.com UX Docs.'
-                }) }}
+                <twig:DocsLink
+                    url="https://symfonycasts.com/screencast/stimulus"
+                    title="Screencasts"
+                    text="Jump right into with the Symfony UX & Stimulus screencast."
+                />
+                <twig:DocsLink
+                    url="https://symfony.com/doc/current/frontend/ux.html"
+                    title="Documentation"
+                    text="Ready to get started? The official symfony.com UX Docs."
+                />
             </div>
         </div>
     </div>

--- a/ux.symfony.com/templates/ux_packages/live_component.html.twig
+++ b/ux.symfony.com/templates/ux_packages/live_component.html.twig
@@ -28,7 +28,7 @@
     Live Components
 {% endblock %}
 {% block demo_content %}
-    {{ component('SearchPackages') }}
+    <twig:SearchPackages />
 
     <div class="d-flex eyebrows pt-5 align-items-center justify-content-center">
         <div>Automatic <em>debouncing</em></div>

--- a/ux.symfony.com/templates/ux_packages/twig-component.html.twig
+++ b/ux.symfony.com/templates/ux_packages/twig-component.html.twig
@@ -29,9 +29,7 @@
     <div class="row align-items-center">
         <div class="col-6">
             {% block alert_success_example %}
-                {{ component('Alert', {
-                    message: 'I am a success alert!',
-                }) }}
+                <twig:Alert message="I am a success alert!" />
             {% endblock %}
         </div>
         <div class="col-6">
@@ -48,10 +46,10 @@
     <div class="row my-2 align-items-center">
         <div class="col-6">
             {% block alert_danger_example %}
-                {{ component('Alert', {
-                    type: 'danger',
-                    message: 'Oh no! The dinos escaped!',
-                }) }}
+                <twig:Alert
+                    type="danger"
+                    message="Oh no! The dinos escaped!"
+                />
             {% endblock %}
         </div>
         <div class="col-6">


### PR DESCRIPTION
* Replace remaining `{{ component(... }}` with `<twig:.. />`
* Fix a route in product demo