### PR TITLE
[TwigComponent] Fix twig:lint bug with anonymous component tag

### DIFF
--- a/src/TwigComponent/src/ComponentTemplateFinder.php
+++ b/src/TwigComponent/src/ComponentTemplateFinder.php
@@ -12,16 +12,24 @@
 namespace Symfony\UX\TwigComponent;
 
 use Twig\Environment;
+use Twig\Loader\LoaderInterface;
 
 /**
  * @author Matheo Daninos <matheo.daninos@gmail.com>
  */
 final class ComponentTemplateFinder implements ComponentTemplateFinderInterface
 {
+    private readonly LoaderInterface $loader;
+
     public function __construct(
-        private Environment $environment,
+        Environment|LoaderInterface $loader,
         private readonly ?string $directory = null,
     ) {
+        if ($loader instanceof Environment) {
+            trigger_deprecation('symfony/ux-twig-component', '2.13', 'The "%s()" method will require "%s $loader" as first argument in 3.0. Passing an "Environment" instance is deprecated.', __METHOD__, LoaderInterface::class);
+            $loader = $loader->getLoader();
+        }
+        $this->loader = $loader;
         if (null === $this->directory) {
             trigger_deprecation('symfony/ux-twig-component', '2.13', 'The "%s()" method will require "string $directory" argument in 3.0. Not defining it or passing null is deprecated.', __METHOD__);
         }
@@ -29,7 +37,7 @@ final class ComponentTemplateFinder implements ComponentTemplateFinderInterface
 
     public function findAnonymousComponentTemplate(string $name): ?string
     {
-        $loader = $this->environment->getLoader();
+        $loader = $this->loader;
         $componentPath = rtrim(str_replace(':', '/', $name));
 
         // Legacy auto-naming rules < 2.13

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -65,11 +65,9 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
 
         $container->register('ux.twig_component.component_template_finder', ComponentTemplateFinder::class)
             ->setArguments([
-                new Reference('twig'),
+                new Reference('twig.loader'),
                 $config['anonymous_template_directory'],
-            ])
-        ;
-
+            ]);
         $container->setAlias(ComponentRendererInterface::class, 'ux.twig_component.component_renderer');
 
         $container->registerAttributeForAutoconfiguration(
@@ -100,8 +98,6 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                 new Reference('ux.twig_component.component_stack'),
             ])
         ;
-
-        $container->register(ComponentTemplateFinder::class, 'ux.twig_component.component_template_finder');
 
         $container->register('ux.twig_component.twig.component_extension', ComponentExtension::class)
             ->addTag('twig.extension')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #1089
| License       | MIT

Sincerely i'm not sure how to handle this properly "today".. 

There is a lot of things i'd like to refactor in a future version, and the fact than auto-closing tags and classic ones are handled by two entirely different processes is at the top of my todo :) 

But right now, i'm not sure we can do better than a quick patch, allowing the "lint:twig" to not crash for anonymous <twig:Foo></twig:Foo> tags.

Timeline of what "bugs":
- the lint:twig command find all templates, and for each one create an empty template loader, then parse & compile the template
- during the parsing, the ComponentParser calls [ComponentFactory::metadataFor](https://github.com/symfony/ux/blob/46d0b6885830b8cf546cd2c2479be2024f154ed3/src/TwigComponent/src/Twig/ComponentTokenParser.php#L50) to find the template matching the component name
- if no class-based component matches, the ComponentFactory calls the the [ComponentTemplateFinder](https://github.com/symfony/ux/blob/2.x/src/TwigComponent/src/ComponentTemplateFinder.php) 
- the ComponentTemplateFinder then asks the Loader if a matching template exists
- but as the Loader is temporary "empty".... 🐞 


So we must ether:
- A) stop resolving template during the parser/compiler work
- B) ensure the TemplateFinder always contains the real "full" loader
- C) change the way the lint:twig command works


A is my long-term objective, but clearly not "today". 
C is not so easy, as the corresponding code is hidden between 3 private methods 

So....  first suggestion (dirty but working)






 

