### PR TITLE
[ChartJs] Remove <3.9 boundary and fix testsuite

### DIFF
--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -21,12 +21,12 @@
     },
     "peerDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "chart.js": "^3.4.1 <3.9 || ^4.0"
+        "chart.js": "^3.4.1 || ^4.0"
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
         "@types/chart.js": "^2.9.34",
-        "chart.js": "^3.4.1 <3.9 || ^4.0",
+        "chart.js": "^3.4.1 || ^4.0",
         "resize-observer-polyfill": "^1.5.1",
         "vitest-canvas-mock": "^0.3.3"
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Relates to #1013 and #1417
| License       | MIT

In #1013 the version of `chartjs` was restricted to `<3.9` and since adjusting the test script in #1417 (and later merging #1389) it seemed that version constraint notation `^3.4.1 <3.9` wasn't supported ([see](https://github.com/symfony/ux/actions/runs/7723726257/job/21054412107?pr=1431#step:6:32)) by it. I tried supporting the boundary condition but it turned into quite the rabbit hole correctly parsing it and keeping it simple/pragmatic.

If I understand correctly, issue #1013, introduced the boundary condition because it was related to our testsuite, since that has been fixed in #1202. It looks like we therefor can drop the upper boundary again. I'm not sure if we cover the issue in our testsuite, but our testsuite passes on `chartjs@3.9.1`.

So the removal of the boundary introduces:
- Fully support `chartjs` versions `^3.4.1` and `^4.0`
- Testscript is fully ran again ([see](https://github.com/symfony/ux/actions/runs/7724645865/job/21057199292?pr=1433#step:6:29)) with no complex adjustments supporting exotic notations
  - When such boundary conditions are necessary in the future we could take a look at it again

Cheers!