### PR TITLE
[TwigComponent] Merge data-action in ComponentAttributes

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -80,7 +80,7 @@ final class ComponentAttributes
         }
 
         foreach ($this->attributes as $key => $value) {
-            if (\in_array($key, ['class', 'data-controller'], true) && isset($attributes[$key])) {
+            if (\in_array($key, ['class', 'data-controller', 'data-action'], true) && isset($attributes[$key])) {
                 $attributes[$key] = "{$attributes[$key]} {$value}";
 
                 continue;

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -146,6 +146,28 @@ final class ComponentAttributesTest extends TestCase
         ], $attributes->all());
     }
 
+    public function testCanAddStimulusActionViaStimulusAttributes(): void
+    {
+        // if PHP less than 8.1, skip
+        if (version_compare(\PHP_VERSION, '8.1.0', '<')) {
+            $this->markTestSkipped('PHP 8.1+ required');
+        }
+
+        $attributes = new ComponentAttributes([
+            'class' => 'foo',
+            'data-action' => 'live#foo',
+        ]);
+
+        $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
+        $stimulusAttributes->addAction('foo', 'barMethod');
+        $attributes = $attributes->defaults([...$stimulusAttributes]);
+
+        $this->assertEquals([
+            'class' => 'foo',
+            'data-action' => 'foo#barMethod live#foo',
+        ], $attributes->all());
+    }
+
     public function testBooleanBehaviour(): void
     {
         $attributes = new ComponentAttributes(['disabled' => true]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | None that I know of
| License       | MIT

If you pass `data-action` into a component & the root `attributes` has a `data-action` already thanks to `attributes.defaults`, they should be merged together. Same behavior as `data-controller`. I found this while adding a `data-action` to a component and suddenly losing my existing `data-action` from inside.

Cheers!