### PR TITLE
[Site] Remove highlight.php

### DIFF
--- a/ux.symfony.com/assets/controllers/code-highlighter-controller.js
+++ b/ux.symfony.com/assets/controllers/code-highlighter-controller.js
@@ -1,0 +1,27 @@
+import { Controller } from '@hotwired/stimulus';
+import hljs from 'highlight.js/lib/core';
+import hljs_javascript from 'highlight.js/lib/languages/javascript';
+import hljs_php from 'highlight.js/lib/languages/php';
+import hljs_xml from 'highlight.js/lib/languages/xml';
+import hljs_twig from 'highlight.js/lib/languages/twig';
+
+hljs.registerLanguage('javascript', hljs_javascript);
+hljs.registerLanguage('php', hljs_php);
+hljs.registerLanguage('twig', hljs_twig);
+// xml is the language used for HTML
+hljs.registerLanguage('xml', hljs_xml);
+
+export default class extends Controller {
+    static targets = ['codeBlock'];
+
+    codeBlockTargetConnected() {
+        this.codeBlockTargets.forEach(this.#highlightCodeBlock)
+    }
+
+    #highlightCodeBlock(codeBlock) {
+        if (codeBlock.dataset.highlighted) {
+            return;
+        }
+        hljs.highlightElement(codeBlock);
+    }
+}

--- a/ux.symfony.com/assets/styles/components/_Terminal.scss
+++ b/ux.symfony.com/assets/styles/components/_Terminal.scss
@@ -140,10 +140,16 @@
     overflow-inline: auto;
 }
 .Terminal_body pre {
-    padding: 1rem;
+    padding: 0;
     margin: 0;
 }
-
 .Terminal_content {
     font-size: .9rem;
+    overflow-x: auto;
+    overflow-y: auto;
+    padding: 1rem;
+
+    pre {
+        overflow: visible;
+    }
 }

--- a/ux.symfony.com/composer.json
+++ b/ux.symfony.com/composer.json
@@ -16,7 +16,6 @@
         "kornrunner/blurhash": "^1.2.2",
         "league/commonmark": "^2.4",
         "pagerfanta/twig": "^3.8",
-        "scrivo/highlight.php": "^9.18.1.10",
         "symfony/asset": "6.4.*",
         "symfony/asset-mapper": "6.4.*",
         "symfony/console": "6.4.*",

