### PR TITLE
Fix error in TwigComponent documentation breaking the display of the …

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -63,14 +63,14 @@ file to control the template directory for your components:
 
 .. _default_config:
 
-```
-# config/packages/twig_component.yaml
-twig_component:
-    anonymous_template_directory: 'components/'
-    defaults:
-        # Namespace & directory for components
-        App\Twig\Components: 'components/'
-```
+.. code-block:: yaml
+
+    # config/packages/twig_component.yaml
+    twig_component:
+        anonymous_template_directory: 'components/'
+        defaults:
+            # Namespace & directory for components
+            App\Twig\Components: 'components/'
 
 Component Basics
 ----------------


### PR DESCRIPTION
…default config

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | 
| License       | MIT

Fix error in TwigComponent documentation breaking the display of the default config (see screenshot below)
![image](https://github.com/symfony/ux/assets/11990607/6e9534f4-bc36-4de6-98ce-a74f76607382)
