### PR TITLE
append backslash to namespace in twig_component.yaml

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -70,7 +70,7 @@ file to control the template directory for your components:
         anonymous_template_directory: 'components/'
         defaults:
             # Namespace & directory for components
-            App\Twig\Components: 'components/'
+            App\Twig\Components\: 'components/'
 
 Component Basics
 ----------------


### PR DESCRIPTION
This is the way the [flex recipe](https://github.com/symfony/recipes/blob/flex/main/symfony.ux-twig-component.2.13.json) creates this file and it throws an error without the final backslash.

