### PR TITLE
[Translator] Update intl-messageformat range version to ^10.5.11, close #1437

### DIFF
--- a/src/Translator/CHANGELOG.md
+++ b/src/Translator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Increase version range of `intl-messageformat` to `^10.5.11`, in order tou se a faster implementation of ICU messages parsing.
+
 ## 2.13.2
 
 -   Revert "Change JavaScript package to `type: module`"

--- a/src/Translator/assets/package.json
+++ b/src/Translator/assets/package.json
@@ -7,14 +7,14 @@
     "types": "dist/translator_controller.d.ts",
     "symfony": {
         "importmap": {
-            "intl-messageformat": "^10.2.5",
+            "intl-messageformat": "^10.5.11",
             "@symfony/ux-translator": "path:%PACKAGE%/dist/translator_controller.js",
             "@app/translations": "path:var/translations/index.js",
             "@app/translations/configuration": "path:var/translations/configuration.js"
         }
     },
     "peerDependencies": {
-        "intl-messageformat": "^10.2.5"
+        "intl-messageformat": "^10.5.11"
     },
     "peerDependenciesMeta": {
         "intl-messageformat": {
@@ -22,6 +22,6 @@
         }
     },
     "devDependencies": {
-        "intl-messageformat": "^10.2.5"
+        "intl-messageformat": "^10.5.11"
     }
 }

--- a/src/Translator/assets/src/formatters/intl-formatter.ts
+++ b/src/Translator/assets/src/formatters/intl-formatter.ts
@@ -1,4 +1,4 @@
-import {IntlMessageFormat} from 'intl-messageformat';
+import { IntlMessageFormat } from 'intl-messageformat';
 
 /**
  * @private
@@ -8,13 +8,13 @@ import {IntlMessageFormat} from 'intl-messageformat';
  * @param locale     The locale
  */
 export function formatIntl(id: string, parameters: Record<string, string | number> = {}, locale: string): string {
-    if (id === '' ) {
+    if (id === '') {
         return '';
     }
 
-    const intlMessage = new IntlMessageFormat(id, [locale.replace('_', '-')], undefined, {ignoreTag: true});
+    const intlMessage = new IntlMessageFormat(id, [locale.replace('_', '-')], undefined, { ignoreTag: true });
 
-    parameters = {...parameters};
+    parameters = { ...parameters };
 
     Object.entries(parameters).forEach(([key, value]) => {
         if (key.includes('%') || key.includes('{')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #1437 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This way, we can ensure users will use a version of `intl-messageformat` that use `@formatjs/icu-messageformat-parser`, a 6x faster and backward compatible implementation of `intl-messageformat-parser`. 