### PR TITLE
[Autocomplete] Support the `render.loading_more` Tom Select option

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add support for the `render.loading_more` Tom Select Virtual Scroll option (`loading_more_text`)
+
 ## 2.13.2
 
 -   Revert "Change JavaScript package to `type: module`"

--- a/src/Autocomplete/assets/dist/controller.d.ts
+++ b/src/Autocomplete/assets/dist/controller.d.ts
@@ -12,6 +12,7 @@ export default class extends Controller {
     static values: {
         url: StringConstructor;
         optionsAsHtml: BooleanConstructor;
+        loadingMoreText: StringConstructor;
         noResultsFoundText: StringConstructor;
         noMoreResultsText: StringConstructor;
         minCharacters: NumberConstructor;
@@ -20,6 +21,7 @@ export default class extends Controller {
     };
     readonly urlValue: string;
     readonly optionsAsHtmlValue: boolean;
+    readonly loadingMoreTextValue: string;
     readonly noMoreResultsTextValue: string;
     readonly noResultsFoundTextValue: string;
     readonly minCharactersValue: number;

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -317,6 +317,9 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
             item: function (item) {
                 return `<div>${item.text}</div>`;
             },
+            loading_more: () => {
+                return `<div class="loading-more-results">${this.loadingMoreTextValue}</div>`;
+            },
             no_more_results: () => {
                 return `<div class="no-more-results">${this.noMoreResultsTextValue}</div>`;
             },
@@ -342,6 +345,7 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
 default_1.values = {
     url: String,
     optionsAsHtml: Boolean,
+    loadingMoreText: String,
     noResultsFoundText: String,
     noMoreResultsText: String,
     minCharacters: Number,

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -15,6 +15,7 @@ export default class extends Controller {
     static values = {
         url: String,
         optionsAsHtml: Boolean,
+        loadingMoreText: String,
         noResultsFoundText: String,
         noMoreResultsText: String,
         minCharacters: Number,
@@ -24,6 +25,7 @@ export default class extends Controller {
 
     declare readonly urlValue: string;
     declare readonly optionsAsHtmlValue: boolean;
+    declare readonly loadingMoreTextValue: string;
     declare readonly noMoreResultsTextValue: string;
     declare readonly noResultsFoundTextValue: string;
     declare readonly minCharactersValue: number;
@@ -223,6 +225,9 @@ export default class extends Controller {
                 },
                 item: function (item: any) {
                     return `<div>${item.text}</div>`;
+                },
+                loading_more: (): string => {
+                    return `<div class="loading-more-results">${this.loadingMoreTextValue}</div>`;
                 },
                 no_more_results: (): string => {
                     return `<div class="no-more-results">${this.noMoreResultsTextValue}</div>`;

--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -213,6 +213,10 @@ e.g. ``FoodAutocompleteField`` from above):
     an autocomplete-Ajax endpoint (e.g. for a custom ``ChoiceType``), then set this
     to change the field into an AJAX-powered select.
 
+``loading_more_text`` (default: 'Loading more results...')
+    Rendered at the bottom of the list while fetching more results. This message is
+    automatically translated using the ``AutocompleteBundle`` domain.
+
 ``no_results_found_text`` (default: 'No results found')
     Rendered when no matching results are found. This message is automatically translated
     using the ``AutocompleteBundle`` domain.

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -79,6 +79,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             $values['min-characters'] = $options['min_characters'];
         }
 
+        $values['loading-more-text'] = $this->trans($options['loading_more_text']);
         $values['no-results-found-text'] = $this->trans($options['no_results_found_text']);
         $values['no-more-results-text'] = $this->trans($options['no_more_results_text']);
         $values['preload'] = $options['preload'];
@@ -99,6 +100,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'tom_select_options' => [],
             'options_as_html' => false,
             'allow_options_create' => false,
+            'loading_more_text' => 'Loading more results...',
             'no_results_found_text' => 'No results found',
             'no_more_results_text' => 'No more results',
             'min_characters' => null,

--- a/src/Autocomplete/translations/AutocompleteBundle.ar.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.ar.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'لم يتم العثور على أي نتائج',
     'No more results' => 'لا توجد نتائج أٌخرى',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.bg.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.bg.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Няма намерени съвпадения',
     'No more results' => 'Няма повече резултати',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.ca.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.ca.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'No s\'han trobat resultats',
     'No more results' => 'No hi ha més resultats',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.cs.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.cs.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Nenalezeny žádné položky',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.da.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.da.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Ingen resultater fundet',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.de.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.de.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Keine Übereinstimmungen gefunden',
     'No more results' => 'Keine weiteren Ergebnisse',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.el.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.el.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Δεν βρέθηκαν αποτελέσματα',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.en.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.en.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    'Loading more results...' => 'Loading more results...',
     'No results found' => 'No results found',
     'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.es.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.es.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'No se han encontrado resultados',
     'No more results' => 'No hay más resultados',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.eu.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.eu.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Ez da bat datorrenik aurkitu',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.fa.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.fa.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'هیچ نتیجه‌ای یافت نشد',
     'No more results' => 'نتیجه دیگری وجود ندارد',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.fi.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.fi.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Ei tuloksia',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.fr.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.fr.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    'Loading more results...' => 'Chargement d\'autres résultats...',
     'No results found' => 'Aucun résultat trouvé',
     'No more results' => 'Aucun autre résultat trouvé',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.gl.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.gl.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Non se atoparon resultados',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.hr.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.hr.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Nema rezultata',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.hu.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.hu.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    'Loading more results...' => 'További találatok betöltése...',
     'No results found' => 'Nincs találat',
     'No more results' => 'Nincs több találat',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.id.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.id.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Tidak ada hasil yang ditemukan',
     'No more results' => 'Tidak ada hasil lagi',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.it.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.it.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Nessun risultato trovato',
     'No more results' => 'Non ci sono altri risultati',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.lb.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.lb.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Keng Resultater fonnt',
     'No more results' => 'Keng weider Resultater',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.lt.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.lt.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Atitikmenų nerasta',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.nl.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.nl.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    'Loading more results...' => 'Meer resultaten aan het laden...',
     'No results found' => 'Geen resultaten gevonden…',
     'No more results' => 'Niet meer resultaten gevonden…',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.pl.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.pl.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Brak wyników',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.pt.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.pt.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Sem resultados',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.pt_BR.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.pt_BR.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Nenhum resultado encontrado',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.ro.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.ro.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Nu au fost găsite rezultate',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.ru.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.ru.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Совпадений не найдено',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.sl.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.sl.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Ni zadetkov',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.sr_RS.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.sr_RS.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Nema rezultata',
     'No more results' => 'Nema više rezultata',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.sv.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.sv.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Inga träffar',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.tr.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.tr.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Sonuç bulunamadı',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.uk.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.uk.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => 'Нічого не знайдено',
     // 'No more results' => 'No more results',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.zh_CN.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.zh_CN.php
@@ -10,6 +10,7 @@
  */
 
 return [
+    // 'Loading more results...' => 'Loading more results...',
     'No results found' => '未找到结果',
     // 'No more results' => 'No more results',
 ];


### PR DESCRIPTION
| Q            | A         |
| ------------ | --------- |
| Bug fix?     | no        |
| New feature? | yes       |
| Issues       | Fix #1159 |
| License      | MIT       |

Here is my proposal for the support of the `render.loading_more` option from the Virtual Scroll plugin of Tom Select ([docs](https://tom-select.js.org/plugins/virtual_scroll/)). I also suggested a French translation, as it is my main language.

NB: I have slightly modified the default value ("Loading more results ... "  :arrow_right: "Loading more results...").