### PR TITLE
Add "type: module" for all packages and changing main -> module

### DIFF
--- a/src/Autocomplete/assets/package.json
+++ b/src/Autocomplete/assets/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@symfony/ux-autocomplete",
     "description": "JavaScript-powered autocompletion functionality for forms.",
-    "main": "dist/controller.js",
+    "module": "dist/controller.js",
+    "type": "module",
     "types": "dist/controller.d.ts",
     "version": "1.0.0",
     "license": "MIT",

--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Chart.js integration for Symfony",
     "license": "MIT",
     "version": "1.1.0",
-    "main": "dist/controller.js",
+    "module": "dist/controller.js",
+    "type": "module",
     "types": "dist/controller.d.ts",
     "symfony": {
         "controllers": {

--- a/src/Cropperjs/assets/package.json
+++ b/src/Cropperjs/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Cropper.js integration for Symfony",
     "license": "MIT",
     "version": "1.1.0",
-    "main": "dist/controller.js",
+    "module": "dist/controller.js",
+    "type": "module",
     "types": "dist/controller.d.ts",
     "config": {
         "css_source": "src/style.css"

--- a/src/Dropzone/assets/package.json
+++ b/src/Dropzone/assets/package.json
@@ -3,7 +3,8 @@
     "description": "File input dropzones for Symfony Forms",
     "license": "MIT",
     "version": "1.1.0",
-    "main": "dist/controller.js",
+    "module": "dist/controller.js",
+    "type": "module",
     "types": "dist/controller.d.ts",
     "config": {
         "css_source": "src/style.css"

--- a/src/LazyImage/assets/package.json
+++ b/src/LazyImage/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Lazy image loader and utilities for Symfony",
     "license": "MIT",
     "version": "1.1.0",
-    "main": "dist/controller.js",
+    "module": "dist/controller.js",
+    "type": "module",
     "types": "dist/controller.d.ts",
     "symfony": {
         "controllers": {

--- a/src/LiveComponent/assets/package.json
+++ b/src/LiveComponent/assets/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@symfony/ux-live-component",
     "description": "Live Component: bring server-side re-rendering & model binding to any element.",
-    "main": "dist/live_controller.js",
+    "module": "dist/live_controller.js",
+    "type": "module",
     "types": "dist/live_controller.d.ts",
     "version": "1.0.0",
     "config": {

--- a/src/Notify/assets/package.json
+++ b/src/Notify/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Native notification integration for Symfony using Mercure",
     "license": "MIT",
     "version": "1.0.0",
-    "main": "dist/controller.js",
+    "module": "dist/controller.js",
+    "type": "module",
     "types": "dist/controller.d.ts",
     "symfony": {
         "controllers": {

--- a/src/React/assets/package.json
+++ b/src/React/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Integration of React in Symfony",
     "license": "MIT",
     "version": "1.0.0",
-    "main": "dist/register_controller.js",
+    "module": "dist/register_controller.js",
+    "type": "module",
     "types": "dist/register_controller.d.ts",
     "symfony": {
         "controllers": {

--- a/src/StimulusBundle/assets/package.json
+++ b/src/StimulusBundle/assets/package.json
@@ -3,6 +3,8 @@
     "description": "Integration of @hotwired/stimulus into Symfony",
     "version": "1.0.0",
     "license": "MIT",
+    "module": "dist/loader.js",
+    "type": "module",
     "symfony": {
         "needsPackageAsADependency": false,
         "importmap": {

--- a/src/Svelte/assets/package.json
+++ b/src/Svelte/assets/package.json
@@ -1,11 +1,10 @@
 {
     "name": "@symfony/ux-svelte",
     "description": "Integration of Svelte in Symfony",
-    "main": "dist/register_controller.js",
     "module": "dist/register_controller.js",
+    "type": "module",
     "version": "1.0.0",
     "license": "MIT",
-    "type": "module",
     "symfony": {
         "controllers": {
             "svelte": {

--- a/src/Swup/assets/package.json
+++ b/src/Swup/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Swup integration for Symfony",
     "license": "MIT",
     "version": "1.1.0",
-    "main": "dist/controller.js",
+    "module": "dist/controller.js",
+    "type": "module",
     "types": "dist/controller.d.ts",
     "symfony": {
         "controllers": {

--- a/src/TogglePassword/assets/package.json
+++ b/src/TogglePassword/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Toggle visibility of password inputs for Symfony Forms",
     "license": "MIT",
     "version": "1.0.0",
-    "main": "dist/controller.js",
+    "module": "dist/controller.js",
+    "type": "module",
     "types": "dist/controller.d.ts",
     "config": {
         "css_source": "src/style.css"

--- a/src/Translator/assets/package.json
+++ b/src/Translator/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Symfony Translator for JavaScript",
     "license": "MIT",
     "version": "1.0.0",
-    "main": "dist/translator_controller.js",
+    "module": "dist/translator_controller.js",
+    "type": "module",
     "types": "dist/translator_controller.d.ts",
     "symfony": {
         "importmap": {

--- a/src/Turbo/assets/package.json
+++ b/src/Turbo/assets/package.json
@@ -4,7 +4,8 @@
     "license": "MIT",
     "private": true,
     "version": "0.1.0",
-    "main": "dist/turbo_controller.js",
+    "module": "dist/turbo_controller.js",
+    "type": "module",
     "types": "dist/turbo_controller.d.ts",
     "symfony": {
         "controllers": {

--- a/src/Typed/assets/package.json
+++ b/src/Typed/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Typed integration for Symfony",
     "license": "MIT",
     "version": "1.0.0",
-    "main": "dist/controller.js",
+    "module": "dist/controller.js",
+    "type": "module",
     "types": "dist/controller.d.ts",
     "symfony": {
         "controllers": {

--- a/src/Vue/assets/package.json
+++ b/src/Vue/assets/package.json
@@ -3,7 +3,8 @@
     "description": "Integration of Vue.js in Symfony",
     "license": "MIT",
     "version": "1.0.0",
-    "main": "dist/register_controller.js",
+    "module": "dist/register_controller.js",
+    "type": "module",
     "types": "dist/register_controller.d.ts",
     "symfony": {
         "controllers": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tickets       | None
| License       | MIT

Follow up on https://github.com/symfony/ux/pull/1202/files#r1367791334

We already use ESM inside of our packages. This makes that official with `type: module`. Some notes / questions:

A) I believe, since we already ONLY made "modules" available, that this will have no effect on end users, but I'm not 100% sure about that. If someone is using `require` instead of `import`, it would affect them... but in that case, I believe `require` would not have worked before anyway. But if anyone knows better than I do, I'd appreciate your notes.

B) Because we are a `type: module`, my impression is that `main` will not be used. And we can instead rely on `module`.

tl;dr I believe these changes won't have user-facing effects, but I'm not 100% sure about that... though I'm pretty sure that if they DO have user-facing effects, it would be limited to people who are currently using `require` with these packages.

Cheers!