### PR TITLE
[TwigComponent] Add 'require ** as **' to alias components

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Deprecate calling `ComponentTemplateFinder` constructor without `directory` argument.
 -   Add profiler integration: `TwigComponentDataCollector` and debug toolbar templates
 -   Add search feature in `debug:twig-component` command.
+-   Add `{% require % as % %}` to reference components via alias.
 
 ## 2.12.0
 

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -32,9 +32,39 @@ final class TwigPreLexerTest extends TestCase
             '{{ component(\'foo\') }}',
         ];
 
+        yield 'simple_component_with_require' => [
+            '{% require foo as bar %}<twig:bar />',
+            '{{ component(\'foo\') }}',
+        ];
+
+        yield 'simple_component_with_long_name' => [
+            '{% require long:component:name as foo %}<twig:foo />',
+            '{{ component(\'long:component:name\') }}',
+        ];
+
+        yield 'simple_component_with_alias_substring_of_other_component' => [
+            '{% require long:component:name as foo %}<twig:foo:bar />',
+            '{{ component(\'foo:bar\') }}',
+        ];
+
+        yield 'simple_component_with_multiple_requires' => [
+            '{% require long:component:name as foo %}{% require other:long:component:name as bar %}<twig:bar /><twig:foo />',
+            '{{ component(\'other:long:component:name\') }}{{ component(\'long:component:name\') }}',
+        ];
+
+        yield 'simple_component_with_require_not_used' => [
+            '{% require long:component:name as bar %}<twig:foo />',
+            '{{ component(\'foo\') }}',
+        ];
+
         yield 'component_with_attributes' => [
             '<twig:foo bar="baz" with_quotes="It\'s with quotes" />',
             "{{ component('foo', { bar: 'baz', with_quotes: 'It\'s with quotes' }) }}",
+        ];
+
+        yield 'component_with_attributes_and_require' => [
+            '{% require long:component:name as foo %}<twig:foo bar="baz" with_quotes="It\'s with quotes" />',
+            "{{ component('long:component:name', { bar: 'baz', with_quotes: 'It\'s with quotes' }) }}",
         ];
 
         yield 'component_with_dynamic_attributes' => [
@@ -42,9 +72,19 @@ final class TwigPreLexerTest extends TestCase
             '{{ component(\'foo\', { dynamic: (dynamicVar), otherDynamic: anotherVar }) }}',
         ];
 
+        yield 'component_with_dynamic_attributes_with_require' => [
+            '{% require long:component:name as foo %}<twig:foo dynamic="{{ dynamicVar }}" :otherDynamic="anotherVar" />',
+            '{{ component(\'long:component:name\', { dynamic: (dynamicVar), otherDynamic: anotherVar }) }}',
+        ];
+
         yield 'component_with_closing_tag' => [
             '<twig:foo></twig:foo>',
             '{% component \'foo\' %}{% endcomponent %}',
+        ];
+
+        yield 'component_with_closing_tag_with_require' => [
+            '{% require long:component:name as foo %}<twig:foo></twig:foo>',
+            '{% component \'long:component:name\' %}{% endcomponent %}',
         ];
 
         yield 'component_with_block' => [
@@ -100,17 +140,33 @@ final class TwigPreLexerTest extends TestCase
             '<twig:foo:bar></twig:foo:bar>',
             '{% component \'foo:bar\' %}{% endcomponent %}',
         ];
+        yield 'component_with_require_with_character_:_on_his_name' => [
+            '{% require long:component:name as foo:bar %}<twig:foo:bar></twig:foo:bar>',
+            '{% component \'long:component:name\' %}{% endcomponent %}',
+        ];
         yield 'component_with_character_@_on_his_name' => [
             '<twig:@foo></twig:@foo>',
             '{% component \'@foo\' %}{% endcomponent %}',
+        ];
+        yield 'component_with_character_@_on_his_name_with_require' => [
+            '{% require long:component:n@me as @foo %}<twig:@foo></twig:@foo>',
+            '{% component \'long:component:n@me\' %}{% endcomponent %}',
         ];
         yield 'component_with_character_-_on_his_name' => [
             '<twig:foo-bar></twig:foo-bar>',
             '{% component \'foo-bar\' %}{% endcomponent %}',
         ];
+        yield 'component_with_character_-_on_his_name_with_require' => [
+            '{% require long:component-name as foo-bar %}<twig:foo-bar></twig:foo-bar>',
+            '{% component \'long:component-name\' %}{% endcomponent %}',
+        ];
         yield 'component_with_character_._on_his_name' => [
             '<twig:foo.bar></twig:foo.bar>',
             '{% component \'foo.bar\' %}{% endcomponent %}',
+        ];
+        yield 'component_with_character_._on_his_name_with_require' => [
+            '{% require long:component.name as foo.bar %}<twig:foo.bar></twig:foo.bar>',
+            '{% component \'long:component.name\' %}{% endcomponent %}',
         ];
         yield 'nested_component_2_levels' => [
             '<twig:foo><twig:block name="child"><twig:bar><twig:block name="message">Hello World!</twig:block></twig:bar></twig:block></twig:foo>',
@@ -200,6 +256,11 @@ final class TwigPreLexerTest extends TestCase
         yield 'ignore_twig_comment' => [
             '{# <twig:Alert/> #} <twig:Alert/>',
             '{# <twig:Alert/> #} {{ component(\'Alert\') }}',
+        ];
+
+        yield 'ignore_twig_comment_with_require' => [
+            '{% require component:alert as Alert %} {# <twig:Alert/> #} <twig:Alert/>',
+            ' {# <twig:Alert/> #} {{ component(\'component:alert\') }}',
         ];
 
         yield 'file_ended_with_comments' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #1108
| License       | MIT

As suggested in #1108 and #801, this PR adds a new step in `TwigPreLexer` to replace components aliases by there full name.
This will be useful when reusing many times the same components in your template, especially when making extensive use of components : having a well organized component folder will lead to longer component names.

What do you think ?

TODO:
- [ ] Handle the case when require declaration is commented
- [ ] Handle the case when require declaration is in a verbatim block
