### PR TITLE
[Twig] Allow `string[]` for `ComponentAttribute` values

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Allow `string[]` for component attribute values (filter non-strings).
+
 ## 2.13.0
 
 -   [BC BREAK] Add component metadata to `PreMountEvent` and `PostMountEvent`

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -39,6 +39,11 @@ final class ComponentAttributes
             function (string $carry, string $key) {
                 $value = $this->attributes[$key];
 
+                if (null === $value) {
+                    trigger_deprecation('symfony/ux-twig-component', '2.8.0', 'Passing "null" as an attribute value is deprecated and will throw an exception in 3.0.');
+                    $value = true;
+                }
+
                 return match ($value) {
                     true => "{$carry} {$key}",
                     false => $carry,
@@ -170,16 +175,11 @@ final class ComponentAttributes
     private static function normalize(array &$attributes): void
     {
         foreach ($attributes as $key => &$value) {
-            if (null === $value) {
-                trigger_deprecation('symfony/ux-twig-component', '2.8.0', 'Passing "null" as an attribute value is deprecated and will throw an exception in 3.0.');
-                $value = true;
-            }
-
             if (\is_array($value) && array_is_list($value)) {
                 $value = implode(' ', array_filter($value, static fn ($v) => \is_string($v) && '' !== $v));
             }
 
-            if (!\is_scalar($value)) {
+            if (!\is_scalar($value) && null !== $value) {
                 throw new \LogicException(sprintf('A "%s" prop was passed when creating the component. No matching "%s" property or mount() argument was found, so we attempted to use this as an HTML attribute. But, the value is not a scalar (it\'s a %s). Did you mean to pass this to your component or is there a typo on its name?', $key, $key, get_debug_type($value)));
             }
         }

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -188,7 +188,7 @@ final class ComponentAttributesTest extends TestCase
     {
         $attributes = new ComponentAttributes(['disabled' => null]);
 
-        $this->assertSame(['disabled' => true], $attributes->all());
+        $this->assertSame(['disabled' => null], $attributes->all());
         $this->assertSame(' disabled', (string) $attributes);
     }
 
@@ -203,9 +203,18 @@ final class ComponentAttributesTest extends TestCase
     {
         $attributes = new ComponentAttributes([
             'style' => ['foo', null, false, true, '', new \stdClass(), 'bar'],
+            'class' => ['baz', ''],
         ]);
 
-        $this->assertSame(' style="foo bar"', (string) $attributes);
-        $this->assertSame(['style' => 'foo bar'], $attributes->all());
+        $this->assertSame(' style="foo bar" class="baz"', (string) $attributes);
+        $this->assertSame(['style' => 'foo bar', 'class' => 'baz'], $attributes->all());
+
+        $attributes = $attributes->defaults([
+            'style' => ['baz', false],
+            'class' => ['', 'qux'],
+        ]);
+
+        $this->assertSame(' style="foo bar" class="qux baz"', (string) $attributes);
+        $this->assertSame(['style' => 'foo bar', 'class' => 'qux baz'], $attributes->all());
     }
 }

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -188,7 +188,24 @@ final class ComponentAttributesTest extends TestCase
     {
         $attributes = new ComponentAttributes(['disabled' => null]);
 
-        $this->assertSame(['disabled' => null], $attributes->all());
+        $this->assertSame(['disabled' => true], $attributes->all());
         $this->assertSame(' disabled', (string) $attributes);
+    }
+
+    public function testCannotPassNonScalarValues(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        (string) new ComponentAttributes(['data-foo' => new \stdClass()]);
+    }
+
+    public function testListAttributeValues(): void
+    {
+        $attributes = new ComponentAttributes([
+            'style' => ['foo', null, false, true, '', new \stdClass(), 'bar'],
+        ]);
+
+        $this->assertSame(' style="foo bar"', (string) $attributes);
+        $this->assertSame(['style' => 'foo bar'], $attributes->all());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | n/a
| License       | MIT

This allows the following:

```twig
{% set errors = false %}
{% set valid = true %}

<div{{ attributes.defaults({
    class: [
        'form-row',
        errors ? 'has-errors',
        valid ? 'is-valid',
    ],
}) }})

{# renders as: #}
<div class="form-row is-valid">
```
