### PR TITLE
[Autocomplete][Doc] Fix event listeners are not removed

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -351,8 +351,8 @@ events that the core Stimulus controller dispatches:
 
         disconnect() {
             // You should always remove listeners when the controller is disconnected to avoid side-effects
-            this.element.removeEventListener('autocomplete:pre-connect', this._onConnect);
-            this.element.removeEventListener('autocomplete:connect', this._onPreConnect);
+            this.element.removeEventListener('autocomplete:connect', this._onConnect);
+            this.element.removeEventListener('autocomplete:pre-connect', this._onPreConnect);
         }
 
         _onPreConnect(event) {


### PR DESCRIPTION
Fix the [documentation snippet](https://symfony.com/bundles/ux-autocomplete/current/index.html#extending-tom-select), causing listeners to not be removed on disconnect.

From
```js
this.element.removeEventListener('autocomplete:pre-connect', this._onConnect);
this.element.removeEventListener('autocomplete:connect', this._onPreConnect);
```

To
```js
this.element.removeEventListener('autocomplete:connect', this._onConnect);
this.element.removeEventListener('autocomplete:pre-connect', this._onPreConnect);
```