### PR TITLE
Bumping 2.14.2 CHANGELOG and reverting minor feature temporarily

### DIFF
--- a/src/StimulusBundle/CHANGELOG.md
+++ b/src/StimulusBundle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.14.2
+
+-   Fix bug with finding UX Packages with non-standard project structure
+
 ## 2.14.1
 
 -   Fixed bug with Stimulus controllers in subdirectories on Windows

--- a/src/Turbo/CHANGELOG.md
+++ b/src/Turbo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.14.2
+
+-   Fix using old `ClassUtils` class that's not used in newer versions of Doctrine
+
 ## 2.13.2
 
 -   Revert "Change JavaScript package to `type: module`"

--- a/src/Turbo/assets/package.json
+++ b/src/Turbo/assets/package.json
@@ -21,7 +21,7 @@
             }
         },
         "importmap": {
-            "@hotwired/turbo": "^7.1.0 || ^8.0",
+            "@hotwired/turbo": "^7.1.0",
             "@hotwired/stimulus": "^3.0.0"
         }
     },
@@ -30,7 +30,7 @@
         "@hotwired/stimulus": "^3.0.0"
     },
     "devDependencies": {
-        "@hotwired/turbo": "^7.1.0 || ^8.0",
+        "@hotwired/turbo": "^7.1.0",
         "@hotwired/stimulus": "^3.0.0"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

Hi!

I'd like to get a bug fix release out - especially for the UX turbo package and newer Doctrine versions. Out of an abundance of caution, I'm reverting the Turbo 8 support in this PR, so the patch release is clean. After merging, I'll remake a PR to re-add the support.

Cheers!