### PR TITLE
[CS] Update phpcs rules

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -28,6 +28,7 @@ return (new PhpCsFixer\Config())
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'header_comment' => ['header' => $fileHeaderComment],
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'match', 'parameters']],
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/Autocomplete/src/AutocompleterRegistry.php
+++ b/src/Autocomplete/src/AutocompleterRegistry.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 final class AutocompleterRegistry
 {
     public function __construct(
-        private ServiceLocator $autocompletersLocator
+        private ServiceLocator $autocompletersLocator,
     ) {
     }
 

--- a/src/Autocomplete/src/Doctrine/DoctrineRegistryWrapper.php
+++ b/src/Autocomplete/src/Doctrine/DoctrineRegistryWrapper.php
@@ -23,7 +23,7 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
 class DoctrineRegistryWrapper
 {
     public function __construct(
-        private ?ManagerRegistry $registry = null
+        private ?ManagerRegistry $registry = null,
     ) {
     }
 

--- a/src/Autocomplete/src/Doctrine/EntityMetadata.php
+++ b/src/Autocomplete/src/Doctrine/EntityMetadata.php
@@ -19,7 +19,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 class EntityMetadata
 {
     public function __construct(
-        private ClassMetadata $metadata
+        private ClassMetadata $metadata,
     ) {
     }
 

--- a/src/Autocomplete/src/Doctrine/EntityMetadataFactory.php
+++ b/src/Autocomplete/src/Doctrine/EntityMetadataFactory.php
@@ -20,7 +20,7 @@ use Doctrine\Persistence\ObjectManager;
 class EntityMetadataFactory
 {
     public function __construct(
-        private DoctrineRegistryWrapper $doctrine
+        private DoctrineRegistryWrapper $doctrine,
     ) {
     }
 

--- a/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
+++ b/src/Autocomplete/src/Form/AutocompleteEntityTypeSubscriber.php
@@ -28,7 +28,7 @@ use Symfony\Component\Form\FormEvents;
 final class AutocompleteEntityTypeSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private ?string $autocompleteUrl = null
+        private ?string $autocompleteUrl = null,
     ) {
     }
 

--- a/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
+++ b/src/Autocomplete/src/Form/ParentEntityAutocompleteType.php
@@ -29,7 +29,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 final class ParentEntityAutocompleteType extends AbstractType implements DataMapperInterface
 {
     public function __construct(
-        private UrlGeneratorInterface $urlGenerator
+        private UrlGeneratorInterface $urlGenerator,
     ) {
     }
 

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -39,7 +39,7 @@ final class WrappedEntityTypeAutocompleter implements EntityAutocompleterInterfa
         private FormFactoryInterface $formFactory,
         private EntityMetadataFactory $metadataFactory,
         private PropertyAccessorInterface $propertyAccessor,
-        private EntitySearchUtil $entitySearchUtil
+        private EntitySearchUtil $entitySearchUtil,
     ) {
     }
 

--- a/src/Autocomplete/src/Maker/MakeAutocompleteField.php
+++ b/src/Autocomplete/src/Maker/MakeAutocompleteField.php
@@ -39,7 +39,7 @@ class MakeAutocompleteField extends AbstractMaker
     private string $entityClass;
 
     public function __construct(
-        private ?DoctrineHelper $doctrineHelper = null
+        private ?DoctrineHelper $doctrineHelper = null,
     ) {
     }
 

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -41,7 +41,7 @@ final class AsLiveComponent extends AsTwigComponent
         bool $exposePublicProps = true,
         string $attributesVar = 'attributes',
         public bool $csrf = true,
-        public string $route = 'ux_live_component'
+        public string $route = 'ux_live_component',
     ) {
         parent::__construct($name, $template, $exposePublicProps, $attributesVar);
     }

--- a/src/LiveComponent/src/EventListener/ResetDeterministicIdSubscriber.php
+++ b/src/LiveComponent/src/EventListener/ResetDeterministicIdSubscriber.php
@@ -44,7 +44,7 @@ final class ResetDeterministicIdSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private DeterministicTwigIdCalculator $idCalculator,
-        private ComponentStack $componentStack
+        private ComponentStack $componentStack,
     ) {
     }
 

--- a/src/React/src/AssetMapper/ReactReplaceProcessEnvAssetCompiler.php
+++ b/src/React/src/AssetMapper/ReactReplaceProcessEnvAssetCompiler.php
@@ -23,7 +23,7 @@ use Symfony\Component\AssetMapper\MappedAsset;
 class ReactReplaceProcessEnvAssetCompiler implements AssetCompilerInterface
 {
     public function __construct(
-        private bool $isDebug
+        private bool $isDebug,
     ) {
     }
 

--- a/src/StimulusBundle/src/AssetMapper/MappedControllerAutoImport.php
+++ b/src/StimulusBundle/src/AssetMapper/MappedControllerAutoImport.php
@@ -20,7 +20,7 @@ class MappedControllerAutoImport
 {
     public function __construct(
         public string $path,
-        public bool $isBareImport
+        public bool $isBareImport,
     ) {
     }
 }

--- a/src/Translator/src/Intl/IntlMessageParser.php
+++ b/src/Translator/src/Intl/IntlMessageParser.php
@@ -246,7 +246,7 @@ class IntlMessageParser
 
     private function tryParseUnquoted(
         int $nestingLevel,
-        string $parentArgType
+        string $parentArgType,
     ): string|null {
         if ($this->isEOF()) {
             return null;
@@ -273,7 +273,7 @@ class IntlMessageParser
      */
     private function parseArgument(
         int $nestingLevel,
-        bool $expectingCloseTag
+        bool $expectingCloseTag,
     ): array {
         $openingBracePosition = clone $this->position;
         $this->bump(); // `{`
@@ -381,7 +381,7 @@ class IntlMessageParser
         int $nestingLevel,
         bool $expectingCloseTag,
         string $value,
-        Position $openingBracePosition
+        Position $openingBracePosition,
     ): array {
         // Parse this range:
         // {name, type, style}
@@ -611,7 +611,7 @@ class IntlMessageParser
     }
 
     private function tryParseArgumentClose(
-        Position $openingBracePosition
+        Position $openingBracePosition,
     ): array {
         // Parse: {value, number, ::currency/GBP }
         //
@@ -683,7 +683,7 @@ class IntlMessageParser
 
     private function parseNumberSkeletonFromString(
         string $skeleton,
-        Location $location
+        Location $location,
     ) {
         $tokens = [];
 
@@ -712,7 +712,7 @@ class IntlMessageParser
         int $nestingLevel,
         string $parentArgType,
         bool $expectCloseTag,
-        array $parsedFirstIdentifier
+        array $parsedFirstIdentifier,
     ): array {
         $hasOtherClause = false;
         $options = [];

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -35,7 +35,7 @@ final class ComponentFactory
         private PropertyAccessorInterface $propertyAccessor,
         private EventDispatcherInterface $eventDispatcher,
         private array $config,
-        private array $classMap
+        private array $classMap,
     ) {
     }
 

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -34,7 +34,7 @@ final class ComponentRenderer implements ComponentRendererInterface
         private EventDispatcherInterface $dispatcher,
         private ComponentFactory $factory,
         private PropertyAccessorInterface $propertyAccessor,
-        private ComponentStack $componentStack
+        private ComponentStack $componentStack,
     ) {
     }
 

--- a/src/TwigComponent/src/Event/PostMountEvent.php
+++ b/src/TwigComponent/src/Event/PostMountEvent.php
@@ -26,7 +26,7 @@ final class PostMountEvent extends Event
         private object $component,
         private array $data,
         array|ComponentMetadata $metadata = [],
-        $extraMetadata = []
+        $extraMetadata = [],
     ) {
         if (\is_array($metadata)) {
             trigger_deprecation('symfony/ux-twig-component', '2.13', 'In TwigComponent 3.0, the third argument of "%s()" will be a "%s" object and the "$extraMetadata" array should be passed as the fourth argument.', __METHOD__, ComponentMetadata::class);

--- a/src/TwigComponent/src/Event/PreCreateForRenderEvent.php
+++ b/src/TwigComponent/src/Event/PreCreateForRenderEvent.php
@@ -24,7 +24,7 @@ final class PreCreateForRenderEvent extends Event
 
     public function __construct(
         private string $name,
-        private array $inputProps = []
+        private array $inputProps = [],
     ) {
     }
 

--- a/src/TwigComponent/src/Event/PreRenderEvent.php
+++ b/src/TwigComponent/src/Event/PreRenderEvent.php
@@ -38,7 +38,7 @@ final class PreRenderEvent extends Event
     public function __construct(
         private MountedComponent $mounted,
         private ComponentMetadata $metadata,
-        private array $variables
+        private array $variables,
     ) {
         $this->template = $this->metadata->getTemplate();
         $this->parentTemplateForEmbedded = $this->template;

--- a/src/TwigComponent/src/Twig/TwigEnvironmentConfigurator.php
+++ b/src/TwigComponent/src/Twig/TwigEnvironmentConfigurator.php
@@ -19,7 +19,7 @@ class TwigEnvironmentConfigurator
     private EnvironmentConfigurator $decorated;
 
     public function __construct(
-        EnvironmentConfigurator $decorated
+        EnvironmentConfigurator $decorated,
     ) {
         $this->decorated = $decorated;
     }

--- a/ux.symfony.com/src/Controller/UxPackage/CropperjsController.php
+++ b/ux.symfony.com/src/Controller/UxPackage/CropperjsController.php
@@ -25,7 +25,7 @@ class CropperjsController extends AbstractController
 {
     public function __construct(
         private Packages $assets,
-        private string $projectDir
+        private string $projectDir,
     ) {
     }
 

--- a/ux.symfony.com/src/Service/TwigPackageHelper.php
+++ b/ux.symfony.com/src/Service/TwigPackageHelper.php
@@ -17,7 +17,7 @@ class TwigPackageHelper
 {
     public function __construct(
         private UxPackageRepository $packageRepository,
-        private PackageContext $packageContext
+        private PackageContext $packageContext,
     ) {
     }
 


### PR DESCRIPTION
Update php-cs-fixer rules to add

```
'trailing_comma_in_multiline' => ['elements' => ['arrays', 'match', 'parameters']],
```

(synchronize with symfony/symfony after  [CS: trailing commas #53352](https://github.com/symfony/symfony/pull/53352/files)  )