### PR TITLE
[LiveComponent]: fix typo in event emit php function documentation

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2401,7 +2401,7 @@ use the ``name()`` modifier:
 
 Or, in PHP::
 
-    $this->emit('productAdded', name: 'ProductList');
+    $this->emit('productAdded', componentName: 'ProductList');
 
 Emitting only to Yourself
 .........................


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tickets       | N/A
| License       | MIT

Playing around with LiveComponent, i noticed a small "typo" in the scoping events section 
