### PR TITLE
[LiveComponent] Add informations for AssetMapper and Stimulus

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -791,6 +791,22 @@ Want to change the value of a model or even trigger an action from your
 own custom JavaScript? No problem, thanks to a JavaScript ``Component``
 object, which is attached to each root component element.
 
+Before going any further, check that the controller entry ``@symfony/ux-live-component`` has been added to ``assets/controllers.json``, like this::
+
+    // controllers.json
+    {
+        "controllers": {
+            // ...
+            "@symfony/ux-live-component": {
+                "live": {
+                    "enabled": true,
+                    "fetch": "eager"
+                }
+            }
+        },
+    }
+
+
 For example, to write your custom JavaScript, you create a Stimulus
 controller and put it around (or attached to) your root component element:
 
@@ -840,6 +856,21 @@ of the change:
 
     input.dispatchEvent(new Event('change', { bubbles: true }));
 
+With AssetMapper
+~~~~~~~~~~~~~~~~
+
+If you're using AssetMapper, you new to add one new entry to you ``importmap.php``::
+
+    // importmap.php
+    return [
+        // ...
+
+        '@symfony/stimulus-bundle' => [
+            'path' => '@symfony/stimulus-bundle/loader.js',
+        ],
+    ];
+
+
 JavaScript Component Hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -873,6 +904,7 @@ The following hooks are available (along with the arguments that are passed):
 * ``loading.state:started`` args ``(element: HTMLElement, request: BackendRequest)``
 * ``loading.state:finished`` args ``(element: HTMLElement)``
 * ``model:set`` args ``(model: string, value: any, component: Component)``
+
 
 Adding a Stimulus Controller to your Component Root Element
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -859,7 +859,7 @@ of the change:
 With AssetMapper
 ~~~~~~~~~~~~~~~~
 
-If you're using AssetMapper, you new to add one new entry to you ``importmap.php``::
+If you're using AssetMapper, you need to add one new entry to you ``importmap.php``::
 
     // importmap.php
     return [


### PR DESCRIPTION
I tried to reproduce this part of the documentation, without success. 

There's no bug, just some missing information in the documentation.

How to reproduce this issue :
* Create a webapp project
* Install AssetMapper : `composer require symfony/asset-mapper symfony/asset symfony/twig-pack`
* Install LiveComponent : `composer require symfony/ux-live-component`
* Install Stimulus : `composer require symfony/ux-live-component`

* Create a Live component : 
```php
<?php

declare(strict_types=1);

namespace App\Component;

use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
use Symfony\UX\LiveComponent\Attribute\LiveAction;
use Symfony\UX\LiveComponent\Attribute\LiveProp;
use Symfony\UX\LiveComponent\DefaultActionTrait;

#[AsLiveComponent('foo')]
class FooComponent
{
    use DefaultActionTrait;


    #[LiveProp]
    public int $count = 0;

    #[LiveAction]
    public function increase(): void
    {
        $this->count++;
    }
}
```
* Create the Twig file : 
```twig
<div {{ attributes.defaults(stimulus_controller('foo')) }}>
    {{ count }}
</div>
```
* And create the stimulus controller `foo_controller.js` : 
```js
import { Controller } from '@hotwired/stimulus';
import { getComponent } from '@symfony/ux-live-component';

export default class extends Controller {
    async initialize() {
        this.component = await getComponent(this.element);

        this.component.action('increase');
    }
}
```

* First error in the browser console : 
```
Uncaught TypeError: Failed to resolve module specifier "@symfony/ux-live-component". Relative references must start with either "/", "./", or "../".
```

* To fix this error, I add a new entry in `importmap.php` : 
```php
<?php

return [
    //...
    '@symfony/ux-live-component' => [
        'path' => '@symfony/ux-live-component/live_controller.js',
    ],
];
```
* New error in the browser console : 
```
Uncaught (in promise) Error: Component not found for element <div data-controller="foo live" [...]
```
* To fix this, I add a new entry in `assets/controllers.json` : 
```json
{
  "controllers": {
    "@symfony/ux-live-component": {
      "live": {
        "enabled": true,
        "fetch": "eager"
      }
    }
  },
  "entrypoints": []
}
```
* And now, we can see the property `count` increase to 1 and re-render the component automatically.

So I've added a bit of documentation, but please excuse my poor English. 