### PR TITLE
[live-component docs] Fix typo and format warning at top of page

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1,8 +1,10 @@
 Live Components
 ===============
 
-**EXPERIMENTAL** This component is currently experimental and is likely
-to change, or even change drastically.
+.. caution::
+
+    This component is currently experimental and is likely to change, or even
+    change drastically.
 
 Live components builds on top of the `TwigComponent`_ library
 to give you the power to automatically update your Twig components on
@@ -3256,7 +3258,7 @@ uses Symfony's test client to render and make requests to your components::
             // refresh the component
             $testComponent->refresh();
 
-            // access the component object (in it's current state)
+            // access the component object (in its current state)
             $component = $testComponent->component(); // MyComponent
 
             $this->assertSame(99, $component->count);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | n/a
| License       | MIT

- Format the "experimental" warning as a caution box
- Fix typo in code sample ("it's" -> "its")