### PR TITLE
[Twig] Allow nested attributes

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.17.0
+
+-   Add nested attribute support #1405
+
 ## 2.16.0
 
 -   Introduce CVA to style TwigComponent #1416

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1058,6 +1058,63 @@ Exclude specific attributes:
       My Component!
     </div>
 
+Nested Attributes
+~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.17
+
+    The Nested Attributes feature was added in TwigComponents 2.17.
+
+You can have attributes that aren't meant to be used on the *root* element
+but one of its *descendants*. This is useful for, say, a dialog component where
+you want to allow customizing the attributes of the dialog's content, title,
+and footer. Here's an example of this:
+
+.. code-block:: html+twig
+
+    {# templates/components/Dialog.html.twig #}
+    <div{{ attributes }}>
+        <div{{ attributes.nested('title') }}>
+            {% block title %}Default Title{% endblock %}
+        </div>
+        <div{{ attributes.nested('body') }}>
+            {% block content %}{% endblock %}
+        </div>
+        <div{{ attributes.nested('footer') }}>
+            {% block footer %}Default Footer{% endblock %}
+        </div>
+    </div>
+
+    {# render #}
+    <twig:Dialog class="foo" title:class="bar" body:class="baz" footer:class="qux">
+        Some content
+    </twig:MyDialog>
+
+    {# output #}
+    <div class="foo">
+        <div class="bar">
+            Default Title
+        </div>
+        <div class="baz">
+            Some content
+        </div>
+        <div class="qux">
+            Default Footer
+        </div>
+    </div>
+
+The nesting is recursive so you could potentially do something like this:
+
+.. code-block:: html+twig
+
+    <twig:Form
+        :form="form"
+        class="ui-form"
+        row:class="ui-form-row"
+        row:label:class="ui-form-label"
+        row:widget:class="ui-form-widget"
+    />
+
 Component with Complex Variants (CVA)
 -------------------------------------
 

--- a/src/TwigComponent/tests/Fixtures/templates/components/JustAttributes.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/JustAttributes.html.twig
@@ -1,0 +1,1 @@
+<div{{ attributes }}/>

--- a/src/TwigComponent/tests/Fixtures/templates/components/NestedAttributes.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/NestedAttributes.html.twig
@@ -1,0 +1,7 @@
+<main{{ attributes }}>
+    <div{{ attributes.nested('title') }}>
+        <span{{ attributes.nested('title').nested('span') }}>
+            {{ component('JustAttributes', [...attributes.nested('inner')]) }}
+        </span>
+    </div>
+</main>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -263,6 +263,84 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('class="alert alert-red alert-lg font-semibold rounded-md dark:bg-gray-600 flex p-4"', $output);
     }
 
+    public function testRenderingComponentWithNestedAttributes(): void
+    {
+        $output = $this->renderComponent('NestedAttributes');
+
+        $this->assertSame(<<<HTML
+            <main>
+                <div>
+                    <span>
+                        <div/>
+
+                    </span>
+                </div>
+            </main>
+            HTML,
+            trim($output)
+        );
+
+        $output = $this->renderComponent('NestedAttributes', [
+            'class' => 'foo',
+            'title:class' => 'bar',
+            'title:span:class' => 'baz',
+        ]);
+
+        $this->assertSame(<<<HTML
+            <main class="foo">
+                <div class="bar">
+                    <span class="baz">
+                        <div/>
+
+                    </span>
+                </div>
+            </main>
+            HTML,
+            trim($output)
+        );
+    }
+
+    public function testRenderingHtmlSyntaxComponentWithNestedAttributes(): void
+    {
+        $output = self::getContainer()
+            ->get(Environment::class)
+            ->createTemplate('<twig:NestedAttributes />')
+            ->render()
+        ;
+
+        $this->assertSame(<<<HTML
+            <main>
+                <div>
+                    <span>
+                        <div/>
+
+                    </span>
+                </div>
+            </main>
+            HTML,
+            trim($output)
+        );
+
+        $output = self::getContainer()
+            ->get(Environment::class)
+            ->createTemplate('<twig:NestedAttributes class="foo" title:class="bar" title:span:class="baz" inner:class="foo" />')
+            ->render()
+        ;
+
+        $this->assertSame(<<<HTML
+            <main class="foo">
+                <div class="bar">
+                    <span class="baz">
+                        <div class="foo"/>
+
+                    </span>
+                </div>
+            </main>
+            HTML,
+            trim($output)
+        );
+    }
+
     private function renderComponent(string $name, array $data = []): string
     {
         return self::getContainer()->get(Environment::class)->render('render_component.html.twig', [

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -244,4 +244,18 @@ final class ComponentAttributesTest extends TestCase
 
         $this->assertTrue($attributes->has('foo'));
     }
+
+    public function testNestedAttributes(): void
+    {
+        $attributes = new ComponentAttributes([
+            'class' => 'foo',
+            'title:class' => 'bar',
+            'title:span:class' => 'baz',
+        ]);
+
+        $this->assertSame(' class="foo"', (string) $attributes);
+        $this->assertSame(' class="bar"', (string) $attributes->nested('title'));
+        $this->assertSame(' class="baz"', (string) $attributes->nested('title')->nested('span'));
+        $this->assertSame('', (string) $attributes->nested('invalid'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Ref #1047 (possible solution)
| License       | MIT

This PR adds a syntax for nested attributes: attributes that aren't meant to be used on the _root_ element but one of its _descendants_.

Here's an example:

```twig
{# MyDialog #}
<div{{ attributes }}>
    <div{{ attributes.nested('title') }}>
        {% block title %}Default Title{% endblock %}
    </div>
    <div{{ attributes.nested('body') }}>
        {% block content %}{% endblock %}
    </div>
    <div{{ attributes.nested('footer') }}>
        {% block title %}Default Footer{% endblock %}
    </div>
</div>

{# render #}
<twig:MyDialog class="foo" body:class="bar" footer:class="baz">
   Some content
</twig:MyDialog>

{# output #}
<div class="foo">
    <div>
        Default Title
    </div>
    <div class="bar">
        Some content
    </div>
    <div class="baz">
        Default Footer
    </div>
</div>
```

The nesting is recursive so you could potentially do something like this:

```twig
<twig:Form
    :form="form"
    class="ui-form"
    row:class="ui-form-row"
    row:label:class="ui-form-label"
    row:widget:class="ui-form-widget"
/>
```