### PR TITLE
[LiveComponent] Fix component syntax error in doc

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2257,9 +2257,9 @@ Or override the ``loadingContent`` block:
 
 .. code-block:: twig
 
-    {% component SomeHeavyComponent with { defer: true }) }}
+    {% component SomeHeavyComponent with { defer: true } %}
         {% block loadingContent %}Loading...{% endblock %}
-    {{ end_component() }}
+    {% endcomponent %}
 
 To change the initial tag from a ``div`` to something else, use the ``loading-tag`` option:
 


### PR DESCRIPTION
Spotted by @fGuix in #1424 (thanks)