### PR TITLE
[TwigComponent] Fix typo in documentation

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -235,7 +235,7 @@ available in every component template:
 
 .. code-block:: html+twig
 
-    <div {{ attributes.defaults({ class: 'alert alert'~ type }) }}">
+    <div {{ attributes.defaults({ class: 'alert alert-'~ type }) }}>
         {{ message }}
     </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Issues        | Fix #1274
| License       | MIT

Remove the double quote in TwigComponent documentation.
