### PR TITLE
[Site] Make package box titles visible in dark mode

### DIFF
--- a/ux.symfony.com/assets/styles/components/_PackageBox.scss
+++ b/ux.symfony.com/assets/styles/components/_PackageBox.scss
@@ -120,6 +120,10 @@
   letter-spacing: -1px;
   color: #0A0A0A;
   text-decoration: none;
+  
+  [data-bs-theme="dark"] & {
+    filter: invert(1);
+  }
 }
 
 .PackageBox_link {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | desc below
| License       | MIT

Right now package box titles are really dark in the dark mode:
<img width="1304" alt="Zrzut ekranu 2023-11-29 o 16 54 15" src="https://github.com/symfony/ux/assets/67402/e7459bd2-ba2a-49eb-aa62-6fcce0c4b992">

With that change it will look like:
<img width="1268" alt="Zrzut ekranu 2023-11-29 o 16 54 08" src="https://github.com/symfony/ux/assets/67402/8f11e471-2517-4fd2-bb2b-5481751d96fe">

