### PR TITLE
[LiveComponent] Fix test Kernel deprecations

### DIFF
--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -609,7 +609,8 @@ final class LiveComponentHydratorTest extends KernelTestCase
                     'invoice.lineItems.2' => ['name' => 'item3_updated', 'quantity' => 2, 'price' => 2000],
                 ])
                 ->assertObjectAfterHydration(function (object $object) {
-                    self::assertSame([
+                    self::assertSame(
+                        [
                         'number' => '456',
                         'lineItems' => [
                             ['name' => 'item1', 'quantity' => 5, 'price' => 100],
@@ -752,7 +753,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
             return HydrationTest::create(new class() {
                 #[LiveProp()]
                 /** @var \Symfony\UX\LiveComponent\Tests\Fixtures\Entity\ProductFixtureEntity[] */
-                public $products = [];
+                public array $products = [];
             })
                 ->mountWith(['products' => [$prod1, $prod2, $prod3]])
                 ->assertDehydratesTo([


### PR DESCRIPTION
Fix some Kernel deprecation.

But the CS remains, because (and it's kinda weird) PhpCSFixer says

```diff
 --- /home/runner/work/ux/ux/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ /home/runner/work/ux/ux/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -752,7 +752,7 @@
 
             return HydrationTest::create(new class() {
                 #[LiveProp()]
-                /** @var \Symfony\UX\LiveComponent\Tests\Fixtures\Entity\ProductFixtureEntity[] */
+                /** @var ProductFixtureEntity[] */
                 public array $products = [];
             })
                 ->mountWith(['products' => [$prod1, $prod2, $prod3]])
```                 

But if we do that ....


```
1) Symfony\UX\LiveComponent\Tests\Integration\LiveComponentHydratorTest::testCanDehydrateAndHydrateComponentWithTestCases with data set "Array with objects: (de)hydrates correctly" (Closure Object (...))
LogicException: The LiveProp "products" on component "class@anonymous[...]src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php:753$4c" is an array. We determined the array is full of \ProductFixtureEntity objects, but at least on key had a different value of Symfony\UX\LiveComponent\Tests\Fixtures\Entity\ProductFixtureEntity
```
