### PR TITLE
[Autocomplete] Allow passing extra options to the autocomplete fields

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -11,6 +11,8 @@
 -   Added `tom-select/dist/css/tom-select.bootstrap4.css` to `autoimport` - this
     will cause this to appear in your `controllers.json` file by default, but disabled
     see.
+-   Allow passing `extra_options` key in an array passed as a `3rd` argument of the `->add()` method.
+    It will be used during the Ajax call to fetch results.
 
 ## 2.13.2
 

--- a/src/Autocomplete/src/Checksum/ChecksumCalculator.php
+++ b/src/Autocomplete/src/Checksum/ChecksumCalculator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Autocomplete\Checksum;
+
+/** @internal */
+class ChecksumCalculator
+{
+    public function __construct(private readonly string $secret)
+    {
+    }
+
+    public function calculateForArray(array $data): string
+    {
+        $this->sortKeysRecursively($data);
+
+        return base64_encode(hash_hmac('sha256', json_encode($data), $this->secret, true));
+    }
+
+    private function sortKeysRecursively(array &$data): void
+    {
+        foreach ($data as &$value) {
+            if (\is_array($value)) {
+                $this->sortKeysRecursively($value);
+            }
+        }
+        ksort($data);
+    }
+}

--- a/src/Autocomplete/src/Controller/EntityAutocompleteController.php
+++ b/src/Autocomplete/src/Controller/EntityAutocompleteController.php
@@ -14,20 +14,27 @@ namespace Symfony\UX\Autocomplete\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\Autocomplete\AutocompleteResultsExecutor;
 use Symfony\UX\Autocomplete\AutocompleterRegistry;
+use Symfony\UX\Autocomplete\Checksum\ChecksumCalculator;
+use Symfony\UX\Autocomplete\Form\AutocompleteChoiceTypeExtension;
+use Symfony\UX\Autocomplete\OptionsAwareEntityAutocompleterInterface;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 final class EntityAutocompleteController
 {
+    public const EXTRA_OPTIONS = 'extra_options';
+
     public function __construct(
         private AutocompleterRegistry $autocompleteFieldRegistry,
         private AutocompleteResultsExecutor $autocompleteResultsExecutor,
         private UrlGeneratorInterface $urlGenerator,
+        private ChecksumCalculator $checksumCalculator,
     ) {
     }
 
@@ -36,6 +43,11 @@ final class EntityAutocompleteController
         $autocompleter = $this->autocompleteFieldRegistry->getAutocompleter($alias);
         if (!$autocompleter) {
             throw new NotFoundHttpException(sprintf('No autocompleter found for "%s". Available autocompleters are: (%s)', $alias, implode(', ', $this->autocompleteFieldRegistry->getAutocompleterNames())));
+        }
+
+        if ($autocompleter instanceof OptionsAwareEntityAutocompleterInterface) {
+            $extraOptions = $this->getExtraOptions($request);
+            $autocompleter->setOptions([self::EXTRA_OPTIONS => $extraOptions]);
         }
 
         $page = $request->query->getInt('page', 1);
@@ -53,5 +65,49 @@ final class EntityAutocompleteController
             'results' => ($data->optgroups) ? ['options' => $data->results, 'optgroups' => $data->optgroups] : $data->results,
             'next_page' => $nextPage,
         ]);
