### PR TITLE
[Chart.js] Reverting chart.js type: module

### DIFF
--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -4,7 +4,6 @@
     "license": "MIT",
     "version": "1.1.0",
     "module": "dist/controller.js",
-    "type": "module",
     "types": "dist/controller.d.ts",
     "symfony": {
         "controllers": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1262
| License       | MIT

This is complex, and relates to some hard/weird/broken changes that chart.js made in 3.9. Facts:

* Changing `type: module` and making no other changes breaks `chart.js` v3 (but v4 works fine)
* Changing the import from `chart.js/auto'` to `chart.js` - like #1263 fixes things. However, it breaks the tests in 3.9... because chart.js doesn't have an `exports` key in that version, so our tests / node environment continue to load the `main` key instead of the `module` key.

So, this will "put thing back" and get chart.js working again. 

After this, we should:

1) Re-add `type: module` to chart.js
2) Upgrade `chart.js` to v4

By doing that, other than actually migrating any custom chart.js code from 3 -> 4 (https://www.chartjs.org/docs/latest/migration/v4-migration.html), users won't need to make any other changes. 

The question about 3 -> 4 is if we can do that in a minor UX version of it needs to be a major. Technically, nothing in `symfony/ux-chart.js` changes... except that it will force you to change a JS dep up a major version. It's a gray area.

Cheers!
