### PR TITLE
[WIP][Site] Bootstrapping section to find "UI Components"

### DIFF
--- a/ux.symfony.com/.gitignore
+++ b/ux.symfony.com/.gitignore
@@ -14,5 +14,5 @@
 
 ###> symfony/asset-mapper ###
 /public/assets/
-/assets/vendor/
+/assets/vendor
 ###< symfony/asset-mapper ###

--- a/ux.symfony.com/assets/controllers/closeable_controller.js
+++ b/ux.symfony.com/assets/controllers/closeable_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from '@hotwired/stimulus';
+import { useTransition } from 'stimulus-use';
+
+export default class extends Controller {
+    static values = {
+        autoClose: Number,
+    };
+
+    static targets = ['timerbar']
+
+    connect() {
+        useTransition(this, {
+            leaveActive: 'transition ease-in duration-200',
+            leaveFrom: 'opacity-100',
+            leaveTo: 'opacity-0',
+            transitioned: true,
+        });
+
+        if (this.autoCloseValue) {
+            setTimeout(() => {
+                this.close();
+            }, this.autoCloseValue);
+
+            if (this.hasTimerbarTarget) {
+                setTimeout(() => {
+                    this.timerbarTarget.style.width = 0;
+                }, 10);
+            }
+        }
+    }
+
+    close() {
+        this.leave();
+    }
+}

--- a/ux.symfony.com/assets/controllers/iframe-content-controller.js
+++ b/ux.symfony.com/assets/controllers/iframe-content-controller.js
@@ -1,0 +1,16 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static values = {
+        content: String
+    }
+
+    connect() {
+        /** @type {HTMLIFrameElement} */
+        const iframe = this.element;
+        const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+        iframeDoc.open();
+        iframeDoc.write(this.contentValue);
+        iframeDoc.close();
+    }
+}

--- a/ux.symfony.com/assets/styles/tailwind.css
+++ b/ux.symfony.com/assets/styles/tailwind.css
@@ -1,0 +1,4 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+

--- a/ux.symfony.com/composer.json
+++ b/ux.symfony.com/composer.json
@@ -52,6 +52,7 @@
         "symfony/yaml": "6.4.*",
         "symfonycasts/dynamic-forms": "^0.1.0",
         "symfonycasts/sass-bundle": "^0.2.0",
+        "symfonycasts/tailwind-bundle": "^0.5.0",
         "twbs/bootstrap": "^5.3",
         "twig/extra-bundle": "^2.12|^3.6.1",
         "twig/intl-extra": "^3.6",