+    }
+
+    /**
+     * @return array<string, scalar|array|null>
+     */
+    private function getExtraOptions(Request $request): array
+    {
+        if (!$request->query->has(self::EXTRA_OPTIONS)) {
+            return [];
+        }
+
+        $extraOptions = $this->getDecodedExtraOptions($request->query->getString(self::EXTRA_OPTIONS));
+
+        if (!\array_key_exists(AutocompleteChoiceTypeExtension::CHECKSUM_KEY, $extraOptions)) {
+            throw new BadRequestHttpException('The extra options are missing the checksum.');
+        }
+
+        $this->validateChecksum($extraOptions[AutocompleteChoiceTypeExtension::CHECKSUM_KEY], $extraOptions);
+
+        return $extraOptions;
+    }
+
+    /**
+     * @return array<string, scalar>
+     */
+    private function getDecodedExtraOptions(string $extraOptions): array
+    {
+        return json_decode(base64_decode($extraOptions), true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, scalar> $extraOptions
+     */
+    private function validateChecksum(string $checksum, array $extraOptions): void
+    {
+        $extraOptionsWithoutChecksum = array_filter(
+            $extraOptions,
+            fn (string $key) => AutocompleteChoiceTypeExtension::CHECKSUM_KEY !== $key,
+            \ARRAY_FILTER_USE_KEY,
+        );
+
+        if ($checksum !== $this->checksumCalculator->calculateForArray($extraOptionsWithoutChecksum)) {
+            throw new BadRequestHttpException('The extra options have been tampered with.');
+        }
     }
 }

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\UX\Autocomplete\AutocompleteResultsExecutor;
 use Symfony\UX\Autocomplete\AutocompleterRegistry;
+use Symfony\UX\Autocomplete\Checksum\ChecksumCalculator;
 use Symfony\UX\Autocomplete\Controller\EntityAutocompleteController;
 use Symfony\UX\Autocomplete\Doctrine\DoctrineRegistryWrapper;
 use Symfony\UX\Autocomplete\Doctrine\EntityMetadataFactory;
@@ -116,6 +117,7 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
                 new Reference('ux.autocomplete.autocompleter_registry'),
                 new Reference('ux.autocomplete.results_executor'),
                 new Reference('router'),
+                new Reference('ux.autocomplete.checksum_calculator'),
             ])
             ->addTag('controller.service_arguments')
         ;
@@ -126,6 +128,13 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
                 new Reference('maker.doctrine_helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
             ])
             ->addTag('maker.command')
+        ;
+
+        $container
+            ->register('ux.autocomplete.checksum_calculator', ChecksumCalculator::class)
+            ->setArguments([
+                '%kernel.secret%',
+            ])
         ;
     }
 
