### PR TITLE
[Live] Control the type of generated URLs

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -6,6 +6,8 @@
 -   Allow multiple `LiveListener` attributes on a single method.
 -   Requests to LiveComponent are sent as POST by default
 -   Add method prop to AsLiveComponent to still allow GET requests, usage: `#[AsLiveComponent(method: 'get')]`
+-   Add a new `urlReferenceType` parameter to `AsLiveComponent`, which allows to
+    generate different type URL (e.g. absolute) for the component Ajax calls.
 
 ## 2.13.2
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3279,6 +3279,26 @@ Then specify this new route on your component:
           use DefaultActionTrait;
       }
 
+.. versionadded:: 2.14
+
+    The ``urlReferenceType`` option  was added in LiveComponents 2.14.
+
+You can also control the type of the generated URL:
+
+.. code-block:: diff
+
+      // src/Components/RandomNumber.php
+    + use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+      use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+      use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+    - #[AsLiveComponent]
+    + #[AsLiveComponent(urlReferenceType: UrlGeneratorInterface::ABSOLUTE_URL)]
+      class RandomNumber
+      {
+          use DefaultActionTrait;
+      }
+
 Add a Hook on LiveProp Update
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\LiveComponent\Attribute;
 
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 /**
@@ -33,6 +34,7 @@ final class AsLiveComponent extends AsTwigComponent
      * @param string      $attributesVar     The name of the special "attributes" variable in the template
      * @param bool        $csrf              Whether to enable CSRF protection (default: true)
      * @param string      $route             The route used to render the component & handle actions (default: ux_live_component)
+     * @param int         $urlReferenceType  Which type of URL should be generated for the given route. Use the constants from UrlGeneratorInterface (default: absolute path, e.g. "/dir/file").
      */
     public function __construct(
         string $name = null,
@@ -43,6 +45,7 @@ final class AsLiveComponent extends AsTwigComponent
         public bool $csrf = true,
         public string $route = 'ux_live_component',
         public string $method = 'post',
+        public int $urlReferenceType = UrlGeneratorInterface::ABSOLUTE_PATH,
     ) {
         parent::__construct($name, $template, $exposePublicProps, $attributesVar);
 
@@ -64,6 +67,7 @@ final class AsLiveComponent extends AsTwigComponent
             'csrf' => $this->csrf,
             'route' => $this->route,
             'method' => $this->method,
+            'url_reference_type' => $this->urlReferenceType,
         ]);
     }
 

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -89,7 +89,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             AsLiveComponent::class,
             function (ChildDefinition $definition, AsLiveComponent $attribute) {
                 $definition
-                    ->addTag('twig.component', array_filter($attribute->serviceConfig()))
+                    ->addTag('twig.component', array_filter($attribute->serviceConfig(), static fn ($v) => null !== $v && '' !== $v))
                     ->addTag('controller.service_arguments')
                 ;
             }

--- a/src/LiveComponent/src/Twig/LiveComponentRuntime.php
+++ b/src/LiveComponent/src/Twig/LiveComponentRuntime.php
@@ -45,6 +45,6 @@ final class LiveComponentRuntime
 
         $metadata = $this->factory->metadataFor($mounted->getName());
 
-        return $this->urlGenerator->generate($metadata->get('route'), $params);
+        return $this->urlGenerator->generate($metadata->get('route'), $params, $metadata->get('url_reference_type'));
     }
 }

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -61,7 +61,7 @@ class LiveControllerAttributesCreator
         $attributesCollection = $this->attributeHelper->create();
         $attributesCollection->setLiveController($mounted->getName());
 
-        $url = $this->urlGenerator->generate($metadata->get('route'), ['_live_component' => $mounted->getName()]);
+        $url = $this->urlGenerator->generate($metadata->get('route'), ['_live_component' => $mounted->getName()], $metadata->get('url_reference_type'));
         $attributesCollection->setUrl($url);
 
         $liveListeners = AsLiveComponent::liveListeners($mounted->getComponent());

--- a/src/LiveComponent/tests/Fixtures/Component/WithAbsoluteUrl.php
+++ b/src/LiveComponent/tests/Fixtures/Component/WithAbsoluteUrl.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * @author Gábor Egyed <gabor.egyed@gmail.com>
+ */
+#[AsLiveComponent('with_absolute_url', urlReferenceType: UrlGeneratorInterface::ABSOLUTE_URL)]
+final class WithAbsoluteUrl
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true, url: true)]
+    public int $count = 0;
+
+    #[LiveAction]
+    public function increase(): void
+    {
+        ++$this->count;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/templates/component_url.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/component_url.html.twig
@@ -1,2 +1,3 @@
 {{ component_url('component1', {prop1: null, prop2: date}) }}
 {{ component_url('alternate_route') }}
+{{ component_url('with_absolute_url') }}

--- a/src/LiveComponent/tests/Fixtures/templates/components/with_absolute_url.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/with_absolute_url.html.twig
@@ -1,0 +1,3 @@
+<div{{ attributes }}>
+    From absolute url. Count: {{ count }}
+</div>

--- a/src/LiveComponent/tests/Fixtures/templates/render_with_absolute_url.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/render_with_absolute_url.html.twig
@@ -1,0 +1,1 @@
+{{ component('with_absolute_url') }}

--- a/src/LiveComponent/tests/Integration/Twig/LiveComponentExtensionTest.php
+++ b/src/LiveComponent/tests/Integration/Twig/LiveComponentExtensionTest.php
@@ -26,5 +26,6 @@ final class LiveComponentExtensionTest extends KernelTestCase
 
         $this->assertStringContainsString('/_components/component1?props=%7B%22prop1%22:null,%22prop2%22:%222022-10-06T00:00:00%2B00:00%22,%22prop3%22:null,', $rendered);
         $this->assertStringContainsString('/alt/alternate_route?', $rendered);
+        $this->assertStringContainsString('http://localhost/_components/with_absolute_url?', $rendered);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | -
| License       | MIT

Add a way to generate absolute URLs for live components.

My use case is that I embed a page with live components 
into a site on a different host, so I need absolute URLs 
for the components to work properly.

