### PR TITLE
Fix code indentation for emit events

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2319,12 +2319,12 @@ There are three ways to emit an event:
 
 1. From Twig:
 
-.. code-block:: html+twig
+   .. code-block:: html+twig
 
-    <button
-        data-action="live#emit"
-        data-event="productAdded"
-    >
+       <button
+           data-action="live#emit"
+           data-event="productAdded"
+       >
 
 2. From your PHP component via ``ComponentToolsTrait``::
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | N/A
| License       | MIT

Currently there's both a numbering issue for the list & an indentation issue for code blocks:

![image](https://github.com/symfony/ux/assets/3929498/d57732e8-ce29-49a8-9edb-c3dba7da47c4)

This PR should fix this :) 