### PR TITLE
[Twig] Add (alternate) attribute rendering system

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Make `ComponentAttributes` traversable/countable
 -   Fixed lexing some `{# twig comments #}` with HTML Twig syntax
 -   Fix various usages of deprecated Twig code
+-   Add attribute rendering system
 
 ## 2.13.0
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -945,6 +945,79 @@ the exception of *class*. For ``class``, the defaults are prepended:
     {# renders as: #}
     <button class="bar foo" type="submit">Save</button>
 
+Render
+~~~~~~
+
+.. versionadded:: 2.15
+
+    The ability to *render* attributes was added in TwigComponents 2.15.
+
+You can take full control over the attributes that are rendered by using the
+``render()`` method.
+
+.. code-block:: html+twig
+
+    {# templates/components/MyComponent.html.twig #}
+    <div
+      style="{{ attributes.render('style') }} display:block;"
+      {{ attributes }} {# be sure to always render the remaining attributes! #}
+    >
+      My Component!
+    </div>
+
+    {# render component #}
+    {{ component('MyComponent', { style: 'color:red;' }) }}
+
+    {# renders as: #}
+    <div style="color:red; display:block;">
+      My Component!
+    </div>
+
+.. caution::
+
+    There are a few important things to know about using ``render()``:
+
+    1. You need to be sure to call your ``render()`` methods before calling ``{{ attributes }}`` or some
+       attributes could be rendered twice. For instance:
+
+            .. code-block:: html+twig
+
+                {# templates/components/MyComponent.html.twig #}
+                <div
+                    {{ attributes }} {# called before style is rendered #}
+                    style="{{ attributes.render('style') }} display:block;"
+                >
+                    My Component!
+                </div>
+
+                {# render component #}
+                {{ component('MyComponent', { style: 'color:red;' }) }}
+
+                {# renders as: #}
+                <div style="color:red;" style="color:red; display:block;"> {# style is rendered twice! #}
+                    My Component!
+                </div>
+
+    2. If you add an attribute without calling ``render()``, it will be rendered twice. For instance:
+
+         .. code-block:: html+twig
+
+              {# templates/components/MyComponent.html.twig #}
+              <div
+                 style="display:block;" {# not calling attributes.render('style') #}
+                 {{ attributes }}
+              >
+                 My Component!
+              </div>
+
+              {# render component #}
+              {{ component('MyComponent', { style: 'color:red;' }) }}
+
+              {# renders as: #}
+              <div style="display:block;" style="color:red;"> {# style is rendered twice! #}
+                 My Component!
+              </div>
+
 Only
 ~~~~
 

--- a/src/TwigComponent/tests/Fixtures/templates/components/RenderAttributes.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/RenderAttributes.html.twig
@@ -1,0 +1,7 @@
+<div
+    foo="{{ attributes.render('foo') }}"
+    bar="{{ attributes.render('bar')|default('default') }}"
+    baz="default {{ attributes.render('baz') }}"
+    qux="{{ attributes.render('qux') }} default"
+    {{ attributes }}
+/>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -216,6 +216,51 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('Hello FOO, 123, and 456', $output);
     }
 
+    /**
+     * @dataProvider renderingAttributesManuallyProvider
+     */
+    public function testRenderingAttributesManually(array $attributes, string $expected): void
+    {
+        $actual = trim($this->renderComponent('RenderAttributes', $attributes));
+
+        $this->assertSame($expected, trim($actual));
+    }
+
+    public static function renderingAttributesManuallyProvider(): iterable
+    {
+        yield [
+            ['class' => 'block'],
+            <<<HTML
+            <div
+                foo=""
+                bar="default"
+                baz="default "
+                qux=" default"
+                 class="block"
+            />
+            HTML,
+        ];
+
+        yield [
+            [
+                'class' => 'block',
+                'foo' => 'value',
+                'bar' => 'value',
+                'baz' => 'value',
+                'qux' => 'value',
+            ],
+            <<<HTML
+            <div
+                foo="value"
+                bar="value"
+                baz="default value"
+                qux="value default"
+                 class="block"
+            />
+            HTML,
+        ];
+    }
+
     private function renderComponent(string $name, array $data = []): string
     {
         return self::getContainer()->get(Environment::class)->render('render_component.html.twig', [

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -199,4 +199,29 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame($attributes->all(), iterator_to_array($attributes));
         $this->assertCount(1, $attributes);
     }
+
+    public function testRenderSingleAttribute(): void
+    {
+        $attributes = new ComponentAttributes(['attr1' => 'value1', 'attr2' => 'value2']);
+
+        $this->assertSame('value1', $attributes->render('attr1'));
+        $this->assertNull($attributes->render('attr3'));
+    }
+
+    public function testRenderingSingleAttributeExcludesFromString(): void
+    {
+        $attributes = new ComponentAttributes(['attr1' => 'value1', 'attr2' => 'value2']);
+
+        $this->assertSame('value1', $attributes->render('attr1'));
+        $this->assertSame(' attr2="value2"', (string) $attributes);
+    }
+
+    public function testCannotRenderNonStringAttribute(): void
+    {
+        $attributes = new ComponentAttributes(['attr1' => false]);
+
+        $this->expectException(\LogicException::class);
+
+        $attributes->render('attr1');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | n/a
| License       | MIT

This is an alternate to https://github.com/symfony/ux/pull/1404 as suggested by Ryan [here](https://github.com/symfony/ux/pull/1404#issuecomment-1915640350).

This PR allows the following:

```twig
<div
    class="{{ attributes.render('class') }} appended-default"
    style="prepended-default {{ attributes.render('style') }}"
    data-foo="{{ attributes.render('data-foo')|default('replaced-default') }}"
    {{ attributes }}
>
```

When calling `attributes.render('name')` ~(or magically via `attributes.name`)~, the attribute is marked as _rendered_. Later when calling just `{{ attributes }}`, the attributes marked as already rendered are excluded. Whether or not an attribute is considered rendered is only evaluated when converting `ComponentAttributes` to a string.

TODO:
- [x] Docs
- [x] Add test ensuring works in real twig component
