### PR TITLE
[LiveComponent] Trigger model:set if a prop changes on the server

### DIFF
--- a/src/LiveComponent/assets/dist/Component/ValueStore.d.ts
+++ b/src/LiveComponent/assets/dist/Component/ValueStore.d.ts
@@ -11,7 +11,8 @@ export default class {
     getDirtyProps(): any;
     getUpdatedPropsFromParent(): any;
     flushDirtyPropsToPending(): void;
-    reinitializeAllProps(props: any): void;
+    reinitializeAllProps(props: any): string[];
     pushPendingPropsBackToDirty(): void;
     storeNewPropsFromParent(props: any): boolean;
+    private deepDiff;
 }

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -472,7 +472,7 @@ export default class Component {
         }
 
         const newProps = this.elementDriver.getComponentProps(newElement);
-        this.valueStore.reinitializeAllProps(newProps);
+        const changedProps = this.valueStore.reinitializeAllProps(newProps);
 
         const eventsToEmit = this.elementDriver.getEventsToEmit(newElement);
         const browserEventsToDispatch = this.elementDriver.getBrowserEventsToDispatch(newElement);
@@ -495,6 +495,10 @@ export default class Component {
         // reset the modified values back to their client-side version
         Object.keys(modifiedModelValues).forEach((modelName) => {
             this.valueStore.set(modelName, modifiedModelValues[modelName]);
+        });
+
+        changedProps.forEach((modelName) => {
+            this.hooks.triggerHook('model:set', modelName, this.valueStore.get(modelName), this);
         });
 
         eventsToEmit.forEach(({ event, data, target, componentName }) => {

--- a/src/LiveComponent/assets/test/ValueStore.test.ts
+++ b/src/LiveComponent/assets/test/ValueStore.test.ts
@@ -337,4 +337,41 @@ describe('ValueStore', () => {
             expect(store.getUpdatedPropsFromParent()).toEqual(changed ? newProps : {});
         });
     });
+
+    it('returns the correctly changed models from reinitializeAllProps()', () => {
+        const store = new ValueStore({
+            firstName: 'Ryan',
+            lastName: 'Weaver',
+            user: {
+                firstName: 'Ryan',
+                lastName: 'Weaver',
+            },
+            product: 5,
+            color: 'purple',
+        });
+
+        // "dirty" props are not returned because the dirty value remains
+        // and overrides the new value
+        store.set('color', 'orange');
+
+        const changedProps = store.reinitializeAllProps({
+            firstName: 'Ryan',
+            lastName: 'Bond',
+            user: {
+                firstName: 'Ryan',
+                lastName: 'Bond',
+            },
+            product: {
+                id: 5,
+                name: 'cool stuff',
+            },
+            color: 'green'
+        });
+
+        expect(changedProps).toEqual([
+            'lastName',
+            'user.lastName',
+            'product',
+        ]);
+    });
 });

--- a/src/LiveComponent/assets/test/tools.ts
+++ b/src/LiveComponent/assets/test/tools.ts
@@ -408,7 +408,7 @@ const getControllerElement = (container: HTMLElement): HTMLElement => {
     return element;
 };
 
-const dataToJsonAttribute = (data: any): string => {
+export const dataToJsonAttribute = (data: any): string => {
     const container = document.createElement('div');
     container.dataset.foo = JSON.stringify(data);
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -873,6 +873,8 @@ The following hooks are available (along with the arguments that are passed):
 * ``loading.state:started`` args ``(element: HTMLElement, request: BackendRequest)``
 * ``loading.state:finished`` args ``(element: HTMLElement)``
 * ``model:set`` args ``(model: string, value: any, component: Component)``
+  Triggered immediately when a prop is changed via any means on the frontend
+  or a prop is changed on the server during a re-render/action.
 
 Adding a Stimulus Controller to your Component Root Element
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -257,15 +257,15 @@ final class LiveComponentHydrator
         return base64_encode(hash_hmac('sha256', json_encode($dehydratedPropsData), $this->secret, true));
     }
 
-    private function verifyChecksum(array $identifierPops, string $error = 'Invalid checksum sent when updating the live component.'): void
+    private function verifyChecksum(array $identifierProps, string $error = 'Invalid checksum sent when updating the live component.'): void
     {
-        if (!\array_key_exists(self::CHECKSUM_KEY, $identifierPops)) {
+        if (!\array_key_exists(self::CHECKSUM_KEY, $identifierProps)) {
             throw new HydrationException(sprintf('Missing %s. key', self::CHECKSUM_KEY));
         }
-        $sentChecksum = $identifierPops[self::CHECKSUM_KEY];
-        unset($identifierPops[self::CHECKSUM_KEY]);
+        $sentChecksum = $identifierProps[self::CHECKSUM_KEY];
+        unset($identifierProps[self::CHECKSUM_KEY]);
 
-        $expectedChecksum = $this->calculateChecksum($identifierPops);
+        $expectedChecksum = $this->calculateChecksum($identifierProps);
 
         if (hash_equals($expectedChecksum, $sentChecksum)) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #1212
| License       | MIT

Hi!

If you use the `model:set` hook, and a prop changes on the server during a re-render, when the Ajax call finishes, `model:set` will now be called. Details:

A) The code was a bit complex, but for writable sub-properties (`#[LiveProp(writable: 'firstName, 'lastName']` above a `user` property), `model:set` is called for each sub-key that changes - e.g. `user.firstName` and `user.lastName`. That is consistent with the behavior if those were changed by the user (e.g. by typing into a `user.firstName` input).

B) If the user changes a prop *during* the Ajax request (e.g. they type into `user.firstName`), then `model:set` will not be triggered for this one model. That's because the "frontend value" takes precedence over any server updates (this has always been the case). And so, the end result is that, even if the server changed `user.firstName`, after the Ajax call finishes, the actual value of that prop on the frontend will be whatever the user changed it to during the re-render.

Cheers!