@@ -91,7 +92,8 @@
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
-            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+            "assets:install %PUBLIC_DIR%": "symfony-cmd",
+            "importmap:install": "symfony-cmd"
         },
         "post-install-cmd": [
             "@auto-scripts"

--- a/ux.symfony.com/composer.lock
+++ b/ux.symfony.com/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a3652b42255ce0490a8b3f688ec4c15",
+    "content-hash": "fa006b457bd314d184490b100d526306",
     "packages": [
         {
             "name": "babdev/pagerfanta-bundle",
@@ -8999,6 +8999,60 @@
                 "source": "https://github.com/SymfonyCasts/sass-bundle/tree/v0.2.3"
             },
             "time": "2023-10-23T09:46:14+00:00"
+        },
+        {
+            "name": "symfonycasts/tailwind-bundle",
+            "version": "v0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SymfonyCasts/tailwind-bundle.git",
+                "reference": "f313019da18d6e938f7557319ee4fcadc26f0baa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SymfonyCasts/tailwind-bundle/zipball/f313019da18d6e938f7557319ee4fcadc26f0baa",
+                "reference": "f313019da18d6e938f7557319ee4fcadc26f0baa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/asset-mapper": "^6.3|^7.0",
+                "symfony/console": "^5.4|^6.3|^7.0",
+                "symfony/http-client": "^5.4|^6.3|^7.0",
+                "symfony/process": "^5.4|^6.3|^7.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.11.x-dev",
+                "symfony/filesystem": "^6.3|^7.0",
+                "symfony/framework-bundle": "^6.3|^7.0",
+                "symfony/phpunit-bridge": "^6.3|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfonycasts\\TailwindBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ryan Weaver",
+                    "homepage": "https://symfonycasts.com"
+                }
+            ],
+            "description": "Delightful Tailwind Support for Symfony + AssetMapper",
+            "keywords": [
+                "asset-mapper",
+                "tailwind"
+            ],
+            "support": {
+                "issues": "https://github.com/SymfonyCasts/tailwind-bundle/issues",
+                "source": "https://github.com/SymfonyCasts/tailwind-bundle/tree/v0.5.0"
+            },
+            "time": "2023-12-18T16:55:43+00:00"
         },
         {
             "name": "twbs/bootstrap",

--- a/ux.symfony.com/config/bundles.php
+++ b/ux.symfony.com/config/bundles.php
@@ -31,4 +31,5 @@ return [
     Zenstruck\Foundry\ZenstruckFoundryBundle::class => ['dev' => true, 'test' => true],
     Symfony\UX\TogglePassword\TogglePasswordBundle::class => ['all' => true],
     Symfonycasts\SassBundle\SymfonycastsSassBundle::class => ['all' => true],
+    Symfonycasts\TailwindBundle\SymfonycastsTailwindBundle::class => ['all' => true],
 ];

--- a/ux.symfony.com/config/packages/symfonycasts_tailwind.yaml
+++ b/ux.symfony.com/config/packages/symfonycasts_tailwind.yaml
@@ -1,0 +1,2 @@
+symfonycasts_tailwind:
+    input_css: 'assets/styles/tailwind.css'

--- a/ux.symfony.com/importmap.php
+++ b/ux.symfony.com/importmap.php
@@ -61,7 +61,7 @@ return [
         'version' => '3.3.0',
     ],
     '@hotwired/stimulus' => [
-        'version' => '3.2.1',
+        'version' => '3.2.2',
     ],
     'tom-select' => [
         'version' => '2.2.2',
@@ -179,5 +179,8 @@ return [
     ],
     'scheduler' => [
         'version' => '0.23.0',
+    ],
+    'stimulus-use' => [
+        'version' => '0.52.1',
     ],
 ];

--- a/ux.symfony.com/src/Controller/UIComponentController.php
+++ b/ux.symfony.com/src/Controller/UIComponentController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Controller;
+
+use App\UIComponent\UIComponentCollection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Attribute\Route;
+
+class UIComponentController extends AbstractController
+{
+    #[Route('/components', name: 'app_ui_component_index')]
+    public function index(UIComponentCollection $componentCollection)
+    {
+        return $this->render('ui_component/index.html.twig', [
+            'components' => $componentCollection,
+        ]);
+    }
+
+    #[Route('/components/{key}', name: 'app_ui_component_show')]
+    public function show(string $key, UIComponentCollection $componentCollection)
+    {
+        $component = $componentCollection->get($key);
+        if (!$component) {
+            throw $this->createNotFoundException(sprintf('Component with key "%s" not found', $key));
+        }
+
+        return $this->render('ui_component/'.$component->getTemplate(), [
+            'component' => $component,
+        ]);
+    }
+}

--- a/ux.symfony.com/src/UIComponent/ToastUIComponent.php
+++ b/ux.symfony.com/src/UIComponent/ToastUIComponent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\UIComponent;
+
+class ToastUIComponent implements UIComponentInterface
+{
+    public static function getName(): string
+    {
+        return 'Toast';
+    }
+
+    public static function getKey(): string
+    {
+        return 'toast';
+    }
+
+    public function getTemplate(): string
+    {
+        return 'toast.html.twig';
+    }
+}

--- a/ux.symfony.com/src/UIComponent/UIComponentCollection.php
+++ b/ux.symfony.com/src/UIComponent/UIComponentCollection.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\UIComponent;
+
+use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Zenstruck\Browser\Component;
+
+class UIComponentCollection implements \IteratorAggregate
+{
+    public function __construct(
+        #[TaggedIterator(UIComponentInterface::class)]
+        private iterable $components
+    )
+    {
+    }
+
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(iterator_to_array($this->components));
+    }
+
+    public function get(string $key): ?UIComponentInterface
+    {
+        foreach ($this->components as $component) {
+            if ($component::getKey() === $key) {
+                return $component;
+            }
+        }
+
+        return null;
+    }
+}

--- a/ux.symfony.com/src/UIComponent/UIComponentInterface.php
+++ b/ux.symfony.com/src/UIComponent/UIComponentInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\UIComponent;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag()]
+interface UIComponentInterface
+{
+    public static function getName(): string;
+
+    public static function getKey(): string;
+
+    public function getTemplate(): string;
+}

