### PR TITLE
Fixed accessing crawler in test example

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -980,7 +980,7 @@ You can test how your component is mounted and rendered using the
             $this->assertStringContainsString('bar', $rendered);
 
             // use the crawler
-            $this->assertCount(5, $rendered->crawler->filter('ul li'));
+            $this->assertCount(5, $rendered->crawler()->filter('ul li'));
         }
 
         public function testEmbeddedComponentRenders(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix n/a
| License       | MIT

Hey,

I've just copied the test code example and stumbled upon a little type in the code. This PR fixes accessing the crawler through the provided method instead of a non-existing property.

Kind regards
Matthias