### PR TITLE
[Twig] Add `attributes()` twig function

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add `attributes()` twig function.
+
 ## 2.13.0
 
 -   [BC BREAK] Add component metadata to `PreMountEvent` and `PostMountEvent`

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -110,13 +110,27 @@ final class ComponentRenderer implements ComponentRendererInterface
         $this->dispatcher->dispatch($event);
     }
 
+    public function createAttributes(array $attributes = []): ComponentAttributes
+    {
+        $this->registerSafeClasses();
+
+        return new ComponentAttributes($attributes);
+    }
+
+    private function registerSafeClasses(): void
+    {
+        if ($this->safeClassesRegistered) {
+            return;
+        }
+
+        $this->twig->getExtension(EscaperExtension::class)->addSafeClass(ComponentAttributes::class, ['html']);
+
+        $this->safeClassesRegistered = true;
+    }
+
     private function preRender(MountedComponent $mounted, array $context = []): PreRenderEvent
     {
-        if (!$this->safeClassesRegistered) {
-            $this->twig->getExtension(EscaperExtension::class)->addSafeClass(ComponentAttributes::class, ['html']);
-
-            $this->safeClassesRegistered = true;
-        }
+        $this->registerSafeClasses();
 
         $component = $mounted->getComponent();
         $metadata = $this->factory->metadataFor($mounted->getName());

--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\TwigComponent\Twig;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\UX\TwigComponent\ComponentAttributes;
 use Symfony\UX\TwigComponent\ComponentRenderer;
 use Symfony\UX\TwigComponent\Event\PreRenderEvent;
 use Twig\Error\RuntimeError;
@@ -41,6 +42,7 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
     {
         return [
             new TwigFunction('component', [$this, 'render'], ['is_safe' => ['all']]),
+            new TwigFunction('attributes', [$this, 'attributes']),
         ];
     }
 
@@ -59,6 +61,11 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
         } catch (\Throwable $e) {
             $this->throwRuntimeError($name, $e);
         }
+    }
+
+    public function attributes(array $attributes = []): ComponentAttributes
+    {
+        return $this->container->get(ComponentRenderer::class)->createAttributes($attributes);
     }
 
     public function extensionPreCreateForRender(string $name, array $props): ?string

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -216,6 +216,16 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('Hello FOO, 123, and 456', $output);
     }
 
+    public function testAttributesFunction(): void
+    {
+        $output = self::getContainer()->get(Environment::class)
+            ->createTemplate('<div{{ attributes({class: "foo", "data-controller": "bar"}) }}/>')
+            ->render()
+        ;
+
+        $this->assertSame('<div class="foo" data-controller="bar"/>', $output);
+    }
+
     private function renderComponent(string $name, array $data = []): string
     {
         return self::getContainer()->get(Environment::class)->render('render_component.html.twig', [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | n/a
| License       | MIT

This allows passing attributes to elements easier.

```twig
<div{{ attributes({foo: 'bar'})>
```

When/if #1413 is merged, the following will also be possible:

```twig
<twig:Some:Component {{ ...attributes({foo: 'bar'}) }} />
```
