### PR TITLE
Introduce CVA to style TwigComponent

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -5,12 +5,14 @@
 -   Add the ability to render specific attributes from the `attributes` variable #1442
 -   Restrict Twig 3.9 for now #1486
 -   Build reproducible TemplateMap to fix possible post-deploy breakage #1497
+-   Add CVA (Class variant authority) integration #1416
 
 ## 2.14.0
 
 -   Make `ComponentAttributes` traversable/countable
 -   Fixed lexing some `{# twig comments #}` with HTML Twig syntax
 -   Fix various usages of deprecated Twig code
+-   Add attribute rendering system
 
 ## 2.13.0
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1058,6 +1058,198 @@ Exclude specific attributes:
       My Component!
     </div>
 
+Component with Complex Variants (CVA)
+-------------------------------------
+
+CVA (Class Variant Authority) is a concept from the JS world (https://cva.style/docs/getting-started/variants).
+It's a concept used by the famous shadcn/ui library (https://ui.shadcn.com).
+CVA allows you to display a component with different variants (color, size, etc.),
+to create highly reusable and customizable components.
+You can use the cva function to define variants for your component.
+The cva function take as argument an array key-value pairs.
+The base key allow you define a set of classes commune to all variants.
+In the variants key you define the different variants of your component.
+
+.. code-block:: html+twig
+
+    {# templates/components/Alert.html.twig #}
+    {% props color = 'blue', size = 'md' %}
+
+     {% set alert = cva({
+        base: 'alert ',
+        variants: {
+            color: {
+                blue: 'bg-blue',
+                red: 'bg-red',
+                green: 'bg-green',
+            },
+            size: {
+                sm: 'text-sm',
+                md: 'text-md',
+                lg: 'text-lg',
+            }
+        }
+    }) %}
+
+    <div class="{{ alert.apply({color, size}, attributes.render('class')) }}">
+         {% block content %}{% endblock %}
+    </div>
+
+
+    {# index.html.twig #}
+
+    <twig:Alert color="red" size="lg">
+        <div>My content</div>
+    </twig:Alert>
+    // class="alert bg-red text-lg"
+
+    <twig:Alert color="green" size="sm">
+        <div>My content</div>
+    </twig:Alert>
+    // class="alert bg-green text-sm"
+
+    <twig:Alert class="flex items-center justify-center">
+        <div>My content</div>
+    </twig:Alert>
+    // class="alert bg-blue text-md flex items-center justify-center"
+
+CVA and Tailwind CSS
+~~~~~~~~~~~~~~~~~~~~
+
+CVA work perfectly with tailwindcss. The only drawback is you can have class conflicts,
+to have a better control you can use this following bundle (
+https://github.com/tales-from-a-dev/twig-tailwind-extra
+) in addition to the cva function:
+
+.. code-block:: terminal
+
+    $ composer require tales-from-a-dev/twig-tailwind-extra
+
+.. code-block:: html+twig
+
+    {# templates/components/Alert.html.twig #}
+    {% props color = 'blue', size = 'md' %}
+
+   {% set alert = cva({
+        base: 'alert ',
+        variants: {
+            color: {
+                blue: 'bg-blue',
+                red: 'bg-red',
+                green: 'bg-green',
+            },
+            size: {
+                sm: 'text-sm',
+                md: 'text-md',
+                lg: 'text-lg',
+            }
+        }
+    }) %}
+
+    <div class="{{ alert.apply({color, size}, attributes.render('class')) | tailwind_merge }}">
+         {% block content %}{% endblock %}
+    </div>
+
+Compounds variants
+~~~~~~~~~~~~~~~~~~
+
+You can define compound variants. A compound variant is a variants that apply
+when multiple other variant conditions are met.
+
+.. code-block:: html+twig
+
+    {# templates/components/Alert.html.twig #}
+    {% props color = 'blue', size = 'md' %}
+
+    {% set alert = cva({
+        base: 'alert ',
+        variants: {
+            color: {
+                blue: 'bg-blue',
+                red: 'bg-red',
+                green: 'bg-green',
+            },
+            size: {
+                sm: 'text-sm',
+                md: 'text-md',
+                lg: 'text-lg',
+            }
+        },
+        compound: {
+            colors: ['red'],
+            size: ['md', 'lg'],
+            class: 'font-bold'
+        }
+    }) %}
+
+    <div class="{{ alert.apply({color, size}) }}">
+         {% block content %}{% endblock %}
+    </div>
+
+    {# index.html.twig #}
+
+    <twig:Alert color="red" size="lg">
+        <div>My content</div>
+    </twig:Alert>
+    // class="alert bg-red text-lg font-bold"
+
+    <twig:Alert color="green" size="sm">
+        <div>My content</div>
+    </twig:Alert>
+    // class="alert bg-green text-sm"
+
+    <twig:Alert color="red" size="md">
+        <div>My content</div>
+    </twig:Alert>
+    // class="alert bg-green text-lg font-bold"
+
+Default variants
+~~~~~~~~~~~~~~~~
+
+You can define defaults variants, so if no variants are matching you
+can still defined a default set of class to apply.
+
+.. code-block:: html+twig
+
+    {# templates/components/Alert.html.twig #}
+    {% props color = 'blue', size = 'md' %}
+
+    {% set alert = cva({
+        base: 'alert ',
+        variants: {
+            color: {
+                blue: 'bg-blue',
+                red: 'bg-red',
+                green: 'bg-green',
+            },
+            size: {
+                sm: 'text-sm',
+                md: 'text-md',
+                lg: 'text-lg',
+            },
+            rounded: {
+                sm: 'rounded-sm',
+                md: 'rounded-md',
+                lg: 'rounded-lg',
+            }
+        },
+        defaultsVariants: {
+            rounded: 'rounded-md',
+        }
+    }) %}
+
+    <div class="{{ alert.apply({color, size}) }}">
+         {% block content %}{% endblock %}
+    </div>
+
+    {# index.html.twig #}
+
+    <twig:Alert color="red" size="lg">
+        <div>My content</div>
+    </twig:Alert>
+    // class="alert bg-red text-lg font-bold rounded-md"
+
+
 Test Helpers
 ------------
 

--- a/src/TwigComponent/src/CVA.php
+++ b/src/TwigComponent/src/CVA.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent;
+
+/**
+ * @author Mathéo Daninos <matheo.daninos@gmail.com>
+ *
+ * CVA (class variant authority), is a concept from the js world.
+ * https://cva.style/docs
+ * The UI library shadcn is build on top of this principle
+ * https://ui.shadcn.com
+ * The concept behind CVA is to let you build component with a lot of different variations called recipes.
+ *
+ * @experimental
+ */
+final class CVA
+{
+    /**
+     * @var string|list<string|null>|null
+     * @var array<string, array<string, string>>|null the array should have the following format [variantCategory => [variantName => classes]]
+     *                                                ex: ['colors' => ['primary' => 'bleu-8000', 'danger' => 'red-800 text-bold'], 'size' => [...]]
+     * @var array<array<string, string[]>>|null       the array should have the following format ['variantsCategory' => ['variantName', 'variantName'], 'class' => 'text-red-500']
+     * @var array<string, string>|null
+     */
+    public function __construct(
+        private string|array|null $base = null,
+        private ?array $variants = null,
+        private ?array $compoundVariants = null,
+        private ?array $defaultVariants = null,
+    ) {
+    }
+
+    public function apply(array $recipes, string ...$classes): string
+    {
+        return trim($this->resolve($recipes).' '.implode(' ', $classes));
+    }
+
+    public function resolve(array $recipes): string
+    {
+        if (\is_array($this->base)) {
+            $classes = implode(' ', $this->base);
+        } else {
+            $classes = $this->base ?? '';
+        }
+
+        foreach ($recipes as $recipeName => $recipeValue) {
+            if (!isset($this->variants[$recipeName][$recipeValue])) {
+                continue;
+            }
+
+            $classes .= ' '.$this->variants[$recipeName][$recipeValue];
+        }
+
+        if (null !== $this->compoundVariants) {
+            foreach ($this->compoundVariants as $compound) {
+                $isCompound = true;
+                foreach ($compound as $compoundName => $compoundValues) {
+                    if ('class' === $compoundName) {
+                        continue;
+                    }
+
+                    if (!isset($recipes[$compoundName])) {
+                        $isCompound = false;
+                        break;
+                    }
+
+                    if (!\in_array($recipes[$compoundName], $compoundValues)) {
+                        $isCompound = false;
+                        break;
+                    }
+                }
+
+                if ($isCompound) {
+                    if (!isset($compound['class']) || !\is_string($compound['class'])) {
+                        throw new \LogicException('A compound recipe matched but no classes are registered for this match');
+                    }
+
+                    $classes .= ' '.$compound['class'];
+                }
+            }
+        }
+
+        if (null !== $this->defaultVariants) {
+            foreach ($this->defaultVariants as $defaultVariantName => $defaultVariantValue) {
+                if (!isset($recipes[$defaultVariantName])) {
+                    $classes .= ' '.$this->variants[$defaultVariantName][$defaultVariantValue];
+                }
+            }
+        }
+
+        return trim($classes);
+    }
+}

--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\TwigComponent\Twig;
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\UX\TwigComponent\ComponentRenderer;
+use Symfony\UX\TwigComponent\CVA;
 use Symfony\UX\TwigComponent\Event\PreRenderEvent;
 use Twig\Error\RuntimeError;
 use Twig\Extension\AbstractExtension;
@@ -41,6 +42,7 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
     {
         return [
             new TwigFunction('component', [$this, 'render'], ['is_safe' => ['all']]),
+            new TwigFunction('cva', [$this, 'cva']),
         ];
     }
 
@@ -82,6 +84,29 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
     public function finishEmbeddedComponentRender(): void
     {
         $this->container->get(ComponentRenderer::class)->finishEmbeddedComponentRender();
+    }
+
+    /**
+     * @param array{
+     *     base: string|string[]|null,
+     *     variants: array<string, array<string, string>>,
+     *     compoundVariants: array<array<string, string>>,
+     *     defaultVariants: array<string, string>
+     *  } $cva
+     *
+     * base some base class you want to have in every matching recipes
+     * variants your recipes class
+     * compoundVariants compounds allow you to add extra class when multiple variation are matching in the same time
+     * defaultVariants allow you to add a default class when no recipe is matching
+     */
+    public function cva(array $cva): CVA
+    {
+        return new CVA(
+            $cva['base'] ?? null,
+            $cva['variants'] ?? null,
+            $cva['compoundVariants'] ?? null,
+            $cva['defaultVariants'] ?? null,
+        );
     }
 
     private function throwRuntimeError(string $name, \Throwable $e): void

--- a/src/TwigComponent/tests/Fixtures/templates/class_merge.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/class_merge.html.twig
@@ -1,0 +1,1 @@
+<twig:Alert color='red' size='lg' class='dark:bg-gray-600'/>

--- a/src/TwigComponent/tests/Fixtures/templates/components/Alert.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/Alert.html.twig
@@ -1,0 +1,35 @@
+{% props color = 'blue', size = 'md' %}
+
+{% set alert = cva({
+        base: ['alert'],
+        variants: {
+            color: {
+                blue: 'alert-blue',
+                red: 'alert-red',
+                green: 'alert-green',
+                yellow: 'alert-yellow',
+            },
+            size: {
+                sm: 'alert-sm',
+                md: 'alert-md',
+                lg: 'alert-lg',
+            },
+            rounded: {
+                sm: 'rounded-sm',
+                md: 'rounded-md',
+                lg: 'rounded-lg',
+            }
+        },
+        compoundVariants: [{
+            color: ['red'],
+            size: ['lg'],
+            class: 'font-semibold'
+        }],
+        defaultVariants: {
+            rounded: 'md'
+        }
+}) %}
+
+<div class="{{ alert.apply({color, size}, attributes.render('class'), 'flex p-4') }}">
+    ...
+</div>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -14,7 +14,6 @@ namespace Symfony\UX\TwigComponent\Tests\Integration;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\TwigComponent\Tests\Fixtures\User;
 use Twig\Environment;
-use Twig\Error\RuntimeError;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -255,6 +254,13 @@ final class ComponentExtensionTest extends KernelTestCase
             />
             HTML,
         ];
+    }
+
+    public function testComponentWithClassMerge(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('class_merge.html.twig');
+
+        $this->assertStringContainsString('class="alert alert-red alert-lg font-semibold rounded-md dark:bg-gray-600 flex p-4"', $output);
     }
 
     private function renderComponent(string $name, array $data = []): string

--- a/src/TwigComponent/tests/Unit/CVATest.php
+++ b/src/TwigComponent/tests/Unit/CVATest.php
@@ -1,0 +1,339 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\TwigComponent\CVA;
+
+/**
+ * @author Mathéo Daninos <matheo.daninos@gmail.com>
+ */
+class CVATest extends TestCase
+{
+    /**
+     * @dataProvider recipeProvider
+     */
+    public function testRecipes(array $recipe, array $recipes, string $expected): void
+    {
+        $recipeClass = new CVA($recipe['base'] ?? '', $recipe['variants'] ?? [], $recipe['compounds'] ?? [], $recipe['defaultVariants'] ?? []);
+
+        $this->assertEquals($expected, $recipeClass->resolve($recipes));
+    }
+
+    public static function recipeProvider(): iterable
+    {
+        yield 'base null' => [
+            ['variants' => [
+                'colors' => [
+                    'primary' => 'text-primary',
+                    'secondary' => 'text-secondary',
+                ],
+                'sizes' => [
+                    'sm' => 'text-sm',
+                    'md' => 'text-md',
+                    'lg' => 'text-lg',
+                ],
+            ]],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'text-primary text-sm',
+        ];
+
+        yield 'base empty' => [
+            [
+                'base' => '',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ]],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'text-primary text-sm',
+        ];
+
+        yield 'no recipes match' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+            ],
+            ['colors' => 'red', 'sizes' => 'test'],
+            'font-semibold border rounded',
+        ];
+
+        yield 'simple variants' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm',
+        ];
+
+        yield 'simple variants with custom' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+            ],
+            ['colors' => 'secondary', 'sizes' => 'md'],
+            'font-semibold border rounded text-secondary text-md',
+        ];
+
+        yield 'compound variants' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['primary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm text-red-500',
+        ];
+
+        yield 'multiple compound variants' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['primary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                    [
+                        'colors' => ['primary'],
+                        'sizes' => ['md'],
+                        'class' => 'text-blue-500',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm text-red-500',
+        ];
+
+        yield 'compound with multiple variants' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['primary', 'secondary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm text-red-500',
+        ];
+
+        yield 'compound doesn\'t match' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['danger', 'secondary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm',
+        ];
+        yield 'default variables' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                    'rounded' => [
+                        'sm' => 'rounded-sm',
+                        'md' => 'rounded-md',
+                        'lg' => 'rounded-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['danger', 'secondary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                ],
+                'defaultVariants' => [
+                    'colors' => 'primary',
+                    'sizes' => 'sm',
+                    'rounded' => 'md',
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm rounded-md',
+        ];
+        yield 'default variables all overwrite' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                    'rounded' => [
+                        'sm' => 'rounded-sm',
+                        'md' => 'rounded-md',
+                        'lg' => 'rounded-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['danger', 'secondary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                ],
+                'defaultVariants' => [
+                    'colors' => 'primary',
+                    'sizes' => 'sm',
+                    'rounded' => 'md',
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm', 'rounded' => 'lg'],
+            'font-semibold border rounded text-primary text-sm rounded-lg',
+        ];
+        yield 'default variables without matching variants' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                    'rounded' => [
+                        'sm' => 'rounded-sm',
+                        'md' => 'rounded-md',
+                        'lg' => 'rounded-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['danger', 'secondary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                ],
+                'defaultVariants' => [
+                    'colors' => 'primary',
+                    'sizes' => 'sm',
+                    'rounded' => 'md',
+                ],
+            ],
+            [],
+            'font-semibold border rounded text-primary text-sm rounded-md',
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | 
| License       | MIT

This PR introduces a new concept CVA (Class Variance Authority), by adding a1 twig function, to help you manage your class in your component.

Let's take an example an Alert component. In your app, an alert can have a lot of different styles one for success, one for alert, one for warning, and different sizes, with icons or not... You need something that lets you completely change the style of your component without creating a new component, and without creating too much complexity in your template.

Here is the reason came CVA.

Your Alert component can now look like this:

```twig
{% props color = 'blue', size = 'md' %}

{% set alert =  cva({
     base: 'alert rounded-lg',
     variants: {
        color: {
            blue: 'text-blue-800 bg-blue-50 dark:bg-gray-800 dark:text-blue-400',
            red: 'text-red-800 bg-red-50 dark:bg-gray-800 dark:text-red-400',
            green: 'text-green-800 bg-green-50 dark:bg-gray-800 dark:text-green-400',
            yellow: 'text-yellow-800 bg-yellow-50 dark:bg-gray-800 dark:text-yellow-400',
        },
        size: {
            sm: 'px-4 py-3 text-sm',
            md: 'px-6 py-4 text-base',
            lg: 'px-8 py-5 text-lg',
        }
    },
    compoundVariants: [{
           color: ['red'],
           size: ['lg'],
          class: 'font-semibold'
    }],
    defaultVariants: {
           rounded: 'md'
    }
}) %}

<div class="{{ cva.apply({color, size}, attribute.render('class'), 'flex p-4') }}">
    ...
</div>
```

So here you have a `cva` function that lets you define different variants of your component.

You can now use your component like this:
```twig
<twig:Alert color="red" size="md"/>

<twig:Alert color="green" size="sm"/>

<twig:Alert color="yellow" size="lg"/>

<twig:Alert color="red" size="md" class="dark:bg-gray-800"/>
```

And then you get the following result:

<img width="1269" alt="Capture d’écran 2024-01-24 à 00 52 33" src="https://github.com/symfony/ux/assets/32077734/6a5e25be-5b81-4ae7-8385-0fa5422d0396">

If you want to know more about the concept I implement here you can look at:
- CVA (js version): https://cva.style/docs
- tailwind merge: https://github.com/gehrisandro/tailwind-merge-php, https://github.com/dcastil/tailwind-merge
- this implementation by using tailwind-merge and cva is inspired a lot by: https://ui.shadcn.com/ (shadcn is the most starred library on github in 2023) 
- a really good article that explains the philosophy behind https://manupa.dev/blog/anatomy-of-shadcn-ui
- this PR works great in a LASTstack: https://symfonycasts.com/screencast/last-stack/last-stack

Tell me what you think about it! Thanks for your time! Cheers 🧡
