### PR TITLE
[Autocomplete] Fix bug of not using choice_value

### DIFF
--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -99,7 +99,17 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
 
     public function getValue(object $entity): string
     {
-        return $this->getEntityMetadata()->getIdValue($entity);
+        $choiceValue = $this->getFormOption('choice_value');
+
+        if (\is_string($choiceValue) || $choiceValue instanceof PropertyPathInterface) {
+            return $this->propertyAccessor->getValue($entity, $choiceValue);
+        }
+
+        if ($choiceValue instanceof Cache\ChoiceValue) {
+            $choiceValue = $choiceValue->getOption();
+        }
+
+        return $choiceValue($entity);
     }
 
     public function isGranted(Security $security): bool

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -14,7 +14,7 @@ namespace Symfony\UX\Autocomplete\Form;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLabel;
+use Symfony\Component\Form\ChoiceList\Factory\Cache;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -89,7 +89,7 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
             return $this->propertyAccessor->getValue($entity, $choiceLabel);
         }
 
-        if ($choiceLabel instanceof ChoiceLabel) {
+        if ($choiceLabel instanceof Cache\ChoiceLabel) {
             $choiceLabel = $choiceLabel->getOption();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | n/a
| License       | MIT

The option choice_value (like EntityType) is not used in Autocomplete ux on `AsEntityAutocompleteField` class.
