### PR TITLE
Allow class-string argument in AsLiveComponent static methods

### DIFF
--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -48,8 +48,10 @@ final class AsLiveComponent extends AsTwigComponent
 
     /**
      * @internal
+     *
+     * @param object|class-string $component
      */
-    public static function isActionAllowed(object $component, string $action): bool
+    public static function isActionAllowed(object|string $component, string $action): bool
     {
         foreach (self::attributeMethodsFor(LiveAction::class, $component) as $method) {
             if ($action === $method->getName()) {
@@ -63,9 +65,11 @@ final class AsLiveComponent extends AsTwigComponent
     /**
      * @internal
      *
+     * @param object|class-string $component
+     *
      * @return \ReflectionMethod[]
      */
-    public static function preReRenderMethods(object $component): iterable
+    public static function preReRenderMethods(object|string $component): iterable
     {
         return self::attributeMethodsByPriorityFor($component, PreReRender::class);
     }
@@ -73,9 +77,11 @@ final class AsLiveComponent extends AsTwigComponent
     /**
      * @internal
      *
+     * @param object|class-string $component
+     *
      * @return \ReflectionMethod[]
      */
-    public static function postHydrateMethods(object $component): iterable
+    public static function postHydrateMethods(object|string $component): iterable
     {
         return self::attributeMethodsByPriorityFor($component, PostHydrate::class);
     }
@@ -83,14 +89,23 @@ final class AsLiveComponent extends AsTwigComponent
     /**
      * @internal
      *
+     * @param object|class-string $component
+     *
      * @return \ReflectionMethod[]
      */
-    public static function preDehydrateMethods(object $component): iterable
+    public static function preDehydrateMethods(object|string $component): iterable
     {
         return self::attributeMethodsByPriorityFor($component, PreDehydrate::class);
     }
 
-    public static function liveListeners(object $component): array
+    /**
+     * @internal
+     *
+     * @param object|class-string $component
+     *
+     * @return array<array{action: string, event: string}>
+     */
+    public static function liveListeners(object|string $component): array
     {
         $listeners = [];
         foreach (self::attributeMethodsFor(LiveListener::class, $component) as $method) {

--- a/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
@@ -13,6 +13,8 @@ namespace Symfony\UX\LiveComponent\Tests\Unit\Attribute;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveListener;
 use Symfony\UX\LiveComponent\Attribute\PostHydrate;
 use Symfony\UX\LiveComponent\Attribute\PreDehydrate;
 use Symfony\UX\LiveComponent\Attribute\PreReRender;
@@ -104,6 +106,15 @@ final class AsLiveComponentTest extends TestCase
         $this->assertSame('hook1', $hooks[2]->name);
     }
 
+    public function testCanGetPostHydrateMethodsFromClassString(): void
+    {
+        $methods = AsLiveComponent::postHydrateMethods(DummyLiveComponent::class);
+
+        $this->assertCount(1, $methods);
+        $this->assertSame('method', $methods[0]->getName());
+        $this->assertSame(DummyLiveComponent::class, $methods[0]->getDeclaringClass()?->getName());
+    }
+
     public function testCanGetLiveListeners(): void
     {
         $liveListeners = AsLiveComponent::liveListeners(new Component5());
@@ -115,6 +126,17 @@ final class AsLiveComponentTest extends TestCase
         ], $liveListeners[0]);
     }
 
+    public function testCanGetLiveListenersFromClassString(): void
+    {
+        $liveListeners = AsLiveComponent::liveListeners(DummyLiveComponent::class);
+
+        $this->assertCount(1, $liveListeners);
+        $this->assertSame([
+            'action' => 'method',
+            'event' => 'event_name',
+        ], $liveListeners[0]);
+    }
+
     public function testCanCheckIfMethodIsAllowed(): void
     {
         $component = new Component5();
@@ -122,5 +144,19 @@ final class AsLiveComponentTest extends TestCase
         $this->assertTrue(AsLiveComponent::isActionAllowed($component, 'method1'));
         $this->assertFalse(AsLiveComponent::isActionAllowed($component, 'method2'));
         $this->assertTrue(AsLiveComponent::isActionAllowed($component, 'aListenerActionMethod'));
+    }
+}
+
+#[AsLiveComponent]
+class DummyLiveComponent
+{
+    #[PreDehydrate]
+    #[PreReRender]
+    #[PostHydrate]
+    #[LiveListener('event_name')]
+    #[LiveAction]
+    public function method(): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | ??
| License       | MIT

As done in AsTwigComponent attribute, this PR allow to extract metadata about LiveComponent using their class name.

Test failures unrelated