### PR TITLE
[LiveComponent] Normalize "true" & "false" model values

### DIFF
--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -244,9 +244,21 @@ final class LiveComponentHydrator
         return match ($type) {
             'int' => (int) $value,
             'float' => (float) $value,
-            'bool' => (bool) $value,
+            'bool' => self::coerceStringToBoolean($value),
             default => throw new \LogicException(sprintf('Cannot coerce value "%s" to type "%s"', $value, $type)),
         };
+    }
+
+    private static function coerceStringToBoolean(string $value): bool
+    {
+        $booleanMap = [
+            '0' => false,
+            '1' => true,
+            'false' => false,
+            'true' => true,
+        ];
+
+        return $booleanMap[$value] ?? (bool) $value;
     }
 
     private function calculateChecksum(array $dehydratedPropsData): ?string

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -1461,6 +1461,20 @@ final class LiveComponentHydratorTest extends KernelTestCase
     }
 
     /**
+     * @dataProvider truthyValueProvider
+     */
+    public function testCoerceTruthyValuesForScalarTypes($prop, $value, $expected): void
+    {
+        $dehydratedProps = $this->dehydrateComponent($this->mountComponent('scalar_types'))->getProps();
+
+        $updatedProps = [$prop => $value];
+        $hydratedComponent = $this->getComponent('scalar_types');
+        $this->hydrateComponent($hydratedComponent, 'scalar_types', $dehydratedProps, $updatedProps);
+
+        $this->assertSame($expected, $hydratedComponent->$prop);
+    }
+
+    /**
      * @dataProvider falseyValueProvider
      */
     public function testCoerceFalseyValuesForScalarTypes($prop, $value, $expected): void
@@ -1474,6 +1488,15 @@ final class LiveComponentHydratorTest extends KernelTestCase
         $this->assertSame($expected, $hydratedComponent->$prop);
     }
 
+    public static function truthyValueProvider(): iterable
+    {
+        yield ['int', '1', 1];
+        yield ['float', '1', 1.0];
+        yield ['float', 'true', 0.0];
+        yield ['bool', 'true', true];
+        yield ['bool', '1', true];
+    }
+
     public static function falseyValueProvider(): iterable
     {
         yield ['int', '', 0];
@@ -1484,6 +1507,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         yield ['float', 'apple', 0.0];
         yield ['bool', '', false];
         yield ['bool', '   ', false];
+        yield ['bool', 'false', false];
 
         yield ['nullableInt', '', null];
         yield ['nullableInt', '   ', null];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes?
| New feature?  | no? 
| Issues        | Fix #1211
| License       | MIT


Coerce strings "true" & "false" to their boolean equivalent (same for 0 and 1)

```php
  private static function coerceStringToBoolean(string $value): bool
    {
        $booleanMap = [
            '0' => false,
            '1' => true,
            'false' => false,
            'true' => true,
        ];

        return $booleanMap[$value] ?? (bool) $value;
    }
```

Is that what you had in mind @weaverryan ?
