### PR TITLE
Fix loadingContent block name in example

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2254,7 +2254,7 @@ Or override the ``loadingContent`` block:
 .. code-block:: twig
 
     {% component SomeHeavyComponent with { defer: true }) }}
-        {% block content %}Loading...{% endblock %}
+        {% block loadingContent %}Loading...{% endblock %}
     {{ end_component() }}
 
 To change the initial tag from a ``div`` to something else, use the ``loading-tag`` option:


### PR DESCRIPTION
Just a documentation typo fix.
