### PR TITLE
[StimulusBundle] Remove stimulus.asset_mapper.loader_javascript_compiler when no asset-mapper

### DIFF
--- a/src/StimulusBundle/src/DependencyInjection/Compiler/RemoveAssetMapperServicesCompiler.php
+++ b/src/StimulusBundle/src/DependencyInjection/Compiler/RemoveAssetMapperServicesCompiler.php
@@ -26,7 +26,7 @@ class RemoveAssetMapperServicesCompiler implements CompilerPassInterface
         if (!$container->hasDefinition('asset_mapper')) {
             $container->removeDefinition('stimulus.ux_controllers_twig_runtime');
             $container->removeDefinition('stimulus.asset_mapper.controllers_map_generator');
-            $container->removeDefinition('stimulus.asset_mapper.stimulus_loader_javascript_compiler');
+            $container->removeDefinition('stimulus.asset_mapper.loader_javascript_compiler');
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #1313 
| License       | MIT

The service name was incorrect here. 

All credits to @smnandre who found this gem