### PR TITLE
[Site] Improve DinoChart labels / colors 

### DIFF
--- a/ux.symfony.com/assets/styles/app/_html.scss
+++ b/ux.symfony.com/assets/styles/app/_html.scss
@@ -10,7 +10,7 @@ body {
 
 a, a.page-link, a.page-link:hover {
   text-decoration: none;
-  color: var(--color-primary);
+  color: inherit;
 }
 
 ::selection {
@@ -27,6 +27,7 @@ a, a.page-link, a.page-link:hover {
   min-width: 320px;
   overflow-x: clip;
 }
+
 main {
   flex-grow: 1;
 }
@@ -34,4 +35,29 @@ header,
 main,
 footer {
   flex-shrink: 0;
+}
+
+a.link {
+  --color: #d9438e;
+  color: var(--color);
+  position: relative;
+  &:after {
+    position: absolute;
+    content:"";
+    bottom: -2px;
+    left: 0;
+    right: 0;
+    height: 1px;
+    display: block;
+    transition: all .2s ease-in-out;
+    background: var(--color);
+    transform: scaleX(0);
+    transform-origin: center left;
+  }
+  &:hover {
+    &:after {
+      transform: scaleX(1);
+      transition: transform .15s ease-in-out revert;
+    }
+  }
 }

--- a/ux.symfony.com/src/Service/DinoStatsService.php
+++ b/ux.symfony.com/src/Service/DinoStatsService.php
@@ -17,6 +17,21 @@ class DinoStatsService
 
     private const ALL_DINOS = 'all';
 
+    private const COLORS = [
+        'de3232',
+        'de6732',
+        'dede32',
+        '67de32',
+        '32de32',
+        '32de67',
+        '32dede',
+        '3267de',
+        '3232de',
+        '6732de',
+        'de32de',
+        'de3267',
+    ];
+
     public static function getAllTypes(): array
     {
         return [
@@ -48,8 +63,11 @@ class DinoStatsService
 
         $datasets = [];
 
+        $colors = self::COLORS;
+        shuffle($colors);
+
         foreach ($types as $type) {
-            $color = sprintf('rgb(%d, %d, %d, .4)', mt_rand(0, 255), mt_rand(0, 255), mt_rand(0, 255));
+            $color = '#'.(next($colors) ?: reset($colors));
 
             $datasets[] = [
                 'label' => ucwords($type),

--- a/ux.symfony.com/src/Twig/DinoChart.php
+++ b/ux.symfony.com/src/Twig/DinoChart.php
@@ -29,6 +29,7 @@ class DinoChart
 
     #[LiveProp(writable: true)]
     public int $fromYear = -200;
+
     #[LiveProp(writable: true)]
     public int $toYear = -65;
 
@@ -58,6 +59,24 @@ class DinoChart
                         abs($this->fromYear),
                         abs($this->toYear)
                     ),
+                ],
+                'legend' => [
+                    'labels' => [
+                        'boxHeight' => 20,
+                        'boxWidth' => 50,
+                        'padding' => 20,
+                        'font' => [
+                            'size' => 14,
+                        ],
+                    ],
+                ],
+            ],
+            'elements' => [
+                'line' => [
+                    'borderWidth' => 5,
+                    'tension' => 0.25,
+                    'borderCapStyle' => 'round',
+                    'borderJoinStyle' => 'round',
                 ],
             ],
             'maintainAspectRatio' => false,

--- a/ux.symfony.com/templates/components/DinoChart.html.twig
+++ b/ux.symfony.com/templates/components/DinoChart.html.twig
@@ -45,9 +45,13 @@
 
     <hr>
 
-    <div style="min-height: 400px;">
+    <div style="min-height: 480px; margin-bottom: 1.5rem;">
         {{ render_chart(chart) }}
     </div>
 
-    <small>Source: <a href="https://www.nhm.ac.uk/">National History Museum</a> courtesy of https://github.com/kjanjua26/jurassic-park</small>
+    <small>Source:
+        <a href="https://www.nhm.ac.uk/" class="link">National History Museum</a> courtesy of
+        <a href="https://github.com/kjanjua26/jurassic-park" class="link">https://github.com/kjanjua26/jurassic-park</a>
+    </small>
+
 </div>


### PR DESCRIPTION
Google "complained" about the size of the DinoChart labels ... so i enlarged them ....

... and I seized the opportunity to fix the color generation, and update a couple of Chart.js options to improve readability.


| Before | Before | 
| - | - | 
| ![dino_before2](https://github.com/symfony/ux/assets/1359581/2bd7e44b-48e3-4b7c-94a7-33dedbe88257) | ![dino_before](https://github.com/symfony/ux/assets/1359581/76c1a6f3-c034-4245-909a-3bf8bf07f0f4)  

| After | After |
| - | - | 
| ![dino_after2](https://github.com/symfony/ux/assets/1359581/4b2688cf-d698-49ee-8cc1-5791bff84d3c) | ![dino_after](https://github.com/symfony/ux/assets/1359581/55d61efc-3939-46ff-8102-60fe9ac613d8) | 
