### PR TITLE
Live component force post requests

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 -   Add support for URL binding in `LiveProp`
 -   Allow multiple `LiveListener` attributes on a single method.
+-   Requests to LiveComponent are sent as POST by default
+-   Add method prop to AsLiveComponent to still allow GET requests, usage: `#[AsLiveComponent(method: 'get')]`
 
 ## 2.13.2
 

--- a/src/LiveComponent/assets/dist/Backend/Backend.d.ts
+++ b/src/LiveComponent/assets/dist/Backend/Backend.d.ts
@@ -20,7 +20,7 @@ export interface BackendAction {
 }
 export default class implements BackendInterface {
     private readonly requestBuilder;
-    constructor(url: string, csrfToken?: string | null);
+    constructor(url: string, method?: 'get' | 'post', csrfToken?: string | null);
     makeRequest(props: any, actions: BackendAction[], updated: {
         [key: string]: any;
     }, children: ChildrenFingerprints, updatedPropsFromParent: {

--- a/src/LiveComponent/assets/dist/Backend/RequestBuilder.d.ts
+++ b/src/LiveComponent/assets/dist/Backend/RequestBuilder.d.ts
@@ -1,8 +1,9 @@
 import { BackendAction, ChildrenFingerprints } from './Backend';
 export default class {
     private url;
+    private method;
     private readonly csrfToken;
-    constructor(url: string, csrfToken?: string | null);
+    constructor(url: string, method?: 'get' | 'post', csrfToken?: string | null);
     buildRequest(props: any, actions: BackendAction[], updated: {
         [key: string]: any;
     }, children: ChildrenFingerprints, updatedPropsFromParent: {

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -32,6 +32,10 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
             type: StringConstructor;
             default: string;
         };
+        requestMethod: {
+            type: StringConstructor;
+            default: string;
+        };
         queryMapping: {
             type: ObjectConstructor;
             default: {};
@@ -48,6 +52,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     readonly hasDebounceValue: boolean;
     readonly debounceValue: number;
     readonly fingerprintValue: string;
+    readonly requestMethodValue: 'get' | 'post';
     readonly queryMappingValue: {
         [p: string]: {
             name: string;

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2169,8 +2169,9 @@ class BackendRequest {
 }
 
 class RequestBuilder {
-    constructor(url, csrfToken = null) {
+    constructor(url, method = 'post', csrfToken = null) {
         this.url = url;
+        this.method = method;
         this.csrfToken = csrfToken;
     }
     buildRequest(props, actions, updated, children, updatedPropsFromParent, files) {
@@ -2187,6 +2188,7 @@ class RequestBuilder {
         const hasFingerprints = Object.keys(children).length > 0;
         if (actions.length === 0 &&
             totalFiles === 0 &&
+            this.method === 'get' &&
             this.willDataFitInUrl(JSON.stringify(props), JSON.stringify(updated), params, JSON.stringify(children), JSON.stringify(updatedPropsFromParent))) {
             params.set('props', JSON.stringify(props));
             params.set('updated', JSON.stringify(updated));
@@ -2244,8 +2246,8 @@ class RequestBuilder {
 }
 
 class Backend {
-    constructor(url, csrfToken = null) {
-        this.requestBuilder = new RequestBuilder(url, csrfToken);
+    constructor(url, method = 'post', csrfToken = null) {
+        this.requestBuilder = new RequestBuilder(url, method, csrfToken);
     }
     makeRequest(props, actions, updated, children, updatedPropsFromParent, files) {
         const { url, fetchOptions } = this.requestBuilder.buildRequest(props, actions, updated, children, updatedPropsFromParent, files);
@@ -2840,7 +2842,7 @@ class LiveControllerDefault extends Controller {
     initialize() {
         this.handleDisconnectedChildControllerEvent = this.handleDisconnectedChildControllerEvent.bind(this);
         const id = this.element.dataset.liveId || null;
-        this.component = new Component(this.element, this.nameValue, this.propsValue, this.listenersValue, (currentComponent, onlyParents, onlyMatchName) => LiveControllerDefault.componentRegistry.findComponents(currentComponent, onlyParents, onlyMatchName), this.fingerprintValue, id, new Backend(this.urlValue, this.csrfValue), new StandardElementDriver());
+        this.component = new Component(this.element, this.nameValue, this.propsValue, this.listenersValue, (currentComponent, onlyParents, onlyMatchName) => LiveControllerDefault.componentRegistry.findComponents(currentComponent, onlyParents, onlyMatchName), this.fingerprintValue, id, new Backend(this.urlValue, this.requestMethodValue, this.csrfValue), new StandardElementDriver());
         this.proxiedComponent = proxifyComponent(this.component);
         this.element.__component = this.proxiedComponent;
         if (this.hasDebounceValue) {
@@ -3073,6 +3075,7 @@ LiveControllerDefault.values = {
     debounce: { type: Number, default: 150 },
     id: String,
     fingerprint: { type: String, default: '' },
+    requestMethod: { type: String, default: 'post' },
     queryMapping: { type: Object, default: {} },
 };
 LiveControllerDefault.componentRegistry = new ComponentRegistry();

--- a/src/LiveComponent/assets/src/Backend/Backend.ts
+++ b/src/LiveComponent/assets/src/Backend/Backend.ts
@@ -25,8 +25,8 @@ export interface BackendAction {
 export default class implements BackendInterface {
     private readonly requestBuilder: RequestBuilder;
 
-    constructor(url: string, csrfToken: string | null = null) {
-        this.requestBuilder = new RequestBuilder(url, csrfToken);
+    constructor(url: string, method: 'get' | 'post' = 'post', csrfToken: string | null = null) {
+        this.requestBuilder = new RequestBuilder(url, method, csrfToken);
     }
 
     makeRequest(

--- a/src/LiveComponent/assets/src/Backend/RequestBuilder.ts
+++ b/src/LiveComponent/assets/src/Backend/RequestBuilder.ts
@@ -2,10 +2,12 @@ import { BackendAction, ChildrenFingerprints } from './Backend';
 
 export default class {
     private url: string;
+    private method: 'get' | 'post';
     private readonly csrfToken: string | null;
 
-    constructor(url: string, csrfToken: string | null = null) {
+    constructor(url: string, method: 'get' | 'post' = 'post', csrfToken: string | null = null) {
         this.url = url;
+        this.method = method;
         this.csrfToken = csrfToken;
     }
 
@@ -37,6 +39,7 @@ export default class {
         if (
             actions.length === 0 &&
             totalFiles === 0 &&
+            this.method === 'get' &&
             this.willDataFitInUrl(JSON.stringify(props), JSON.stringify(updated), params, JSON.stringify(children), JSON.stringify(updatedPropsFromParent))
         ) {
             params.set('props', JSON.stringify(props));

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -45,6 +45,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
         debounce: { type: Number, default: 150 },
         id: String,
         fingerprint: { type: String, default: '' },
+        requestMethod: { type: String, default: 'post' },
         queryMapping: { type: Object, default: {} },
     };
 
@@ -56,6 +57,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     declare readonly hasDebounceValue: boolean;
     declare readonly debounceValue: number;
     declare readonly fingerprintValue: string;
+    declare readonly requestMethodValue: 'get' | 'post';
     declare readonly queryMappingValue: { [p: string]: { name: string } };
 
     /** The component, wrapped in the convenience Proxy */
@@ -87,7 +89,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
                 LiveControllerDefault.componentRegistry.findComponents(currentComponent, onlyParents, onlyMatchName),
             this.fingerprintValue,
             id,
-            new Backend(this.urlValue, this.csrfValue),
+            new Backend(this.urlValue, this.requestMethodValue, this.csrfValue),
             new StandardElementDriver()
         );
         this.proxiedComponent = proxifyComponent(this.component);

--- a/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
+++ b/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
@@ -2,7 +2,7 @@ import RequestBuilder from '../../src/Backend/RequestBuilder';
 
 describe('buildRequest', () => {
     it('sets basic data on GET request', () => {
-        const builder = new RequestBuilder('/_components?existing_param=1', '_the_csrf_token');
+        const builder = new RequestBuilder('/_components?existing_param=1', 'get', '_the_csrf_token');
         const { url, fetchOptions } = builder.buildRequest(
             { firstName: 'Ryan' },
             [],
@@ -21,7 +21,7 @@ describe('buildRequest', () => {
     });
 
     it('sets basic data on POST request', () => {
-        const builder = new RequestBuilder('/_components', '_the_csrf_token');
+        const builder = new RequestBuilder('/_components', 'post', '_the_csrf_token');
         const { url, fetchOptions } = builder.buildRequest(
             { firstName: 'Ryan' },
             [{
@@ -52,7 +52,7 @@ describe('buildRequest', () => {
     });
 
     it('sets basic data on POST request with batch actions', () => {
-        const builder = new RequestBuilder('/_components', '_the_csrf_token');
+        const builder = new RequestBuilder('/_components', 'post', '_the_csrf_token');
         const { url, fetchOptions } = builder.buildRequest(
             { firstName: 'Ryan' },
             [{
@@ -87,7 +87,7 @@ describe('buildRequest', () => {
 
     // when data is too long it makes a post request
     it('makes a POST request when data is too long', () => {
-        const builder = new RequestBuilder('/_components', '_the_csrf_token');
+        const builder = new RequestBuilder('/_components', 'get', '_the_csrf_token');
         const { url, fetchOptions } = builder.buildRequest(
             { firstName: 'Ryan'.repeat(1000) },
             [],
@@ -112,8 +112,38 @@ describe('buildRequest', () => {
         }));
     });
 
+    it('makes a POST request when method is post', () => {
+        const builder = new RequestBuilder('/_components', 'post', '_the_csrf_token');
+        const { url, fetchOptions } = builder.buildRequest(
+            {
+                firstName: 'Ryan'
+            },
+            [],
+            { firstName: 'Kevin' },
+            {},
+            {},
+            {}
+        );
+
+        expect(url).toEqual('/_components');
+        expect(fetchOptions.method).toEqual('POST');
+        expect(fetchOptions.headers).toEqual({
+            // no token
+            Accept: 'application/vnd.live-component+html',
+            'X-Requested-With': 'XMLHttpRequest',
+        });
+        const body = <FormData>fetchOptions.body;
+        expect(body).toBeInstanceOf(FormData);
+        expect(body.get('data')).toEqual(JSON.stringify({
+            props: {
+                firstName: 'Ryan'
+            },
+            updated: { firstName: 'Kevin' },
+        }));
+    });
+
     it('sends propsFromParent when specified', () => {
-        const builder = new RequestBuilder('/_components?existing_param=1', '_the_csrf_token');
+        const builder = new RequestBuilder('/_components?existing_param=1', 'get', '_the_csrf_token');
         const { url } = builder.buildRequest(
             { firstName: 'Ryan' },
             [],
@@ -167,7 +197,7 @@ describe('buildRequest', () => {
     };
 
     it('Sends file with request', () => {
-        const builder = new RequestBuilder('/_components', '_the_csrf_token');
+        const builder = new RequestBuilder('/_components', 'post', '_the_csrf_token');
 
         const { url, fetchOptions } = builder.buildRequest(
             { firstName: 'Ryan' },
@@ -192,7 +222,7 @@ describe('buildRequest', () => {
     });
 
     it('Sends multiple files with request', () => {
-        const builder = new RequestBuilder('/_components', '_the_csrf_token');
+        const builder = new RequestBuilder('/_components', 'post', '_the_csrf_token');
 
         const { url, fetchOptions } = builder.buildRequest(
             { firstName: 'Ryan' },

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -42,8 +42,15 @@ final class AsLiveComponent extends AsTwigComponent
         string $attributesVar = 'attributes',
         public bool $csrf = true,
         public string $route = 'ux_live_component',
+        public string $method = 'post',
     ) {
         parent::__construct($name, $template, $exposePublicProps, $attributesVar);
+
+        $this->method = strtolower($this->method);
+
+        if (!\in_array($this->method, ['get', 'post'])) {
+            throw new \UnexpectedValueException('$method must be either \'get\' or \'post\'');
+        }
     }
 
     /**
@@ -56,6 +63,7 @@ final class AsLiveComponent extends AsTwigComponent
             'live' => true,
             'csrf' => $this->csrf,
             'route' => $this->route,
+            'method' => $this->method,
         ]);
     }
 

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -164,6 +164,17 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
             throw new NotFoundHttpException(sprintf('The action "%s" either doesn\'t exist or is not allowed in "%s". Make sure it exist and has the LiveAction attribute above it.', $action, $component::class));
         }
 
+        $componentName = $request->attributes->get('_component_name') ?? $request->attributes->get('_mounted_component')->getName();
+        $requestMethod = $this->container->get(ComponentFactory::class)->metadataFor($componentName)?->get('method') ?? 'post';
+
+        /**
+         * $requestMethod 'post' allows POST requests only
+         * $requestMethod 'get' allows GET and POST requests.
+         */
+        if ($request->isMethod('get') && 'post' === $requestMethod) {
+            throw new MethodNotAllowedHttpException([strtoupper($requestMethod)]);
+        }
+
         /*
          * Either we:
          *      A) We do NOT have a _mounted_component, so hydrate $component

--- a/src/LiveComponent/src/Util/LiveAttributesCollection.php
+++ b/src/LiveComponent/src/Util/LiveAttributesCollection.php
@@ -98,6 +98,11 @@ final class LiveAttributesCollection
         $this->attributes['data-live-browser-dispatch'] = $browserEventsToDispatch;
     }
 
+    public function setRequestMethod(string $requestMethod): void
+    {
+        $this->attributes['data-live-request-method-value'] = $requestMethod;
+    }
+
     public function setQueryUrlMapping(array $queryUrlMapping): void
     {
         $this->attributes['data-live-query-mapping-value'] = $queryUrlMapping;

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -99,6 +99,8 @@ class LiveControllerAttributesCreator
         }
 
         $liveMetadata = $this->metadataFactory->getMetadata($mounted->getName());
+        $requestMethod = $liveMetadata->getComponentMetadata()?->get('method') ?? 'post';
+        $attributesCollection->setRequestMethod($requestMethod);
 
         if ($liveMetadata->hasQueryStringBindings()) {
             $queryMapping = [];

--- a/src/LiveComponent/tests/Fixtures/Component/Component1.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component1.php
@@ -20,7 +20,7 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity1;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-#[AsLiveComponent('component1')]
+#[AsLiveComponent('component1', method: 'get')]
 final class Component1
 {
     use DefaultActionTrait;

--- a/src/LiveComponent/tests/Fixtures/Component/Component2.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component2.php
@@ -25,7 +25,7 @@ use Symfony\UX\LiveComponent\Attribute\PreDehydrate;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-#[AsLiveComponent('component2', defaultAction: 'defaultAction()')]
+#[AsLiveComponent('component2', defaultAction: 'defaultAction()', method: 'get')]
 final class Component2
 {
     #[LiveProp]

--- a/src/LiveComponent/tests/Fixtures/Component/Component6.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component6.php
@@ -20,7 +20,7 @@ use Symfony\UX\LiveComponent\DefaultActionTrait;
 /**
  * @author Tomas Norkūnas <norkunas.tom@gmail.com>
  */
-#[AsLiveComponent('component6')]
+#[AsLiveComponent('component6', method: 'get')]
 class Component6
 {
     use DefaultActionTrait;

--- a/src/LiveComponent/tests/Fixtures/Component/ComponentWithMethodPost.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ComponentWithMethodPost.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('with_method_post', method: 'post')]
+final class ComponentWithMethodPost
+{
+    use DefaultActionTrait;
+}

--- a/src/LiveComponent/tests/Fixtures/Component/ComponentWithWritableProps.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ComponentWithWritableProps.php
@@ -11,17 +11,11 @@
 
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
-use Symfony\UX\LiveComponent\Attribute\PreReRender;
-use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
-use Symfony\UX\LiveComponent\Attribute\PostHydrate;
-use Symfony\UX\LiveComponent\Attribute\PreDehydrate;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent('component_with_writable_props')]
+#[AsLiveComponent('component_with_writable_props', method: 'get')]
 final class ComponentWithWritableProps
 {
     use DefaultActionTrait;

--- a/src/LiveComponent/tests/Fixtures/Component/DeferredComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/DeferredComponent.php
@@ -7,7 +7,7 @@ namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent('deferred_component')]
+#[AsLiveComponent('deferred_component', method: 'get')]
 final class DeferredComponent
 {
     use DefaultActionTrait;

--- a/src/LiveComponent/tests/Fixtures/Component/TodoListComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/TodoListComponent.php
@@ -15,7 +15,7 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent('todo_list')]
+#[AsLiveComponent('todo_list', method: 'get')]
 final class TodoListComponent
 {
     #[LiveProp(writable: true)]

--- a/src/LiveComponent/tests/Fixtures/Component/TodoListWithKeysComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/TodoListWithKeysComponent.php
@@ -15,7 +15,7 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent('todo_list_with_keys')]
+#[AsLiveComponent('todo_list_with_keys', method: 'get')]
 final class TodoListWithKeysComponent
 {
     use DefaultActionTrait;

--- a/src/LiveComponent/tests/Fixtures/Component/TrackRenders.php
+++ b/src/LiveComponent/tests/Fixtures/Component/TrackRenders.php
@@ -16,7 +16,7 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent('track_renders')]
+#[AsLiveComponent('track_renders', method: 'get')]
 final class TrackRenders
 {
     use DefaultActionTrait;

--- a/src/LiveComponent/tests/Functional/Controller/BatchActionControllerTest.php
+++ b/src/LiveComponent/tests/Functional/Controller/BatchActionControllerTest.php
@@ -32,7 +32,13 @@ final class BatchActionControllerTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/with_actions', ['query' => ['props' => json_encode($dehydrated->getProps())]])
+            ->post('/_components/with_actions', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertSee('initial')
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
@@ -83,7 +89,13 @@ final class BatchActionControllerTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/alt/alternate_route', ['query' => ['props' => json_encode($dehydrated->getProps())]])
+            ->post('/alt/alternate_route', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertSee('count: 0')
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
@@ -129,7 +141,13 @@ final class BatchActionControllerTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/with_actions', ['query' => ['props' => json_encode($dehydrated->getProps())]])
+            ->post('/_components/with_actions', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->interceptRedirects()
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
@@ -160,7 +178,13 @@ final class BatchActionControllerTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/with_actions', ['query' => ['props' => json_encode($dehydrated->getProps())]])
+            ->post('/_components/with_actions', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->interceptRedirects()
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
@@ -193,7 +217,13 @@ final class BatchActionControllerTest extends KernelTestCase
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
         $this->browser()
-            ->get('/_components/with_actions', ['query' => ['props' => json_encode($dehydrated->getProps())]])
+            ->post('/_components/with_actions', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->expectException(\RuntimeException::class, 'Exception message')
             ->use(function (Crawler $crawler, KernelBrowser $browser) {
@@ -222,7 +252,13 @@ final class BatchActionControllerTest extends KernelTestCase
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
         $this->browser()
-            ->get('/_components/with_actions', ['query' => ['props' => json_encode($dehydrated->getProps())]])
+            ->post('/_components/with_actions', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->expectException(NotFoundHttpException::class, 'The action "nonLive" either doesn\'t exist or is not allowed')
             ->use(function (Crawler $crawler, KernelBrowser $browser) {

--- a/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
@@ -94,11 +94,11 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
                 ), $content);
                 // new props are JUST the "textLength" + a checksum for it specifically
                 $this->assertStringContainsString(sprintf(
-                    '<li data-live-name-value="todo_item" data-live-id="%s0" data-live-fingerprint-value="sMvvf7q68tz&#x2F;Cuk&#x2B;vDeisDiq&#x2B;7YPWzT&#x2B;WZFzI37dGHY&#x3D;" data-live-props-value="&#x7B;&quot;textLength&quot;&#x3A;18,&quot;&#x40;checksum&quot;&#x3A;&quot;LGxXa9fMKrJ6PelkUPfqmdwnfkk&#x2B;LORgoJHXyPpS3Pw&#x3D;&quot;&#x7D;"></li>',
+                    '<li data-live-name-value="todo_item" data-live-id="%s0" data-live-request-method-value="post" data-live-fingerprint-value="sMvvf7q68tz&#x2F;Cuk&#x2B;vDeisDiq&#x2B;7YPWzT&#x2B;WZFzI37dGHY&#x3D;" data-live-props-value="&#x7B;&quot;textLength&quot;&#x3A;18,&quot;&#x40;checksum&quot;&#x3A;&quot;LGxXa9fMKrJ6PelkUPfqmdwnfkk&#x2B;LORgoJHXyPpS3Pw&#x3D;&quot;&#x7D;"></li>',
                     AddLiveAttributesSubscriberTest::TODO_ITEM_DETERMINISTIC_PREFIX_EMBEDDED
                 ), $content);
                 $this->assertStringContainsString(sprintf(
-                    '<li data-live-name-value="todo_item" data-live-id="%s1" data-live-fingerprint-value="8AooEz36WYQyxj54BCaDm&#x2F;jKbcdDdPDLaNO4&#x2F;49bcQk&#x3D;" data-live-props-value="&#x7B;&quot;textLength&quot;&#x3A;10,&quot;&#x40;checksum&quot;&#x3A;&quot;BXUk7q6LI&#x5C;&#x2F;6Qx3c62Xiui6287YndmoK3QmVq6e5mcGk&#x3D;&quot;&#x7D;"></li>',
+                    '<li data-live-name-value="todo_item" data-live-id="%s1" data-live-request-method-value="post" data-live-fingerprint-value="8AooEz36WYQyxj54BCaDm&#x2F;jKbcdDdPDLaNO4&#x2F;49bcQk&#x3D;" data-live-props-value="&#x7B;&quot;textLength&quot;&#x3A;10,&quot;&#x40;checksum&quot;&#x3A;&quot;BXUk7q6LI&#x5C;&#x2F;6Qx3c62Xiui6287YndmoK3QmVq6e5mcGk&#x3D;&quot;&#x7D;"></li>',
                     AddLiveAttributesSubscriberTest::TODO_ITEM_DETERMINISTIC_PREFIX
                 ), $content);
             });

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -56,7 +56,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/component1?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/_components/component1', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Prop1: '.$entity->id)
@@ -72,7 +78,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/alt/alternate_route?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/alt/alternate_route', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertOn('/alt/alternate_route', parts: ['path'])
             ->assertContains('From alternate route. (count: 0)')
@@ -98,7 +110,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/_components/component2', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Count: 1')
@@ -124,7 +142,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/alt/alternate_route?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/alt/alternate_route', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertContains('count: 0')
             ->use(function (Crawler $crawler) use (&$token) {
@@ -145,6 +169,14 @@ final class LiveComponentSubscriberTest extends KernelTestCase
     {
         $this->browser()
             ->get('/_components/component2/increase')
+            ->assertStatus(405)
+        ;
+    }
+
+    public function testCannotExecuteComponentDefaultActionForGetRequestWhenMethodIsPost(): void
+    {
+        $this->browser()
+            ->get('/_components/with_method_post/__invoke')
             ->assertStatus(405)
         ;
     }
@@ -201,7 +233,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/disabled_csrf?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/_components/disabled_csrf', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Count: 1')
@@ -222,7 +260,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ->visit('/render-template/render_component2')
             ->assertSuccessful()
             ->assertSee('PreReRenderCalled: No')
-            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/_components/component2', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertSee('PreReRenderCalled: Yes')
         ;
@@ -252,7 +296,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ->assertSeeElement('.component2')
             ->assertElementAttributeContains('.component2', 'data-live-props-value', '"data-host-template":"'.$obscuredName.'"')
             ->assertElementAttributeContains('.component2', 'data-live-props-value', '"data-embedded-template-index":'.self::DETERMINISTIC_ID)
-            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/_components/component2', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertSee('PreReRenderCalled: Yes')
             ->assertSee('Embedded content with access to context, like count=1')
@@ -357,7 +407,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/component2?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/_components/component2', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->use(function (Crawler $crawler) use (&$token) {
                 // get a valid token to use for actions
@@ -394,7 +450,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         $arguments = ['arg1' => 'hello', 'arg2' => 666, 'custom' => '33.3'];
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/component6?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/_components/component6', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertHeaderContains('Content-Type', 'html')
             ->assertContains('Arg1: not provided')
@@ -427,7 +489,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
         $this->browser()
             ->throwExceptions()
-            ->get('/_components/with_nullable_entity?props='.urlencode(json_encode($dehydrated->getProps())))
+            ->post('/_components/with_nullable_entity', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated->getProps(),
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertContains('Prop1: default')
         ;

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -147,7 +147,14 @@ class ComponentWithFormTest extends KernelTestCase
         ];
 
         $this->browser()
-            ->get('/_components/form_with_collection_type?props='.urlencode(json_encode($dehydratedProps)).'&updated='.urlencode(json_encode($updatedProps)))
+            ->post('/_components/form_with_collection_type', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                        'updated' => $updatedProps,
+                    ]),
+                ],
+            ])
             // normal validation happened
             ->assertContains('The content field is too short')
             // title is STILL validated as all fields should be validated
@@ -197,7 +204,13 @@ class ComponentWithFormTest extends KernelTestCase
 
         $browser = $this->browser()
             ->throwExceptions()
-            ->get($getUrl($dehydratedProps))
+            ->post('/_components/form_with_many_different_fields_type', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertContains('<input type="checkbox" id="form_choice_multiple_1" name="form[choice_multiple][]" value="2" checked="checked"')
             ->assertContains('<input type="checkbox" id="form_choice_multiple_0" name="form[choice_multiple][]" value="1"')
@@ -209,7 +222,14 @@ class ComponentWithFormTest extends KernelTestCase
         $updatedProps = ['form' => ['choice_multiple' => ['1', '2']]];
 
         $crawler = $browser
-            ->get($getUrl($dehydratedProps, $updatedProps))
+            ->post('/_components/form_with_many_different_fields_type', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                        'updated' => $updatedProps,
+                    ]),
+                ],
+            ])
             ->assertContains('<input type="checkbox" id="form_choice_multiple_1" name="form[choice_multiple][]" value="2" checked="checked"')
             ->assertContains('<input type="checkbox" id="form_choice_multiple_0" name="form[choice_multiple][]" value="1" checked="checked"')
             ->crawler()
@@ -227,7 +247,14 @@ class ComponentWithFormTest extends KernelTestCase
         ]];
 
         $crawler = $browser
-            ->get($getUrl($dehydratedProps, $updatedProps))
+            ->post('/_components/form_with_many_different_fields_type', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                        'updated' => $updatedProps,
+                    ]),
+                ],
+            ])
             ->assertContains('<input type="checkbox" id="form_choice_multiple_1" name="form[choice_multiple][]" value="2"')
             ->assertContains('<input type="checkbox" id="form_choice_multiple_0" name="form[choice_multiple][]" value="1"')
             ->assertContains('<input type="checkbox" id="form_checkbox" name="form[checkbox]" required="required" value="1" checked="checked"')
@@ -244,7 +271,14 @@ class ComponentWithFormTest extends KernelTestCase
         ]];
 
         $browser
-            ->get($getUrl($dehydratedProps, $updatedProps))
+            ->post('/_components/form_with_many_different_fields_type', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                        'updated' => $updatedProps,
+                    ]),
+                ],
+            ])
             ->assertContains('<option value="2" selected="selected">')
             ->assertContains('<option value="1" selected="selected">')
         ;
@@ -255,7 +289,13 @@ class ComponentWithFormTest extends KernelTestCase
         $dehydrated = $this->dehydrateComponent($this->mountComponent('form_with_live_collection_type'))->getProps();
 
         $this->browser()
-            ->get('/_components/form_with_live_collection_type?props='.urlencode(json_encode($dehydrated)))
+            ->post('/_components/form_with_live_collection_type', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated,
+                    ]),
+                ],
+            ])
             ->assertContains('<button type="button" id="blog_post_form_comments_add"')
             ->assertContains('<button type="button" id="blog_post_form_comments_0_delete"')
         ;
@@ -267,24 +307,22 @@ class ComponentWithFormTest extends KernelTestCase
 
         $dehydratedProps = $this->dehydrateComponent($mounted)->getProps();
 
-        $getUrl = function (array $props, array $updatedProps = null) {
-            $url = '/_components/form_with_many_different_fields_type?props='.urlencode(json_encode($props));
-            if (null !== $updatedProps) {
-                $url .= '&updated='.urlencode(json_encode($updatedProps));
-            }
-
-            return $url;
-        };
-
         $browser = $this->browser();
         $crawler = $browser
-            ->get($getUrl($dehydratedProps, [
-                'form' => [
-                    'text' => 'foo',
-                    'textarea' => 'longer than 5',
+            ->post('/_components/form_with_many_different_fields_type', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                        'updated' => [
+                            'form' => [
+                                'text' => 'foo',
+                                'textarea' => 'longer than 5',
+                            ],
+                            'validatedFields' => ['form.text', 'form.textarea'],
+                        ],
+                    ]),
                 ],
-                'validatedFields' => ['form.text', 'form.textarea'],
-            ]))
+            ])
             ->assertStatus(422)
             ->assertContains('textarea is too long')
             ->crawler()
@@ -325,7 +363,13 @@ class ComponentWithFormTest extends KernelTestCase
         $token = null;
 
         $this->browser()
-            ->get('/_components/form_with_live_collection_type?props='.urlencode(json_encode($dehydratedProps)))
+            ->post('/_components/form_with_live_collection_type', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                    ]),
+                ],
+            ])
             ->use(function (Crawler $crawler) use (&$dehydratedProps, &$token, &$updatedProps) {
                 // mimic user typing
                 $updatedProps = [
@@ -398,7 +442,13 @@ class ComponentWithFormTest extends KernelTestCase
         $dehydrated = $this->dehydrateComponent($this->mountComponent('form_with_collection_type'))->getProps();
 
         $this->browser()
-            ->get('/_components/form_with_collection_type?props='.urlencode(json_encode($dehydrated)))
+            ->post('/_components/form_with_collection_type', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated,
+                    ]),
+                ],
+            ])
             ->assertElementAttributeContains('form', 'data-model', 'on(change)|*')
         ;
     }

--- a/src/LiveComponent/tests/Functional/ValidatableComponentTraitTest.php
+++ b/src/LiveComponent/tests/Functional/ValidatableComponentTraitTest.php
@@ -30,20 +30,29 @@ class ValidatableComponentTraitTest extends KernelTestCase
     {
         $dehydratedProps = $this->dehydrateComponent($this->mountComponent('validating_component'))->getProps();
 
-        $createUrl = function (array $props, array $updated = []) {
-            return '/_components/validating_component?props='.urlencode(json_encode($props)).'&updated='.urlencode(json_encode($updated));
-        };
-
         $browser = $this->browser();
         $browser
-            ->get($createUrl($dehydratedProps))
+            ->post('/_components/validating_component', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertContains('Has Error: no')
             ->assertContains('Error: ""')
         ;
 
         $crawler = $browser
-            ->get($createUrl($dehydratedProps, ['name' => 'h', 'validatedFields' => ['name']]))
+            ->post('/_components/validating_component', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                        'updated' => ['name' => 'h', 'validatedFields' => ['name']],
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertContains('Has Error: yes')
             ->assertContains('Error: "This value is too short. It should have 3 characters or more."')
@@ -53,9 +62,15 @@ class ValidatableComponentTraitTest extends KernelTestCase
         $div = $crawler->filter('[data-controller="live"]');
         $dehydratedProps = json_decode($div->attr('data-live-props-value'), true);
 
-        // make a normal GET request with no updates and verify validation still happens
+        // make a normal POST request with no updates and verify validation still happens
         $browser
-            ->get($createUrl($dehydratedProps))
+            ->post('/_components/validating_component', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydratedProps,
+                    ]),
+                ],
+            ])
             ->assertSuccessful()
             ->assertContains('Has Error: yes')
         ;

--- a/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
@@ -193,3 +193,8 @@ class DummyLiveComponent
         return true;
     }
 }
+
+#[AsLiveComponent(method: 'get')]
+class GetMethodComponent
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | Fix #1208
| License       | MIT

When your component model may contain sensitive data, you probably don't want your data being transferred via GET requests, because then the data might leak to browser history, server logs etc.

With this PR you can add `forcePost: true` to `#[AsLiveComponent]` and your component will always use POST requests to talk to the backend.

```php
#[AsLiveComponent(forcePost: true)]
class MySensitiveComponent
{
// ...
}
```