### PR TITLE
[stimulus-bundle] Add support for typescript/react stimulus controllers

### DIFF
--- a/src/StimulusBundle/.gitignore
+++ b/src/StimulusBundle/.gitignore
@@ -1,5 +1,6 @@
 .php-cs-fixer.cache
 .phpunit.result.cache
 composer.lock
+var/
 vendor/
 tests/fixtures/var

--- a/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
+++ b/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
@@ -24,6 +24,8 @@ use Symfony\UX\StimulusBundle\Ux\UxPackageReader;
  */
 class ControllersMapGenerator
 {
+    private const FILENAME_REGEX = '/^.*[-_](controller\.[jt]sx?)$/';
+
     public function __construct(
         private AssetMapperInterface $assetMapper,
         private UxPackageReader $uxPackageReader,
@@ -61,12 +63,14 @@ class ControllersMapGenerator
         $finder = new Finder();
         $finder->in($this->controllerPaths)
             ->files()
-            ->name('/^.*[-_]controller\.js$/');
+            ->name(self::FILENAME_REGEX);
 
         $controllersMap = [];
         foreach ($finder as $file) {
             $name = $file->getRelativePathname();
-            $name = str_replace(['_controller.js', '-controller.js'], '', $name);
+            // use regex to extract 'controller'-postfix including extension
+            preg_match(self::FILENAME_REGEX, $name, $matches);
+            $name = str_replace(['_'.$matches[1], '-'.$matches[1]], '', $name);
             $name = str_replace(['_', '/'], ['-', '--'], $name);
 
             $asset = $this->assetMapper->getAssetFromSourcePath($file->getRealPath());

--- a/src/StimulusBundle/tests/AssetMapper/ControllerMapGeneratorTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/ControllerMapGeneratorTest.php
@@ -54,8 +54,8 @@ class ControllerMapGeneratorTest extends TestCase
         $map = $generator->getControllersMap();
         // + 3 controller.json UX controllers
         // - 1 controllers.json UX controller is disabled
-        // + 8 custom controllers (1 file is not a controller & 1 is overridden)
-        $this->assertCount(10, $map);
+        // + 11 custom controllers (1 file is not a controller & 1 is overridden)
+        $this->assertCount(13, $map);
         $packageNames = array_keys($map);
         sort($packageNames);
         $this->assertSame([
@@ -66,9 +66,12 @@ class ControllerMapGeneratorTest extends TestCase
             'hello-with-dashes',
             'hello-with-underscores',
             'other',
+            'react',
             'subdir--deeper',
             'subdir--deeper-with-dashes',
             'subdir--deeper-with-underscores',
+            'typescript',
+            'typescript-react',
         ], $packageNames);
 
         $controllerSecond = $map['fake-vendor--ux-package1--controller-second'];

--- a/src/StimulusBundle/tests/fixtures/assets/controllers/react-controller.jsx
+++ b/src/StimulusBundle/tests/fixtures/assets/controllers/react-controller.jsx
@@ -1,0 +1,5 @@
+// react-controller.jsx
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+}

--- a/src/StimulusBundle/tests/fixtures/assets/controllers/typescript-controller.ts
+++ b/src/StimulusBundle/tests/fixtures/assets/controllers/typescript-controller.ts
@@ -1,0 +1,5 @@
+// typescript-controller.ts
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+}

--- a/src/StimulusBundle/tests/fixtures/assets/controllers/typescript-react-controller.tsx
+++ b/src/StimulusBundle/tests/fixtures/assets/controllers/typescript-react-controller.tsx
@@ -1,0 +1,5 @@
+// typescript-react-controller.tsx
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kinda? (see below)
| New feature?  | no? <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Previously using the `webpack-encode-bundle` icw `stimulus`, 'custom' controllers were loaded via the `bootstrap.js` file which used a [regex](https://github.com/symfony/recipes/blob/main/symfony/webpack-encore-bundle/1.10/assets/bootstrap.js#L7) to match the controllers to be loaded. 

In the new `stimulus-bundle`; loading the controllers was simplified, resulting in not loading `typescript` / `react` controllers anymore. This PR adds back the support for those files.