### PR TITLE
[LiveComponent][LiveComponentBundle] Add groups to components validation

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.13.2
 
 -   Revert "Change JavaScript package to `type: module`"
+-   Add capability to use validation groups in Live Components validation trait.
+
 
 ## 2.13.0
 

--- a/src/LiveComponent/src/ComponentValidator.php
+++ b/src/LiveComponent/src/ComponentValidator.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\LiveComponent;
 
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
@@ -32,9 +33,9 @@ class ComponentValidator implements ComponentValidatorInterface, ServiceSubscrib
     /**
      * @return ConstraintViolation[][]
      */
-    public function validate(object $component): array
+    public function validate(object $component, string|GroupSequence|array $groups = null): array
     {
-        $errors = $this->getValidator()->validate($component);
+        $errors = $this->getValidator()->validate($component, groups: $groups);
 
         $validationErrors = [];
         foreach ($errors as $error) {
@@ -59,12 +60,12 @@ class ComponentValidator implements ComponentValidatorInterface, ServiceSubscrib
      *
      * @return ConstraintViolation[]
      */
-    public function validateField(object $component, string $propertyPath): array
+    public function validateField(object $component, string $propertyPath, string|GroupSequence|array $groups = null): array
     {
         $propertyParts = explode('.', $propertyPath);
         $propertyName = $propertyParts[0];
 
-        $errors = $this->getValidator()->validateProperty($component, $propertyName);
+        $errors = $this->getValidator()->validateProperty($component, $propertyName, groups: $groups);
 
         $errorsForPath = [];
         foreach ($errors as $error) {

--- a/src/LiveComponent/src/ComponentValidatorInterface.php
+++ b/src/LiveComponent/src/ComponentValidatorInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\LiveComponent;
 
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolation;
 
 /**
@@ -32,12 +33,12 @@ interface ComponentValidatorInterface
      *
      * @return ConstraintViolation[][]
      */
-    public function validate(object $component): array;
+    public function validate(object $component, string|GroupSequence|array $groups = null): array;
 
     /**
      * Returns an array of violations for this one specific property.
      *
      * @return ConstraintViolation[]
      */
-    public function validateField(object $component, string $propertyName): array;
+    public function validateField(object $component, string $propertyName, string|GroupSequence|array $groups = null): array;
 }

--- a/src/LiveComponent/src/ValidatableComponentTrait.php
+++ b/src/LiveComponent/src/ValidatableComponentTrait.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\LiveComponent;
 
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -52,12 +53,12 @@ trait ValidatableComponentTrait
      *
      * This stores the validation errors: accessible via the getError() method.
      */
-    public function validate(bool $throw = true): void
+    public function validate(bool $throw = true, string|GroupSequence|array $groups = null): void
     {
         // set fields back to empty, as now the *entire* object is validated.
         $this->validatedFields = [];
         $this->isValidated = true;
-        $this->getValidationErrors()->setAll($this->getValidator()->validate($this));
+        $this->getValidationErrors()->setAll($this->getValidator()->validate($this, $groups));
 
         if ($throw && \count($this->getValidationErrors()) > 0) {
             throw new UnprocessableEntityHttpException('Component validation failed');
@@ -71,13 +72,13 @@ trait ValidatableComponentTrait
      * validate the *entire* "post" property. It will then loop
      * over all the errors and collect only those for "post.title".
      */
-    public function validateField(string $propertyName, bool $throw = true): void
+    public function validateField(string $propertyName, bool $throw = true, string|GroupSequence|array $groups = null): void
     {
         if (!\in_array($propertyName, $this->validatedFields, true)) {
             $this->validatedFields[] = $propertyName;
         }
 
-        $errors = $this->getValidator()->validateField($this, $propertyName);
+        $errors = $this->getValidator()->validateField($this, $propertyName, $groups);
         $this->getValidationErrors()->set($propertyName, $errors);
 
         if ($throw && \count($errors) > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | no
| License       | MIT

I've had the possibility to use validation groups with `ValidatableComponentTrait` in Live Components.

Example:

```php
use App\Entity\User;
use Symfony\Component\Validator\Constraints as Assert;
use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
use Symfony\UX\LiveComponent\Attribute\LiveProp;
use Symfony\UX\LiveComponent\ValidatableComponentTrait;

#[AsLiveComponent]
class EditUser
{
    use ValidatableComponentTrait;

    #[LiveProp(writable: ['email', 'plainPassword'])]
    #[Assert\Valid(groups: ['my_group'])]
    public User $user;

     #[LiveProp]
     #[Assert\IsTrue(groups: ['my_group'])]
    public bool $agreeToTerms = false;
    
    // Use your own groups
    private function getValidationGroups(): array
    {
        return ['my_group'];
    }
}
```
