### PR TITLE
add tom-select bootstrap4 css file to default config file

### DIFF
--- a/src/Autocomplete/assets/package.json
+++ b/src/Autocomplete/assets/package.json
@@ -14,6 +14,7 @@
                 "enabled": true,
                 "autoimport": {
                     "tom-select/dist/css/tom-select.default.css": true,
+                    "tom-select/dist/css/tom-select.bootstrap4.css": false,
                     "tom-select/dist/css/tom-select.bootstrap5.css": false
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1307 
| License       | MIT

Add tom-select bootstrap4 css file to default config file.
Without this, if you have replaced the bootstrap5.css value with a boostrap4 with value set to true, it will be replaced every time you perform a composer update (with the help of flex).

Like this :
![image](https://github.com/symfony/ux/assets/63842196/9a436c6b-3efb-4d61-98ce-e0e8a14da68c)