### PR TITLE
[TwigComponents] Fixing inconsistency with how {% component rendered vs {{ component()

### DIFF
--- a/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
@@ -28,17 +28,17 @@ final class DeferLiveComponentSubscriber implements EventSubscriberInterface
         $data = $event->getData();
         if (\array_key_exists('defer', $data)) {
             $event->addExtraMetadata('defer', true);
-            unset($event->getData()['defer']);
+            unset($data['defer']);
         }
 
         if (\array_key_exists('loading-template', $data)) {
             $event->addExtraMetadata('loading-template', $data['loading-template']);
-            unset($event->getData()['loading-template']);
+            unset($data['loading-template']);
         }
 
         if (\array_key_exists('loading-tag', $data)) {
             $event->addExtraMetadata('loading-tag', $data['loading-tag']);
-            unset($event->getData()['loading-tag']);
+            unset($data['loading-tag']);
         }
 
         $event->setData($data);

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -102,7 +102,6 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
         $container->register('ux.twig_component.twig.component_extension', ComponentExtension::class)
             ->addTag('twig.extension')
             ->addTag('container.service_subscriber', ['key' => ComponentRenderer::class, 'id' => 'ux.twig_component.component_renderer'])
-            ->addTag('container.service_subscriber', ['key' => ComponentFactory::class, 'id' => 'ux.twig_component.component_factory'])
         ;
 
         $container->register('ux.twig_component.twig.lexer', ComponentLexer::class);

--- a/src/TwigComponent/src/Event/PreRenderEvent.php
+++ b/src/TwigComponent/src/Event/PreRenderEvent.php
@@ -23,8 +23,13 @@ final class PreRenderEvent extends Event
     /** @internal */
     public const EMBEDDED = '__embedded';
 
+    /**
+     * Only relevant when rendering a specific embedded component.
+     * This is the "component template" that the embedded component
+     * should extend.
+     */
+    private string $parentTemplateForEmbedded;
     private string $template;
-
     private ?int $templateIndex = null;
 
     /**
@@ -36,6 +41,7 @@ final class PreRenderEvent extends Event
         private array $variables
     ) {
         $this->template = $this->metadata->getTemplate();
+        $this->parentTemplateForEmbedded = $this->template;
     }
 
     public function isEmbedded(): bool
@@ -58,6 +64,10 @@ final class PreRenderEvent extends Event
     {
         $this->template = $template;
         $this->templateIndex = $index;
+        // only if we are *not* targeting an embedded component, change the parent template
+        if (null === $index) {
+            $this->parentTemplateForEmbedded = $template;
+        }
 
         return $this;
     }
@@ -68,6 +78,11 @@ final class PreRenderEvent extends Event
     public function getTemplateIndex(): ?int
     {
         return $this->templateIndex;
+    }
+
+    public function getParentTemplateForEmbedded(): string
+    {
+        return $this->parentTemplateForEmbedded;
     }
 
     public function getComponent(): object

--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -13,8 +13,8 @@ namespace Symfony\UX\TwigComponent\Twig;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
-use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentRenderer;
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
 use Twig\Error\RuntimeError;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -34,7 +34,6 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
     {
         return [
             ComponentRenderer::class,
-            ComponentFactory::class,
         ];
     }
 
@@ -48,7 +47,7 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
     public function getTokenParsers(): array
     {
         return [
-            new ComponentTokenParser(fn () => $this->container->get(ComponentFactory::class)),
+            new ComponentTokenParser(),
             new PropsTokenParser(),
         ];
     }
@@ -62,7 +61,7 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
         }
     }
 
-    public function preRender(string $name, array $props): ?string
+    public function extensionPreCreateForRender(string $name, array $props): ?string
     {
         try {
             return $this->container->get(ComponentRenderer::class)->preCreateForRender($name, $props);
@@ -71,10 +70,10 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
         }
     }
 
-    public function embeddedContext(string $name, array $props, array $context, string $hostTemplateName, int $index): array
+    public function startEmbeddedComponentRender(string $name, array $props, array $context, string $hostTemplateName, int $index): PreRenderEvent
     {
         try {
-            return $this->container->get(ComponentRenderer::class)->embeddedContext($name, $props, $context, $hostTemplateName, $index);
+            return $this->container->get(ComponentRenderer::class)->startEmbeddedComponentRender($name, $props, $context, $hostTemplateName, $index);
         } catch (\Throwable $e) {
             $this->throwRuntimeError($name, $e);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1205 (?) and maybe others?
| License       | MIT

tl;dr `{% component` was rendered slightly differently than `{{ component`. Additionally, for `{% component`, the template was determined too early, which didn't allow for the template to be overridden via an event.

**Longer Explanation**

This cleans up `ComponentTokenParser`, removing some unnecessary parts. We now always set the "embedded" component parent to a magic `__parent__` variable. This allows us to delay the determination of the component template until runtime, after the `PreRenderEvent` has been called.

TODO:

* [ ] Bring in tests from #1236 and #1237 and check other tests
* [ ] Check #1205 to verify this fixes
* [ ] Check debug:twig-component command for any changes needed

Cheers!