### PR TITLE
[Live] Fixed idiomorph id child handling & JavaScript cleanup

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.15.0
+
+-   [BC BREAK] The `data-live-id` attribute was changed to `id`.
+
 ## 2.14.1
 
 -   Fixed a regression in the testing tools related to the default HTTP
@@ -7,8 +11,10 @@
 
 ## 2.14.0
 
+-   [BC BREAK] DOM morphing changed from `morphdom` to `idiomorph`. As this is
+    a different morphing library, there may be some edge cases where the
+    morphing behavior is different.
 -   Add support for URL binding in `LiveProp`
--   DOM morphing changed from `morphdom` to `idiomorph`
 -   Allow multiple `LiveListener` attributes on a single method
 -   Requests to LiveComponent are sent as POST by default
 -   Add method prop to AsLiveComponent to still allow GET requests, usage: `#[AsLiveComponent(method: 'get')]`

--- a/src/LiveComponent/assets/dist/Component/ElementDriver.d.ts
+++ b/src/LiveComponent/assets/dist/Component/ElementDriver.d.ts
@@ -1,31 +1,30 @@
+import LiveControllerDefault from '../live_controller';
 export interface ElementDriver {
     getModelName(element: HTMLElement): string | null;
-    getComponentProps(rootElement: HTMLElement): any;
-    findChildComponentElement(id: string, element: HTMLElement): HTMLElement | null;
-    getKeyFromElement(element: HTMLElement): string | null;
-    getEventsToEmit(element: HTMLElement): Array<{
+    getComponentProps(): any;
+    getEventsToEmit(): Array<{
         event: string;
         data: any;
         target: string | null;
         componentName: string | null;
     }>;
-    getBrowserEventsToDispatch(element: HTMLElement): Array<{
+    getBrowserEventsToDispatch(): Array<{
         event: string;
         payload: any;
     }>;
 }
-export declare class StandardElementDriver implements ElementDriver {
+export declare class StimulusElementDriver implements ElementDriver {
+    private readonly controller;
+    constructor(controller: LiveControllerDefault);
     getModelName(element: HTMLElement): string | null;
-    getComponentProps(rootElement: HTMLElement): any;
-    findChildComponentElement(id: string, element: HTMLElement): HTMLElement | null;
-    getKeyFromElement(element: HTMLElement): string | null;
-    getEventsToEmit(element: HTMLElement): Array<{
+    getComponentProps(): any;
+    getEventsToEmit(): Array<{
         event: string;
         data: any;
         target: string | null;
         componentName: string | null;
     }>;
-    getBrowserEventsToDispatch(element: HTMLElement): Array<{
+    getBrowserEventsToDispatch(): Array<{
         event: string;
         payload: any;
     }>;

--- a/src/LiveComponent/assets/dist/Component/index.d.ts
+++ b/src/LiveComponent/assets/dist/Component/index.d.ts
@@ -3,17 +3,14 @@ import ValueStore from './ValueStore';
 import { ElementDriver } from './ElementDriver';
 import { PluginInterface } from './plugins/PluginInterface';
 import BackendResponse from '../Backend/BackendResponse';
-import { ModelBinding } from '../Directive/get_model_binding';
-export type ComponentFinder = (currentComponent: Component, onlyParents: boolean, onlyMatchName: string | null) => Component[];
 export default class Component {
     readonly element: HTMLElement;
     readonly name: string;
     readonly listeners: Map<string, string[]>;
-    private readonly componentFinder;
     private backend;
-    private readonly elementDriver;
+    readonly elementDriver: ElementDriver;
     id: string | null;
-    fingerprint: string | null;
+    fingerprint: string;
     readonly valueStore: ValueStore;
     private readonly unsyncedInputsTracker;
     private hooks;
@@ -25,14 +22,11 @@ export default class Component {
     private requestDebounceTimeout;
     private nextRequestPromise;
     private nextRequestPromiseResolve;
-    private children;
-    private parent;
     private externalMutationTracker;
     constructor(element: HTMLElement, name: string, props: any, listeners: Array<{
         event: string;
         action: string;
-    }>, componentFinder: ComponentFinder, fingerprint: string | null, id: string | null, backend: BackendInterface, elementDriver: ElementDriver);
-    _swapBackend(backend: BackendInterface): void;
+    }>, id: string | null, backend: BackendInterface, elementDriver: ElementDriver);
     addPlugin(plugin: PluginInterface): void;
     connect(): void;
     disconnect(): void;
@@ -44,17 +38,11 @@ export default class Component {
     files(key: string, input: HTMLInputElement): void;
     render(): Promise<BackendResponse>;
     getUnsyncedModels(): string[];
-    addChild(child: Component, modelBindings?: ModelBinding[]): void;
-    removeChild(child: Component): void;
-    getParent(): Component | null;
-    getChildren(): Map<string, Component>;
     emit(name: string, data: any, onlyMatchingComponentsNamed?: string | null): void;
     emitUp(name: string, data: any, onlyMatchingComponentsNamed?: string | null): void;
     emitSelf(name: string, data: any): void;
     private performEmit;
     private doEmit;
-    updateFromNewElementFromParentRender(toEl: HTMLElement): boolean;
-    onChildComponentModelUpdate(modelName: string, value: any, childComponent: Component): void;
     private isTurboEnabled;
     private tryStartingRequest;
     private performRequest;
@@ -63,7 +51,7 @@ export default class Component {
     private clearRequestDebounceTimeout;
     private debouncedStartRequest;
     private renderError;
-    private getChildrenFingerprints;
     private resetPromise;
+    _updateFromParentProps(props: any): void;
 }
 export declare function proxifyComponent(component: Component): Component;

--- a/src/LiveComponent/assets/dist/Component/plugins/ChildComponentPlugin.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/ChildComponentPlugin.d.ts
@@ -1,0 +1,11 @@
+import Component from '../../Component';
+import { PluginInterface } from './PluginInterface';
+export default class implements PluginInterface {
+    private readonly component;
+    private parentModelBindings;
+    constructor(component: Component);
+    attachToComponent(component: Component): void;
+    private getChildrenFingerprints;
+    private notifyParentModelChange;
+    private getChildren;
+}

--- a/src/LiveComponent/assets/dist/ComponentRegistry.d.ts
+++ b/src/LiveComponent/assets/dist/ComponentRegistry.d.ts
@@ -1,9 +1,8 @@
 import Component from './Component';
-export default class {
-    private componentMapByElement;
-    private componentMapByComponent;
-    registerComponent(element: HTMLElement, component: Component): void;
-    unregisterComponent(component: Component): void;
-    getComponent(element: HTMLElement): Promise<Component>;
-    findComponents(currentComponent: Component, onlyParents: boolean, onlyMatchName: string | null): Component[];
-}
+export declare const resetRegistry: () => void;
+export declare const registerComponent: (component: Component) => void;
+export declare const unregisterComponent: (component: Component) => void;
+export declare const getComponent: (element: HTMLElement) => Promise<Component>;
+export declare const findComponents: (currentComponent: Component, onlyParents: boolean, onlyMatchName: string | null) => Component[];
+export declare const findChildren: (currentComponent: Component) => Component[];
+export declare const findParent: (currentComponent: Component) => Component | null;

--- a/src/LiveComponent/assets/dist/Util/getElementAsTagText.d.ts
+++ b/src/LiveComponent/assets/dist/Util/getElementAsTagText.d.ts
@@ -1,0 +1,1 @@
+export default function getElementAsTagText(element: HTMLElement): string;

--- a/src/LiveComponent/assets/dist/dom_utils.d.ts
+++ b/src/LiveComponent/assets/dist/dom_utils.d.ts
@@ -8,4 +8,3 @@ export declare function getModelDirectiveFromElement(element: HTMLElement, throw
 export declare function elementBelongsToThisComponent(element: Element, component: Component): boolean;
 export declare function cloneHTMLElement(element: HTMLElement): HTMLElement;
 export declare function htmlToElement(html: string): HTMLElement;
-export declare function getElementAsTagText(element: HTMLElement): string;

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -1,8 +1,8 @@
 import { Controller } from '@hotwired/stimulus';
 import Component from './Component';
-import ComponentRegistry from './ComponentRegistry';
+import { BackendInterface } from './Backend/Backend';
 export { Component };
-export declare const getComponent: (element: HTMLElement) => Promise<Component>;
+export { getComponent } from './ComponentRegistry';
 export interface LiveEvent extends CustomEvent {
     detail: {
         controller: LiveController;
@@ -17,9 +17,24 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     static values: {
         name: StringConstructor;
         url: StringConstructor;
-        props: ObjectConstructor;
+        props: {
+            type: ObjectConstructor;
+            default: {};
+        };
+        propsUpdatedFromParent: {
+            type: ObjectConstructor;
+            default: {};
+        };
         csrf: StringConstructor;
         listeners: {
+            type: ArrayConstructor;
+            default: never[];
+        };
+        eventsToEmit: {
+            type: ArrayConstructor;
+            default: never[];
+        };
+        eventsToDispatch: {
             type: ArrayConstructor;
             default: never[];
         };
@@ -27,7 +42,6 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
             type: NumberConstructor;
             default: number;
         };
-        id: StringConstructor;
         fingerprint: {
             type: StringConstructor;
             default: string;
@@ -44,10 +58,21 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     readonly nameValue: string;
     readonly urlValue: string;
     readonly propsValue: any;
+    propsUpdatedFromParentValue: any;
     readonly csrfValue: string;
     readonly listenersValue: Array<{
         event: string;
         action: string;
+    }>;
+    readonly eventsToEmitValue: Array<{
+        event: string;
+        data: any;
+        target: string | null;
+        componentName: string | null;
+    }>;
+    readonly eventsToDispatchValue: Array<{
+        event: string;
+        payload: any;
     }>;
     readonly hasDebounceValue: boolean;
     readonly debounceValue: number;
@@ -59,26 +84,31 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
         };
     };
     private proxiedComponent;
+    private mutationObserver;
     component: Component;
     pendingActionTriggerModelElement: HTMLElement | null;
     private elementEventListeners;
     private pendingFiles;
-    static componentRegistry: ComponentRegistry;
+    static backendFactory: (controller: LiveControllerDefault) => BackendInterface;
     initialize(): void;
     connect(): void;
     disconnect(): void;
     update(event: any): void;
     action(event: any): void;
-    $render(): Promise<import("./Backend/BackendResponse").default>;
     emit(event: Event): void;
     emitUp(event: Event): void;
     emitSelf(event: Event): void;
-    private getEmitDirectives;
+    $render(): Promise<import("./Backend/BackendResponse").default>;
     $updateModel(model: string, value: any, shouldRender?: boolean, debounce?: number | boolean): Promise<import("./Backend/BackendResponse").default>;
+    propsUpdatedFromParentValueChanged(): void;
+    fingerprintValueChanged(): void;
+    private getEmitDirectives;
+    private createComponent;
+    private connectComponent;
+    private disconnectComponent;
     private handleInputEvent;
     private handleChangeEvent;
     private updateModelFromElementEvent;
-    handleConnectedControllerEvent(event: LiveEvent): void;
-    handleDisconnectedChildControllerEvent(event: LiveEvent): void;
     private dispatchEvent;
+    private onMutations;
 }

--- a/src/LiveComponent/assets/dist/morphdom.d.ts
+++ b/src/LiveComponent/assets/dist/morphdom.d.ts
@@ -1,3 +1,2 @@
-import Component from './Component';
 import ExternalMutationTracker from './Rendering/ExternalMutationTracker';
-export declare function executeMorphdom(rootFromElement: HTMLElement, rootToElement: HTMLElement, modifiedFieldElements: Array<HTMLElement>, getElementValue: (element: HTMLElement) => any, childComponents: Component[], findChildComponent: (id: string, element: HTMLElement) => HTMLElement | null, getKeyFromElement: (element: HTMLElement) => string | null, externalMutationTracker: ExternalMutationTracker): void;
+export declare function executeMorphdom(rootFromElement: HTMLElement, rootToElement: HTMLElement, modifiedFieldElements: Array<HTMLElement>, getElementValue: (element: HTMLElement) => any, externalMutationTracker: ExternalMutationTracker): void;

--- a/src/LiveComponent/assets/src/Component/ElementDriver.ts
+++ b/src/LiveComponent/assets/src/Component/ElementDriver.ts
@@ -1,32 +1,29 @@
 import {getModelDirectiveFromElement} from '../dom_utils';
+import LiveControllerDefault from '../live_controller';
 
 export interface ElementDriver {
     getModelName(element: HTMLElement): string|null;
 
-    getComponentProps(rootElement: HTMLElement): any;
-
-    /**
-     * Given an HtmlElement and a child id, find the root element for that child.
-     */
-    findChildComponentElement(id: string, element: HTMLElement): HTMLElement|null;
-
-    /**
-     * Given an element, find the "key" that should be used to identify it;
-     */
-    getKeyFromElement(element: HTMLElement): string|null;
+    getComponentProps(): any;
 
     /**
      * Given an element from a response, find all the events that should be emitted.
      */
-    getEventsToEmit(element: HTMLElement): Array<{event: string, data: any, target: string|null, componentName: string|null }>;
+    getEventsToEmit(): Array<{event: string, data: any, target: string|null, componentName: string|null }>;
 
     /**
      * Given an element from a response, find all the events that should be dispatched.
      */
-    getBrowserEventsToDispatch(element: HTMLElement): Array<{event: string, payload: any }>;
+    getBrowserEventsToDispatch(): Array<{event: string, payload: any }>;
 }
 
-export class StandardElementDriver implements ElementDriver {
+export class StimulusElementDriver implements ElementDriver {
+    private readonly controller: LiveControllerDefault;
+
+    constructor(controller: LiveControllerDefault) {
+        this.controller = controller;
+    }
+
     getModelName(element: HTMLElement): string|null {
         const modelDirective = getModelDirectiveFromElement(element, false);
 
@@ -37,29 +34,15 @@ export class StandardElementDriver implements ElementDriver {
         return modelDirective.action;
     }
 
-    getComponentProps(rootElement: HTMLElement): any {
-        const propsJson = rootElement.dataset.livePropsValue ?? '{}';
-
-        return JSON.parse(propsJson);
+    getComponentProps(): any {
+        return this.controller.propsValue;
     }
 
-    findChildComponentElement(id: string, element: HTMLElement): HTMLElement|null {
-        return element.querySelector(`[data-live-id=${id}]`);
+    getEventsToEmit(): Array<{event: string, data: any, target: string|null, componentName: string|null }> {
+        return this.controller.eventsToEmitValue;
     }
 
-    getKeyFromElement(element: HTMLElement): string|null {
-        return element.dataset.liveId || null;
-    }
-
-    getEventsToEmit(element: HTMLElement): Array<{event: string, data: any, target: string|null, componentName: string|null }> {
-        const eventsJson = element.dataset.liveEmit ?? '[]';
-
-        return JSON.parse(eventsJson);
-    }
-
-    getBrowserEventsToDispatch(element: HTMLElement): Array<{event: string, payload: any }> {
-        const eventsJson = element.dataset.liveBrowserDispatch ?? '[]';
-
-        return JSON.parse(eventsJson);
+    getBrowserEventsToDispatch(): Array<{event: string, payload: any }> {
+        return this.controller.eventsToDispatchValue;
     }
 }

--- a/src/LiveComponent/assets/src/Component/plugins/ChildComponentPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/ChildComponentPlugin.ts
@@ -1,0 +1,88 @@
+import Component from '../../Component';
+import { PluginInterface } from './PluginInterface';
+import { ChildrenFingerprints } from '../../Backend/Backend';
+import getModelBinding, { ModelBinding } from '../../Directive/get_model_binding';
+import { getAllModelDirectiveFromElements } from '../../dom_utils';
+import { findChildren, findParent } from '../../ComponentRegistry';
+
+/**
+ * Handles all interactions for child components of a component.
+ *
+ *      A) This parent component handling its children:
+ *      * Sending children fingerprints to the server.
+ *
+ *      B) This child component handling its parent:
+ *      * Notifying the parent of a model change.
+ */
+export default class implements PluginInterface {
+    private readonly component: Component;
+    private parentModelBindings: ModelBinding[] = [];
+
+    constructor(component: Component) {
+        this.component  = component;
+
+        const modelDirectives = getAllModelDirectiveFromElements(this.component.element);
+        this.parentModelBindings = modelDirectives.map(getModelBinding);
+    }
+
+    attachToComponent(component: Component): void {
+        component.on('request:started', (requestData: any) => {
+            requestData.children = this.getChildrenFingerprints();
+        });
+
+        component.on('model:set', (model: string, value: any) => {
+            this.notifyParentModelChange(model, value);
+        });
+    }
+
+    private getChildrenFingerprints(): ChildrenFingerprints {
+        const fingerprints: ChildrenFingerprints = {};
+
+        this.getChildren().forEach((child) => {
+            if (!child.id) {
+                throw new Error('missing id');
+            }
+
+            fingerprints[child.id] = {
+                fingerprint: child.fingerprint as string,
+                tag: child.element.tagName.toLowerCase(),
+            };
+        });
+
+        return fingerprints;
+    }
+
+    /**
+     * Notifies parent of a model change if desired.
+     *
+     * This makes the child "behave" like it's a normal `<input>` element,
+     * where, when its value changes, the parent is notified.
+     */
+    private notifyParentModelChange(modelName: string, value: any): void {
+        const parentComponent = findParent(this.component);
+
+        if (!parentComponent) {
+            return;
+        }
+
+        this.parentModelBindings.forEach((modelBinding) => {
+            const childModelName = modelBinding.innerModelName || 'value';
+
+            // skip, unless childModelName matches the model that just changed
+            if (childModelName !== modelName) {
+                return;
+            }
+
+            parentComponent.set(
+                modelBinding.modelName,
+                value,
+                modelBinding.shouldRender,
+                modelBinding.debounce
+            );
+        });
+    }
+
+    private getChildren(): Component[] {
+        return findChildren(this.component);
+    }
+}

--- a/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
@@ -151,7 +151,7 @@ export default class implements PluginInterface {
 
     getLoadingDirectives(component: Component, element: HTMLElement|SVGElement) {
         const loadingDirectives: ElementLoadingDirectives[] = [];
-        let matchingElements = [...element.querySelectorAll('[data-loading]')];
+        let matchingElements = [...Array.from(element.querySelectorAll('[data-loading]'))];
 
         // ignore elements which are inside a nested "live" component
         matchingElements = matchingElements.filter((elt) => elementBelongsToThisComponent(elt, component));

--- a/src/LiveComponent/assets/src/Util/getElementAsTagText.ts
+++ b/src/LiveComponent/assets/src/Util/getElementAsTagText.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns just the outer element's HTML as a string - useful for error messages.
+ *
+ * For example:
+ *      <div class="outer">And text inside <p>more text</p></div>
+ *
+ * Would return:
+ *      <div class="outer">
+ */
+export default function getElementAsTagText(element: HTMLElement): string {
+    return element.innerHTML
+        ? element.outerHTML.slice(0, element.outerHTML.indexOf(element.innerHTML))
+        : element.outerHTML;
+}

--- a/src/LiveComponent/assets/src/dom_utils.ts
+++ b/src/LiveComponent/assets/src/dom_utils.ts
@@ -2,6 +2,8 @@ import ValueStore from './Component/ValueStore';
 import { Directive, parseDirectives } from './Directive/directives_parser';
 import { normalizeModelName } from './string_utils';
 import Component from './Component';
+import { findChildren } from './ComponentRegistry';
+import getElementAsTagText from './Util/getElementAsTagText';
 
 /**
  * Return the "value" of any given element.
@@ -206,7 +208,7 @@ export function elementBelongsToThisComponent(element: Element, component: Compo
     }
 
     let foundChildComponent = false;
-    component.getChildren().forEach((childComponent) => {
+    findChildren(component).forEach((childComponent) => {
         if (foundChildComponent) {
             // return early
             return;
@@ -252,21 +254,6 @@ export function htmlToElement(html: string): HTMLElement {
     }
 
     return child;
-}
-
-/**
- * Returns just the outer element's HTML as a string - useful for error messages.
- *
- * For example:
- *      <div class="outer">And text inside <p>more text</p></div>
- *
- * Would return:
- *      <div class="outer">
- */
-export function getElementAsTagText(element: HTMLElement): string {
-    return element.innerHTML
-        ? element.outerHTML.slice(0, element.outerHTML.indexOf(element.innerHTML))
-        : element.outerHTML;
 }
 
 const getMultipleCheckboxValue = function (element: HTMLInputElement, currentValues: Array<string>): Array<string> {

--- a/src/LiveComponent/assets/test/Component/index.test.ts
+++ b/src/LiveComponent/assets/test/Component/index.test.ts
@@ -1,10 +1,10 @@
 import Component, { proxifyComponent } from '../../src/Component';
 import {BackendAction, BackendInterface} from '../../src/Backend/Backend';
-import { StandardElementDriver } from '../../src/Component/ElementDriver';
 import BackendRequest from '../../src/Backend/BackendRequest';
 import { Response } from 'node-fetch';
 import { waitFor } from '@testing-library/dom';
 import BackendResponse from '../../src/Backend/BackendResponse';
+import { noopElementDriver } from '../tools';
 
 interface MockBackend extends BackendInterface {
     actions: BackendAction[],
@@ -30,11 +30,9 @@ const makeTestComponent = (): { component: Component, backend: MockBackend } => 
         'test-component',
         { firstName: '', product: { name: '' } },
         [],
-        () => [],
-        null,
         null,
         backend,
-        new StandardElementDriver()
+        new noopElementDriver(),
     );
 
     return {

--- a/src/LiveComponent/assets/test/ComponentRegistry.test.ts
+++ b/src/LiveComponent/assets/test/ComponentRegistry.test.ts
@@ -1,9 +1,14 @@
 import Component from '../src/Component';
-import ComponentRegistry from '../src/ComponentRegistry';
+import {
+    registerComponent,
+    resetRegistry,
+    getComponent,
+    findComponents,
+} from '../src/ComponentRegistry';
 import BackendRequest from '../src/Backend/BackendRequest';
 import { BackendInterface } from '../src/Backend/Backend';
 import { Response } from 'node-fetch';
-import { StandardElementDriver } from '../src/Component/ElementDriver';
+import { noopElementDriver } from './tools';
 
 const createComponent = (element: HTMLElement, name = 'foo-component'): Component => {
     const backend: BackendInterface = {
@@ -22,61 +27,55 @@ const createComponent = (element: HTMLElement, name = 'foo-component'): Componen
         name,
         {},
         [],
-        () => [],
-        null,
         null,
         backend,
-        new StandardElementDriver(),
+        new noopElementDriver(),
     );
 };
 
 describe('ComponentRegistry', () => {
-    it('can add and retrieve components', async () => {
-        const registry = new ComponentRegistry();
+    beforeEach(() => {
+        resetRegistry();
+    });
 
+    it('can add and retrieve components', async () => {
         const element1 = document.createElement('div');
         const component1 = createComponent(element1);
         const element2 = document.createElement('div');
         const component2 = createComponent(element2);
 
-        registry.registerComponent(element1, component1);
-        registry.registerComponent(element2, component2);
+        registerComponent(component1);
+        registerComponent(component2);
 
-        const promise1 = registry.getComponent(element1);
-        const promise2 = registry.getComponent(element2);
+        const promise1 = getComponent(element1);
+        const promise2 = getComponent(element2);
         await expect(promise1).resolves.toBe(component1);
         await expect(promise2).resolves.toBe(component2);
     });
 
     it('fails if component is not found soon', async () => {
-        const registry = new ComponentRegistry();
-
         const element1 = document.createElement('div');
-        const promise = registry.getComponent(element1);
+        const promise = getComponent(element1);
         expect.assertions(1);
         await expect(promise).rejects.toEqual(new Error('Component not found for element <div></div>'));
     });
 
     it('can find components in the simple case', () => {
-        const registry = new ComponentRegistry();
-
         const element1 = document.createElement('div');
         const component1 = createComponent(element1);
         const element2 = document.createElement('div');
         const component2 = createComponent(element2);
 
-        registry.registerComponent(element1, component1);
-        registry.registerComponent(element2, component2);
+        registerComponent(component1);
+        registerComponent(component2);
 
         const otherComponent = createComponent(document.createElement('div'));
 
-        const components = registry.findComponents(otherComponent, false, null);
+        const components = findComponents(otherComponent, false, null);
         expect(components).toEqual([component1, component2]);
     });
 
     it('can find components with only parents', () => {
-        const registry = new ComponentRegistry();
-
         const element1 = document.createElement('div');
         const component1 = createComponent(element1);
         const element2 = document.createElement('div');
@@ -87,17 +86,15 @@ describe('ComponentRegistry', () => {
         // put component 2 inside component 1
         element1.appendChild(element2);
 
-        registry.registerComponent(element1, component1);
-        registry.registerComponent(element2, component2);
-        registry.registerComponent(element3, component3);
+        registerComponent(component1);
+        registerComponent(component2);
+        registerComponent(component3);
 
-        const components = registry.findComponents(component2, true, null);
+        const components = findComponents(component2, true, null);
         expect(components).toEqual([component1]);
     });
 
     it('can find components by name', () => {
-        const registry = new ComponentRegistry();
-
         const element1 = document.createElement('div');
         const component1 = createComponent(element1, 'component-type1');
         const element2 = document.createElement('div');
@@ -105,28 +102,26 @@ describe('ComponentRegistry', () => {
         const element3 = document.createElement('div');
         const component3 = createComponent(element3, 'component-type2');
 
-        registry.registerComponent(element1, component1);
-        registry.registerComponent(element2, component2);
-        registry.registerComponent(element3, component3);
+        registerComponent(component1);
+        registerComponent(component2);
+        registerComponent(component3);
 
         const otherComponent = createComponent(document.createElement('div'));
 
-        const components = registry.findComponents(otherComponent, false, 'component-type1');
+        const components = findComponents(otherComponent, false, 'component-type1');
         expect(components).toEqual([component1, component2]);
     });
 
     it('will find components including itself', () => {
-        const registry = new ComponentRegistry();
-
         const element1 = document.createElement('div');
         const component1 = createComponent(element1, 'component-type1');
         const element2 = document.createElement('div');
         const component2 = createComponent(element2, 'component-type1');
 
-        registry.registerComponent(element1, component1);
-        registry.registerComponent(element2, component2);
+        registerComponent(component1);
+        registerComponent(component2);
 
-        const components = registry.findComponents(component2, false, null);
+        const components = findComponents(component2, false, null);
         expect(components).toEqual([component1, component2]);
     });
 });

--- a/src/LiveComponent/assets/test/Util/getElementAsTagText.test.ts
+++ b/src/LiveComponent/assets/test/Util/getElementAsTagText.test.ts
@@ -1,0 +1,16 @@
+import { htmlToElement } from '../../src/dom_utils';
+import getElementAsTagText from '../../src/Util/getElementAsTagText';
+
+describe('getElementAsTagText', () => {
+    it('returns self-closing tag correctly', () => {
+        const element = htmlToElement('<input name="user[firstName]">');
+
+        expect(getElementAsTagText(element)).toEqual('<input name="user[firstName]">')
+    });
+
+    it('returns tag text without the innerHTML', () => {
+        const element = htmlToElement('<div class="foo">Name: <input name="user[firstName]"></div>');
+
+        expect(getElementAsTagText(element)).toEqual('<div class="foo">')
+    });
+});

--- a/src/LiveComponent/assets/test/controller/basic.test.ts
+++ b/src/LiveComponent/assets/test/controller/basic.test.ts
@@ -12,7 +12,8 @@
 import {createTest, initComponent, shutdownTests, startStimulus} from '../tools';
 import { htmlToElement } from '../../src/dom_utils';
 import Component from '../../src/Component';
-import LiveControllerDefault, { getComponent } from '../../src/live_controller';
+import { getComponent } from '../../src/live_controller';
+import { findComponents } from '../../src/ComponentRegistry';
 
 describe('LiveController Basic Tests', () => {
     afterEach(() => {
@@ -41,13 +42,12 @@ describe('LiveController Basic Tests', () => {
         expect(test.component).toBeInstanceOf(Component);
         expect(test.component.defaultDebounce).toEqual(115);
         expect(test.component.id).toEqual('the-id');
-        expect(test.component.fingerprint).toEqual('the-fingerprint');
         await expect(getComponent(test.element)).resolves.toBe(test.component);
-        expect(LiveControllerDefault.componentRegistry.findComponents(test.component, false, null)[0]).toBe(test.component);
+        expect(findComponents(test.component, false, null)[0]).toBe(test.component);
 
         // check that it disconnects
         document.body.innerHTML = '';
         await expect(getComponent(test.element)).rejects.toThrow('Component not found for element');
-        expect(LiveControllerDefault.componentRegistry.findComponents(test.component, false, null)).toEqual([]);
+        expect(findComponents(test.component, false, null)).toEqual([]);
     });
 });

--- a/src/LiveComponent/assets/test/controller/child-model.test.ts
+++ b/src/LiveComponent/assets/test/controller/child-model.test.ts
@@ -43,7 +43,7 @@ describe('Component parent -> child data-model binding tests', () => {
             .willReturn((data: any) => `
                 <div ${initComponent(data)}>
                     Food Name ${data.foodName}
-                    <div data-live-id="the-child-id">
+                    <div id="the-child-id">
                 </div>
             `);
 
@@ -76,7 +76,7 @@ describe('Component parent -> child data-model binding tests', () => {
             .willReturn((data: any) => `
                 <div ${initComponent(data)}>
                     Food Name ${data.foodName}
-                    <div data-live-id="the-child-id">
+                    <div id="the-child-id">
                 </div>
             `);
 
@@ -135,7 +135,7 @@ describe('Component parent -> child data-model binding tests', () => {
             .willReturn((data: any) => `
                 <div ${initComponent(data)}>
                     Food Name ${data.foodName}
-                    <div data-live-id="the-child-id">
+                    <div id="the-child-id" data-live-preserve></div>
                 </div>
             `);
 

--- a/src/LiveComponent/assets/test/controller/model.test.ts
+++ b/src/LiveComponent/assets/test/controller/model.test.ts
@@ -705,11 +705,15 @@ describe('LiveController data-model Tests', () => {
     });
 
     it('does not try to set the value of inputs inside a child component', async () => {
-        const test = await createTest({ comment: 'cookie', childComment: 'mmmm' }, (data: any) => `
+        const test = await createTest({ comment: 'cookie', childComment: 'mmmm', skipChild: false }, (data: any) => `
             <div ${initComponent(data)}>
                 <textarea data-model="comment" id="parent-comment"></textarea>
 
-                <div ${initComponent({ comment: data.childComment }, {id: 'the-child-id'})}>
+                <div
+                    ${initComponent({ comment: data.childComment })}
+                    id="the-child-id"
+                    ${data.skipChild ? 'data-live-preserve' : ''}
+                >
                     <textarea data-model="comment" id="child-comment"></textarea>
                 </div>
             </div>
@@ -732,6 +736,7 @@ describe('LiveController data-model Tests', () => {
             // change the data to be extra tricky
             .serverWillChangeProps((data) => {
                 data.comment = 'i like apples';
+                data.skipChild = true;
             });
 
         await test.component.render();

--- a/src/LiveComponent/assets/test/controller/render.test.ts
+++ b/src/LiveComponent/assets/test/controller/render.test.ts
@@ -179,10 +179,10 @@ describe('LiveController rendering Tests', () => {
         expect(test.element.innerHTML).toContain('I should not be removed');
     });
 
-    it('if data-live-id changes, data-live-ignore elements ARE re-rendered', async () => {
+    it('if id changes, data-live-ignore elements ARE re-rendered', async () => {
         const test = await createTest({ firstName: 'Ryan', containerId: 'original' }, (data: any) => `
             <div ${initComponent(data)}>
-                <div data-live-id="${data.containerId}">
+                <div id="${data.containerId}">
                     <div data-live-ignore>Inside Ignore Name: <span>${data.firstName}</span></div>
                 </div>
                 

--- a/src/LiveComponent/assets/test/dom_utils.test.ts
+++ b/src/LiveComponent/assets/test/dom_utils.test.ts
@@ -4,13 +4,13 @@ import {
     htmlToElement,
     getModelDirectiveFromElement,
     elementBelongsToThisComponent,
-    getElementAsTagText,
     setValueOnElement
 } from '../src/dom_utils';
 import ValueStore from '../src/Component/ValueStore';
 import Component from '../src/Component';
 import Backend from '../src/Backend/Backend';
-import {StandardElementDriver} from '../src/Component/ElementDriver';
+import {StimulusElementDriver} from '../src/Component/ElementDriver';
+import { noopElementDriver } from './tools';
 
 const createStore = function(props: any = {}): ValueStore {
     return new ValueStore(props);
@@ -266,21 +266,17 @@ describe('getModelDirectiveFromInput', () => {
 });
 
 describe('elementBelongsToThisComponent', () => {
-    const createComponent = (html: string, childComponents: Component[] = []) => {
+    const createComponent = (html: string) => {
         const component = new Component(
             htmlToElement(html),
             'some-component',
             {},
             [],
-            () => [],
             null,
-            'some-id-' + Math.floor((Math.random() * 100)),
             new Backend(''),
-            new StandardElementDriver()
+            new noopElementDriver(),
         );
-        childComponents.forEach((childComponent) => {
-            component.addChild(childComponent);
-        })
+        component.connect();
 
         return component;
     };
@@ -305,34 +301,20 @@ describe('elementBelongsToThisComponent', () => {
         const childComponent = createComponent('<div class="child"></div>');
         childComponent.element.appendChild(targetElement);
 
-        const component = createComponent('<div class="parent"></div>', [childComponent]);
+        const component = createComponent('<div class="parent"></div>');
         component.element.appendChild(childComponent.element);
 
-        expect(elementBelongsToThisComponent(targetElement, childComponent)).toBeTruthy();
+        //expect(elementBelongsToThisComponent(targetElement, childComponent)).toBeTruthy();
         expect(elementBelongsToThisComponent(targetElement, component)).toBeFalsy();
     });
 
     it('returns false if element *is* a child controller element', () => {
         const childComponent = createComponent('<div class="child"></div>');
 
-        const component = createComponent('<div class="parent"></div>', [childComponent]);
+        const component = createComponent('<div class="parent"></div>');
         component.element.appendChild(childComponent.element);
 
         expect(elementBelongsToThisComponent(childComponent.element, component)).toBeFalsy();
-    });
-});
-
-describe('getElementAsTagText', () => {
-    it('returns self-closing tag correctly', () => {
-        const element = htmlToElement('<input name="user[firstName]">');
-
-        expect(getElementAsTagText(element)).toEqual('<input name="user[firstName]">')
-    });
-
-    it('returns tag text without the innerHTML', () => {
-        const element = htmlToElement('<div class="foo">Name: <input name="user[firstName]"></div>');
-
-        expect(getElementAsTagText(element)).toEqual('<div class="foo">')
     });
 });
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2738,7 +2738,7 @@ current value for all props, except for those that are marked as
 
 What if you *do* want your entire child component to re-render (including
 resetting writable live props) when some value in the parent changes? This
-can be done by manually giving your component a ``data-live-id`` attribute
+can be done by manually giving your component an ``id`` attribute
 that will change if the component should be totally re-rendered:
 
 .. code-block:: html+twig
@@ -2749,11 +2749,11 @@ that will change if the component should be totally re-rendered:
 
         {{ component('TodoFooter', {
             count: todos|length,
-            'data-live-id': 'todo-footer-'~todos|length
+            id: 'todo-footer-'~todos|length
         }) }}
     </div>
 
-In this case, if the number of todos change, then the ``data-live-id``
+In this case, if the number of todos change, then the ``id``
 attribute of the component will also change. This signals that the
 component should re-render itself completely, discarding any writable
 LiveProp values.
@@ -2959,14 +2959,14 @@ Rendering Quirks with List of Elements
 
 If you're rendering a list of elements in your component, to help LiveComponents
 understand which element is which between re-renders (i.e. if something re-orders
-or removes some of those elements), you can add a ``data-live-id`` attribute to
+or removes some of those elements), you can add a ``id`` attribute to
 each element
 
 .. code-block:: html+twig
 
     {# templates/components/Invoice.html.twig #}
     {% for lineItem in lineItems %}
-        <div data-live-id="{{ lineItem.id }}">
+        <div id="{{ lineItem.id }}">
             {{ lineItem.name }}
         </div>
     {% endfor %}
@@ -2998,9 +2998,9 @@ to that component:
         }) }}
     {% endfor %}
 
-The ``key`` will be used to generate a ``data-live-id`` attribute,
+The ``key`` will be used to generate an ``id`` attribute,
 which will be used to identify each child component. You can
-also pass in a ``data-live-id`` attribute directly, but ``key`` is
+also pass in a ``id`` attribute directly, but ``key`` is
 a bit more convenient.
 
 .. _rendering-loop-new-element:
@@ -3190,39 +3190,23 @@ The system doesn't handle every edge case, so here are some things to keep in mi
   that change is **lost**: the element will be re-added in its original location
   during the next re-render.
 
-The Mystical data-live-id Attribute
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Mystical id Attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``data-live-id`` attribute is mentioned several times throughout the documentation
+The ``id`` attribute is mentioned several times throughout the documentation
 to solve various problems. It's usually not needed, but can be the key to solving
 certain complex problems. But what is it?
 
 .. note::
 
-    The :ref:`key prop <key-prop>` is used to create a ``data-live-id`` attribute
+    The :ref:`key prop <key-prop>` is used to create a ``id`` attribute
     on child components. So everything in this section applies equally to the
     ``key`` prop.
 
-The ``data-live-id`` attribute is a unique identifier for an element or a component.
-It's used when a component re-renders and helps Live Components "connect" elements
-or components in the existing HTML with the new HTML. The logic works like this:
-
-Suppose an element or component in the new HTML has a ``data-live-id="some-id"`` attribute.
-Then:
-
-A) If there **is** an element or component with ``data-live-id="some-id"`` in the
-   existing HTML, then the old and new elements/components are considered to be the
-   "same". For elements, the new element will be used to update the old element even
-   if the two elements appear in different places - e.g. like if :ref:`elements are moved <rendering-loop-of-elements>`
-   or re-ordered. For components, because child components render independently
-   from their parent, the existing component will be "left alone" and not re-rendered
-   (unless some ``updateFromParent`` props have changed - see :ref:`child-component-independent-rerender`).
-
-B) If there is **not** an element or component with ``data-live-id="some-id"`` in
-   the existing HTML, then the new element or component is considered to be "new".
-   In both cases, the new element or component will be added to the page. If there
-   is a component/element with a ``data-live-id`` attribute that is *not* in the
-   new HTML, that component/element will be removed from the page.
+The ``id`` attribute is a unique identifier for an element or a component.
+It's used during the morphing process when a component re-renders: it helps the
+`morphing library`_ "connect" elements or components in the existing HTML with the new
+HTML.
 
 Skipping Updating Certain Elements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3239,8 +3223,8 @@ an element, that changes is preserved (see :ref:`smart-rerender-algorithm`).
 
 .. note::
 
-    To *force* an ignored element to re-render, give its parent element a
-    ``data-live-id`` attribute. During a re-render, if this value changes, all
+    To *force* an ignored element to re-render, give its parent element an
+    ``id`` attribute. During a re-render, if this value changes, all
     of the children of the element will be re-rendered, even those with ``data-live-ignore``.
 
 Overwrite HTML Instead of Morphing
@@ -3482,3 +3466,4 @@ bound to Symfony's BC policy for the moment.
 .. _`Twig Component debug command`: https://symfony.com/bundles/ux-twig-component/current/index.html#debugging-components
 .. _`PostMount hook`: https://symfony.com/bundles/ux-twig-component/current/index.html#postmount-hook
 .. _`validation groups`: https://symfony.com/doc/current/form/validation_groups.html
+.. _morphing library: https://github.com/bigskysoftware/idiomorph

--- a/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
+++ b/src/LiveComponent/src/EventListener/InterceptChildComponentRenderSubscriber.php
@@ -53,8 +53,8 @@ class InterceptChildComponentRenderSubscriber implements EventSubscriberInterfac
         $childFingerprints = $parentComponent->getExtraMetadata(self::CHILDREN_FINGERPRINTS_METADATA_KEY);
 
         // get the deterministic id for this child, but without incrementing the counter yet
-        if (isset($event->getInputProps()['data-live-id'])) {
-            $deterministicId = $event->getInputProps()['data-live-id'];
+        if (isset($event->getInputProps()['id'])) {
+            $deterministicId = $event->getInputProps()['id'];
         } else {
             $key = $event->getInputProps()[LiveControllerAttributesCreator::KEY_PROP_NAME] ?? null;
             $deterministicId = $this->getDeterministicIdCalculator()->calculateDeterministicId(increment: false, key: $key);

--- a/src/LiveComponent/src/Test/TestLiveComponent.php
+++ b/src/LiveComponent/src/Test/TestLiveComponent.php
@@ -42,7 +42,7 @@ final class TestLiveComponent
     ) {
         $this->client->catchExceptions(false);
 
-        $data['attributes']['data-live-id'] ??= 'in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed';
+        $data['attributes']['id'] ??= 'in-a-real-scenario-it-would-already-have-one---provide-one-yourself-if-needed';
 
         $mounted = $this->factory->create($this->metadata->getName(), $data);
         $props = $this->hydrator->dehydrate(

--- a/src/LiveComponent/src/Util/ChildComponentPartialRenderer.php
+++ b/src/LiveComponent/src/Util/ChildComponentPartialRenderer.php
@@ -51,7 +51,7 @@ class ChildComponentPartialRenderer implements ServiceSubscriberInterface
         /*
          * The props passed to create this child HAVE changed.
          * Send back a fake element with:
-         *      * data-live-id
+         *      * id
          *      * data-live-fingerprint-value (new fingerprint)
          *      * data-live-props-value (dehydrated props that "accept updates from parent")
          */
@@ -69,12 +69,13 @@ class ChildComponentPartialRenderer implements ServiceSubscriberInterface
         $readonlyDehydratedProps = $liveMetadata->getOnlyPropsThatAcceptUpdatesFromParent($props);
         $readonlyDehydratedProps = $this->getLiveComponentHydrator()->addChecksumToData($readonlyDehydratedProps);
 
-        $attributesCollection->setProps($readonlyDehydratedProps);
+        $attributesCollection->setPropsUpdatedFromParent($readonlyDehydratedProps);
         $attributes = $attributesCollection->toEscapedArray();
         // optional, but these just aren't needed by the frontend at this point
         unset($attributes['data-controller']);
         unset($attributes['data-live-url-value']);
         unset($attributes['data-live-csrf-value']);
+        unset($attributes['data-live-props-value']);
 
         return $this->createHtml($attributes, $childTag);
     }
@@ -88,6 +89,7 @@ class ChildComponentPartialRenderer implements ServiceSubscriberInterface
         $attributes = array_map(function ($key, $value) {
             return sprintf('%s="%s"', $key, $value);
         }, array_keys($attributes), $attributes);
+        $attributes[] = 'data-live-preserve="true"';
 
         return sprintf('<%s %s></%s>', $childTag, implode(' ', $attributes), $childTag);
     }

--- a/src/LiveComponent/src/Util/LiveAttributesCollection.php
+++ b/src/LiveComponent/src/Util/LiveAttributesCollection.php
@@ -49,9 +49,10 @@ final class LiveAttributesCollection
         $this->attributes['data-live-name-value'] = $componentName;
     }
 
+    // TODO rename that
     public function setLiveId(string $id): void
     {
-        $this->attributes['data-live-id'] = $id;
+        $this->attributes['id'] = $id;
     }
 
     public function setFingerprint(string $fingerprint): void
@@ -62,6 +63,11 @@ final class LiveAttributesCollection
     public function setProps(array $dehydratedProps): void
     {
         $this->attributes['data-live-props-value'] = $dehydratedProps;
+    }
+
+    public function setPropsUpdatedFromParent(array $dehydratedProps): void
+    {
+        $this->attributes['data-live-props-updated-from-parent-value'] = $dehydratedProps;
     }
 
     public function getProps(): array
@@ -90,12 +96,12 @@ final class LiveAttributesCollection
 
     public function setEventsToEmit(array $events): void
     {
-        $this->attributes['data-live-emit'] = $events;
+        $this->attributes['data-live-events-to-emit-value'] = $events;
     }
 
     public function setBrowserEventsToDispatch(array $browserEventsToDispatch): void
     {
-        $this->attributes['data-live-browser-dispatch'] = $browserEventsToDispatch;
+        $this->attributes['data-live-events-to-dispatch-value'] = $browserEventsToDispatch;
     }
 
     public function setRequestMethod(string $requestMethod): void

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -35,7 +35,7 @@ class LiveControllerAttributesCreator
     /**
      * Prop name that can be passed into a component to keep it unique in a loop.
      *
-     * This is used to generate the unique data-live-id for the child component.
+     * This is used to generate the unique id for the child component.
      */
     public const KEY_PROP_NAME = 'key';
 
@@ -89,18 +89,21 @@ class LiveControllerAttributesCreator
             ]);
         }
 
-        if (!isset($mountedAttributes->all()['data-live-id'])) {
+        if (!isset($mountedAttributes->all()['id'])) {
             $id = $deterministicId ?: $this->idCalculator
                 ->calculateDeterministicId(key: $mounted->getInputProps()[self::KEY_PROP_NAME] ?? null);
             $attributesCollection->setLiveId($id);
             // we need to add this to the mounted attributes so that it is
             // will be included in the "attributes" part of the props data.
-            $mountedAttributes = $mountedAttributes->defaults(['data-live-id' => $id]);
+            $mountedAttributes = $mountedAttributes->defaults(['id' => $id]);
         }
 
         $liveMetadata = $this->metadataFactory->getMetadata($mounted->getName());
         $requestMethod = $liveMetadata->getComponentMetadata()?->get('method') ?? 'post';
-        $attributesCollection->setRequestMethod($requestMethod);
+        // set attribute if needed
+        if ('post' !== $requestMethod) {
+            $attributesCollection->setRequestMethod($requestMethod);
+        }
 
         if ($liveMetadata->hasQueryStringBindings()) {
             $queryMapping = [];

--- a/src/LiveComponent/tests/Fixtures/templates/components/todo_list.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/todo_list.html.twig
@@ -5,7 +5,7 @@
     {% for item in items %}
         {% set componentProps = { text: item.text, textLength: item.text|length } %}
         {% if includeDataLiveId %}
-            {% set componentProps = componentProps|merge({'data-live-id': ('todo-item-' ~ loop.index) }) %}
+            {% set componentProps = componentProps|merge({id: ('todo-item-' ~ loop.index) }) %}
         {% endif %}
         {% if loop.index is odd %}
             {{ component('todo_item', componentProps) }}

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -50,7 +50,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertSame(1, $props['count']);
         $this->assertArrayHasKey('@checksum', $props);
         $this->assertArrayHasKey('@attributes', $props);
-        $this->assertArrayHasKey('data-live-id', $props['@attributes']);
+        $this->assertArrayHasKey('id', $props['@attributes']);
     }
 
     public function testCanUseCustomAttributesVariableName(): void
@@ -99,13 +99,13 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
 
         $lis = $ul->children('li');
         // deterministic id: should not change, and counter should increase
-        $this->assertSame(self::TODO_ITEM_DETERMINISTIC_PREFIX.'0', $lis->first()->attr('data-live-id'));
-        $this->assertSame(self::TODO_ITEM_DETERMINISTIC_PREFIX.'1', $lis->last()->attr('data-live-id'));
+        $this->assertSame(self::TODO_ITEM_DETERMINISTIC_PREFIX.'0', $lis->first()->attr('id'));
+        $this->assertSame(self::TODO_ITEM_DETERMINISTIC_PREFIX.'1', $lis->last()->attr('id'));
 
-        // the data-live-id attribute also needs to be part of the "props" so that it persists on renders
+        // the id attribute also needs to be part of the "props" so that it persists on renders
         $props = json_decode($lis->first()->attr('data-live-props-value'), true);
         $attributesProps = $props['@attributes'];
-        $this->assertArrayHasKey('data-live-id', $attributesProps);
+        $this->assertArrayHasKey('id', $attributesProps);
 
         // fingerprints
         // first and last both have the same length "text" input, and since "textLength"
@@ -130,9 +130,9 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         ;
 
         $lis = $ul->children('li');
-        // deterministic id: is not used: data-live-id was passed in manually
-        $this->assertSame('todo-item-1', $lis->first()->attr('data-live-id'));
-        $this->assertSame('todo-item-3', $lis->last()->attr('data-live-id'));
+        // deterministic id: is not used: id was passed in manually
+        $this->assertSame('todo-item-1', $lis->first()->attr('id'));
+        $this->assertSame('todo-item-3', $lis->last()->attr('id'));
     }
 
     public function testQueryStringMappingAttribute()
@@ -174,7 +174,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertCount(3, $props);
         $this->assertArrayHasKey('@checksum', $props);
         $this->assertArrayHasKey('@attributes', $props);
-        $this->assertArrayHasKey('data-live-id', $props['@attributes']);
+        $this->assertArrayHasKey('id', $props['@attributes']);
         $this->assertArrayHasKey('count', $props);
         $this->assertSame($props['count'], 0);
     }
@@ -209,7 +209,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertCount(3, $props);
         $this->assertArrayHasKey('@checksum', $props);
         $this->assertArrayHasKey('@attributes', $props);
-        $this->assertArrayHasKey('data-live-id', $props['@attributes']);
+        $this->assertArrayHasKey('id', $props['@attributes']);
         $this->assertArrayHasKey('count', $props);
         $this->assertSame($props['count'], 2);
     }

--- a/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
@@ -35,7 +35,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         $this->assertSame('live:connect->live#$render', $div->attr('data-action'));
 
         $component = $this->mountComponent('deferred_component', [
-            'data-live-id' => $div->attr('data-live-id'),
+            'id' => $div->attr('id'),
         ]);
 
         $dehydrated = $this->dehydrateComponent($component);
@@ -62,7 +62,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         $this->assertSame('I\'m loading a reaaaally slow live component', trim($div->html()));
 
         $component = $this->mountComponent('deferred_component', [
-            'data-live-id' => $div->attr('data-live-id'),
+            'id' => $div->attr('id'),
         ]);
 
         $dehydrated = $this->dehydrateComponent($component);

--- a/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
@@ -86,19 +86,19 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
             ->use(function (AbstractBrowser $browser) {
                 $content = $browser->getResponse()->getContent();
 
-                // 1st and 3rd render empty
-                // fingerprint changed in 2nd, so it renders new fingerprint + props
+                // 1st renders empty
+                // fingerprint changed in 2nd & 3rd, so it renders new fingerprint + props
                 $this->assertStringContainsString(sprintf(
-                    '<li data-live-id="%s0"></li>',
+                    '<li id="%s0" data-live-preserve="true"></li>',
                     AddLiveAttributesSubscriberTest::TODO_ITEM_DETERMINISTIC_PREFIX
                 ), $content);
                 // new props are JUST the "textLength" + a checksum for it specifically
                 $this->assertStringContainsString(sprintf(
-                    '<li data-live-name-value="todo_item" data-live-id="%s0" data-live-request-method-value="post" data-live-fingerprint-value="sMvvf7q68tz&#x2F;Cuk&#x2B;vDeisDiq&#x2B;7YPWzT&#x2B;WZFzI37dGHY&#x3D;" data-live-props-value="&#x7B;&quot;textLength&quot;&#x3A;18,&quot;&#x40;checksum&quot;&#x3A;&quot;LGxXa9fMKrJ6PelkUPfqmdwnfkk&#x2B;LORgoJHXyPpS3Pw&#x3D;&quot;&#x7D;"></li>',
+                    '<li data-live-name-value="todo_item" id="%s0" data-live-fingerprint-value="sMvvf7q68tz&#x2F;Cuk&#x2B;vDeisDiq&#x2B;7YPWzT&#x2B;WZFzI37dGHY&#x3D;" data-live-props-updated-from-parent-value="&#x7B;&quot;textLength&quot;&#x3A;18,&quot;&#x40;checksum&quot;&#x3A;&quot;LGxXa9fMKrJ6PelkUPfqmdwnfkk&#x2B;LORgoJHXyPpS3Pw&#x3D;&quot;&#x7D;" data-live-preserve="true"></li>',
                     AddLiveAttributesSubscriberTest::TODO_ITEM_DETERMINISTIC_PREFIX_EMBEDDED
                 ), $content);
                 $this->assertStringContainsString(sprintf(
-                    '<li data-live-name-value="todo_item" data-live-id="%s1" data-live-request-method-value="post" data-live-fingerprint-value="8AooEz36WYQyxj54BCaDm&#x2F;jKbcdDdPDLaNO4&#x2F;49bcQk&#x3D;" data-live-props-value="&#x7B;&quot;textLength&quot;&#x3A;10,&quot;&#x40;checksum&quot;&#x3A;&quot;BXUk7q6LI&#x5C;&#x2F;6Qx3c62Xiui6287YndmoK3QmVq6e5mcGk&#x3D;&quot;&#x7D;"></li>',
+                    '<li data-live-name-value="todo_item" id="%s1" data-live-fingerprint-value="8AooEz36WYQyxj54BCaDm&#x2F;jKbcdDdPDLaNO4&#x2F;49bcQk&#x3D;" data-live-props-updated-from-parent-value="&#x7B;&quot;textLength&quot;&#x3A;10,&quot;&#x40;checksum&quot;&#x3A;&quot;BXUk7q6LI&#x5C;&#x2F;6Qx3c62Xiui6287YndmoK3QmVq6e5mcGk&#x3D;&quot;&#x7D;" data-live-preserve="true"></li>',
                     AddLiveAttributesSubscriberTest::TODO_ITEM_DETERMINISTIC_PREFIX
                 ), $content);
             });
@@ -129,12 +129,12 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
             ->assertHtml()
             ->assertElementCount('ul li', 3)
             // check for the live-id we expect based on the key
-            ->assertContains('data-live-id="live-521026374-the-key0"')
+            ->assertContains('id="live-521026374-the-key0"')
             ->assertNotContains('key="the-key0"')
             ->visit($urlWithChangedFingerprints)
-            ->assertContains('<li data-live-id="live-521026374-the-key0"></li>')
+            ->assertContains('<li id="live-521026374-the-key0" data-live-preserve="true"></li>')
             // this one is changed, so it renders a full element
-            ->assertContains('<li data-live-name-value="todo_item" data-live-id="live-4172682817-the-key1"')
+            ->assertContains('<li data-live-name-value="todo_item" id="live-4172682817-the-key1"')
         ;
     }
 

--- a/src/LiveComponent/tests/Functional/LiveResponderTest.php
+++ b/src/LiveComponent/tests/Functional/LiveResponderTest.php
@@ -53,7 +53,7 @@ final class LiveResponderTest extends KernelTestCase
         ;
 
         $div = $crawler->filter('div');
-        $browserDispatch = $div->attr('data-live-browser-dispatch');
+        $browserDispatch = $div->attr('data-live-events-to-dispatch-value');
         $this->assertNotNull($browserDispatch);
         $browserDispatchData = json_decode($browserDispatch, true);
         $this->assertSame([

--- a/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
+++ b/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
@@ -34,7 +34,7 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
             // Normally createAndRender is always called from within a Template via the ComponentExtension.
             // To avoid that the DeterministicTwigIdCalculator complains that there's no Template
             // to base the live id on, we'll add this dummy one, so it gets skipped.
-            'attributes' => ['data-live-id' => 'dummy-live-id'],
+            'attributes' => ['id' => 'dummy-live-id'],
         ]);
 
         $this->assertStringContainsString('<textarea data-model="content:value">Hello data-model!</textarea>', $html);
@@ -53,7 +53,7 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
         $renderer = self::getContainer()->get('ux.twig_component.component_renderer');
 
         $html = $renderer->createAndRender('parent_component_data_model', [
-            'attributes' => ['data-live-id' => 'dummy-live-id'],
+            'attributes' => ['id' => 'dummy-live-id'],
         ]);
 
         $this->assertStringContainsString('<textarea data-model="content">default content on mount</textarea>', $html);

--- a/src/LiveComponent/tests/Integration/Twig/LiveComponentRuntimeTest.php
+++ b/src/LiveComponent/tests/Integration/Twig/LiveComponentRuntimeTest.php
@@ -31,7 +31,7 @@ final class LiveComponentRuntimeTest extends KernelTestCase
             'prop1' => null,
             'prop2' => new \DateTime('2022-10-06-0'),
             'prop3' => 'howdy',
-            'attributes' => ['data-live-id' => 'in-a-real-scenario-it-would-already-have-one'],
+            'attributes' => ['id' => 'in-a-real-scenario-it-would-already-have-one'],
         ]);
 
         $this->assertStringStartsWith('/_components/component1?props=%7B%22prop1%22:null,%22prop2%22:%222022-10-06T00:00:00%2B00:00%22,%22prop3%22:%22howdy%22,%22', $url);

--- a/src/LiveComponent/tests/LiveComponentTestHelper.php
+++ b/src/LiveComponent/tests/LiveComponentTestHelper.php
@@ -43,8 +43,8 @@ trait LiveComponentTestHelper
 
     private function mountComponent(string $name, array $data = [], $addDummyLiveId = true): MountedComponent
     {
-        if ($addDummyLiveId && empty($data['attributes']['data-live-id'])) {
-            $data['attributes']['data-live-id'] = 'in-a-real-scenario-it-would-already-have-one';
+        if ($addDummyLiveId && empty($data['attributes']['id'])) {
+            $data['attributes']['id'] = 'in-a-real-scenario-it-would-already-have-one';
         }
 
         return $this->factory()->create($name, $data);

--- a/src/LiveComponent/tests/Unit/Util/LiveAttributesCollectionTest.php
+++ b/src/LiveComponent/tests/Unit/Util/LiveAttributesCollectionTest.php
@@ -51,13 +51,13 @@ class LiveAttributesCollectionTest extends KernelTestCase
         $expected = [
             'data-controller' => 'live',
             'data-live-name-value' => 'my-component',
-            'data-live-id' => 'the-live-id',
+            'id' => 'the-live-id',
             'data-live-fingerprint-value' => 'the-fingerprint',
             'data-live-props-value' => '&#x7B;&quot;the&quot;&#x3A;&quot;props&quot;&#x7D;',
             'data-live-url-value' => 'the-live-url',
             'data-live-csrf-value' => 'the-csrf-token',
             'data-live-listeners-value' => '&#x7B;&quot;event_name&quot;&#x3A;&quot;theActionName&quot;&#x7D;',
-            'data-live-emit' => '&#x5B;&#x7B;&quot;event&quot;&#x3A;&quot;event_name1&quot;,&quot;data&quot;&#x3A;&#x7B;&quot;the&quot;&#x3A;&quot;data&quot;&#x7D;,&quot;target&quot;&#x3A;&quot;up&quot;,&quot;componentName&quot;&#x3A;&quot;the-component&quot;&#x7D;,&#x7B;&quot;event&quot;&#x3A;&quot;event_name2&quot;,&quot;data&quot;&#x3A;&#x7B;&quot;the&quot;&#x3A;&quot;data&quot;&#x7D;,&quot;target&quot;&#x3A;null,&quot;componentName&quot;&#x3A;null&#x7D;&#x5D;',
+            'data-live-events-to-emit-value' => '&#x5B;&#x7B;&quot;event&quot;&#x3A;&quot;event_name1&quot;,&quot;data&quot;&#x3A;&#x7B;&quot;the&quot;&#x3A;&quot;data&quot;&#x7D;,&quot;target&quot;&#x3A;&quot;up&quot;,&quot;componentName&quot;&#x3A;&quot;the-component&quot;&#x7D;,&#x7B;&quot;event&quot;&#x3A;&quot;event_name2&quot;,&quot;data&quot;&#x3A;&#x7B;&quot;the&quot;&#x3A;&quot;data&quot;&#x7D;,&quot;target&quot;&#x3A;null,&quot;componentName&quot;&#x3A;null&#x7D;&#x5D;',
             'data-live-query-mapping-value' => '&#x7B;&quot;foo&quot;&#x3A;&#x7B;&quot;name&quot;&#x3A;&quot;foo&quot;&#x7D;,&quot;bar&quot;&#x3A;&#x7B;&quot;name&quot;&#x3A;&quot;bar&quot;&#x7D;&#x7D;',
         ];
 

--- a/ux.symfony.com/templates/components/LiveMemory/Card.html.twig
+++ b/ux.symfony.com/templates/components/LiveMemory/Card.html.twig
@@ -1,5 +1,5 @@
 <div
-    data-live-id="card-{{ key }}"
+    id="card-{{ key }}"
     class="{{ html_classes('LiveMemory-Card', {
         'LiveMemory-Card--flipped': flipped,
         'LiveMemory-Card--selected': selected,

--- a/ux.symfony.com/templates/components/LiveMemory/Tableau.html.twig
+++ b/ux.symfony.com/templates/components/LiveMemory/Tableau.html.twig
@@ -11,7 +11,7 @@
             "--slot-y": y
         } %}
         <div class="LiveMemory-CardSlot"
-             data-live-id="slot-{{ key }}"
+             id="slot-{{ key }}"
              style="{{ style|map((v, k) => '%s: %s;'|format(k, v))|join(' ') }}"
         >
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Issues        |  Fix #1470 Fix #1472
| License       | MIT

Hi!

TODO:

* [x] Finish fixing minor js tests

Sorry, quite a lot going on here to get morphing & child rendering *just* right after switching to Idiomorph. The referenced tickets exposed a few cases that were not handled by the tests:

## IMPORTANT CHANGES

* A) `data-live-id` is now `id`. That's because Idiomorph uses `id` as its special key. So it's time to embrace that.
* B) Fixed a bug if `ChildComponentA` were changed to `ChildComponentB` in the same location. Under some situations, we would NOT swap for the new HTML, and would instead "refresh" `ChildComponentA`.
* C) In the above situation, even when we DID swap to `ChildComponentB` correctly, the `LiveController` would still be attached to a `Component` object representing `ChildComponentA`. That would cause problems later on. We now watch for the `id` attribute to change, and then re-create a new `Component` if changed.
* D) Removed special "morph" handling for children components (which are always empty). Instead added a new `data-live-preserve` attribute for elements that want to keep their current element. Improved handling of this.

## OTHER CHANGES

* Various internal attributes like `data-live-emit` were changed to Stimulus values, like `data-events-to-emit-value`. These are not attributes the user ever sets directly.
* Moved the remaining JS child handling into a plugin
* Added `morph:started` and `morph:finished` 
* Simplified "child" handling. Previously we really tried to keep track of our children as they were attached / detached. Now, if we need to know our children, we loop over all components to find children.

Cheers!