### PR TITLE
[Site] Lazily load the toggle-password assets

### DIFF
--- a/ux.symfony.com/assets/controllers.json
+++ b/ux.symfony.com/assets/controllers.json
@@ -77,7 +77,7 @@
         "@symfony/ux-toggle-password": {
             "toggle-password": {
                 "enabled": true,
-                "fetch": "eager",
+                "fetch": "lazy",
                 "autoimport": {
                     "@symfony/ux-toggle-password/dist/style.min.css": true
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

Small performance improvement, especially since this controller contains a CSS file. Currently, that results in an extra, render-blocking `<link rel="stylesheet"` tag on the page. This is the perfect type of thing to make lazy.

Cheers!
