### PR TITLE
check not to access a character longer than the string

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -263,6 +263,10 @@ class TwigPreLexer
      */
     private function consume(string $string): bool
     {
+        if (strlen($this->input) >= $this->position) {
+            return false;
+        }
+
         if ($string[0] !== $this->input[$this->position]) {
             return false;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1306 
| License       | MIT

Makes sure that $this->input[$this->position] won't fail if position is greater than the input length.