### PR TITLE
[Docs] Remove double {{ form_start(form) }}

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1944,8 +1944,6 @@ Override the specific block for comment items:
 
     <div {{ attributes }}>
         {{ form_start(form) }}
-
-        {{ form_start(form) }}
             {{ form_row(form.title)
 
             <h3>Comments:</h3>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no
| Issues        | Fix
| License       | MIT

Remove double form start in docs.