### PR TITLE
Run tests for all supported versions defined for peerDependencies per component

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,5 +143,5 @@ jobs:
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
                   restore-keys: |
                       ${{ runner.os }}-yarn-
-            - run: yarn --frozen-lockfile
+            - run: yarn --immutable
             - run: yarn test

--- a/bin/run-vitest-all.sh
+++ b/bin/run-vitest-all.sh
@@ -1,23 +1,72 @@
 #!/bin/bash
 
-# Get all workspace names
-workspaces=$(yarn workspaces info | grep -o '@symfony/[^"]*')
-
 # Flag to track if any test fails
 all_tests_passed=true
 
-for workspace in $workspaces; do
-  echo "Running tests in $workspace..."
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+    echo "jq is required but not installed. Aborting."
+    exit 1
+fi
 
-  # Run the tests and if they fail, set the flag to false
-  yarn workspace $workspace run vitest --run || { echo "$workspace failed"; all_tests_passed=false; }
-done
+runTestSuite() {
+    echo -e "Running tests for $workspace...\n"
+    yarn workspace $workspace run vitest --run || { all_tests_passed=false; }
+}
+
+processWorkspace() {
+    local workspace="$1"
+    local location="$2"
+
+    echo -e "Processing workspace $workspace at location $location...\n"
+
+    package_json_path="$location/package.json"
+    echo "Checking '$package_json_path' for peerDependencies with multiple versions defined"
+    deps_with_multiple_versions=$(jq -r '.peerDependencies | to_entries[] | select(.value | contains("||")) | .key' "$package_json_path")
+
+    if [ -n "$deps_with_multiple_versions" ]; then
+        echo " -> Multiple versions found for peerDependencies: $deps_with_multiple_versions"
+        for library in $deps_with_multiple_versions; do
+            versionValue=$(jq -r ".peerDependencies.\"$library\"" "$package_json_path")
+
+            IFS="||" read -ra versions <<< "$versionValue"
+
+            for version in "${versions[@]}"; do
+                trimmed_version=$(echo "$version" | tr -d '[:space:]')
+                if [ -n "$trimmed_version" ]; then
+                    # Install each version of the library separately
+                    echo -e "  - Install $library@$trimmed_version for $workspace\n"
+                    yarn workspace "$workspace" add "$library@$trimmed_version" --peer
+
+                    runTestSuite
+                fi
+            done
+        done
+    else
+        echo -e " -> No peerDependencies found with multiple versions defined\n"
+        runTestSuite
+    fi
+}
+
+# Get all workspace names
+workspaces_info=$(yarn workspaces info)
+
+# Iterate over each workspace using process substitution
+while IFS= read -r workspace_info; do
+    # Split the workspace_info into workspace and location
+    workspace=$(echo "$workspace_info" | awk '{print $1}')
+    location=$(echo "$workspace_info" | awk '{print $2}')
+
+    # Call the function to process the workspace
+    processWorkspace "$workspace" "$location"
+
+done < <(echo "$workspaces_info" | jq -r 'to_entries[0:] | .[] | "\(.key) \(.value.location)"')
 
 # Check the flag at the end and exit with code 1 if any test failed
 if [ "$all_tests_passed" = false ]; then
-  echo "Some tests failed."
-  exit 1
+    echo "Some tests failed."
+    exit 1
 else
-  echo "All tests passed!"
-  exit 0
+    echo "All tests passed!"
+    exit 0
 fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Relates to #1389
| License       | MIT

Refactored the `run-vitest-all.sh` script to loop over every component/workspace and check if there are `peerDependencies` who defined support for multiple versions (like https://github.com/symfony/ux/blob/2.x/src/Svelte/assets/package.json#L23). The script then runs the tests for every defined version for that library in that workspace.

The greatest benefit of this change is that this needs no extra administration in keeping a `matrix` value up-to-date in the GitHub workflow for every library in a workspace that supports more than 1 version as it checks every `package.json` automatically.

Tell me what you think about it! Cheers!

- https://github.com/symfony/ux/actions/runs/7646573943/job/20835661388?pr=1417#step:6:200 -> `svelte@3.59.2` is installed
- https://github.com/symfony/ux/actions/runs/7646573943/job/20835661388?pr=1417#step:6:259 -> `svelte@4.2.9` is installed