### PR TITLE
[Turbo] add missing use statement

### DIFF
--- a/src/Turbo/src/Doctrine/ClassUtil.php
+++ b/src/Turbo/src/Doctrine/ClassUtil.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\Turbo\Doctrine;
 
+use Doctrine\Common\Util\ClassUtils as LegacyClassUtils;
 use Symfony\Component\VarExporter\LazyObjectInterface;
 
 /**
@@ -30,8 +31,8 @@ final class ClassUtil
         }
 
         // @legacy for old versions of Doctrine
-        if (class_exists(ClassUtils::class)) {
-            return ClassUtils::getClass($entity);
+        if (class_exists(LegacyClassUtils::class)) {
+            return LegacyClassUtils::getClass($entity);
         }
 
         return $entity::class;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | 
| License       | MIT

The new `Ux\...\ClassUtil` and the legacy `Doctrine\...\ClassUtils` are very similar. Adding the missing use statement with an alias to avoid IDE confusion :)
