### PR TITLE
[StimulusBundle] throw exception for inaccessible assets

### DIFF
--- a/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
+++ b/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
@@ -72,6 +72,9 @@ class ControllersMapGenerator
             $name = str_replace(['_', '/'], ['-', '--'], $name);
 
             $asset = $this->assetMapper->getAssetFromSourcePath($file->getRealPath());
+            if (null === $packageControllerConfig) {
+                throw new \RuntimeException(sprintf('Asset "%s" is not accessible.', $file->getRealPath()));
+            }
             $isLazy = preg_match('/\/\*\s*stimulusFetch:\s*\'lazy\'\s*\*\//i', $asset->content);
 
             $controllersMap[$name] = new MappedControllerAsset($asset, $isLazy);


### PR DESCRIPTION
Handle inaccessible assets, e.g. permissions or an invalid symlink

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #1210
| License       | MIT

