### PR TITLE
[live-component docs] Rearrange information about using custom Stimul…

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -842,6 +842,21 @@ of the change:
 
     input.dispatchEvent(new Event('change', { bubbles: true }));
 
+Adding a Stimulus Controller to your Component Root Element
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.9
+
+    The ability to use the ``defaults()`` method with ``stimulus_controller()``
+    was added in TwigComponents 2.9 and requires ``symfony/stimulus-bundle``.
+    Previously, ``stimulus_controller()`` was passed to ``attributes.add()``.
+
+To add a custom Stimulus controller to your root component element:
+
+.. code-block:: html+twig
+
+    <div {{ attributes.defaults(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
+
 JavaScript Component Hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -875,21 +890,6 @@ The following hooks are available (along with the arguments that are passed):
 * ``loading.state:started`` args ``(element: HTMLElement, request: BackendRequest)``
 * ``loading.state:finished`` args ``(element: HTMLElement)``
 * ``model:set`` args ``(model: string, value: any, component: Component)``
-
-Adding a Stimulus Controller to your Component Root Element
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 2.9
-
-    The ability to use the ``defaults()`` method with ``stimulus_controller()``
-    was added in TwigComponents 2.9 and requires ``symfony/stimulus-bundle``.
-    Previously, ``stimulus_controller()`` was passed to ``attributes.add()``.
-
-To add a custom Stimulus controller to your root component element:
-
-.. code-block:: html+twig
-
-    <div {{ attributes.defaults(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
 
 Loading States
 --------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | n/a
| License       | MIT

In the section 'Working with the Component in JavaScript', the preamble mentions that you can create a custom Stimulus controller, and attach it to or put it around the root component element, in order to control its behaviour.

How to attach a custom controller is, however, only explained further down in the subsection 'Adding a Stimulus Controller to your Component Root Element'. This subsection is currently buried beneath an intervening subsection on a different topic, 'JavaScript Component Hooks', making it easy for a reader to overlook.

I have therefore swapped these two subsections around to improve their logical flow.

It is especially important that this information is presented clearly because it has caused confusion in the past; see e.g. #687.