### PR TITLE
[Site] Use AssetMapper for 6.4 for install

### DIFF
--- a/ux.symfony.com/templates/main/homepage.html.twig
+++ b/ux.symfony.com/templates/main/homepage.html.twig
@@ -31,10 +31,8 @@
 
     <div class="row">
         <div class="col-12 col-md-6">
-            <twig:Terminal>
-                composer require symfony/webpack-encore-bundle symfony/stimulus-bundle
-                npm install
-                npm run watch
+            <twig:Terminal bottomPadding="145">
+                composer require symfony/asset-mapper symfony/stimulus-bundle
             </twig:Terminal>
         </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

Waiting for AssetMapper 6.4 release.

The only problem now is... the install instructions are so short, the terminal block seems unnecessarily huge...

<img width="1212" alt="Screenshot 2023-11-06 at 4 18 47 PM" src="https://github.com/symfony/ux/assets/121003/e29e44d9-caaa-4038-85b2-1120ae593d81">

