### PR TITLE
[TwigComponent] Fix `debug:twig-component` command (anonymous vs non-anonymous components)

### DIFF
--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -27,6 +27,7 @@ use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentMetadata;
 use Symfony\UX\TwigComponent\Twig\PropsNode;
 use Twig\Environment;
+use Twig\Error\LoaderError;
 
 #[AsCommand(name: 'debug:twig-component', description: 'Display components and them usages for an application')]
 class TwigComponentDebugCommand extends Command
@@ -137,8 +138,13 @@ EOF
             $metadata = $this->componentFactory->metadataFor($name);
             $components[$name] ??= $metadata;
             $template = $metadata->getTemplate();
-            $resolvedPath = $loader->getSourceContext($template)->getPath();
-            $usedResolvedTemplatePaths[$resolvedPath] = true;
+
+            try {
+                $resolvedPath = $loader->getSourceContext($template)->getPath();
+                $usedResolvedTemplatePaths[$resolvedPath] = true;
+            } catch (LoaderError) {
+                // Ignore unresolvable paths.
+            }
         }
 
         foreach ($this->findAnonymousComponents() as $name) {

--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -141,7 +141,7 @@ EOF
             $usedResolvedTemplatePaths[$resolvedPath] = true;
         }
 
-        foreach (array_keys($this->findAnonymousComponents()) as $name) {
+        foreach ($this->findAnonymousComponents() as $name) {
             // Ignore if anonymous component name is same as a class based component.
             if (isset($components[$name])) {
                 continue;
@@ -163,9 +163,9 @@ EOF
     }
 
     /**
-     * Return a map of component name => template.
+     * Returns a component names inside anonymous component directory.
      *
-     * @return array<string, string>
+     * @return list<string>
      */
     private function findAnonymousComponents(): array
     {
@@ -173,10 +173,11 @@ EOF
         $anonymousPath = $this->twigTemplatesPath.'/'.$this->anonymousDirectory;
         $finderTemplates = new Finder();
         $finderTemplates->files()->in($anonymousPath)->notPath('/_');
+
         foreach ($finderTemplates as $template) {
             $component = str_replace('/', ':', $template->getRelativePathname());
             $component = preg_replace('/(\.html)?\.twig$/', '', $component);
-            $components[$component] = $component;
+            $components[] = $component;
         }
 
         return $components;

--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -153,9 +153,7 @@ EOF
         $finderTemplates->files()->in($anonymousPath)->notPath('/_');
         foreach ($finderTemplates as $template) {
             $component = str_replace('/', ':', $template->getRelativePathname());
-            if (str_ends_with($component, '.html.twig')) {
-                $component = substr($component, 0, -10);
-            }
+            $component = preg_replace('/(\.html)?\.twig$/', '', $component);
             $components[$component] = $component;
         }
 

--- a/src/TwigComponent/src/ComponentTemplateFinder.php
+++ b/src/TwigComponent/src/ComponentTemplateFinder.php
@@ -42,28 +42,27 @@ final class ComponentTemplateFinder implements ComponentTemplateFinderInterface
 
         // Legacy auto-naming rules < 2.13
         if (null === $this->directory) {
-            if ($loader->exists('components/'.$componentPath.'.html.twig')) {
-                return 'components/'.$componentPath.'.html.twig';
-            }
-
-            if ($loader->exists($componentPath.'.html.twig')) {
-                return $componentPath.'.html.twig';
-            }
-
-            if ($loader->exists('components/'.$componentPath)) {
-                return 'components/'.$componentPath;
-            }
-
-            if ($loader->exists($componentPath)) {
-                return $componentPath;
+            foreach ([
+                'components/'.$componentPath.'.html.twig',
+                'components/'.$componentPath.'.twig',
+                $componentPath.'.html.twig',
+                $componentPath.'.twig',
+                'components/'.$componentPath,
+                $componentPath,
+            ] as $path) {
+                if ($loader->exists($path)) {
+                    return $path;
+                }
             }
 
             return null;
         }
 
-        $template = rtrim($this->directory, '/').'/'.$componentPath.'.html.twig';
-        if ($loader->exists($template)) {
-            return $template;
+        foreach (['.html.twig', '.twig'] as $extension) {
+            $template = rtrim($this->directory, '/').'/'.$componentPath.$extension;
+            if ($loader->exists($template)) {
+                return $template;
+            }
         }
 
         return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

The `debug:twig-component` command had problems when anonymous and non-anonymous components were in the same directory.

- Templates are now also taken into account when they have just a `.twig` extension instead of a `.html.twig` extension.
- Templates belonging to non-anonymous components now are not additionally listed as  anonymous component.

_Parts of #1320 includes some discussion about this bug._