### PR TITLE
[Autocomplete] Add conflict on doctrine/orm:^3.0

### DIFF
--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -52,7 +52,7 @@
         "zenstruck/foundry": "^1.33"
     },
     "conflict": {
-        "doctrine/orm": "2.9.0 || 2.9.1"
+        "doctrine/orm": "2.9.0 || 2.9.1 || ^3.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | see below
| License       | MIT

Since [doctrine/orm:3.0](https://github.com/doctrine/orm/releases/tag/3.0.0) is released and there is no direct dependency defined in the `Autocomplete`-component on `doctrine/orm`, you're able to install it in your project. However when doing so it will result in an error when using the autocomplete:

![Capture-2024-02-05-150938](https://github.com/symfony/ux/assets/308513/b7f60d05-7b26-4a7b-b386-2fcafa2f1196)

A hacky workaround fix in `\Symfony\UX\Autocomplete\Doctrine\EntityMetadata:47` to keep BC, could be:

```php
if (\array_key_exists($propertyName, $this->metadata->fieldMappings)) {
    return (array) $this->metadata->fieldMappings[$propertyName];
}
```

But also since `zenstruck/foundry` doesn't support `doctrine/orm:^3.0` yet, we would not be able to run the testsuite and see any other incompatibilities in the component. So we need to take a closer look for all implications.

So for now it's probably wise to add a conflict on `doctrine/orm:^3.0` until we are able to confidently add support for it. Alternatively we could also add a direct dependency on `doctrine/orm:^2.9.4` (instead of only a dev dep)?

- [LiveComponent](https://github.com/symfony/ux/blob/2.x/src/LiveComponent/composer.json#L38) doesn't seem to be impacted atm, as it requires `doctrine/annotations:^1.0` which requires `doctrine/lexer:^1 || ^2` which does not allow `doctrine/orm:^3.0`.
- [Turbo](https://github.com/symfony/ux/blob/2.x/src/Turbo/composer.json#L42) already seems to have support for it.