### PR TITLE
[Twig] Removing duplication in docs

### DIFF
--- a/ux.symfony.com/src/Controller/Demo/LiveMemoryController.php
+++ b/ux.symfony.com/src/Controller/Demo/LiveMemoryController.php
@@ -11,8 +11,8 @@
 
 namespace App\Controller\Demo;
 
-use App\Service\LiveDemoRepository;
 use App\LiveMemory\GameStorageInterface;
+use App\Service\LiveDemoRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;

--- a/ux.symfony.com/src/Twig/Components/LiveMemory/Board.php
+++ b/ux.symfony.com/src/Twig/Components/LiveMemory/Board.php
@@ -29,6 +29,7 @@ use Symfony\UX\TwigComponent\Attribute\PostMount;
 
 /**
  * @demo   LiveMemory
+ *
  * @author Simon André <smn.andre@gmail.com>
  */
 #[AsLiveComponent('LiveMemory:Board')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

Somehow, I think during some rewriting I did, I didn't remove old sections. This removes the duplicated sections, but keeps one piece that was new.

Cheers!