### PR TITLE
[Doc] Fix preConnect/connect inversion in "disconnect()" doc examples

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -351,8 +351,8 @@ events that the core Stimulus controller dispatches:
 
         disconnect() {
             // You should always remove listeners when the controller is disconnected to avoid side-effects
-            this.element.removeEventListener('autocomplete:pre-connect', this._onConnect);
-            this.element.removeEventListener('autocomplete:connect', this._onPreConnect);
+            this.element.removeEventListener('autocomplete:connect', this._onConnect);
+            this.element.removeEventListener('autocomplete:pre-connect', this._onPreConnect);
         }
 
         _onPreConnect(event) {

--- a/src/Cropperjs/doc/index.rst
+++ b/src/Cropperjs/doc/index.rst
@@ -104,8 +104,8 @@ custom Stimulus controller:
 
         disconnect() {
             // You should always remove listeners when the controller is disconnected to avoid side effects
-            this.element.removeEventListener('cropperjs:pre-connect', this._onConnect);
             this.element.removeEventListener('cropperjs:connect', this._onConnect);
+            this.element.removeEventListener('cropperjs:pre-connect', this._onPreConnect);
         }
 
         _onPreConnect(event) {

--- a/src/Swup/doc/index.rst
+++ b/src/Swup/doc/index.rst
@@ -154,8 +154,8 @@ Stimulus controller:
 
         disconnect() {
             // You should always remove listeners when the controller is disconnected to avoid side-effects
-            this.element.removeEventListener('swup:pre-connect', this._onConnect);
-            this.element.removeEventListener('swup:connect', this._onPreConnect);
+            this.element.removeEventListener('swup:connect', this._onConnect);
+            this.element.removeEventListener('swup:pre-connect', this._onPreConnect);
         }
 
         _onPreConnect(event) {

--- a/src/Typed/doc/index.rst
+++ b/src/Typed/doc/index.rst
@@ -99,8 +99,8 @@ Stimulus controller:
 
         disconnect() {
             // You should always remove listeners when the controller is disconnected to avoid side-effects
-            this.element.removeEventListener('typed:pre-connect', this._onConnect);
-            this.element.removeEventListener('typed:connect', this._onPreConnect);
+            this.element.removeEventListener('typed:connect', this._onConnect);
+            this.element.removeEventListener('typed:pre-connect', this._onPreConnect);
         }
 
         _onPreConnect(event) {


### PR DESCRIPTION
Following https://github.com/symfony/ux/pull/1227 i found other similar cases of callback inversion in the documentation.

