### PR TITLE
[Autocomplete] Add support for doctrine/orm:^3.0

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+-   Add doctrine/orm 3 support.
+
 ## 2.14.0
 
 -   Fixed behavior of Autocomplete when the underlying `select` or `option`

--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -26,6 +26,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/dependency-injection": "^6.3|^7.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-foundation": "^6.3|^7.0",
         "symfony/http-kernel": "^6.3|^7.0",
         "symfony/property-access": "^6.3|^7.0",
@@ -34,7 +35,7 @@
     "require-dev": {
         "doctrine/collections": "^1.6.8|^2.0",
         "doctrine/doctrine-bundle": "^2.4.3",
-        "doctrine/orm": "^2.9.4",
+        "doctrine/orm": "^2.9.4|^3.0",
         "fakerphp/faker": "^1.22",
         "mtdowling/jmespath.php": "^2.6",
         "symfony/form": "^6.3|^7.0",

--- a/src/Autocomplete/src/Doctrine/EntitySearchUtil.php
+++ b/src/Autocomplete/src/Doctrine/EntitySearchUtil.php
@@ -60,7 +60,7 @@ class EntitySearchUtil
                 }
 
                 $originalPropertyName = $associatedProperties[0];
-                $originalPropertyMetadata = $entityMetadata->getPropertyMetadata($originalPropertyName);
+                $originalPropertyMetadata = $entityMetadata->getAssociationMetadata($originalPropertyName);
                 $associatedEntityDto = $this->metadataFactory->create($originalPropertyMetadata['targetEntity']);
 
                 for ($i = 0; $i < $numAssociatedProperties - 1; ++$i) {
@@ -75,9 +75,8 @@ class EntitySearchUtil
                     }
 
                     if ($i < $numAssociatedProperties - 2) {
-                        $propertyMetadata = $associatedEntityDto->getPropertyMetadata($associatedPropertyName);
-                        $targetEntity = $propertyMetadata['targetEntity'];
-                        $associatedEntityDto = $this->metadataFactory->create($targetEntity);
+                        $propertyMetadata = $associatedEntityDto->getAssociationMetadata($associatedPropertyName);
+                        $associatedEntityDto = $this->metadataFactory->create($propertyMetadata['targetEntity']);
                     }
                 }
 

--- a/src/Autocomplete/tests/Integration/Doctrine/EntityMetadataTest.php
+++ b/src/Autocomplete/tests/Integration/Doctrine/EntityMetadataTest.php
@@ -54,7 +54,7 @@ class EntityMetadataTest extends KernelTestCase
         $this->assertEquals(ClassMetadataInfo::MANY_TO_ONE, $metadata->getPropertyDataType('category'));
     }
 
-    public function testGetPropertyMetadata(): void
+    public function testGetFieldMetadata(): void
     {
         $metadata = $this->getMetadata();
         $this->assertSame([
@@ -66,7 +66,48 @@ class EntityMetadataTest extends KernelTestCase
             'nullable' => false,
             'precision' => null,
             'columnName' => 'name',
-        ], $metadata->getPropertyMetadata('name'));
+        ], $metadata->getFieldMetadata('name'));
+    }
+
+    public function testGetAssociationMetadata(): void
+    {
+        $metadata = $this->getMetadata();
+        $this->assertSame([
+            'fieldName' => 'category',
+            'joinColumns' => [
+                [
+                    'name' => 'category_id',
+                    'unique' => false,
+                    'nullable' => false,
+                    'onDelete' => null,
+                    'columnDefinition' => null,
+                    'referencedColumnName' => 'id',
+                ],
+            ],
+            'cascade' => [],
+            'inversedBy' => 'products',
+            'targetEntity' => 'Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Category',
+            'fetch' => 2,
+            'type' => 2,
+            'mappedBy' => null,
+            'isOwningSide' => true,
+            'sourceEntity' => 'Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Product',
+            'isCascadeRemove' => false,
+            'isCascadePersist' => false,
+            'isCascadeRefresh' => false,
+            'isCascadeMerge' => false,
+            'isCascadeDetach' => false,
+            'sourceToTargetKeyColumns' => [
+                'category_id' => 'id',
+            ],
+            'joinColumnFieldNames' => [
+                'category_id' => 'category_id',
+            ],
+            'targetToSourceKeyColumns' => [
+                'id' => 'category_id',
+            ],
+            'orphanRemoval' => false,
+        ], $metadata->getAssociationMetadata('category'));
     }
 
     public function testIsEmbeddedClassProperty(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes-ish?
| Issues        | Replaces #1459
| License       | MIT

Follow up on #1459 as it seemed a bit more complicated :)

Because in the current `getPropertyMetadata` function, [see](https://github.com/symfony/ux/blob/2.x/src/Autocomplete/src/Doctrine/EntityMetadata.php#L44) and below:

```php
public function getPropertyMetadata(string $propertyName): array
{
    if (\array_key_exists($propertyName, $this->metadata->fieldMappings)) {
        return $this->metadata->fieldMappings[$propertyName];
    }

    if (\array_key_exists($propertyName, $this->metadata->associationMappings)) {
        return $this->metadata->associationMappings[$propertyName];
    }

    throw new \InvalidArgumentException(sprintf('The "%s" field does not exist in the "%s" entity.', $propertyName, $this->metadata->getName()));
}
```

The function combines getting metadata from `fieldMappings` and `associationMappings`, that both return an `array` in **Doctrine ORM 2**. 

This however changes in **Doctrine ORM 3** in `fieldMappings` returning a `FieldMapping` object and `associationMappings` in an `AssociationMapping` object.

To support both Doctrine ORM 2 and 3, I didn't changed the return type of the function for now, as we would otherwise need to bump the major version for the `Autocomplete` component.

To ease the transition to **Doctrine ORM 3** in the future, I've splitted `getPropertyMetadata` in `getFieldMetadata` and `getAssociationMetadata`.

## TODO
- [x] Should we keep the `getPropertyMetadata()` function as a proxy to the new methods? (I removed it for now as the method shouldn't be used directly as [mentioned](https://github.com/symfony/ux/pull/1459#issuecomment-1928120377).
- [x] Should we retroactively add the `@internal` the `src/Autocomplete/src/Doctrine/EntityMetadata.php` class also (as [mentioned](https://github.com/symfony/ux/pull/1459#issuecomment-1928120377))?
- [ ] Test on Doctrine ORM 3, currently blocked by https://github.com/zenstruck/foundry/pull/556