### PR TITLE
[CI] Fix `jsxBracketSameLine is deprecated`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "printWidth": 120,
         "trailingComma": "es5",
         "tabWidth": 4,
-        "jsxBracketSameLine": true,
+        "bracketSameLine": true,
         "singleQuote": true
     }
 }


### PR DESCRIPTION
Replace `jsxBracketSameLine` with `bracketSameLine`

See: https://prettier.io/docs/en/options.html#deprecated-jsx-brackets
