### PR TITLE
[Site] Add privacy page

### DIFF
--- a/ux.symfony.com/src/Controller/LegalController.php
+++ b/ux.symfony.com/src/Controller/LegalController.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class LegalController extends AbstractController
+{
+    #[Route('/privacy', name: 'app_legal_privacy')]
+    public function privacy(): Response
+    {
+        return $this->render('legal/privacy.html.twig');
+    }
+}

--- a/ux.symfony.com/templates/legal/privacy.html.twig
+++ b/ux.symfony.com/templates/legal/privacy.html.twig
@@ -1,0 +1,29 @@
+{% extends "base.html.twig" %}
+
+{% block content %}
+
+    <div class="hero">
+        <div class="container-fluid container-xxl px-4 pt-4 px-md-5 pt-md-5">
+            <h1 class="text-center ubuntu mt-5">Privacy</h1>
+        </div>
+    </div>
+
+    <div class="container-fluid container px-4 py-4 py-md-5" style="max-width: 40rem;">
+        <h2 class="ubuntu mt-3 mt-md-5">Do we process personal data?</h2>
+
+        <p>No. Absolutely not.</p>
+
+        <p>This is a <strong>concise</strong> yet <strong>unequivocal</strong> answer.</p>
+
+        <p>We do not utilize any advertising platforms or statistical tools.</p>
+
+        <ul>
+            <li>We do not use any shared trackers, such as cross-domain cookies or fingerprint identifiers.</li>
+            <li>We do not store personal information about anyone.</li>
+            <li>We do not share any information with third parties.</li>
+        </ul>
+
+        <p>Privacy is simple when you respect it.</p>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
To maintain legal compliance in Europe ... we need a "privacy" page, just stating the following things.

I just wrote it as i felt it... but if the tone does not suit you [^1], i won't mind a rewrite :) 


<img width="1432" alt="Capture d’écran 2023-10-29 à 00 19 41" src="https://github.com/symfony/ux/assets/1359581/85a1edeb-bc70-4811-ba19-5a1fad227987">



[^1]: i must admit this subtext pleases me :) 



