### PR TITLE
[Live] Rename data-action-name to use standard Stimulus features

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,51 @@
 # CHANGELOG
 
+## 2.16.0
+
+-   [BC BREAK] The `data-action-name` attribute behavior was removed in favor of
+    using Stimulus "action parameters" and `data-live-action-param`. This is a
+    breaking change if you were using the `data-action-name` attribute directly
+    in your templates.
+
+    To upgrade your application, follow these changes:
+
+    ```diff
+    <button
+        data-action="live#action"
+    -    data-action-name="debounce(300)|save"
+    +    data-live-action-param="debounce(300)|save"
+    >Save</button>
+    ```
+
+    To pass arguments to an action, also use the Stimulus "action parameters" syntax:
+
+    ```diff
+    <button
+        data-action="live#action"
+    -     data-action-name="addItem(id={{ item.id }}, itemName=CustomItem)"
+    +     data-live-action-param="addItem"
+    +     data-live-id-param="{{ item.id }}"
+    +     data-live-item-name-param="CustomItem"
+    >Add Item</button>
+    ```
+
+    Additionally, the `prevent` modifier (e.g. `prevent|save`) was removed. Replace
+    this with the standard Stimulus `:prevent` action option:
+
+    ```diff
+    <button
+    -    data-action="live#action
+    +    data-action="live#action:prevent"
+    -    data-action-name="prevent|save"
+    +    data-live-action-param="save"
+     >Save</button>
+    ```
+
+-   [BC BREAK] The `data-event` attribute was removed in favor of using Stimulus
+    "action parameters": rename `data-event` to `data-live-event-param`. Additionally,
+    if you were passing arguments to the event name, use action parameter attributes
+    for those as well - e.g. `data-live-foo-param="bar"`.
+
 ## 2.15.0
 
 -   [BC BREAK] The `data-live-id` attribute was changed to `id` #1484