@@ -149,6 +158,7 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
         $container
             ->register('ux.autocomplete.choice_type_extension', AutocompleteChoiceTypeExtension::class)
             ->setArguments([
+                new Reference('ux.autocomplete.checksum_calculator'),
                 new Reference('translator', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
             ])
             ->addTag('form.type_extension');

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\UX\Autocomplete\Checksum\ChecksumCalculator;
 
 /**
  * Initializes the autocomplete Stimulus controller for any fields with the "autocomplete" option.
@@ -27,8 +28,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
 {
-    public function __construct(private ?TranslatorInterface $translator = null)
-    {
+    public const CHECKSUM_KEY = '@checksum';
+
+    public function __construct(
+        private readonly ChecksumCalculator $checksumCalculator,
+        private readonly ?TranslatorInterface $translator = null,
+    ) {
     }
 
     public static function getExtendedTypes(): iterable
@@ -79,6 +84,10 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             $values['min-characters'] = $options['min_characters'];
         }
 
+        if ($options['extra_options']) {
+            $values['url'] = $this->getUrlWithExtraOptions($values['url'], $options['extra_options']);
+        }
+
         $values['loading-more-text'] = $this->trans($options['loading_more_text']);
         $values['no-results-found-text'] = $this->trans($options['no_results_found_text']);
         $values['no-more-results-text'] = $this->trans($options['no_more_results_text']);
@@ -90,6 +99,41 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
 
         $view->vars['uses_autocomplete'] = true;
         $view->vars['attr'] = $attr;
+    }
+
+    private function getUrlWithExtraOptions(string $url, array $extraOptions): string
+    {
+        $this->validateExtraOptions($extraOptions);
+
+        $extraOptions[self::CHECKSUM_KEY] = $this->checksumCalculator->calculateForArray($extraOptions);
+        $extraOptions = base64_encode(json_encode($extraOptions));
+
+        return sprintf(
+            '%s%s%s',
+            $url,
+            $this->hasUrlParameters($url) ? '&' : '?',
+            http_build_query(['extra_options' => $extraOptions]),
+        );
+    }
+
+    private function hasUrlParameters(string $url): bool
+    {
+        $parsedUrl = parse_url($url);
+
+        return isset($parsedUrl['query']);
+    }
+
+    private function validateExtraOptions(array $extraOptions): void
+    {
+        foreach ($extraOptions as $optionKey => $option) {
+            if (!\is_scalar($option) && !\is_array($option) && null !== $option) {
+                throw new \InvalidArgumentException(sprintf('Extra option with key "%s" must be a scalar value, an array or null. Got "%s".', $optionKey, get_debug_type($option)));
+            }
+
+            if (\is_array($option)) {
+                $this->validateExtraOptions($option);
+            }
+        }
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -106,6 +150,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'min_characters' => null,
             'max_results' => 10,
             'preload' => 'focus',
+            'extra_options' => [],
         ]);
 
         // if autocomplete_url is passed, then HTML options are already supported

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -22,17 +22,18 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
 use Symfony\UX\Autocomplete\Doctrine\EntityMetadata;
 use Symfony\UX\Autocomplete\Doctrine\EntityMetadataFactory;
 use Symfony\UX\Autocomplete\Doctrine\EntitySearchUtil;
-use Symfony\UX\Autocomplete\EntityAutocompleterInterface;
+use Symfony\UX\Autocomplete\OptionsAwareEntityAutocompleterInterface;
 
 /**
  * An entity auto-completer that wraps a form type to get its information.
  *
  * @internal
  */
-final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterface
+final class WrappedEntityTypeAutocompleter implements OptionsAwareEntityAutocompleterInterface
 {
     private ?FormInterface $form = null;
     private ?EntityMetadata $entityMetadata = null;
+    private array $options = [];
 
     public function __construct(
         private string $formType,
@@ -139,7 +140,7 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
     private function getForm(): FormInterface
     {
         if (null === $this->form) {
-            $this->form = $this->formFactory->create($this->formType);
+            $this->form = $this->formFactory->create($this->formType, options: $this->options);
         }
 
         return $this->form;
@@ -167,5 +168,14 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
         }
 
         return $this->entityMetadata;
+    }
+
+    public function setOptions(array $options): void
+    {
+        if (null !== $this->form) {
+            throw new \LogicException('The options can only be set before the form is created.');
+        }
+
+        $this->options = $options;
     }
 }

--- a/src/Autocomplete/src/OptionsAwareEntityAutocompleterInterface.php
+++ b/src/Autocomplete/src/OptionsAwareEntityAutocompleterInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Autocomplete;
+
+/**
+ * Interface for classes that will have an "autocomplete" endpoint exposed with a possibility to pass additional form options.
+ */
+interface OptionsAwareEntityAutocompleterInterface extends EntityAutocompleterInterface
+{
+    public function setOptions(array $options): void;
+}

--- a/src/Autocomplete/tests/Fixtures/Autocompleter/CustomGroupByProductAutocompleter.php
+++ b/src/Autocomplete/tests/Fixtures/Autocompleter/CustomGroupByProductAutocompleter.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter;
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
-use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\QueryBuilder;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\UX\Autocomplete\Doctrine\EntitySearchUtil;
-use Symfony\UX\Autocomplete\EntityAutocompleterInterface;
-use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Product;
+namespace Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter;
 
 class CustomGroupByProductAutocompleter extends CustomProductAutocompleter
 {

--- a/src/Autocomplete/tests/Fixtures/Autocompleter/CustomProductAutocompleter.php
+++ b/src/Autocomplete/tests/Fixtures/Autocompleter/CustomProductAutocompleter.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter;
 
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\UX\Autocomplete\Doctrine\EntitySearchUtil;
 use Symfony\UX\Autocomplete\EntityAutocompleterInterface;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Product;
@@ -14,9 +23,8 @@ class CustomProductAutocompleter implements EntityAutocompleterInterface
 {
     public function __construct(
         private RequestStack $requestStack,
-        private EntitySearchUtil $entitySearchUtil
-    )
-    {
+        private EntitySearchUtil $entitySearchUtil,
+    ) {
     }
 
     public function getEntityClass(): string

--- a/src/Autocomplete/tests/Fixtures/Entity/Category.php
+++ b/src/Autocomplete/tests/Fixtures/Entity/Category.php
@@ -1,10 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity()]

--- a/src/Autocomplete/tests/Fixtures/Entity/Ingredient.php
+++ b/src/Autocomplete/tests/Fixtures/Entity/Ingredient.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Entity;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Autocomplete/tests/Fixtures/Entity/Product.php
+++ b/src/Autocomplete/tests/Fixtures/Entity/Product.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/src/Autocomplete/tests/Fixtures/Factory/CategoryFactory.php
+++ b/src/Autocomplete/tests/Fixtures/Factory/CategoryFactory.php
@@ -1,30 +1,39 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Factory;
 
 use Doctrine\ORM\EntityRepository;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Category;
-use Zenstruck\Foundry\RepositoryProxy;
 use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
 
 /**
  * @extends ModelFactory<Category>
  *
- * @method static Category|Proxy createOne(array $attributes = [])
- * @method static Category[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Category|Proxy find(object|array|mixed $criteria)
- * @method static Category|Proxy findOrCreate(array $attributes)
- * @method static Category|Proxy first(string $sortedField = 'id')
- * @method static Category|Proxy last(string $sortedField = 'id')
- * @method static Category|Proxy random(array $attributes = [])
- * @method static Category|Proxy randomOrCreate(array $attributes = []))
- * @method static Category[]|Proxy[] all()
- * @method static Category[]|Proxy[] findBy(array $attributes)
- * @method static Category[]|Proxy[] randomSet(int $number, array $attributes = []))
- * @method static Category[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
+ * @method static Category|Proxy                   createOne(array $attributes = [])
+ * @method static Category[]|Proxy[]               createMany(int $number, array|callable $attributes = [])
+ * @method static Category|Proxy                   find(object|array|mixed $criteria)
+ * @method static Category|Proxy                   findOrCreate(array $attributes)
+ * @method static Category|Proxy                   first(string $sortedField = 'id')
+ * @method static Category|Proxy                   last(string $sortedField = 'id')
+ * @method static Category|Proxy                   random(array $attributes = [])
+ * @method static Category|Proxy                   randomOrCreate(array $attributes = []))
+ * @method static Category[]|Proxy[]               all()
+ * @method static Category[]|Proxy[]               findBy(array $attributes)
+ * @method static Category[]|Proxy[]               randomSet(int $number, array $attributes = []))
+ * @method static Category[]|Proxy[]               randomRange(int $min, int $max, array $attributes = []))
  * @method static EntityRepository|RepositoryProxy repository()
- * @method Category|Proxy create(array|callable $attributes = [])
+ * @method        Category|Proxy                   create(array|callable $attributes = [])
  */
 final class CategoryFactory extends ModelFactory
 {

--- a/src/Autocomplete/tests/Fixtures/Factory/IngredientFactory.php
+++ b/src/Autocomplete/tests/Fixtures/Factory/IngredientFactory.php
@@ -1,31 +1,40 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Factory;
 
 use Doctrine\ORM\EntityRepository;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Ingredient;
-use Zenstruck\Foundry\RepositoryProxy;
 use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
 
 /**
  * @extends ModelFactory<Ingredient>
  *
- * @method static Ingredient|Proxy createOne(array $attributes = [])
- * @method static Ingredient[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Ingredient|Proxy find(object|array|mixed $criteria)
- * @method static Ingredient|Proxy findOrCreate(array $attributes)
- * @method static Ingredient|Proxy first(string $sortedField = 'id')
- * @method static Ingredient|Proxy last(string $sortedField = 'id')
- * @method static Ingredient|Proxy random(array $attributes = [])
- * @method static Ingredient|Proxy randomOrCreate(array $attributes = []))
- * @method static Ingredient[]|Proxy[] all()
- * @method static Ingredient[]|Proxy[] findBy(array $attributes)
- * @method static Ingredient[]|Proxy[] randomSet(int $number, array $attributes = []))
- * @method static Ingredient[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
+ * @method static Ingredient|Proxy                 createOne(array $attributes = [])
+ * @method static Ingredient[]|Proxy[]             createMany(int $number, array|callable $attributes = [])
+ * @method static Ingredient|Proxy                 find(object|array|mixed $criteria)
+ * @method static Ingredient|Proxy                 findOrCreate(array $attributes)
+ * @method static Ingredient|Proxy                 first(string $sortedField = 'id')
+ * @method static Ingredient|Proxy                 last(string $sortedField = 'id')
+ * @method static Ingredient|Proxy                 random(array $attributes = [])
+ * @method static Ingredient|Proxy                 randomOrCreate(array $attributes = []))
+ * @method static Ingredient[]|Proxy[]             all()
+ * @method static Ingredient[]|Proxy[]             findBy(array $attributes)
+ * @method static Ingredient[]|Proxy[]             randomSet(int $number, array $attributes = []))
+ * @method static Ingredient[]|Proxy[]             randomRange(int $min, int $max, array $attributes = []))
  * @method static EntityRepository|RepositoryProxy repository()
- * @method Ingredient|Proxy create(array|callable $attributes = [])
+ * @method        Ingredient|Proxy                 create(array|callable $attributes = [])
  */
 final class IngredientFactory extends ModelFactory
 {

--- a/src/Autocomplete/tests/Fixtures/Factory/ProductFactory.php
+++ b/src/Autocomplete/tests/Fixtures/Factory/ProductFactory.php
@@ -1,30 +1,39 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Factory;
 
 use Doctrine\ORM\EntityRepository;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Product;
-use Zenstruck\Foundry\RepositoryProxy;
 use Zenstruck\Foundry\ModelFactory;
 use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
 
 /**
  * @extends ModelFactory<Product>
  *
- * @method static Product|Proxy createOne(array $attributes = [])
- * @method static Product[]|Proxy[] createMany(int $number, array|callable $attributes = [])
- * @method static Product|Proxy find(object|array|mixed $criteria)
- * @method static Product|Proxy findOrCreate(array $attributes)
- * @method static Product|Proxy first(string $sortedField = 'id')
- * @method static Product|Proxy last(string $sortedField = 'id')
- * @method static Product|Proxy random(array $attributes = [])
- * @method static Product|Proxy randomOrCreate(array $attributes = []))
- * @method static Product[]|Proxy[] all()
- * @method static Product[]|Proxy[] findBy(array $attributes)
- * @method static Product[]|Proxy[] randomSet(int $number, array $attributes = []))
- * @method static Product[]|Proxy[] randomRange(int $min, int $max, array $attributes = []))
+ * @method static Product|Proxy                    createOne(array $attributes = [])
+ * @method static Product[]|Proxy[]                createMany(int $number, array|callable $attributes = [])
+ * @method static Product|Proxy                    find(object|array|mixed $criteria)
+ * @method static Product|Proxy                    findOrCreate(array $attributes)
+ * @method static Product|Proxy                    first(string $sortedField = 'id')
+ * @method static Product|Proxy                    last(string $sortedField = 'id')
+ * @method static Product|Proxy                    random(array $attributes = [])
+ * @method static Product|Proxy                    randomOrCreate(array $attributes = []))
+ * @method static Product[]|Proxy[]                all()
+ * @method static Product[]|Proxy[]                findBy(array $attributes)
+ * @method static Product[]|Proxy[]                randomSet(int $number, array $attributes = []))
+ * @method static Product[]|Proxy[]                randomRange(int $min, int $max, array $attributes = []))
  * @method static EntityRepository|RepositoryProxy repository()
- * @method Product|Proxy create(array|callable $attributes = [])
+ * @method        Product|Proxy                    create(array|callable $attributes = [])
  */
 final class ProductFactory extends ModelFactory
 {

--- a/src/Autocomplete/tests/Fixtures/Form/AlternateRouteAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/AlternateRouteAutocompleteType.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Form;
 
 use Symfony\Component\Form\AbstractType;
@@ -15,7 +24,7 @@ class AlternateRouteAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => Ingredient::class,
-            'choice_label' => function(Ingredient $ingredient) {
+            'choice_label' => function (Ingredient $ingredient) {
                 return $ingredient->getName();
             },
             'multiple' => true,

--- a/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/CategoryAutocompleteType.php
@@ -1,15 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Form;
 
 use Doctrine\ORM\EntityRepository;
-use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
-use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Category;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Category;
 
 #[AsEntityAutocompleteField]
 class CategoryAutocompleteType extends AbstractType
@@ -22,15 +31,15 @@ class CategoryAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => Category::class,
-            'choice_label' => function(Category $category) {
+            'choice_label' => function (Category $category) {
                 return '<strong>'.$category->getName().'</strong>';
             },
-            'query_builder' => function(EntityRepository $repository) {
+            'query_builder' => function (EntityRepository $repository) {
                 return $repository->createQueryBuilder('category')
                     ->andWhere('category.name LIKE :search')
                     ->setParameter('search', '%foo%');
             },
-            'security' => function(Security $security) {
+            'security' => function (Security $security) {
                 if ($this->requestStack->getCurrentRequest()?->query->get('enforce_test_security')) {
                     return $security->isGranted('ROLE_USER');
                 }

--- a/src/Autocomplete/tests/Fixtures/Form/CategoryNoChoiceLabelAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/CategoryNoChoiceLabelAutocompleteType.php
@@ -1,12 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Form;
 
-use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
-use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Category;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Category;
 
 #[AsEntityAutocompleteField]
 class CategoryNoChoiceLabelAutocompleteType extends AbstractType

--- a/src/Autocomplete/tests/Fixtures/Form/IngredientAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/IngredientAutocompleteType.php
@@ -1,8 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Form;
 
+use Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
 use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
@@ -15,10 +26,22 @@ class IngredientAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => Ingredient::class,
-            'choice_label' => function(Ingredient $ingredient) {
+            'choice_label' => function (Ingredient $ingredient) {
                 return '<strong>'.$ingredient->getName().'</strong>';
             },
             'multiple' => true,
+            'query_builder' => function (Options $options): callable {
+                return function (EntityRepository $repository) use ($options) {
+                    $qb = $repository->createQueryBuilder('o');
+
+                    if ($options['extra_options']['banned_ingredient'] ?? false) {
+                        $qb->andWhere('o.name != :banned_ingredient')
+                            ->setParameter('banned_ingredient', $options['extra_options']['banned_ingredient']);
+                    }
+
+                    return $qb;
+                };
+            },
         ]);
     }
 

--- a/src/Autocomplete/tests/Fixtures/Form/ProductType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/ProductType.php
@@ -1,21 +1,38 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Autocomplete\Tests\Fixtures\Form;
 
-use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Product;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Product;
 
 class ProductType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('category', CategoryAutocompleteType::class)
-            ->add('ingredients', IngredientAutocompleteType::class)
+            ->add('category', CategoryAutocompleteType::class, [
+                'extra_options' => [
+                    'some' => 'cool_option',
+                ],
+            ])
+            ->add('ingredients', IngredientAutocompleteType::class, [
+                'extra_options' => [
+                    'banned_ingredient' => 'Modified Flour',
+                ],
+            ])
             ->add('portionSize', ChoiceType::class, [
                 'choices' => [
                     'extra small <span>🥨</span>' => 'xs',

--- a/src/Autocomplete/tests/Unit/Calculator/ChecksumCalculatorTest.php
+++ b/src/Autocomplete/tests/Unit/Calculator/ChecksumCalculatorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Autocomplete\Tests\Unit\Calculator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Autocomplete\Checksum\ChecksumCalculator;
+
+final class ChecksumCalculatorTest extends TestCase
+{
+    public function testCalculateChecksumForArray(): void
+    {
+        $this->assertSame(
+            'tZ34YQKgpttqybzPws0YJCOHV1QtMjQeuyy+rszdhXU=',
+            $this->createTestSubject()->calculateForArray(['test' => 'test']),
+        );
+    }
+
+    public function testCalculateTheSameChecksumForTheSameArrayButInDifferentOrder(): void
+    {
+        $this->assertSame(
+            $this->createTestSubject()->calculateForArray(['test' => 'test', 'test2' => 'test2']),
+            $this->createTestSubject()->calculateForArray(['test2' => 'test2', 'test' => 'test']),
+        );
+    }
+
+    private function createTestSubject(): ChecksumCalculator
+    {
+        return new ChecksumCalculator('s3cr3t');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | n/a
| License       | MIT

This PR still needs some tweaks and tests, but I want to validate my idea. Currently, if we pass anything as a third argument in the `->add()` method, it is only used on the form render, and is fully ignored during the AJAX call.
![CleanShot 2023-12-03 at 12 36 59](https://github.com/symfony/ux/assets/80641364/28bc4b75-215c-4588-80b2-0db9eb82dcc6)

While implementing UX's Autocomplete in Sylius, I wanted to complete the following user story
```
Given I want to edit a taxon
When I want to assign a parent taxon to it
And I check a list of available taxa
Then I should see all taxa except the edited one
```

So basically, I have to pass a **current** taxon's ID to the autocomplete's query. As we know, currently it's not possible. So after contacting @weaverryan, I decided to implement a mechanism similar to the one from Live Components.

When you pass an array of options as a `3rd` argument, you can use a special `extra_options` key, which is an array consisting `scalars`/`arrays`/`nulls`.

Next, when the form is rendered, I get these values, calculate a checksum for them, then pass them through `json_encode` and `base64_encode` functions. In the end, I glue them to the `url` values in the `\Symfony\UX\Autocomplete\Form\AutocompleteChoiceTypeExtension::finishView` method.

So, basically with the following configuration:
![CleanShot 2023-12-03 at 12 48 51](https://github.com/symfony/ux/assets/80641364/e7b2585c-f052-4803-9473-a83930a4d1c8)

we end up with the following HTML code:
![CleanShot 2023-12-03 at 12 49 36](https://github.com/symfony/ux/assets/80641364/a173220f-19ed-4104-951c-0fee3469768e)

I decided to "glue" the `extra_options` to the URL, as I didn't have to deal with JS. Of course, I do not exclude a chance to refactor it, as a whole method should be refactored anyway.

Finally, the controller decodes the data, checks the checksum and passes the values to the autocomplete's form.