### PR TITLE
[Live][Stimulus] Prepping the LiveComponent Stable Release 🚀 

### DIFF
--- a/src/LiveComponent/README.md
+++ b/src/LiveComponent/README.md
@@ -1,15 +1,12 @@
 # Live Components
 
-**EXPERIMENTAL** This component is currently experimental and is
-likely to change, or even change drastically.
-
 Live components work with the [TwigComponent](https://symfony.com/bundles/ux-twig-component/current/index.html)
 library to give you the power to automatically update your
 Twig components on the frontend as the user interacts with them.
 Inspired by [Livewire](https://laravel-livewire.com/) and
 [Phoenix LiveView](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html).
 
-Want a demo? Check out https://github.com/weaverryan/live-demo.
+Want a demo? Check out https://ux.symfony.com/live-component.
 
 **This repository is a READ-ONLY sub-tree split**. See
 https://github.com/symfony/ux to create issues or submit pull requests.

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1374,9 +1374,9 @@ function executeMorphdom(rootFromElement, rootToElement, modifiedFieldElements, 
                     if (modifiedFieldElements.includes(fromEl)) {
                         setValueOnElement(toEl, getElementValue(fromEl));
                     }
-                    if (fromEl === document.activeElement
-                        && fromEl !== document.body
-                        && null !== getModelDirectiveFromElement(fromEl, false)) {
+                    if (fromEl === document.activeElement &&
+                        fromEl !== document.body &&
+                        null !== getModelDirectiveFromElement(fromEl, false)) {
                         setValueOnElement(toEl, getElementValue(fromEl));
                     }
                     const elementChanges = externalMutationTracker.getChangedElement(fromEl);

--- a/src/LiveComponent/assets/src/morphdom.ts
+++ b/src/LiveComponent/assets/src/morphdom.ts
@@ -110,9 +110,10 @@ export function executeMorphdom(
                     // We skip this for non-model elements and allow this to either
                     // maintain the value if changed (see code above) or for the
                     // morphing process to update it to the value from the server.
-                    if (fromEl === document.activeElement
-                        && fromEl !== document.body
-                        && null !== getModelDirectiveFromElement(fromEl, false)
+                    if (
+                        fromEl === document.activeElement &&
+                        fromEl !== document.body &&
+                        null !== getModelDirectiveFromElement(fromEl, false)
                     ) {
                         setValueOnElement(toEl, getElementValue(fromEl));
                     }

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1,11 +1,6 @@
 Live Components
 ===============
 
-.. caution::
-
-    This component is currently experimental and is likely to change, or even
-    change drastically.
-
 Live components builds on top of the `TwigComponent`_ library
 to give you the power to automatically update your Twig components on
 the frontend as the user interacts with them. Inspired by
@@ -3528,8 +3523,10 @@ This bundle aims at following the same Backward Compatibility promise as
 the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
-However it is currently considered `experimental`_, meaning it is not
-bound to Symfony's BC policy for the moment.
+For JavaScript files, the public API (i.e. documented features and exports
+from the main JavaScript file) is protected by the backward compatibility
+promise. However, any internal implementation in the JavaScript files
+(i.e. exports from internal files) is not protected.
 
 .. _`TwigComponent`: https://symfony.com/bundles/ux-twig-component/current/index.html
 .. _TwigComponent documentation: https://symfony.com/bundles/ux-twig-component/current/index.html
@@ -3538,7 +3535,6 @@ bound to Symfony's BC policy for the moment.
 .. _`Twig Component`: https://symfony.com/bundles/ux-twig-component/current/index.html
 .. _`Twig Component mount documentation`: https://symfony.com/bundles/ux-twig-component/current/index.html#the-mount-method
 .. _`Symfony form`: https://symfony.com/doc/current/forms.html
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`dependent form fields`: https://ux.symfony.com/live-component/demos/dependent-form-fields
 .. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`attributes variable`: https://symfony.com/bundles/ux-twig-component/current/index.html#component-attributes

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -20,8 +20,6 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
  * @see https://symfony.com/bundles/ux-live-component
  *
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class AsLiveComponent extends AsTwigComponent

--- a/src/LiveComponent/src/Attribute/LiveAction.php
+++ b/src/LiveComponent/src/Attribute/LiveAction.php
@@ -15,8 +15,6 @@ namespace Symfony\UX\LiveComponent\Attribute;
  * An attribute to register a LiveAction method.
  *
  * @see https://symfony.com/bundles/ux-live-component/current/index.html#actions
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
 class LiveAction

--- a/src/LiveComponent/src/Attribute/LiveArg.php
+++ b/src/LiveComponent/src/Attribute/LiveArg.php
@@ -17,8 +17,6 @@ namespace Symfony\UX\LiveComponent\Attribute;
  * @see https://symfony.com/bundles/ux-live-component/current/index.html#actions-arguments
  *
  * @author Tomas Norkūnas <norkunas.tom@gmail.com>
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 final class LiveArg

--- a/src/LiveComponent/src/Attribute/LiveListener.php
+++ b/src/LiveComponent/src/Attribute/LiveListener.php
@@ -18,8 +18,6 @@ namespace Symfony\UX\LiveComponent\Attribute;
  * method and re-render the component.
  *
  * @see https://symfony.com/bundles/ux-live-component/current/index.html#listeners
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class LiveListener extends LiveAction

--- a/src/LiveComponent/src/Attribute/LiveProp.php
+++ b/src/LiveComponent/src/Attribute/LiveProp.php
@@ -15,8 +15,6 @@ namespace Symfony\UX\LiveComponent\Attribute;
  * An attribute to mark a property as a "LiveProp".
  *
  * @see https://symfony.com/bundles/ux-live-component/current/index.html#liveprops-stateful-component-properties
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class LiveProp

--- a/src/LiveComponent/src/Attribute/PostHydrate.php
+++ b/src/LiveComponent/src/Attribute/PostHydrate.php
@@ -13,8 +13,6 @@ namespace Symfony\UX\LiveComponent\Attribute;
 
 /**
  * An attribute to register a PostHydrate hook.
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class PostHydrate

--- a/src/LiveComponent/src/Attribute/PreDehydrate.php
+++ b/src/LiveComponent/src/Attribute/PreDehydrate.php
@@ -13,8 +13,6 @@ namespace Symfony\UX\LiveComponent\Attribute;
 
 /**
  * An attribute to register a PreDehydrate hook.
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class PreDehydrate

--- a/src/LiveComponent/src/Attribute/PreReRender.php
+++ b/src/LiveComponent/src/Attribute/PreReRender.php
@@ -16,8 +16,6 @@ namespace Symfony\UX\LiveComponent\Attribute;
  *
  * This hook ONLY happens when rendering via HTTP: it does
  * not happen during the initial render of a component.
- *
- * @experimental
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class PreReRender

--- a/src/LiveComponent/src/ComponentToolsTrait.php
+++ b/src/LiveComponent/src/ComponentToolsTrait.php
@@ -17,8 +17,6 @@ use Symfony\Contracts\Service\Attribute\Required;
  * Trait with shortcut methods useful for live components.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 trait ComponentToolsTrait
 {

--- a/src/LiveComponent/src/ComponentValidator.php
+++ b/src/LiveComponent/src/ComponentValidator.php
@@ -19,8 +19,6 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class ComponentValidator implements ComponentValidatorInterface, ServiceSubscriberInterface

--- a/src/LiveComponent/src/ComponentValidatorInterface.php
+++ b/src/LiveComponent/src/ComponentValidatorInterface.php
@@ -15,8 +15,6 @@ use Symfony\Component\Validator\ConstraintViolation;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 interface ComponentValidatorInterface
 {

--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -23,8 +23,6 @@ use Symfony\UX\TwigComponent\Attribute\PostMount;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 trait ComponentWithFormTrait
 {

--- a/src/LiveComponent/src/DefaultActionTrait.php
+++ b/src/LiveComponent/src/DefaultActionTrait.php
@@ -13,8 +13,6 @@ namespace Symfony\UX\LiveComponent;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 trait DefaultActionTrait
 {

--- a/src/LiveComponent/src/DependencyInjection/Compiler/ComponentDefaultActionPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/ComponentDefaultActionPass.php
@@ -17,8 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @experimental
- *
  * @internal
  */
 final class ComponentDefaultActionPass implements CompilerPassInterface

--- a/src/LiveComponent/src/DependencyInjection/Compiler/OptionalDependencyPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/OptionalDependencyPass.php
@@ -21,8 +21,6 @@ use Symfony\UX\LiveComponent\LiveComponentBundle;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @experimental
- *
  * @internal
  */
 final class OptionalDependencyPass implements CompilerPassInterface

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -55,8 +55,6 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_it
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @experimental
- *
  * @internal
  */
 final class LiveComponentExtension extends Extension implements PrependExtensionInterface

--- a/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
+++ b/src/LiveComponent/src/EventListener/AddLiveAttributesSubscriber.php
@@ -29,8 +29,6 @@ use Symfony\UX\TwigComponent\MountedComponent;
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @experimental
- *
  * @internal
  */
 final class AddLiveAttributesSubscriber implements EventSubscriberInterface, ServiceSubscriberInterface

--- a/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
@@ -17,6 +17,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\UX\TwigComponent\Event\PostMountEvent;
 use Symfony\UX\TwigComponent\Event\PreRenderEvent;
 
+/**
+ * Handles the "defer" key, which causes the component to be rendered asynchronously.
+ *
+ * @internal
+ */
 final class DeferLiveComponentSubscriber implements EventSubscriberInterface
 {
     private const DEFAULT_LOADING_TAG = 'div';

--- a/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
+++ b/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
@@ -25,8 +25,6 @@ use Symfony\UX\TwigComponent\Event\PreCreateForRenderEvent;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class InterceptChildComponentRenderSubscriber implements EventSubscriberInterface, ServiceSubscriberInterface

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -42,8 +42,6 @@ use Symfony\UX\TwigComponent\MountedComponent;
  * @author Kevin Bond <kevinbond@gmail.com>
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscriberInterface

--- a/src/LiveComponent/src/EventListener/QueryStringInitializeSubscriber.php
+++ b/src/LiveComponent/src/EventListener/QueryStringInitializeSubscriber.php
@@ -20,8 +20,6 @@ use Symfony\UX\TwigComponent\Event\PreMountEvent;
 /**
  * @author Nicolas Rigaud <squrious@protonmail.com>
  *
- * @experimental
- *
  * @internal
  */
 class QueryStringInitializeSubscriber implements EventSubscriberInterface

--- a/src/LiveComponent/src/EventListener/ResetDeterministicIdSubscriber.php
+++ b/src/LiveComponent/src/EventListener/ResetDeterministicIdSubscriber.php
@@ -36,8 +36,6 @@ use Symfony\UX\TwigComponent\Event\PostRenderEvent;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 final class ResetDeterministicIdSubscriber implements EventSubscriberInterface

--- a/src/LiveComponent/src/Exception/HydrationException.php
+++ b/src/LiveComponent/src/Exception/HydrationException.php
@@ -20,8 +20,6 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class HydrationException extends BadRequestHttpException

--- a/src/LiveComponent/src/Form/Type/LiveCollectionType.php
+++ b/src/LiveComponent/src/Form/Type/LiveCollectionType.php
@@ -21,8 +21,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Gábor Egyed <gabor.egyed@gmail.com>
- *
- * @experimental
  */
 final class LiveCollectionType extends AbstractType
 {

--- a/src/LiveComponent/src/Hydration/DoctrineEntityHydrationExtension.php
+++ b/src/LiveComponent/src/Hydration/DoctrineEntityHydrationExtension.php
@@ -15,6 +15,11 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * Handles hydration of Doctrine entities.
+ *
+ * @internal
+ */
 class DoctrineEntityHydrationExtension implements HydrationExtensionInterface
 {
     /**

--- a/src/LiveComponent/src/Hydration/HydrationExtensionInterface.php
+++ b/src/LiveComponent/src/Hydration/HydrationExtensionInterface.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\UX\LiveComponent\Hydration;
 
+/**
+ * Interface for custom hydration of objects.
+ */
 interface HydrationExtensionInterface
 {
     /**

--- a/src/LiveComponent/src/LiveCollectionTrait.php
+++ b/src/LiveComponent/src/LiveCollectionTrait.php
@@ -17,8 +17,6 @@ use Symfony\UX\LiveComponent\Attribute\LiveArg;
 
 /**
  * @author Gábor Egyed <gabor.egyed@gmail.com>
- *
- * @experimental
  */
 trait LiveCollectionTrait
 {

--- a/src/LiveComponent/src/LiveComponentBundle.php
+++ b/src/LiveComponent/src/LiveComponentBundle.php
@@ -19,8 +19,6 @@ use Symfony\UX\LiveComponent\DependencyInjection\Compiler\OptionalDependencyPass
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @experimental
  */
 final class LiveComponentBundle extends Bundle
 {

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -35,8 +35,6 @@ use Symfony\UX\TwigComponent\ComponentAttributes;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @experimental
- *
  * @internal
  */
 final class LiveComponentHydrator

--- a/src/LiveComponent/src/LiveResponder.php
+++ b/src/LiveComponent/src/LiveResponder.php
@@ -12,8 +12,6 @@
 namespace Symfony\UX\LiveComponent;
 
 /**
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 final class LiveResponder

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
@@ -16,8 +16,6 @@ use Symfony\UX\TwigComponent\ComponentMetadata;
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class LiveComponentMetadata

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
@@ -20,8 +20,6 @@ use Symfony\UX\TwigComponent\ComponentFactory;
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class LiveComponentMetadataFactory implements ResetInterface

--- a/src/LiveComponent/src/Metadata/LivePropMetadata.php
+++ b/src/LiveComponent/src/Metadata/LivePropMetadata.php
@@ -17,8 +17,6 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @experimental
- *
  * @internal
  */
 final class LivePropMetadata

--- a/src/LiveComponent/src/Twig/DeterministicTwigIdCalculator.php
+++ b/src/LiveComponent/src/Twig/DeterministicTwigIdCalculator.php
@@ -17,8 +17,6 @@ use Twig\Template;
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class DeterministicTwigIdCalculator

--- a/src/LiveComponent/src/Twig/LiveComponentExtension.php
+++ b/src/LiveComponent/src/Twig/LiveComponentExtension.php
@@ -17,8 +17,6 @@ use Twig\TwigFunction;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @experimental
- *
  * @internal
  */
 final class LiveComponentExtension extends AbstractExtension

--- a/src/LiveComponent/src/Twig/LiveComponentRuntime.php
+++ b/src/LiveComponent/src/Twig/LiveComponentRuntime.php
@@ -19,8 +19,6 @@ use Symfony\UX\TwigComponent\ComponentFactory;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @experimental
- *
  * @internal
  */
 final class LiveComponentRuntime

--- a/src/LiveComponent/src/Util/ChildComponentPartialRenderer.php
+++ b/src/LiveComponent/src/Util/ChildComponentPartialRenderer.php
@@ -20,8 +20,6 @@ use Symfony\UX\TwigComponent\ComponentFactory;
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class ChildComponentPartialRenderer implements ServiceSubscriberInterface

--- a/src/LiveComponent/src/Util/DehydratedProps.php
+++ b/src/LiveComponent/src/Util/DehydratedProps.php
@@ -16,8 +16,6 @@ namespace Symfony\UX\LiveComponent\Util;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class DehydratedProps

--- a/src/LiveComponent/src/Util/FingerprintCalculator.php
+++ b/src/LiveComponent/src/Util/FingerprintCalculator.php
@@ -24,8 +24,6 @@ use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadata;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class FingerprintCalculator

--- a/src/LiveComponent/src/Util/JsonUtil.php
+++ b/src/LiveComponent/src/Util/JsonUtil.php
@@ -14,8 +14,6 @@ namespace Symfony\UX\LiveComponent\Util;
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 final class JsonUtil

--- a/src/LiveComponent/src/Util/LiveAttributesCollection.php
+++ b/src/LiveComponent/src/Util/LiveAttributesCollection.php
@@ -17,8 +17,6 @@ use Twig\Extension\EscaperExtension;
 /**
  * An array of attributes that can eventually be returned as an escaped array.
  *
- * @experimental
- *
  * @internal
  */
 final class LiveAttributesCollection

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -26,8 +26,6 @@ use Symfony\UX\TwigComponent\MountedComponent;
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @experimental
- *
  * @internal
  */
 class LiveControllerAttributesCreator

--- a/src/LiveComponent/src/Util/LiveFormUtility.php
+++ b/src/LiveComponent/src/Util/LiveFormUtility.php
@@ -14,8 +14,6 @@ namespace Symfony\UX\LiveComponent\Util;
 use Symfony\Component\Form\FormView;
 
 /**
- * @experimental
- *
  * @internal
  */
 final class LiveFormUtility

--- a/src/LiveComponent/src/Util/QueryStringPropsExtractor.php
+++ b/src/LiveComponent/src/Util/QueryStringPropsExtractor.php
@@ -20,8 +20,6 @@ use Symfony\UX\LiveComponent\Metadata\LivePropMetadata;
 /**
  * @author Nicolas Rigaud <squrious@protonmail.com>
  *
- * @experimental
- *
  * @internal
  */
 final class QueryStringPropsExtractor

--- a/src/LiveComponent/src/Util/TwigAttributeHelperFactory.php
+++ b/src/LiveComponent/src/Util/TwigAttributeHelperFactory.php
@@ -16,8 +16,6 @@ use Twig\Environment;
 /**
  * Helper for building an array of attributes for the live controller element.
  *
- * @experimental
- *
  * @internal
  */
 final class TwigAttributeHelperFactory

--- a/src/LiveComponent/src/ValidatableComponentTrait.php
+++ b/src/LiveComponent/src/ValidatableComponentTrait.php
@@ -21,8 +21,6 @@ use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- *
- * @experimental
  */
 trait ValidatableComponentTrait
 {

--- a/src/LiveComponent/tests/Unit/Form/Type/LiveCollectionTypeTest.php
+++ b/src/LiveComponent/tests/Unit/Form/Type/LiveCollectionTypeTest.php
@@ -17,8 +17,6 @@ use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
 
 /**
  * @author Gábor Egyed <gabor.egyed@gmail.com>
- *
- * @experimental
  */
 final class LiveCollectionTypeTest extends TypeTestCase
 {

--- a/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
+++ b/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
@@ -18,8 +18,6 @@ use Symfony\UX\LiveComponent\LiveCollectionTrait;
 
 /**
  * @author Gábor Egyed <gabor.egyed@gmail.com>
- *
- * @experimental
  */
 final class LiveCollectionTraitTest extends TestCase
 {

--- a/src/StimulusBundle/README.md
+++ b/src/StimulusBundle/README.md
@@ -3,7 +3,7 @@
 This bundle adds integration between Symfony, Stimulus and Symfony UX:
 
 -   A) Twig `stimulus_*` functions & filters to add Stimulus controllers, actions & targets in your templates;
--   B) Integration with Symfony UX & AssetMapper (this integration is [experimental](https://symfony.com/doc/current/contributing/code/experimental.html));
+-   B) Integration with Symfony UX & AssetMapper;
 -   C) A helper service to build the Stimulus data attributes and use them in your services.
 
 [Read the documentation][1]

--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -11,7 +11,6 @@ A) Twig ``stimulus_`` functions & filters to add Stimulus controllers,
    actions & targets in your templates;
 
 B) Integration to load :ref:`UX Packages <ux-packages>` (extra Stimulus controllers)
-   (if you're using AssetMapper, this integration is `experimental`_)
 
 Installation
 ------------
@@ -552,7 +551,6 @@ it will normalize it:
 .. _`parameters`: https://stimulus.hotwired.dev/reference/actions#action-parameters
 .. _`Stimulus Targets`: https://stimulus.hotwired.dev/reference/targets
 .. _`StimulusBundle Flex recipe`: https://github.com/symfony/recipes/tree/main/symfony/stimulus-bundle
-.. _`experimental`: https://symfony.com/doc/current/contributing/code/experimental.html
 .. _`ux-autocomplete`: https://symfony.com/bundles/ux-autocomplete/current/index.html
 .. _`ux-chartjs`: https://symfony.com/bundles/ux-chartjs/current/index.html
 .. _`ux-cropperjs`: https://symfony.com/bundles/ux-cropperjs/current/index.html

--- a/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
+++ b/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
@@ -22,8 +22,6 @@ use Symfony\UX\StimulusBundle\Ux\UxPackageReader;
  *
  * @internal
  *
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 class ControllersMapGenerator

--- a/src/StimulusBundle/src/AssetMapper/MappedControllerAsset.php
+++ b/src/StimulusBundle/src/AssetMapper/MappedControllerAsset.php
@@ -14,9 +14,9 @@ namespace Symfony\UX\StimulusBundle\AssetMapper;
 use Symfony\Component\AssetMapper\MappedAsset;
 
 /**
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @internal
  */
 class MappedControllerAsset
 {

--- a/src/StimulusBundle/src/AssetMapper/MappedControllerAutoImport.php
+++ b/src/StimulusBundle/src/AssetMapper/MappedControllerAutoImport.php
@@ -12,7 +12,7 @@
 namespace Symfony\UX\StimulusBundle\AssetMapper;
 
 /**
- * @experimental
+ * @internal
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */

--- a/src/StimulusBundle/src/AssetMapper/StimulusLoaderJavaScriptCompiler.php
+++ b/src/StimulusBundle/src/AssetMapper/StimulusLoaderJavaScriptCompiler.php
@@ -20,7 +20,7 @@ use Symfony\Component\Filesystem\Path;
 /**
  * Compiles the loader.js file to dynamically import the controllers.
  *
- * @experimental
+ * @internal
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */

--- a/src/StimulusBundle/src/DependencyInjection/Compiler/RemoveAssetMapperServicesCompiler.php
+++ b/src/StimulusBundle/src/DependencyInjection/Compiler/RemoveAssetMapperServicesCompiler.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @experimental
+ * @internal
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */

--- a/src/StimulusBundle/src/Twig/UxControllersTwigExtension.php
+++ b/src/StimulusBundle/src/Twig/UxControllersTwigExtension.php
@@ -17,7 +17,7 @@ use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**
- * @experimental
+ * @internal
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */

--- a/src/StimulusBundle/src/Twig/UxControllersTwigRuntime.php
+++ b/src/StimulusBundle/src/Twig/UxControllersTwigRuntime.php
@@ -20,7 +20,7 @@ use Twig\Extension\RuntimeExtensionInterface;
 /**
  * Returns the link tags for all autoimported CSS files in controllers.json.
  *
- * @experimental
+ * @internal
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */

--- a/src/StimulusBundle/src/Ux/UxPackageMetadata.php
+++ b/src/StimulusBundle/src/Ux/UxPackageMetadata.php
@@ -14,8 +14,6 @@ namespace Symfony\UX\StimulusBundle\Ux;
 /**
  * @internal
  *
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 class UxPackageMetadata

--- a/src/StimulusBundle/src/Ux/UxPackageReader.php
+++ b/src/StimulusBundle/src/Ux/UxPackageReader.php
@@ -16,8 +16,6 @@ use Composer\InstalledVersions;
 /**
  * @internal
  *
- * @experimental
- *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 class UxPackageReader

--- a/src/Translator/src/Intl/IntlMessageParser.php
+++ b/src/Translator/src/Intl/IntlMessageParser.php
@@ -164,7 +164,7 @@ class IntlMessageParser
         ];
     }
 
-    private function tryParseLeftAngleBracket(): string|null
+    private function tryParseLeftAngleBracket(): ?string
     {
         if (
             !$this->isEOF()
@@ -186,7 +186,7 @@ class IntlMessageParser
      * a character that requires quoting (that is, "only where needed"), and works the same in
      * nested messages as on the top level of the pattern. The new behavior is otherwise compatible.
      */
-    private function tryParseQuote(string $parentArgType): string|null
+    private function tryParseQuote(string $parentArgType): ?string
     {
         if ($this->isEOF() || 39 !== $this->char() /* `'` */) {
             return null;
@@ -247,7 +247,7 @@ class IntlMessageParser
     private function tryParseUnquoted(
         int $nestingLevel,
         string $parentArgType,
-    ): string|null {
+    ): ?string {
         if ($this->isEOF()) {
             return null;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | None
| License       | MIT

Hi!

LiveComponents has, really, been quite stable for a long time, but it's kept its experimental status. Removing that is really about deciding that we'll protect backwards-compatibility. It's time to do that :).

This is planned as the 2.15.0 release near the end of Feb (assuming we get the items below done before then).

TODOs:

* #1418 
* Possibly remove Twig 2.x compat
* #1428
* #1392
* Moving `Idiomorph` to a peer dependency would be great, but blocked by https://github.com/bigskysoftware/idiomorph/pull/35 - **still need a tag** for the PR merge
* #1426 as it may include some edge-case BC breaks.

If there's anything else on your mind before stable, now is the time to mention it :).

Cheers!