### PR TITLE
[TwigComponent] Fix usage of {% embed %} with {% block %} in <twig:> components, close #952

### DIFF
--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -183,6 +183,104 @@ final class TwigPreLexerTest extends TestCase
             EOF
         ];
 
+        yield 'component_where_entire_default_block_is_twig_embed' => [
+            <<<EOF
+            <twig:Alert>
+                <p>
+                    {% embed "my_embed.html.twig" with { foo: 'bar' } %}{% endembed %}
+                </p>
+            </twig:Alert>
+            EOF,
+            <<<EOF
+            {% component 'Alert' %}
+                {% block content %}<p>
+                    {% embed "my_embed.html.twig" with { foo: 'bar' } %}{% endembed %}
+                </p>
+            {% endblock %}{% endcomponent %}
+            EOF,
+        ];
+        yield 'component_where_entire_default_block_is_twig_embed_with_block_string' => [
+            <<<EOF
+            <twig:Alert>
+                <p>
+                    {% embed "my_embed.html.twig" %}
+                        {% block my_embed_block "foo" %}
+                    {% endembed %}
+                </p>
+            </twig:Alert>
+            EOF,
+            <<<EOF
+            {% component 'Alert' %}
+                {% block content %}<p>
+                    {% embed "my_embed.html.twig" %}
+                        {% block my_embed_block "foo" %}
+                    {% endembed %}
+                </p>
+            {% endblock %}{% endcomponent %}
+            EOF,
+        ];
+        yield 'component_where_entire_default_block_is_twig_embed_with_block_variable' => [
+            <<<EOF
+            <twig:Alert>
+                <p>
+                    {% embed "my_embed.html.twig" %}
+                        {% block my_embed_block fooVar %}
+                    {% endembed %}
+                </p>
+            </twig:Alert>
+            EOF,
+            <<<EOF
+            {% component 'Alert' %}
+                {% block content %}<p>
+                    {% embed "my_embed.html.twig" %}
+                        {% block my_embed_block fooVar %}
+                    {% endembed %}
+                </p>
+            {% endblock %}{% endcomponent %}
+            EOF,
+        ];
+        yield 'component_where_entire_default_block_is_twig_embed_with_block_expanded' => [
+            <<<EOF
+            <twig:Alert>
+                <p>
+                    {% embed "my_embed.html.twig" %}
+                        {% block my_embed_block %}bar{% endblock %}
+                    {% endembed %}
+                </p>
+            </twig:Alert>
+            EOF,
+            <<<EOF
+            {% component 'Alert' %}
+                {% block content %}<p>
+                    {% embed "my_embed.html.twig" %}
+                        {% block my_embed_block %}bar{% endblock %}
+                    {% endembed %}
+                </p>
+            {% endblock %}{% endcomponent %}
+            EOF,
+        ];
+
+        yield 'component_where_entire_default_block_is_twig_embed_with_block_variable_and_manipulations' => [
+            <<<EOF
+            <twig:Alert>
+                <p>
+                    {% embed "my_embed.html.twig" %}
+                        {% block my_embed_block doSomething(fooVar)|u.camel.title.truncate(5) %}
+                    {% endembed %}
+                </p>
+            </twig:Alert>
+            EOF,
+            <<<EOF
+            {% component 'Alert' %}
+                {% block content %}<p>
+                    {% embed "my_embed.html.twig" %}
+                        {% block my_embed_block doSomething(fooVar)|u.camel.title.truncate(5) %}
+                    {% endembed %}
+                </p>
+            {% endblock %}{% endcomponent %}
+            EOF,
+        ];
+
         yield 'string_inside_of_twig_code_not_escaped' => [
             <<<EOF
             <twig:TabbedCodeBlocks :files="[


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #952 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Hi everyone, this PR is an attempt to fix #952.
It fix supports for `{% block X %}foo{% endblock %}` and `{% block X "foo"%}`, from `{% embed %}`, in `<twig:>` syntax.

The following code:
```twig
<twig:Alert>
    <p>
        {% embed "my_embed.html.twig" %}
            {% block my_embed_block_1 "foo" %}
            {% block my_embed_block_2 %}bar{% endblock %}
        {% endembed %}
    </p>
</twig:Alert>
```

is now properly converted to:
```twig
{% component 'Alert' %}
    {% block content %}<p>
        {% embed "my_embed.html.twig" %}
            {% block my_embed_block_1 "foo" %}
            {% block my_embed_block_2 %}bar{% endblock %}
        {% endembed %}
    </p>
{% endblock %}{% endcomponent %}
```

Since I'm not familiar with the `PreLexer`, let me know if a better solution/implementation exists.