### PR TITLE
[Site] Lessening padding to avoid scroll & removing npm

### DIFF
--- a/ux.symfony.com/templates/components/Terminal.html.twig
+++ b/ux.symfony.com/templates/components/Terminal.html.twig
@@ -9,7 +9,7 @@
         </div>
     </div>
     <div class="Terminal_body">
-        <pre class="Terminal_content ps-4 pt-3" style="padding-bottom: {{ bottomPadding }}px; height: {{ height }}"><code>
+        <pre class="Terminal_content ps-3 pt-3" style="padding-bottom: {{ bottomPadding }}px; height: {{ height }}"><code>
             {{- this.process(block('content'))|raw -}}
         </code></pre>
     </div>

--- a/ux.symfony.com/templates/ux_packages/_package_install.html.twig
+++ b/ux.symfony.com/templates/ux_packages/_package_install.html.twig
@@ -5,8 +5,6 @@
             {% component Terminal with {bottomPadding: 20} %}
                 {% block content %}
                     composer require {{ package.composerName }}
-                    npm install --force
-                    npm run watch
                 {% endblock %}
             {% endcomponent %}
         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

The homepage terminal block on ux.symfony.com has a tiny bit or horizontal scroll. The padding change fixes that.

Cheers!