### PR TITLE
Fix instantiating LiveComponentMetadata multiple times

### DIFF
--- a/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
@@ -25,6 +25,9 @@ use Symfony\UX\TwigComponent\ComponentFactory;
  */
 class LiveComponentMetadataFactory
 {
+    /** @var LiveComponentMetadata[] */
+    private array $liveComponentMetadata = [];
+
     public function __construct(
         private ComponentFactory $componentFactory,
         private PropertyTypeExtractorInterface $propertyTypeExtractor,
@@ -33,12 +36,16 @@ class LiveComponentMetadataFactory
 
     public function getMetadata(string $name): LiveComponentMetadata
     {
+        if (isset($this->liveComponentMetadata[$name])) {
+            return $this->liveComponentMetadata[$name];
+        }
+
         $componentMetadata = $this->componentFactory->metadataFor($name);
 
         $reflectionClass = new \ReflectionClass($componentMetadata->getClass());
         $livePropsMetadata = $this->createPropMetadatas($reflectionClass);
 
-        return new LiveComponentMetadata($componentMetadata, $livePropsMetadata);
+        return $this->liveComponentMetadata[$name] = new LiveComponentMetadata($componentMetadata, $livePropsMetadata);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | N/A
| License       | MIT

This pull request fixes an issue with instantiating LiveComponentMetadata multiple times, when loading the same component multiple times.