--- a/ux.symfony.com/symfony.lock
+++ b/ux.symfony.com/symfony.lock
@@ -233,12 +233,12 @@
         "version": "0.1.4"
     },
     "symfony/asset-mapper": {
-        "version": "6.3",
+        "version": "6.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
-            "version": "6.3",
-            "ref": "445f56412ec437dc0f9f2c31716c867d207bcd62"
+            "version": "6.4",
+            "ref": "8a0d17c04c791b3d7bdd083e1e2b2a53439dc3b0"
         },
         "files": [
             "assets/app.js",
@@ -655,6 +655,9 @@
     },
     "symfonycasts/sass-bundle": {
         "version": "v0.1.0"
+    },
+    "symfonycasts/tailwind-bundle": {
+        "version": "v0.5.0"
     },
     "theseer/tokenizer": {
         "version": "1.2.1"

--- a/ux.symfony.com/tailwind.config.js
+++ b/ux.symfony.com/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./assets/**/*.js",
+    "./templates/**/*.html.twig",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/ux.symfony.com/templates/components/Toast.html.twig
+++ b/ux.symfony.com/templates/components/Toast.html.twig
@@ -1,0 +1,39 @@
+<div
+    {{ attributes }}
+    class="fixed top-5 right-5 flex items-center w-full max-w-xs p-4 mb-4 text-gray-500 bg-white rounded-lg shadow dark:text-gray-400 dark:bg-gray-800"
+    role="alert"
+    data-turbo-temporary
+    data-controller="closeable"
+    data-closeable-auto-close-value="5000"
+>
+    <div
+        class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-green-500 bg-green-100 rounded-lg dark:bg-green-800 dark:text-green-200">
+        <svg class="w-5 h-5" aria-hidden="true"
+             xmlns="http://www.w3.org/2000/svg" fill="currentColor"
+             viewBox="0 0 20 20">
+            <path
+                d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/>
+        </svg>
+        <span class="sr-only">Check icon</span>
+    </div>
+    {% block content %}{% endblock %}
+    <button
+        type="button"
+        class="ms-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8 dark:text-gray-500 dark:hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700"
+        aria-label="Close"
+        data-action="closeable#close"
+    >
+        <span class="sr-only">Close</span>
+        <svg class="w-3 h-3" aria-hidden="true"
+             xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+            <path stroke="currentColor" stroke-linecap="round"
+                  stroke-linejoin="round" stroke-width="2"
+                  d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+        </svg>
+    </button>
+
+    <div
+        class="absolute bottom-0 left-0 h-1 bg-green-500 w-full transition-all duration-[5000ms] ease-linear"
+        data-closeable-target="timerbar"
+    ></div>
+</div>

--- a/ux.symfony.com/templates/components/UIComponentIFrame.html.twig
+++ b/ux.symfony.com/templates/components/UIComponentIFrame.html.twig
@@ -1,0 +1,9 @@
+{% props css %}
+
+<iframe
+    style="width: 70%; height: 500px; margin: 40px; border: 1px solid; border-radius: 5px;" {{ stimulus_controller('iframe-content', {
+    content: include('components/_iframe_content.html.twig', {
+        content: block('content'),
+        css: css,
+    })
+}) }}></iframe>

--- a/ux.symfony.com/templates/components/_iframe_content.html.twig
+++ b/ux.symfony.com/templates/components/_iframe_content.html.twig
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        {% if css == 'tailwind' %}
+            <link rel="stylesheet" href="{{ asset('styles/tailwind.css') }}">
+        {% elseif css == 'bootstrap' %}
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css">
+        {% endif %}
+
+        {{ importmap() }}
+    </head>
+    <body class="p-6" data-turbo="false">
+        {{ content|raw }}
+    </body>
+</html>

--- a/ux.symfony.com/templates/ui_component/index.html.twig
+++ b/ux.symfony.com/templates/ui_component/index.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <h1>Components</h1>
+
+    {% for component in components %}
+        <div>
+            <a href="{{ path('app_ui_component_show', {
+                key: component.key
+            }) }}">
+                {{ component.name }}
+            </a>
+        </div>
+    {% endfor %}
+{% endblock %}

--- a/ux.symfony.com/templates/ui_component/toast.html.twig
+++ b/ux.symfony.com/templates/ui_component/toast.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <h1>{{ component.name }}</h1>
+
+    <twig:UIComponentIFrame css="tailwind" foo="bar">
+        <twig:Toast>
+            <div class="ms-3 text-sm font-normal">Successfully Saved!</div>
+        </twig:Toast>
+    </twig:UIComponentIFrame>
+
+    A) Show the HTML code for the Toast component
+    B) Show the Stimulus code for the toast controller
+    C) Show an install for the `stimulus-use` package
+{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

UI Component = Twig component / markup + Stimulus controller

I'd like a place to share "solutions". What is the general markup and Stimulus controller needed for a modal? A tooltip? Tabs? Toast notifications, etc? How can we help people discover that, if you need to build a popover, there is a [controller for that](https://www.stimulus-components.com/docs/stimulus-popover)?

I'm proposing a new section on ux.symfony.com to find these "pieces". It's meant to be solution-based: you search/browse for your need (e.g. modals) vs the package (e.g. "turbo" or "live components"). We talked about this and Bootstrapped a bit on a live stream - https://www.youtube.com/watch?v=3f65q46k6TM - this is the result.

**Unstyled example page for toasts**

https://github.com/symfony/ux/assets/121003/6091b819-7c24-4a3f-86dd-e4408ac012ae

## UI Component Ideas

* Modal
* Tooltip/Popover
* Button
* Tabs
* Toast
* Dropdown
* Trix
* (video player)
* Clipboard
* Alert
* Form Inputs
* Pagination
* Google Maps & open street maps
* Sliders
* Off-Canvas Menus
* Lightboxes
* Badge
* Progress
* Autocomplete
* Charts
* Image cropper
* Dropzone for upload
* Lazy images
* Password toggle

### Open questions:

* WDYT?
* I use Tailwind. Do we try to have a Bootstrap version? And also a "no CSS" version of each one?
* I've used the word "UI Components" to describe these... "component" is a loaded name, but it might still fit well.