### PR TITLE
[StimulusBundle] Add support for typescript controllers

### DIFF
--- a/src/StimulusBundle/.gitignore
+++ b/src/StimulusBundle/.gitignore
@@ -1,5 +1,6 @@
 .php-cs-fixer.cache
 .phpunit.result.cache
 composer.lock
+var/
 vendor/
 tests/fixtures/var

--- a/src/StimulusBundle/CHANGELOG.md
+++ b/src/StimulusBundle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.x
+
+-   Added Typescript controllers support
+
 ## 2.13.2
 
 -   Revert "Change JavaScript package to `type: module`"

--- a/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
+++ b/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
@@ -28,6 +28,8 @@ use Symfony\UX\StimulusBundle\Ux\UxPackageReader;
  */
 class ControllersMapGenerator
 {
+    private const FILENAME_REGEX = '/^.*[-_](controller\.[jt]s)$/';
+
     public function __construct(
         private AssetMapperInterface $assetMapper,
         private UxPackageReader $uxPackageReader,
@@ -66,12 +68,14 @@ class ControllersMapGenerator
         $finder = new Finder();
         $finder->in($this->controllerPaths)
             ->files()
-            ->name('/^.*[-_]controller\.js$/');
+            ->name(self::FILENAME_REGEX);
 
         $controllersMap = [];
         foreach ($finder as $file) {
             $name = $file->getRelativePathname();
-            $name = str_replace(['_controller.js', '-controller.js'], '', $name);
+            // use regex to extract 'controller'-postfix including extension
+            preg_match(self::FILENAME_REGEX, $name, $matches);
+            $name = str_replace(['_'.$matches[1], '-'.$matches[1]], '', $name);
             $name = str_replace(['_', '/'], ['-', '--'], $name);
 
             $asset = $this->assetMapper->getAssetFromSourcePath($file->getRealPath());

--- a/src/StimulusBundle/tests/AssetMapper/ControllerMapGeneratorTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/ControllerMapGeneratorTest.php
@@ -73,8 +73,8 @@ class ControllerMapGeneratorTest extends TestCase
         $map = $generator->getControllersMap();
         // + 3 controller.json UX controllers
         // - 1 controllers.json UX controller is disabled
-        // + 8 custom controllers (1 file is not a controller & 1 is overridden)
-        $this->assertCount(10, $map);
+        // + 9 custom controllers (1 file is not a controller & 1 is overridden)
+        $this->assertCount(11, $map);
         $packageNames = array_keys($map);
         sort($packageNames);
         $this->assertSame([
@@ -88,6 +88,7 @@ class ControllerMapGeneratorTest extends TestCase
             'subdir--deeper',
             'subdir--deeper-with-dashes',
             'subdir--deeper-with-underscores',
+            'typescript',
         ], $packageNames);
 
         $controllerSecond = $map['fake-vendor--ux-package1--controller-second'];

--- a/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
@@ -52,13 +52,14 @@ class StimulusControllerLoaderFunctionalTest extends WebTestCase
             $this->assertSame([
                 // 1x import from loader.js (which is aliased to @symfony/stimulus-bundle via importmap)
                 '/assets/@symfony/stimulus-bundle/controllers.js',
-                // 6x from "controllers" (hello is overridden)
+                // 7x from "controllers" (hello is overridden)
                 '/assets/controllers/bye_controller.js',
                 '/assets/controllers/hello-with-dashes-controller.js',
                 '/assets/controllers/hello_with_underscores-controller.js',
                 '/assets/controllers/subdir/deeper-controller.js',
                 '/assets/controllers/subdir/deeper-with-dashes-controller.js',
                 '/assets/controllers/subdir/deeper_with_underscores-controller.js',
+                '/assets/controllers/typescript-controller.ts',
                 // 2x from UX packages, which are enabled in controllers.json
                 '/assets/fake-vendor/ux-package1/package-controller-second.js',
                 '/assets/fake-vendor/ux-package2/package-hello-controller.js',
@@ -92,7 +93,7 @@ class StimulusControllerLoaderFunctionalTest extends WebTestCase
             $preLoadHrefs = $crawler->filter('link[rel="modulepreload"]')->each(function ($link) {
                 return $link->attr('href');
             });
-            $this->assertCount(11, $preLoadHrefs);
+            $this->assertCount(12, $preLoadHrefs);
             sort($preLoadHrefs);
             $this->assertStringStartsWith('/assets/@symfony/stimulus-bundle/controllers-', $preLoadHrefs[0]);
             $this->assertStringStartsWith('/assets/@symfony/stimulus-bundle/loader-', $preLoadHrefs[1]);
@@ -101,9 +102,10 @@ class StimulusControllerLoaderFunctionalTest extends WebTestCase
             $this->assertStringStartsWith('/assets/controllers/subdir/deeper-controller-', $preLoadHrefs[5]);
             $this->assertStringStartsWith('/assets/controllers/subdir/deeper-with-dashes-controller-', $preLoadHrefs[6]);
             $this->assertStringStartsWith('/assets/controllers/subdir/deeper_with_underscores-controller-', $preLoadHrefs[7]);
-            $this->assertStringStartsWith('/assets/fake-vendor/ux-package2/package-hello-controller-', $preLoadHrefs[8]);
-            $this->assertStringStartsWith('/assets/more-controllers/hello-controller-', $preLoadHrefs[9]);
-            $this->assertStringStartsWith('/assets/vendor/@hotwired/stimulus/stimulus.index', $preLoadHrefs[10]);
+            $this->assertStringStartsWith('/assets/controllers/typescript-controller-', $preLoadHrefs[8]);
+            $this->assertStringStartsWith('/assets/fake-vendor/ux-package2/package-hello-controller-', $preLoadHrefs[9]);
+            $this->assertStringStartsWith('/assets/more-controllers/hello-controller-', $preLoadHrefs[10]);
+            $this->assertStringStartsWith('/assets/vendor/@hotwired/stimulus/stimulus.index', $preLoadHrefs[11]);
         } else {
             // legacy
             $this->assertSame([

--- a/src/StimulusBundle/tests/fixtures/assets/controllers/typescript-controller.ts
+++ b/src/StimulusBundle/tests/fixtures/assets/controllers/typescript-controller.ts
@@ -1,0 +1,6 @@
+// typescript-controller.js
+// @ts-ignore
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | n/a
| License       | MIT

To be able to use `typescript`-controllers we need to be able to load those controllers. This PR adds support for loading `*.ts` files. 

Full support for `typescript`-controllers needs the [sensiolabs/typescript-bundle](https://github.com/sensiolabs/AssetMapperTypeScriptBundle) to compile the controllers.

A reproducer project can be found [here](https://github.com/evertharmeling/typescript-sass-stimulus). It needs this PR to run.

Also see this [slack conversation](https://symfony-devs.slack.com/archives/C01FN4EQNLX/p1702461840204599).