### PR TITLE
minor(live): add security tests

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -45,7 +45,7 @@
         "symfony/options-resolver": "^5.4|^6.0|^7.0",
         "symfony/phpunit-bridge": "^6.0|^7.0",
         "symfony/property-info": "^5.4|^6.0|^7.0",
-        "symfony/security-csrf": "^5.4|^6.0|^7.0",
+        "symfony/security-bundle": "^5.4|^6.0|^7.0",
         "symfony/serializer": "^5.4|^6.0|^7.0",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",
         "symfony/validator": "^5.4|^6.0|^7.0",

--- a/src/LiveComponent/tests/Fixtures/Component/WithSecurity.php
+++ b/src/LiveComponent/tests/Fixtures/Component/WithSecurity.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsLiveComponent('with_security')]
+#[IsGranted('ROLE_USER')]
+class WithSecurity
+{
+    use DefaultActionTrait;
+
+    public ?string $username = null;
+
+    #[LiveAction]
+    public function setUsername(#[CurrentUser] InMemoryUser $user)
+    {
+        $this->username = $user->getUserIdentifier();
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -16,6 +16,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -24,6 +25,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\UX\LiveComponent\LiveComponentBundle;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Component\Component1;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Serializer\Entity2Normalizer;
@@ -66,6 +68,7 @@ final class Kernel extends BaseKernel
         yield new FrameworkBundle();
         yield new TwigBundle();
         yield new DoctrineBundle();
+        yield new SecurityBundle();
         yield new TwigComponentBundle();
         yield new LiveComponentBundle();
         yield new ZenstruckFoundryBundle();
@@ -113,6 +116,14 @@ final class Kernel extends BaseKernel
 
         $c->extension('twig', [
             'default_path' => '%kernel.project_dir%/tests/Fixtures/templates',
+        ]);
+
+        $c->extension('security', [
+            'password_hashers' => [InMemoryUser::class => 'plaintext'],
+            'providers' => ['users' => ['memory' => ['users' => ['kevin' => ['password' => 'pass', 'roles' => ['ROLE_USER']]]]]],
+            'firewalls' => ['main' => [
+                'lazy' => true,
+            ]],
         ]);
 
         $c->extension('twig_component', [

--- a/src/LiveComponent/tests/Fixtures/templates/components/with_security.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/with_security.html.twig
@@ -1,0 +1,5 @@
+<div{{ attributes }}>
+    Successful.
+
+    Username: {{ username }}
+</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | Could help solve/replicate #1124
| License       | MIT

This PR adds some security-related tests:

- Ensure `IsGranted` at the class level is respected.
- Ensure `#[CurrentUser]` can be injected into actions/listeners.
