### PR TITLE
TwigPreLexer: improve performance

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -34,6 +34,10 @@ class TwigPreLexer
 
     public function preLexComponents(string $input): string
     {
+        if (!str_contains($input, '<twig:')) {
+            return $input;
+        }
+
         $this->input = $input;
         $this->length = \strlen($input);
         $output = '';
@@ -259,6 +263,10 @@ class TwigPreLexer
      */
     private function consume(string $string): bool
     {
+        if ($string[0] !== $this->input[$this->position]) {
+            return false;
+        }
+
         $stringLength = \strlen($string);
         if (substr($this->input, $this->position, $stringLength) === $string) {
             $this->position += $stringLength;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

When using the `cache:warmup` command in my symfony project, 25% of the time is used by the TwigPreLexer:

<img src="https://github.com/symfony/ux/assets/330436/4539dd1d-d8d2-4633-8c1d-503afe2218be" width=500/>

This PR reduces the time of the `cache:warmup` command by 28% in my project (which does not use the html component syntax so far):

<img src="https://github.com/symfony/ux/assets/330436/f6df7275-e15a-40c3-ba36-33b099c5c0b1" width=500/>
