### PR TITLE
Fixed another typo in Live Components code block

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1915,7 +1915,7 @@ Inline rendering:
 
     <div {{ attributes }}>
         {{ form_start(form) }}
-            {{ form_row(form.title)
+            {{ form_row(form.title) }}
 
             <h3>Comments:</h3>
             {% for key, commentForm in form.comments %}


### PR DESCRIPTION
Missing }} after form_start

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | 
| License       | MIT