### PR TITLE
[Twig] Add attribute merging behaviour

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   Make `ComponentAttributes` traversable/countable.
+-   Add attribute merging behaviour notation.
 
 ## 2.13.0
 

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -199,4 +199,113 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame($attributes->all(), iterator_to_array($attributes));
         $this->assertCount(1, $attributes);
     }
+
+    public function testDefaultBehaviourNotation(): void
+    {
+        $attributes = new ComponentAttributes([
+            'data-1' => 'value',
+            'data-2' => '$:value',
+            'data-3' => '^:value',
+            'data-4' => '@:value',
+            'data-5' => true,
+            'data-6' => '^:value',
+            'data-7' => '$:value',
+        ]);
+
+        $attributes = $attributes->defaults([
+            'data-1' => 'default',
+            'data-2' => 'default',
+            'data-3' => 'default',
+            'data-4' => 'default',
+            'data-5' => false,
+            'data-6' => false,
+            'data-7' => true,
+        ]);
+
+        $this->assertSame([
+            'data-1' => 'value',
+            'data-2' => 'default value',
+            'data-3' => 'value default',
+            'data-4' => 'value',
+            'data-5' => true,
+            'data-6' => 'value',
+            'data-7' => 'value',
+        ], $attributes->all());
+    }
+
+    public function testCanOverrideCustomBehaviourAttributes(): void
+    {
+        $attributes = new ComponentAttributes([
+            'class' => '@:value',
+            'data-controller' => '@:value',
+            'data-action' => '@:value',
+        ]);
+
+        $attributes = $attributes->defaults([
+            'class' => 'default',
+            'data-controller' => 'default',
+            'data-action' => 'default',
+        ]);
+
+        $this->assertSame([
+            'class' => 'value',
+            'data-controller' => 'value',
+            'data-action' => 'value',
+        ], $attributes->all());
+    }
+
+    public function testCanPrefixCustomBehaviourAttributes(): void
+    {
+        $attributes = new ComponentAttributes([
+            'class' => '^:value',
+            'data-controller' => '^:value',
+            'data-action' => '^:value',
+        ]);
+
+        $attributes = $attributes->defaults([
+            'class' => 'default',
+            'data-controller' => 'default',
+            'data-action' => 'default',
+        ]);
+
+        $this->assertSame([
+            'class' => 'value default',
+            'data-controller' => 'value default',
+            'data-action' => 'value default',
+        ], $attributes->all());
+    }
+
+    public function testCanSuffixCustomBehaviourAttributes(): void
+    {
+        $attributes = new ComponentAttributes([
+            'class' => '$:value',
+            'data-controller' => '$:value',
+            'data-action' => '$:value',
+        ]);
+
+        $attributes = $attributes->defaults([
+            'class' => 'default',
+            'data-controller' => 'default',
+            'data-action' => 'default',
+        ]);
+
+        $this->assertSame([
+            'class' => 'default value',
+            'data-controller' => 'default value',
+            'data-action' => 'default value',
+        ], $attributes->all());
+    }
+
+    public function testBehaviourNotationIsNotRendered(): void
+    {
+        $attributes = new ComponentAttributes([
+            'data-first' => 'value',
+            'data-second' => '$:value',
+            'data-third' => '^:value',
+            'data-fourth' => '@:value',
+            'data-fifth' => true,
+        ]);
+
+        $this->assertSame(' data-first="value" data-second="value" data-third="value" data-fourth="value" data-fifth', (string) $attributes);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | n/a
| License       | MIT

Currently, when using attribute defaults, the merging behaviour of individual attribute values is a bit arbitrary, `class`, `data-controller` and `data-action` keep the default value as the prefix but any other completely overrides the default:

```twig
{# MyComponent #}
<div {{ attributes.defaults({
    class: 'default',
    style: 'display:block;',
})>

{# render #}
<twig:MyComponent class="new" style="margin: 0;" />

{# output #}
<div
    class="default new"
    style="margin: 0;"
>
```

This PR proposes an attribute value prefix notation to configure the behaviour:

- `^:` - prefix
- `$:` - suffix
- `@:` - replace (default except for the exceptions above - this allows configuring these exceptions)

_Suggestions on a better/alternate notation or even an alternate way to acheive is welcome!_

**Usage:**

```twig
{# MyComponent #}
<div {{ attributes.defaults({
    class: 'default',
    style: 'display:block;',
    'data-something': 'foo',
})>

{# render #}
<twig:MyComponent class="@:new" style="$:margin: 0;" data-something="^:bar" />

{# output #}
<div
    class="new"
    style="display:block; margin: 0;"
    data-something="bar foo"
>
```

I wish we could remove the special exceptions but not sure the best way to do this. We could deprecate not passing a behaviour for these. And set their default to "replace" in 3.0 but this might be heavy handed.