--- a/src/LiveComponent/assets/dist/Directive/directives_parser.d.ts
+++ b/src/LiveComponent/assets/dist/Directive/directives_parser.d.ts
@@ -5,7 +5,6 @@ export interface DirectiveModifier {
 export interface Directive {
     action: string;
     args: string[];
-    named: any;
     modifiers: DirectiveModifier[];
     getString: {
         (): string;

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -95,10 +95,10 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     disconnect(): void;
     update(event: any): void;
     action(event: any): void;
-    emit(event: Event): void;
-    emitUp(event: Event): void;
-    emitSelf(event: Event): void;
     $render(): Promise<import("./Backend/BackendResponse").default>;
+    emit(event: any): void;
+    emitUp(event: any): void;
+    emitSelf(event: any): void;
     $updateModel(model: string, value: any, shouldRender?: boolean, debounce?: number | boolean): Promise<import("./Backend/BackendResponse").default>;
     propsUpdatedFromParentValueChanged(): void;
     fingerprintValueChanged(): void;

--- a/src/LiveComponent/assets/src/dom_utils.ts
+++ b/src/LiveComponent/assets/src/dom_utils.ts
@@ -141,7 +141,7 @@ export function getAllModelDirectiveFromElements(element: HTMLElement): Directiv
     const directives = parseDirectives(element.dataset.model);
 
     directives.forEach((directive) => {
-        if (directive.args.length > 0 || directive.named.length > 0) {
+        if (directive.args.length > 0) {
             throw new Error(
                 `The data-model="${element.dataset.model}" format is invalid: it does not support passing arguments to the model.`
             );
@@ -167,7 +167,7 @@ export function getModelDirectiveFromElement(element: HTMLElement, throwOnMissin
             const directives = parseDirectives(formElement.dataset.model || '*');
             const directive = directives[0];
 
-            if (directive.args.length > 0 || directive.named.length > 0) {
+            if (directive.args.length > 0) {
                 throw new Error(
                     `The data-model="${formElement.dataset.model}" format is invalid: it does not support passing arguments to the model.`
                 );

--- a/src/LiveComponent/assets/test/Directive/directives_parser.test.ts
+++ b/src/LiveComponent/assets/test/Directive/directives_parser.test.ts
@@ -29,7 +29,6 @@ describe('directives parser', () => {
         assertDirectiveEquals(directives[0], {
             action: 'hide',
             args: [],
-            named: {},
             modifiers: [],
         })
     });
@@ -40,7 +39,6 @@ describe('directives parser', () => {
         assertDirectiveEquals(directives[0], {
             action: 'addClass',
             args: ['opacity-50'],
-            named: {},
             modifiers: [],
         })
     });
@@ -51,7 +49,6 @@ describe('directives parser', () => {
         assertDirectiveEquals(directives[0], {
             action: 'addClass',
             args: ['opacity-50 disabled'],
-            named: {},
             modifiers: [],
         })
     });
@@ -63,7 +60,6 @@ describe('directives parser', () => {
             action: 'addClass',
             // space between arguments is trimmed
             args: ['opacity-50', 'disabled'],
-            named: {},
             modifiers: [],
         })
     });
@@ -74,13 +70,11 @@ describe('directives parser', () => {
         assertDirectiveEquals(directives[0], {
             action: 'addClass',
             args: ['opacity-50'],
-            named: {},
             modifiers: [],
         })
         assertDirectiveEquals(directives[1], {
             action: 'addAttribute',
             args: ['disabled'],
-            named: {},
             modifiers: [],
         })
     });
@@ -91,63 +85,16 @@ describe('directives parser', () => {
         assertDirectiveEquals(directives[0], {
             action: 'hide',
             args: [],
-            named: {},
             modifiers: [],
         })
         assertDirectiveEquals(directives[1], {
             action: 'addClass',
             args: ['opacity-50 disabled'],
-            named: {},
             modifiers: [],
         })
         assertDirectiveEquals(directives[2], {
             action: 'addAttribute',
             args: ['disabled'],
-            named: {},
-            modifiers: [],
-        })
-    });
-
-    it('parses single named argument', () => {
-        const directives = parseDirectives('save(foo=bar)');
-        expect(directives).toHaveLength(1);
-        assertDirectiveEquals(directives[0], {
-            action: 'save',
-            args: [],
-            named: { foo: 'bar' },
-            modifiers: [],
-        })
-    });
-
-    it('parses multiple named arguments', () => {
-        const directives = parseDirectives('save(foo=bar, baz=bazzles)');
-        expect(directives).toHaveLength(1);
-        assertDirectiveEquals(directives[0], {
-            action: 'save',
-            args: [],
-            named: { foo: 'bar', baz: 'bazzles' },
-            modifiers: [],
-        })
-    });
-
-    it('parses arguments and spaces are kept', () => {
-        const directives = parseDirectives('save(foo= bar)');
-        expect(directives).toHaveLength(1);
-        assertDirectiveEquals(directives[0], {
-            action: 'save',
-            args: [],
-            named: { foo: ' bar' },
-            modifiers: [],
-        })
-    });
-
-    it('parses argument names with space is trimmed', () => {
-        const directives = parseDirectives('save(foo  =bar)');
-        expect(directives).toHaveLength(1);
-        assertDirectiveEquals(directives[0], {
-            action: 'save',
-            args: [],
-            named: { foo: 'bar' },
             modifiers: [],
         })
     });
@@ -158,7 +105,6 @@ describe('directives parser', () => {
         assertDirectiveEquals(directives[0], {
             action: 'addClass',
             args: ['disabled'],
-            named: {},
             modifiers: [
                 { name: 'delay', value: null }
             ],
@@ -171,7 +117,6 @@ describe('directives parser', () => {
         assertDirectiveEquals(directives[0], {
             action: 'addClass',
             args: ['disabled'],
-            named: {},
             modifiers: [
                 { name: 'delay', value: '400' },
             ],
@@ -179,12 +124,11 @@ describe('directives parser', () => {
     });
 
     it('parses multiple modifiers', () => {
-        const directives = parseDirectives('prevent|debounce(400)|save(foo=bar)');
+        const directives = parseDirectives('prevent|debounce(400)|save');
         expect(directives).toHaveLength(1);
         assertDirectiveEquals(directives[0], {
             action: 'save',
             args: [],
-            named: { foo: 'bar' },
             modifiers: [
                 { name: 'prevent', value: null },
                 { name: 'debounce', value: '400' },
@@ -211,22 +155,10 @@ describe('directives parser', () => {
             }).toThrow('Missing space after addClass()')
         });
 
-        it('named and unnamed arguments cannot be mixed', () => {
-            expect(() => {
-                parseDirectives('save(foo=bar, baz)');
-            }).toThrow('Normal and named arguments cannot be mixed inside "save()"')
-        });
-
         it('modifier cannot have multiple arguments', () => {
             expect(() => {
                 parseDirectives('debounce(10, 20)|save');
             }).toThrow('The modifier "debounce()" does not support multiple arguments.')
-        });
-
-        it('modifier cannot have named arguments', () => {
-            expect(() => {
-                parseDirectives('debounce(foo=bar)|save');
-            }).toThrow('The modifier "debounce()" does not support named arguments.')
         });
     });
 });

--- a/src/LiveComponent/assets/test/controller/action.test.ts
+++ b/src/LiveComponent/assets/test/controller/action.test.ts
@@ -23,7 +23,7 @@ describe('LiveController Action Tests', () => {
             <div ${initComponent(data)}>
                 ${data.isSaved ? 'Comment Saved!' : ''}
 
-                <button data-action="live#action" data-action-name="save">Save</button>
+                <button data-action="live#action" data-live-action-param="save">Save</button>
             </div>
         `);
 
@@ -46,7 +46,7 @@ describe('LiveController Action Tests', () => {
 
                 ${data.isSaved ? 'Comment Saved!' : ''}
 
-                <button data-action="live#action" data-action-name="save">Save</button>
+                <button data-action="live#action" data-live-action-param="save">Save</button>
             </div>
         `);
 
@@ -73,16 +73,22 @@ describe('LiveController Action Tests', () => {
 
     it('Sends action with named args', async () => {
         const test = await createTest({ isSaved: false}, (data: any) => `
-           <div ${initComponent(data)}>
-               ${data.isSaved ? 'Component Saved!' : ''}
+            <div ${initComponent(data)}>
+                ${data.isSaved ? 'Component Saved!' : ''}
 
-               <button data-action="live#action" data-action-name="sendNamedArgs(a=1, b=2, c=3)">Send named args</button>
-           </div>
+                <button
+                    data-action="live#action"
+                    data-live-action-param="sendNamedArgs"
+                    data-live-a-param="1"
+                    data-live-b-param="2"
+                    data-live-c-param="banana"
+                >Send named args</button>
+            </div>
        `);
 
         // ONLY a post is sent, not a re-render GET
         test.expectsAjaxCall()
-            .expectActionCalled('sendNamedArgs', {a: '1', b: '2', c: '3'})
+            .expectActionCalled('sendNamedArgs', {a: 1, b: 2, c: 'banana'})
             .serverWillChangeProps((data: any) => {
                 // server marks component as "saved"
                 data.isSaved = true;
@@ -99,7 +105,7 @@ describe('LiveController Action Tests', () => {
                <select
                    data-model="on(change)|food"
                    data-action="live#action"
-                   data-action-name="changeFood"
+                   data-live-action-param="changeFood"
                >
                    <option value="" ${data.food === '' ? 'selected' : ''}>Choose a food</option>
                    <option value="pizza" ${data.pizza === '' ? 'selected' : ''}>Pizza</option>
@@ -131,7 +137,7 @@ describe('LiveController Action Tests', () => {
 
                 <span>${data.comment}</span>
 
-                <button data-action="live#action" data-action-name="save">Save</button>
+                <button data-action="live#action" data-live-action-param="save">Save</button>
             </div>
         `);
 
@@ -170,8 +176,8 @@ describe('LiveController Action Tests', () => {
         const test = await createTest({ isSaved: false }, (data: any) => `
             <div ${initComponent(data)}>
                 ${data.isSaved ? 'Component Saved!' : ''}
-                <button data-action="live#action" data-action-name="debounce(10)|save">Save</button>
-                <button data-action="live#action" data-action-name="debounce(10)|sync(syncAll=1)">Sync</button>
+                <button data-action="live#action" data-live-action-param="debounce(10)|save">Save</button>
+                <button data-action="live#action" data-live-action-param="debounce(10)|sync" data-live-sync-all-param="1">Sync</button>
             </div>
         `);
 
@@ -179,7 +185,7 @@ describe('LiveController Action Tests', () => {
         test.expectsAjaxCall()
             // 3 actions called
             .expectActionCalled('save')
-            .expectActionCalled('sync', { syncAll: '1' })
+            .expectActionCalled('sync', { syncAll: 1 })
             .expectActionCalled('save')
             .serverWillChangeProps((data: any) => {
                 data.isSaved = true;

--- a/src/LiveComponent/assets/test/controller/emit.test.ts
+++ b/src/LiveComponent/assets/test/controller/emit.test.ts
@@ -26,17 +26,17 @@ describe('LiveController Emit Tests', () => {
                 Render Count: ${data.renderCount}
                 <button
                     data-action="live#emit"
-                    data-event="fooEvent"
+                    data-live-event-param="fooEvent"
                 >Emit Simple</button>
 
                 <button
                     data-action="live#emit"
-                    data-event="name(simple-component)|fooEvent"
+                    data-live-event-param="name(simple-component)|fooEvent"
                 >Emit Named Matching</button>
 
                 <button
                     data-action="live#emit"
-                    data-event="name(other-component)|fooEvent"
+                    data-live-event-param="name(other-component)|fooEvent"
                 >Emit Named Not Matching</button>
             </div>
         `);

--- a/src/LiveComponent/assets/test/controller/error.test.ts
+++ b/src/LiveComponent/assets/test/controller/error.test.ts
@@ -26,7 +26,7 @@ describe('LiveController Error Handling', () => {
         const test = await createTest({ counter: 4 }, (data: any) => `
             <div ${initComponent(data)}>
                 Current count: ${data.counter}
-                <button data-action="live#action" data-action-name="save">Save</button>
+                <button data-action="live#action" data-live-action-param="save">Save</button>
                 <button data-action="live#$render">Render</button>
             </div>
         `);
@@ -62,7 +62,7 @@ describe('LiveController Error Handling', () => {
         const test = await createTest({ }, (data: any) => `
             <div ${initComponent(data)}>
                 Original component text
-                <button data-action="live#action" data-action-name="save">Save</button>
+                <button data-action="live#action" data-live-action-param="save">Save</button>
             </div>
         `);
 

--- a/src/LiveComponent/assets/test/controller/loading.test.ts
+++ b/src/LiveComponent/assets/test/controller/loading.test.ts
@@ -81,8 +81,8 @@ describe('LiveController data-loading Tests', () => {
             <div ${initComponent(data)}> 
                 <span data-loading="action(save)|show" data-testid="loading-element">Loading...</span>
 
-                <button data-action="live#action" data-action-name="save">Save</button>
-                <button data-action="live#action" data-action-name="otherAction">Other Action</button>
+                <button data-action="live#action" data-live-action-param="save">Save</button>
+                <button data-action="live#action" data-live-action-param="otherAction">Other Action</button>
                 <button data-action="live#$render">Re-Render</button>
             </div>
         `);
@@ -176,8 +176,8 @@ describe('LiveController data-loading Tests', () => {
             <div ${initComponent(data)}> 
                 <span data-loading="action(otherAction)|show" data-testid="loading-element">Loading...</span>
 
-                <button data-action="live#action" data-action-name="debounce(50)|save">Save</button>
-                <button data-action="live#action" data-action-name="otherAction">Other Action</button>
+                <button data-action="live#action" data-live-action-param="debounce(50)|save">Save</button>
+                <button data-action="live#action" data-live-action-param="otherAction">Other Action</button>
             </div>
         `);
 
@@ -203,7 +203,7 @@ describe('LiveController data-loading Tests', () => {
            <div ${initComponent(data)}> 
                <span data-loading="action(save)|delay(50)|show" data-testid="loading-element">Loading...</span>
 
-               <button data-action="live#action" data-action-name="save">Save</button>
+               <button data-action="live#action" data-live-action-param="save">Save</button>
            </div>
        `);
 

--- a/src/LiveComponent/assets/test/controller/query-binding.test.ts
+++ b/src/LiveComponent/assets/test/controller/query-binding.test.ts
@@ -149,7 +149,7 @@ describe('LiveController query string binding', () => {
         const test = await createTest({ prop: ''}, (data: any) => `
             <div ${initComponent(data, {queryMapping: {prop: {name: 'prop'}}})}>
                 Prop: ${data.prop}
-                <button data-action="live#action" data-action-name="changeProp">Change prop</button>
+                <button data-action="live#action" data-live-action-param="changeProp">Change prop</button>
             </div>
         `);
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1036,14 +1036,21 @@ the work::
         // ...
     }
 
-To call this, add ``data-action="live#action"`` and ``data-action-name``
-to an element (e.g. a button or form):
+.. versionadded:: 2.16
+
+    The ``data-live-action-param`` attribute way of specifying the action
+    was added in Live Components 2.16. Previously, this was done with
+    ``data-live-action-name``.
+
+To call this, trigger the ``action`` method on the ``live`` Stimulus
+controller and pass ``resetMax`` as a `Stimulus action parameter`_ called
+``action``:
 
 .. code-block:: html+twig
 
     <button
         data-action="live#action"
-        data-action-name="resetMax"
+        data-live-action-param="resetMax"
     >Reset Min/Max</button>
 
 Done! When the user clicks this button, a POST request will be sent that
@@ -1058,14 +1065,12 @@ You can also add several "modifiers" to the action:
     <form>
         <button
             data-action="live#action"
-            data-action-name="prevent|debounce(300)|save"
+            data-live-action-param="debounce(300)|save"
         >Save</button>
     </form>
 
-The ``prevent`` modifier would prevent the form from submitting
-(``event.preventDefault()``). The ``debounce(300)`` modifier will add
-300ms of "debouncing" before the action is executed. In other words, if
-you click really fast 5 times, only one Ajax request will be made!
+The ``debounce(300)`` adds 300ms of "debouncing" before the action is executed.
+In other words, if you click really fast 5 times, only one Ajax request will be made!
 
 Actions & Services
 ~~~~~~~~~~~~~~~~~~
@@ -1099,22 +1104,28 @@ This means that, for example, you can use action autowiring::
 Actions & Arguments
 ~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.1
+.. versionadded:: 2.16
 
-    The ability to pass arguments to actions was added in version 2.1.
+    The ``data-live-{NAME}-param`` attribute way of specifying action
+    arguments was added in Live Components 2.16. Previously, this was done
+    inside the ``data-live-action-name`` attribute.
 
-You can also provide custom arguments to your action:
+You can also pass arguments to your action by adding each as a
+`Stimulus action parameter`_:
 
 .. code-block:: html+twig
 
     <form>
         <button
             data-action="live#action"
-            data-action-name="addItem(id={{ item.id }}, itemName=CustomItem)"
+            data-live-action-param="addItem"
+
+            data-live-id-param="{{ item.id }}"
+            data-live-item-name-param="CustomItem"
         >Add Item</button>
     </form>
 
-In your component, to allow each argument to be passed, we need to add
+In your component, to allow each argument to be passed, add
 the ``#[LiveArg()]`` attribute::
 
     // src/Components/ItemList.php
@@ -1134,10 +1145,6 @@ the ``#[LiveArg()]`` attribute::
             $this->name = $name;
         }
     }
-
-Normally, the argument name in PHP - e.g. ``$id`` - should match the
-argument name used in Twig ``id={{ item.id }}``. But if they don't
-match, you can pass an argument to ``LiveArg``, like we did with ``itemName``.
 
 Actions and CSRF Protection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1216,10 +1223,11 @@ to handle the files and tell the component when the file should be sent:
 
 .. code-block:: html+twig
 
-    <p>
-        <input type="file" name="my_file" />
-        <button data-action="live#action" data-action-name="files|my_action" />
-    </p>
+    <input type="file" name="my_file" />
+    <button
+        data-action="live#action"
+        data-live-action-param="files|my_action"
+    />
 
 To send a file (or files) with an action use ``files`` modifier.
 Without an argument it will send all pending files to your action.
@@ -1233,11 +1241,11 @@ You can also specify a modifier parameter to choose which files should be upload
         <input type="file" name="multiple[]" multiple />
 
         {# Send only file from first input #}
-        <button data-action="live#action" data-action-name="files(my_file)|myAction" />
+        <button data-action="live#action" data-live-action-param="files(my_file)|myAction" />
         {# You can chain modifiers to send multiple files #}
-        <button data-action="live#action" data-action-name="files(my_file)|files(multiple[])|myAction" />
+        <button data-action="live#action" data-live-action-param="files(my_file)|files(multiple[])|myAction" />
         {# Or send all pending files #}
-        <button data-action="live#action" data-action-name="files|myAction" />
+        <button data-action="live#action" data-live-action-param="files|myAction" />
     </p>
 
 The files will be available in a regular ``$request->files`` files bag::
@@ -1456,8 +1464,8 @@ Next, tell the ``form`` element to use this action:
 
     {{ form_start(form, {
         attr: {
-            'data-action': 'live#action',
-            'data-action-name': 'prevent|save'
+            'data-action': 'live#action:prevent',
+            'data-live-action-param': 'save'
         }
     }) }}
 
@@ -1757,7 +1765,8 @@ and ``removeComment()`` actions:
             {% for key, commentForm in form.comments %}
                 <button
                     data-action="live#action"
-                    data-action-name="removeComment(index={{ key }})"
+                    data-live-action-param="removeComment"
+                    data-live-index-param="{{ key }}"
                     type="button"
                 >X</button>
 
@@ -1769,7 +1778,7 @@ and ``removeComment()`` actions:
 
             <button
                 data-action="live#action"
-                data-action-name="addComment"
+                data-live-action-param="addComment"
                 type="button"
             >+ Add Comment</button>
 
@@ -2172,8 +2181,8 @@ re-rendered. In your template, render errors using an ``_errors`` variable:
 
     <button
         type="submit"
-        data-action="live#action"
-        data-action-name="prevent|save"
+        data-action="live#action:prevent"
+        data-live-action-param="save"
     >Save</button>
 
 Once a component has been validated, the component will "remember" that
@@ -2447,13 +2456,18 @@ Emitting an Event
 
 There are three ways to emit an event:
 
+.. versionchanged:: 2.16
+
+    The ``data-live-event-param`` attribute was added in Live Components 2.16.
+    Previously, it was called ``data-event``.
+
 1. From Twig:
 
    .. code-block:: html+twig
 
        <button
            data-action="live#emit"
-           data-event="productAdded"
+           data-live-event-param="productAdded"
        >
 
 2. From your PHP component via ``ComponentToolsTrait``::
@@ -2550,7 +2564,7 @@ If you want to emit an event to only the parent components, use the
 
     <button
         data-action="live#emitUp"
-        data-event="productAdded"
+        data-live-event-param="productAdded"
     >
 
 Or, in PHP::
@@ -2567,7 +2581,7 @@ use the ``name()`` modifier:
 
     <button
         data-action="live#emit"
-        data-event="name(ProductList)|productAdded"
+        data-live-event-param="name(ProductList)|productAdded"
     >
 
 Or, in PHP::
@@ -2583,7 +2597,7 @@ To emit an event to only yourself, use the ``emitSelf()`` method:
 
     <button
         data-action="live#emitSelf"
-        data-event="productAdded"
+        data-live-event-param="productAdded"
     >
 
 Or, in PHP::
@@ -2766,7 +2780,7 @@ suppose your child component has:
 
 .. code-block:: html
 
-    <button data-action="live#action" data-action-name="save">Save</button>
+    <button data-action="live#action" data-live-action-param="save">Save</button>
 
 When the user clicks that button, it will attempt to call the ``save``
 action in the *child* component only, even if the ``save`` action
@@ -2930,7 +2944,7 @@ In the ``EditPost`` template, you render the
 
             <button
                 data-action="live#action"
-                data-action-name="save"
+                data-live-action-param="save"
             >Save</button>
         </form>
     </div>
@@ -3468,3 +3482,4 @@ bound to Symfony's BC policy for the moment.
 .. _morphing library: https://github.com/bigskysoftware/idiomorph
 .. _`_locale route parameter`: https://symfony.com/doc/current/translation.html#the-locale-and-the-url
 .. _`setting the locale in the request`: https://symfony.com/doc/current/translation.html#translation-locale
+.. _`Stimulus action parameter`: https://stimulus.hotwired.dev/reference/actions#action-parameters

--- a/src/LiveComponent/src/Form/Type/LiveCollectionType.php
+++ b/src/LiveComponent/src/Form/Type/LiveCollectionType.php
@@ -47,7 +47,8 @@ final class LiveCollectionType extends AbstractType
 
             $attr = $view->vars['button_add']->vars['attr'];
             $attr['data-action'] ??= 'live#action';
-            $attr['data-action-name'] ??= sprintf('addCollectionItem(name=%s)', $view->vars['full_name']);
+            $attr['data-live-action-param'] ??= 'addCollectionItem';
+            $attr['data-live-name-param'] ??= $view->vars['full_name'];
             $view->vars['button_add']->vars['attr'] = $attr;
 
             array_splice($view->vars['button_add']->vars['block_prefixes'], 1, 0, 'live_collection_button_add');
@@ -85,7 +86,9 @@ final class LiveCollectionType extends AbstractType
 
                 $attr = $entryView->vars['button_delete']->vars['attr'];
                 $attr['data-action'] ??= 'live#action';
-                $attr['data-action-name'] ??= sprintf('removeCollectionItem(name=%s, index=%s)', $view->vars['full_name'], $k);
+                $attr['data-live-action-param'] ??= 'removeCollectionItem';
+                $attr['data-live-name-param'] ??= $view->vars['full_name'];
+                $attr['data-live-index-param'] ??= $k;
                 $entryView->vars['button_delete']->vars['attr'] = $attr;
 
                 array_splice($entryView->vars['button_delete']->vars['block_prefixes'], 1, 0, 'live_collection_button_delete');

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -14,7 +14,6 @@ namespace Symfony\UX\TwigComponent\Tests\Integration;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\TwigComponent\Tests\Fixtures\User;
 use Twig\Environment;
-use Twig\Error\RuntimeError;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #1283 Fix #1065
| License       | MIT

Hi!

The `data-action-name` was flawed because the parser inside couldn't handle things like `,` or `)` - e.g. `data-action-name="save(I am a string with ) inside of it)"`

One solution was to write a giant parser to parse these arguments correctly. Instead, in a live stream, some of us decided to "just use Stimulus":

```diff
    <button
        data-action="live#action"
    -    data-action-name="debounce(300)|save"
    +    data-live-action-param="debounce(300)|save"
    >Save</button>
```

This uses [Stimulus action parameters](https://stimulus.hotwired.dev/reference/actions#action-parameters). The new syntax is basically the same length as the previous one, but it's pure Stimulus. Passing arguments is also slightly different, as they are a query string (this allows us to have special characters in the argument values without inventing our own syntax). For single arguments, things look like before (other than the new attribute name):

```diff
<button
    data-action="live#action"
-     data-action-name="addItem(id={{ item.id }}, itemName=CustomItem)"
+     data-live-action-param="addItem"
+     data-live-id-param="{{ item.id }}"
>Add Item</button>
```

This also removes the `|prevent` modifier... because... again ❗  Stimulus already does this:

```diff
<button
-    data-action="live#action
+    data-action="live#action:prevent"
-    data-action-name="prevent|save"
+    data-live-action-param="save"
 >Save</button>
```

Cheers!