### PR TITLE
[CI] Trim yarn JSON in run-vitest-all

### DIFF
--- a/bin/run-vitest-all.sh
+++ b/bin/run-vitest-all.sh
@@ -49,7 +49,7 @@ processWorkspace() {
 }
 
 # Get all workspace names
-workspaces_info=$(yarn workspaces info)
+workspaces_info=$(yarn -s workspaces info)
 
 # Iterate over each workspace using process substitution
 while IFS= read -r workspace_info; do


### PR DESCRIPTION
On macOS, `yarn workspaces info` outputs some time/debug info outside the JSON, making it impossible to parse.

Trying to find a way to avoid that without messing with the script / other OS


```diff
-workspaces_info=$(yarn workspaces info)
+workspaces_info=$(yarn workspaces info | sed '1d;$d')
```


cc @evertharmeling 