### PR TITLE
fix: use method from metadata for live component test helper

### DIFF
--- a/src/LiveComponent/src/Test/TestLiveComponent.php
+++ b/src/LiveComponent/src/Test/TestLiveComponent.php
@@ -51,13 +51,25 @@ final class TestLiveComponent
             $this->metadataFactory->getMetadata($mounted->getName())
         );
 
-        $this->client->request('GET', $this->router->generate(
-            $this->metadata->get('route'),
-            [
-                '_live_component' => $this->metadata->getName(),
-                'props' => json_encode($props->getProps(), flags: \JSON_THROW_ON_ERROR),
-            ]
-        ));
+        if ('POST' === strtoupper($this->metadata->get('method'))) {
+            $this->client->request(
+                'POST',
+                $this->router->generate($this->metadata->get('route'), [
+                    '_live_component' => $this->metadata->getName(),
+                ]),
+                [
+                    'data' => json_encode(['props' => $props->getProps()], flags: \JSON_THROW_ON_ERROR),
+                ],
+            );
+        } else {
+            $this->client->request('GET', $this->router->generate(
+                $this->metadata->get('route'),
+                [
+                    '_live_component' => $this->metadata->getName(),
+                    'props' => json_encode($props->getProps(), flags: \JSON_THROW_ON_ERROR),
+                ]
+            ));
+        }
     }
 
     public function render(): RenderedComponent


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

After #1218 has been released as part of 2.14.0 my tests fail. This change passes the actual method to the requests made by the test helper.