### PR TITLE
[TwigComponent] Fix typo in Component Attributes docs

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -812,7 +812,7 @@ Component Attributes
 A common need for components is to configure/render attributes for the
 root node. Attributes are any props that are passed when rendering that
 cannot be mounted on the component itself. This extra data is added to a
-``ComponentAttributes`` object that'ss available as ``attributes`` in your
+``ComponentAttributes`` object that's available as ``attributes`` in your
 component's template:
 
 .. code-block:: html+twig


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | none <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Fixing a small typo in the documentation.