### PR TITLE
Allow repeated #[LiveListener] attributes on a method

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.14.0
 
 -   Add support for URL binding in `LiveProp`
+-   Allow multiple `LiveListener` attributes on a single method.
 
 ## 2.13.2
 

--- a/src/LiveComponent/src/Attribute/LiveListener.php
+++ b/src/LiveComponent/src/Attribute/LiveListener.php
@@ -21,7 +21,7 @@ namespace Symfony\UX\LiveComponent\Attribute;
  *
  * @experimental
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class LiveListener extends LiveAction
 {
     /**

--- a/src/LiveComponent/tests/Fixtures/Component/ComponentWithRepeatedLiveListener.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ComponentWithRepeatedLiveListener.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveListener;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent]
+class ComponentWithRepeatedLiveListener
+{
+    use DefaultActionTrait;
+
+    #[LiveListener('bar')]
+    public function onBar(): void
+    {
+    }
+
+    #[LiveListener('foo')]
+    #[LiveListener('bar')]
+    #[LiveListener('foo:bar')]
+    public function onFooBar(): void
+    {
+    }
+}

--- a/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
@@ -19,6 +19,7 @@ use Symfony\UX\LiveComponent\Attribute\PostHydrate;
 use Symfony\UX\LiveComponent\Attribute\PreDehydrate;
 use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Component\Component5;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Component\ComponentWithRepeatedLiveListener;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -135,6 +136,38 @@ final class AsLiveComponentTest extends TestCase
             'action' => 'method',
             'event' => 'event_name',
         ], $liveListeners[0]);
+    }
+
+    public function testCanGetRepeatedLiveListeners(): void
+    {
+        $liveListeners = AsLiveComponent::liveListeners(new ComponentWithRepeatedLiveListener());
+
+        $this->assertCount(4, $liveListeners);
+        $this->assertSame([
+            [
+                'action' => 'onBar',
+                'event' => 'bar',
+            ],
+            [
+                'action' => 'onFooBar',
+                'event' => 'foo',
+            ],
+            [
+                'action' => 'onFooBar',
+                'event' => 'bar',
+            ],
+            [
+                'action' => 'onFooBar',
+                'event' => 'foo:bar',
+            ],
+        ], $liveListeners);
+    }
+
+    public function testCanGetRepeatedLiveListenersFromClassString(): void
+    {
+        $liveListeners = AsLiveComponent::liveListeners(ComponentWithRepeatedLiveListener::class);
+
+        $this->assertCount(4, $liveListeners);
     }
 
     public function testCanCheckIfMethodIsAllowed(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes 
| Feature        | Request #1323  
| License       | MIT

Allow repeated #[LiveListener] attributes on a method

```php
    #[LiveListener('foo')]
    #[LiveListener('bar')]
    #[LiveListener('foo:bar')]
    public function onFooBar(): void
    {
    }
```