### PR TITLE
[StimulusBundle/TwigComponent] Fix "use_yield" to "true" deprecation notice in CI

### DIFF
--- a/src/StimulusBundle/src/Helper/StimulusHelper.php
+++ b/src/StimulusBundle/src/Helper/StimulusHelper.php
@@ -27,7 +27,9 @@ final class StimulusHelper
     public function __construct(?Environment $twig)
     {
         // Twig needed just for its escaping mechanism
-        $this->twig = $twig ?? new Environment(new ArrayLoader());
+        $this->twig = $twig ?? new Environment(new ArrayLoader(), [
+            'use_yield' => true,
+        ]);
     }
 
     public function createStimulusAttributes(): StimulusAttributes

--- a/src/StimulusBundle/tests/Dto/StimulusAttributesTest.php
+++ b/src/StimulusBundle/tests/Dto/StimulusAttributesTest.php
@@ -24,7 +24,9 @@ final class StimulusAttributesTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
+        $this->stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader(), [
+            'use_yield' => true,
+        ]));
     }
 
     public function testAddAction(): void

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -133,7 +133,9 @@ final class ComponentAttributesTest extends TestCase
             'data-live-data-value' => '{}',
         ]);
 
-        $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
+        $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader(), [
+            'use_yield' => true,
+        ]));
         $stimulusAttributes->addController('foo', ['name' => 'ryan', 'some_array' => ['a', 'b']]);
         $attributes = $attributes->defaults($stimulusAttributes);
 
@@ -158,7 +160,9 @@ final class ComponentAttributesTest extends TestCase
             'data-action' => 'live#foo',
         ]);
 
-        $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
+        $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader(), [
+            'use_yield' => true,
+        ]));
         $stimulusAttributes->addAction('foo', 'barMethod');
         $attributes = $attributes->defaults([...$stimulusAttributes]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | 
| License       | MIT

Only this one remains (in StimulusBundle), but I can't find a direct implementation related to the `Environment` in that test. Maybe also related to https://github.com/symfony/symfony/pull/53805 or thoughts anyone?

```
1x: Since twig/twig 3.9.0: Not setting "use_yield" to "true" is deprecated.
    1x in StimulusControllerLoaderFunctionalTest::testFullApplicationLoad from Symfony\UX\StimulusBundle\Tests\AssetMapper
```