### PR TITLE
[LiveComponent] Update importmap conf in package.json

### DIFF
--- a/src/LiveComponent/assets/package.json
+++ b/src/LiveComponent/assets/package.json
@@ -22,7 +22,8 @@
             }
         },
         "importmap": {
-            "@hotwired/stimulus": "^3.0.0"
+            "@hotwired/stimulus": "^3.0.0",
+            "@symfony/ux-live-component": "path:%PACKAGE%/dist/live_controller.js"
         }
     },
     "dependencies": {


### PR DESCRIPTION
Replaces #1406 

Allow using getComponent with no aditional configuration

```js
import { getComponent } from '@symfony/ux-live-component';
```

