### PR TITLE
[Turbo] Allowing version 8

### DIFF
--- a/src/Turbo/assets/package.json
+++ b/src/Turbo/assets/package.json
@@ -21,7 +21,7 @@
             }
         },
         "importmap": {
-            "@hotwired/turbo": "^7.0.1",
+            "@hotwired/turbo": "^7.1.0 || ^8.0",
             "@hotwired/stimulus": "^3.0.0"
         }
     },
@@ -30,7 +30,7 @@
         "@hotwired/stimulus": "^3.0.0"
     },
     "devDependencies": {
-        "@hotwired/turbo": "^7.1.0",
+        "@hotwired/turbo": "^7.1.0 || ^8.0",
         "@hotwired/stimulus": "^3.0.0"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | None
| License       | MIT

Turbo 8 is now beta! This allows Turbo 8 to be installed. There are no BC breaks that would affect us that i'm aware of, which is not surprising as we do very little with Turbo other than supply it to the user.

Once we merge and release this, users installing TurboBundle will get v8 by default, even while in beta stage. From AssetMapper's perspective, that happens because https://data.jsdelivr.com/v1/packages/npm/@hotwired/turbo/resolved already selects beta. I can't find any specifier - e.g. https://data.jsdelivr.com/v1/packages/npm/@hotwired/turbo/resolved?specifier=stable that selects the latest, non-beta version.

Cheers!