### PR TITLE
feat(live): improve `TestLiveComponent::actingAs()`

### DIFF
--- a/src/LiveComponent/src/Test/TestLiveComponent.php
+++ b/src/LiveComponent/src/Test/TestLiveComponent.php
@@ -28,12 +28,14 @@ use Symfony\UX\TwigComponent\Test\RenderedComponent;
  */
 final class TestLiveComponent
 {
+    private bool $performedInitialRequest = false;
+
     /**
      * @internal
      */
     public function __construct(
         private ComponentMetadata $metadata,
-        array $data,
+        private array $data,
         private ComponentFactory $factory,
         private KernelBrowser $client,
         private LiveComponentHydrator $hydrator,
@@ -41,35 +43,7 @@ final class TestLiveComponent
         private UrlGeneratorInterface $router,
     ) {
         $this->client->catchExceptions(false);
-
-        $data['attributes']['id'] ??= 'in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed';
-
-        $mounted = $this->factory->create($this->metadata->getName(), $data);
-        $props = $this->hydrator->dehydrate(
-            $mounted->getComponent(),
-            $mounted->getAttributes(),
-            $this->metadataFactory->getMetadata($mounted->getName())
-        );
-
-        if ('POST' === strtoupper($this->metadata->get('method'))) {
-            $this->client->request(
-                'POST',
-                $this->router->generate($this->metadata->get('route'), [
-                    '_live_component' => $this->metadata->getName(),
-                ]),
-                [
-                    'data' => json_encode(['props' => $props->getProps()], flags: \JSON_THROW_ON_ERROR),
-                ],
-            );
-        } else {
-            $this->client->request('GET', $this->router->generate(
-                $this->metadata->get('route'),
-                [
-                    '_live_component' => $this->metadata->getName(),
-                    'props' => json_encode($props->getProps(), flags: \JSON_THROW_ON_ERROR),
-                ]
-            ));
-        }
+        $this->data['attributes']['data-live-id'] ??= 'in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed';
     }
 
     public function render(): RenderedComponent
@@ -95,6 +69,7 @@ final class TestLiveComponent
      */
     public function actingAs(object $user, string $firewallContext = 'main'): self
     {
+        // we call loginUser() on the raw client in case the entire component requires authentication
         $this->client->loginUser($user, $firewallContext);
 
         return $this;
@@ -145,14 +120,14 @@ final class TestLiveComponent
 
     public function response(): Response
     {
-        return $this->client->getResponse();
+        return $this->client()->getResponse();
     }
 
     private function request(array $content = [], ?string $action = null): self
     {
         $csrfToken = $this->csrfToken();
 
-        $this->client->request(
+        $this->client()->request(
             'POST',
             $this->router->generate(
                 $this->metadata->get('route'),
@@ -170,7 +145,7 @@ final class TestLiveComponent
 
     private function props(): array
     {
-        $crawler = $this->client->getCrawler();
+        $crawler = $this->client()->getCrawler();
 
         if (!\count($node = $crawler->filter('[data-live-props-value]'))) {
             throw new \LogicException('A live component action has redirected and you can no longer access the component.');
@@ -181,12 +156,50 @@ final class TestLiveComponent
 
     private function csrfToken(): ?string
     {
-        $crawler = $this->client->getCrawler();
+        $crawler = $this->client()->getCrawler();
 
         if (!\count($node = $crawler->filter('[data-live-csrf-value]'))) {
             return null;
         }
 
         return $node->attr('data-live-csrf-value');
+    }
+
+    private function client(): KernelBrowser
+    {
+        if ($this->performedInitialRequest) {
+            return $this->client;
+        }
+
+        $mounted = $this->factory->create($this->metadata->getName(), $this->data);
+        $props = $this->hydrator->dehydrate(
+            $mounted->getComponent(),
+            $mounted->getAttributes(),
+            $this->metadataFactory->getMetadata($mounted->getName())
+        );
+
+        if ('POST' === strtoupper($this->metadata->get('method'))) {
+            $this->client->request(
+                'POST',
+                $this->router->generate($this->metadata->get('route'), [
+                    '_live_component' => $this->metadata->getName(),
+                ]),
+                [
+                    'data' => json_encode(['props' => $props->getProps()], flags: \JSON_THROW_ON_ERROR),
+                ],
+            );
+        } else {
+            $this->client->request('GET', $this->router->generate(
+                $this->metadata->get('route'),
+                [
+                    '_live_component' => $this->metadata->getName(),
+                    'props' => json_encode($props->getProps(), flags: \JSON_THROW_ON_ERROR),
+                ]
+            ));
+        }
+
+        $this->performedInitialRequest = true;
+
+        return $this->client;
     }
 }

--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -16,6 +16,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -118,13 +119,19 @@ final class Kernel extends BaseKernel
             'default_path' => '%kernel.project_dir%/tests/Fixtures/templates',
         ]);
 
-        $c->extension('security', [
+        $security = [
             'password_hashers' => [InMemoryUser::class => 'plaintext'],
             'providers' => ['users' => ['memory' => ['users' => ['kevin' => ['password' => 'pass', 'roles' => ['ROLE_USER']]]]]],
             'firewalls' => ['main' => [
                 'lazy' => true,
             ]],
-        ]);
+        ];
+
+        if (!class_exists(Security::class)) {
+            $security['enable_authenticator_manager'] = true;
+        }
+
+        $c->extension('security', $security);
 
         $c->extension('twig_component', [
             'defaults' => [

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity1;
 use Symfony\UX\LiveComponent\Tests\LiveComponentTestHelper;
 use Zenstruck\Browser\Test\HasBrowser;
@@ -504,6 +505,10 @@ final class LiveComponentSubscriberTest extends KernelTestCase
 
     public function testCanHaveControllerAttributes(): void
     {
+        if (!class_exists(IsGranted::class)) {
+            $this->markTestSkipped('The security attributes are not available.');
+        }
+
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_security'));
 
         $this->browser()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | n/a
| License       | MIT

_(depends on #1460)_

Currently, if you have a component that requires authentication for all actions (ie `#[IsGranted]` on the component class), in your tests, as soon as you call `$this->createLiveComponent(...)`, you'll get an access denied exception. You never get a chance to call `->actingAs()`.

This PR makes the initial request for the live component _lazy_. Only when the initial request is required (for other methods), is it made. This gives you the chance to call `->actingAs()` before the initial render.
