### PR TITLE
[TwigComponent] Filter service config in AsTwigComponent

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -89,7 +89,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             AsLiveComponent::class,
             function (ChildDefinition $definition, AsLiveComponent $attribute) {
                 $definition
-                    ->addTag('twig.component', array_filter($attribute->serviceConfig()))
+                    ->addTag('twig.component', $attribute->serviceConfig())
                     ->addTag('controller.service_arguments')
                 ;
             }

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -67,12 +67,12 @@ class AsTwigComponent
      */
     public function serviceConfig(): array
     {
-        return [
+        return array_filter([
             'key' => $this->name,
             'template' => $this->template,
             'expose_public_props' => $this->exposePublicProps,
             'attributes_var' => $this->attributesVar,
-        ];
+        ]);
     }
 
     /**

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -74,7 +74,7 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
         $container->registerAttributeForAutoconfiguration(
             AsTwigComponent::class,
             static function (ChildDefinition $definition, AsTwigComponent $attribute) {
-                $definition->addTag('twig.component', array_filter($attribute->serviceConfig()));
+                $definition->addTag('twig.component', $attribute->serviceConfig());
             }
         );
 

--- a/src/TwigComponent/tests/Unit/Attribute/AsTwigComponentTest.php
+++ b/src/TwigComponent/tests/Unit/Attribute/AsTwigComponentTest.php
@@ -21,6 +21,41 @@ use Symfony\UX\TwigComponent\Attribute\PreMount;
  */
 final class AsTwigComponentTest extends TestCase
 {
+    /**
+     * @dataProvider provideServiceConfigData
+     */
+    public function testServiceConfigValues(AsTwigComponent $attribute, array $expectedConfig): void
+    {
+        $this->assertSame($expectedConfig, $attribute->serviceConfig());
+    }
+
+    public static function provideServiceConfigData(): iterable
+    {
+        yield 'No values' => [
+            new AsTwigComponent(),
+            [
+                'expose_public_props' => true,
+                'attributes_var' => 'attributes',
+            ],
+        ];
+        yield 'Default values' => [
+             new AsTwigComponent(null, null, true, 'attributes'),
+             [
+                 'expose_public_props' => true,
+                 'attributes_var' => 'attributes',
+             ],
+        ];
+        yield 'Name and template set' => [
+             new AsTwigComponent('foo', 'template'),
+             [
+                'key' => 'foo',
+                'template' => 'template',
+                 'expose_public_props' => true,
+                 'attributes_var' => 'attributes',
+             ],
+        ];
+    }
+
     public function testPreMountHooksAreOrderedByPriority(): void
     {
         $hooks = AsTwigComponent::preMountMethods(

--- a/src/TwigComponent/tests/Unit/Attribute/AsTwigComponentTest.php
+++ b/src/TwigComponent/tests/Unit/Attribute/AsTwigComponentTest.php
@@ -39,20 +39,20 @@ final class AsTwigComponentTest extends TestCase
             ],
         ];
         yield 'Default values' => [
-             new AsTwigComponent(null, null, true, 'attributes'),
-             [
-                 'expose_public_props' => true,
-                 'attributes_var' => 'attributes',
-             ],
+            new AsTwigComponent(null, null, true, 'attributes'),
+            [
+                'expose_public_props' => true,
+                'attributes_var' => 'attributes',
+            ],
         ];
         yield 'Name and template set' => [
-             new AsTwigComponent('foo', 'template'),
-             [
+            new AsTwigComponent('foo', 'template'),
+            [
                 'key' => 'foo',
                 'template' => 'template',
-                 'expose_public_props' => true,
-                 'attributes_var' => 'attributes',
-             ],
+                'expose_public_props' => true,
+                'attributes_var' => 'attributes',
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | almost
| New feature?  | no
| License       | MIT

As this attribute is currently extended by AsLiveComponent, it allow us to also call parent::serviceConfig in LiveComponent

(will require a conflict in composer to force Twig&Live update together)