### PR TITLE
Add a note about using raw data attributes as a prefered way

### DIFF
--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -57,12 +57,25 @@ directory. In fact, you should have an example controller there already: ``hello
         }
     }
 
-Use the Twig functions from this bundle to activate your controllers:
+Then, activate the controller in your HTML:
+
+.. code-block:: html+twig
+
+    <div data-controller="hello">
+       ...
+    </div>
+
+Optionally, this bundle has a Twig function to render the attribute:
 
 .. code-block:: html+twig
 
     <div {{ stimulus_controller('hello') }}>
         ...
+    </div>
+
+    <!-- would render -->
+    <div data-controller="hello">
+       ...
     </div>
 
 That's it! Whenever this element appears on the page, the ``hello`` controller
@@ -159,6 +172,17 @@ Stimulus Twig Helpers
 This bundle adds 3 Twig functions/filters to help add Stimulus controllers,
 actions & targets in your templates.
 
+.. note::
+
+    Though this bundle provides these helpful Twig functions/filters, it's
+    recommended to use raw data attributes instead, as they're straightforward.
+
+.. tip::
+
+    If you use PhpStorm IDE - you may want to install
+    [Stimulus plugin](https://plugins.jetbrains.com/plugin/18940-stimulus)
+    to get nice auto-completion for the attributes.
+
 stimulus_controller
 ~~~~~~~~~~~~~~~~~~~
 
@@ -240,6 +264,11 @@ there's also a ``stimulus_controller`` filter:
 .. code-block:: html+twig
 
     <div {{ stimulus_controller('chart', { 'name': 'Likes' })|stimulus_controller('other-controller') }}>
+        Hello
+    </div>
+
+    <!-- would render -->
+    <div data-controller="chart other-controller" data-chart-name-value="Likes">
         Hello
     </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | no <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Now with the Stimulus plugin autocomplete in PhpStorm it's better to use raw data attributes instead of built-in functions/filters. Normal Stimulus code is more readable and cleaner IMO.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
