### PR TITLE
[LiveComponent] Add better error message when hydrating dates

### DIFF
--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -518,7 +518,7 @@ final class LiveComponentHydrator
             }
 
             if (null !== $dateFormat) {
-                return $className::createFromFormat($dateFormat, $value);
+                return $className::createFromFormat($dateFormat, $value) ?: throw new BadRequestHttpException(sprintf('The model path "%s" was sent invalid date data "%s" or in an invalid format. Make sure it\'s a valid date and it matches the expected format "%s".', $propertyPathForError, $value, $dateFormat));
             }
 
             return new $className($value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | -
| License       | MIT

Instead of 

```
Return value must be of type ?object, bool returned"
```
return a proper error message
```
The model path "createdAt" was sent invalid date data "0" or in an invalid format. Make sure it's a valid date and it matches the expected format "Y. m. d.".
```

Not sure if it's a bugfix or feature. Maybe the wording can be tweaked.
