### PR TITLE
[Live] Fix BatchActionController redirection

### DIFF
--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -282,6 +282,10 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
         $request = $event->getRequest();
         $response = $event->getResponse();
 
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
         if (!$this->isLiveComponentRequest($request)) {
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1300
| License       | MIT

This should fix #1300

LiveConponentSubscriber::onKernelResponse should not change response status for subrequests

I'm not sure about test naming