--- a/ux.symfony.com/composer.lock
+++ b/ux.symfony.com/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5926673d04364246c83d5f4fb82e7246",
+    "content-hash": "4a3652b42255ce0490a8b3f688ec4c15",
     "packages": [
         {
             "name": "babdev/pagerfanta-bundle",
@@ -3011,84 +3011,6 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
-        },
-        {
-            "name": "scrivo/highlight.php",
-            "version": "v9.18.1.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/scrivo/highlight.php.git",
-                "reference": "850f4b44697a2552e892ffe71490ba2733c2fc6e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/scrivo/highlight.php/zipball/850f4b44697a2552e892ffe71490ba2733c2fc6e",
-                "reference": "850f4b44697a2552e892ffe71490ba2733c2fc6e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": ">=5.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8|^5.7",
-                "sabberworm/php-css-parser": "^8.3",
-                "symfony/finder": "^2.8|^3.4|^5.4",
-                "symfony/var-dumper": "^2.8|^3.4|^5.4"
-            },
-            "suggest": {
-                "ext-mbstring": "Allows highlighting code with unicode characters and supports language with unicode keywords"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "HighlightUtilities/functions.php"
-                ],
-                "psr-0": {
-                    "Highlight\\": "",
-                    "HighlightUtilities\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Geert Bergman",
-                    "homepage": "http://www.scrivo.org/",
-                    "role": "Project Author"
-                },
-                {
-                    "name": "Vladimir Jimenez",
-                    "homepage": "https://allejo.io",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Martin Folkers",
-                    "homepage": "https://twobrain.io",
-                    "role": "Contributor"
-                }
-            ],
-            "description": "Server side syntax highlighter that supports 185 languages. It's a PHP port of highlight.js",
-            "keywords": [
-                "code",
-                "highlight",
-                "highlight.js",
-                "highlight.php",
-                "syntax"
-            ],
-            "support": {
-                "issues": "https://github.com/scrivo/highlight.php/issues",
-                "source": "https://github.com/scrivo/highlight.php"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/allejo",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-12-17T21:53:22+00:00"
         },
         {
             "name": "symfony/asset",

--- a/ux.symfony.com/importmap.php
+++ b/ux.symfony.com/importmap.php
@@ -115,6 +115,15 @@ return [
     'highlight.js/lib/languages/javascript' => [
         'version' => '11.7.0',
     ],
+    'highlight.js/lib/languages/php' => [
+        'version' => '11.7.0',
+    ],
+    'highlight.js/lib/languages/twig' => [
+        'version' => '11.7.0',
+    ],
+    'highlight.js/lib/languages/xml' => [
+        'version' => '11.7.0',
+    ],
     'intl-messageformat' => [
         'version' => '10.3.5',
     ],

--- a/ux.symfony.com/src/Util/SourceCleaner.php
+++ b/ux.symfony.com/src/Util/SourceCleaner.php
@@ -17,22 +17,25 @@ class SourceCleaner
 {
     public static function cleanupPhpFile(string $contents, bool $removeClass = false): string
     {
+        // Remove <?php
         $contents = u($contents)->replace("<?php\n", '');
 
         // Remove LICENCE header
         if ($contents->indexOf('* This file is part of the Symfony package')) {
-            $contents = $contents->after(' */');
+            $contents = $contents->before('/*')->trim()->append($contents->after(' */')->trim());
         }
 
+        // Remove namespace(s)
         $contents = $contents->replaceMatches('/namespace[^\n]*/', '');
 
+        // Remove class declaration
         if ($removeClass) {
             $contents = $contents->replaceMatches('/class[^\n]*\n{/', '')
                 ->trim('{}')
-                // remove use statements
+                // Remove use statements
                 ->replaceMatches('/^use [^\n]*$/m', '');
 
-            // unindent all lines by 4 spaces
+            // Unindent all lines by 4 spaces
             $lines = explode("\n", $contents);
             $lines = array_map(function (string $line) {
                 return substr($line, 4);

--- a/ux.symfony.com/symfony.lock
+++ b/ux.symfony.com/symfony.lock
@@ -181,9 +181,6 @@
     "ralouphie/getallheaders": {
         "version": "3.0.3"
     },
-    "scrivo/highlight.php": {
-        "version": "v9.18.1.9"
-    },
     "sebastian/cli-parser": {
         "version": "1.0.1"
     },

--- a/ux.symfony.com/templates/components/CodeBlock.html.twig
+++ b/ux.symfony.com/templates/components/CodeBlock.html.twig
@@ -1,23 +1,36 @@
 <div {{ attributes.defaults({
     class: 'Terminal ' ~ this.classString,
 }) }}>
+
     {% if showFilename %}
         <div class="Terminal_header py-2 ps-4 pe-2 mb-0 d-flex justify-content-between align-items-center">
             <a id="{{ this.elementId }}" href="#{{ this.elementId }}" class="Terminal_title"><code>{{ filename }}</code></a>
             <div class="Terminal_actions">
-                <twig:CodeBlockButtons source="{{ this.rawSource }}" link="{{ this.githubLink }}" />
+                <twig:CodeBlockButtons source="{{ this.rawSource }}" link="{{ this.githubLink }}"/>
             </div>
         </div>
     {% endif %}
+
     <div class="Terminal_body" {{ stimulus_controller('code-expander') }}>
         {% if not showFilename %}
             <div class="Terminal_actions">
                 <twig:CodeBlockButtons source="{{ this.rawSource }}" link="{{ this.githubLink }}"/>
             </div>
         {% endif %}
-        <pre style="height: {{ height }};" {{ stimulus_target('code-expander', 'codeContent') }}><code>
-            {{- this.highlightSource()|raw -}}
-        </code></pre>
+        <div class="Terminal_content" style="height: {{ height }};"
+            {{ stimulus_target('code-expander', 'codeContent') }}
+            {{ stimulus_controller('code-highlighter') }}
+        >
+            {% for piece in this.prepareSource %}
+                {% if piece.highlight ?? true %}
+                    <pre><code class="language-{{ this.language }}" {{ stimulus_target('code-highlighter', 'codeBlock') }}>
+                        {{- piece.content -}}
+                    </code></pre>
+                {% else %}
+                    {{- piece.content|raw -}}
+                {% endif %}
+            {% endfor %}
+        </div>
 
         {% block code_content_bottom %}
             <button


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Issues        | Fix [#683](https://github.com/symfony/ux/issues/683)
| License       | MIT

Remove highlight.php and use highlight.js directly.

(highlight.php is in fact abandonned)


