### PR TITLE
[CI][Turbo] Fix direct deprecation notice

### DIFF
--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -93,10 +93,14 @@ class Kernel extends BaseKernel
             ],
         ];
 
-        // https://github.com/doctrine/DoctrineBundle/pull/1661
-        $doctrineBundleVersion = InstalledVersions::getVersion('doctrine/doctrine-bundle');
-        if (null !== $doctrineBundleVersion && version_compare($doctrineBundleVersion, '2.9.0', '>=')) {
-            $doctrineConfig['orm']['report_fields_where_declared'] = true;
+        if (null !== $doctrineBundleVersion = InstalledVersions::getVersion('doctrine/doctrine-bundle')) {
+            if (version_compare($doctrineBundleVersion, '2.8.0', '>=')) {
+                $doctrineConfig['orm']['enable_lazy_ghost_objects'] = true;
+            }
+            // https://github.com/doctrine/DoctrineBundle/pull/1661
+            if (version_compare($doctrineBundleVersion, '2.9.0', '>=')) {
+                $doctrineConfig['orm']['report_fields_where_declared'] = true;
+            }
         }
 
         $container


### PR DESCRIPTION
Fix this deprecation triggered during tests with Doctrine >= 2.8

> Not enabling lazy ghost objects is deprecated and will not be supported in Doctrine ORM 3.0. Ensure Doctrine\ORM\Configuration::setLazyGhostObjectEnabled(true) is called to enable them.

(Failure unrelated)