### PR TITLE
[StimulusBundle] Handles Windows directory separator when normalizing controller names

### DIFF
--- a/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
+++ b/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
@@ -76,7 +76,7 @@ class ControllersMapGenerator
             // use regex to extract 'controller'-postfix including extension
             preg_match(self::FILENAME_REGEX, $name, $matches);
             $name = str_replace(['_'.$matches[1], '-'.$matches[1]], '', $name);
-            $name = str_replace(['_', '/'], ['-', '--'], $name);
+            $name = str_replace(['_', '/', '\\'], ['-', '--', '--'], $name);
 
             $asset = $this->assetMapper->getAssetFromSourcePath($file->getRealPath());
             $content = $asset->content ?: file_get_contents($asset->sourcePath);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #1422
| License       | MIT

This fixes the issue that controller name normalization doesn't work as intended in Windows which uses `\` as the directory separator. In fact, without the fix, PHPUnit fails when running on Windows platform with the following error:

```
1) Symfony\UX\StimulusBundle\Tests\AssetMapper\ControllerMapGeneratorTest::testGetControllersMap
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
     4 => 'hello-with-dashes'
     5 => 'hello-with-underscores'
     6 => 'other'
-    7 => 'subdir--deeper'
-    8 => 'subdir--deeper-with-dashes'
-    9 => 'subdir--deeper-with-underscores'
+    7 => 'subdir\deeper'
+    8 => 'subdir\deeper-with-dashes'
+    9 => 'subdir\deeper-with-underscores'
     10 => 'typescript'
 )
```