### PR TITLE
[LiveComponent] Make LiveComponentHydrator work without Serializer

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -101,7 +101,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
                 tagged_iterator(LiveComponentBundle::HYDRATION_EXTENSION_TAG),
                 new Reference('property_accessor'),
                 new Reference('ux.live_component.metadata_factory'),
-                new Reference('serializer'),
+                new Reference('serializer', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 '%kernel.secret%',
             ])
         ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| License       | MIT

Allow nullable "serializer" argument in LiveComponentHydrator constructor.

(fix #1340  and complete #1327) 