### PR TITLE
[Twig] Make `ComponentAttributes` traversable/countable

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Make `ComponentAttributes` traversable/countable.
+
 ## 2.13.0
 
 -   [BC BREAK] Add component metadata to `PreMountEvent` and `PostMountEvent`

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -19,7 +19,7 @@ use Symfony\WebpackEncoreBundle\Dto\AbstractStimulusDto;
  *
  * @immutable
  */
-final class ComponentAttributes
+final class ComponentAttributes implements \IteratorAggregate, \Countable
 {
     /**
      * @param array<string, string|bool> $attributes
@@ -156,5 +156,15 @@ final class ComponentAttributes
         unset($attributes[$key]);
 
         return new self($attributes);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->attributes);
+    }
+
+    public function count(): int
+    {
+        return \count($this->attributes);
     }
 }

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -191,4 +191,12 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(['disabled' => null], $attributes->all());
         $this->assertSame(' disabled', (string) $attributes);
     }
+
+    public function testIsTraversableAndCountable(): void
+    {
+        $attributes = new ComponentAttributes(['foo' => 'bar']);
+
+        $this->assertSame($attributes->all(), iterator_to_array($attributes));
+        $this->assertCount(1, $attributes);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | n/a
| License       | MIT

This will help with #1405 and #1414.
