### PR TITLE
[StimulusBundle] feat: normalize parameters names given to twig helper 'stimulus_action'

### DIFF
--- a/src/StimulusBundle/CHANGELOG.md
+++ b/src/StimulusBundle/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 2.13.0
+
+-   Normalize parameters names given to twig helper 'stimulus_action()'.
+    **BC Break**: previously, parameters given in camelCase (eg.
+    `bigCrocodile`) were incorrectly registered by the controller as
+    flatcase (`event.params.bigcrocodile`). This was fixed, which means
+    they are now correctly registered as camelCase
+    (`event.params.bigCrocodile`).
+
 ## 2.10.0
 
 -   Handle Stimulus outlets

--- a/src/StimulusBundle/src/Dto/StimulusAttributes.php
+++ b/src/StimulusBundle/src/Dto/StimulusAttributes.php
@@ -79,7 +79,9 @@ class StimulusAttributes implements \Stringable, \IteratorAggregate
         ];
 
         foreach ($parameters as $name => $value) {
-            $this->attributes['data-'.$controllerName.'-'.$name.'-param'] = $this->getFormattedValue($value);
+            $key = $this->normalizeKeyName($name);
+
+            $this->attributes['data-'.$controllerName.'-'.$key.'-param'] = $this->getFormattedValue($value);
         }
     }
 

--- a/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
+++ b/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
@@ -199,6 +199,16 @@ final class StimulusTwigExtensionTest extends TestCase
             'expectedString' => 'data-action="click->symfony--ux-dropzone--dropzone#onClick"',
             'expectedArray' => ['data-action' => 'click->symfony--ux-dropzone--dropzone#onClick'],
         ];
+
+        yield 'normalize-name, with normalized parameters names' => [
+            'controllerName' => 'my-controller',
+            'actionName' => 'onClick',
+            'eventName' => null,
+            'parameters' => ['boolParam' => true, 'intParam' => 4, 'stringParam' => 'test'],
+            'expectedString' => 'data-action="onClick"',
+            'expectedString' => 'data-action="my-controller#onClick" data-my-controller-bool-param-param="true" data-my-controller-int-param-param="4" data-my-controller-string-param-param="test"',
+            'expectedArray' => ['data-action' => 'my-controller#onClick', 'data-my-controller-bool-param-param' => 'true', 'data-my-controller-int-param-param' => '4', 'data-my-controller-string-param-param' => 'test'],
+        ];
     }
 
     public function testAppendStimulusAction(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | NA
| License       | MIT

This allows giving a parameter name as 'myParam', and it will be printed as 'data-controller-name-my-param-param', which will be interpreted as 'myParam' by the Stimulus controller.