### PR TITLE
[Twig][Live] Skip Twig 3.9 🚒  (do not set `use_yield = true` for now)

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -29,7 +29,7 @@
         "php": ">=8.1",
         "symfony/property-access": "^5.4.5|^6.0|^7.0",
         "symfony/ux-twig-component": "^2.8",
-        "twig/twig": "^2.14.7|^3.0.4"
+        "twig/twig": "^2.14.7|~3.8.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.0",

--- a/src/StimulusBundle/composer.json
+++ b/src/StimulusBundle/composer.json
@@ -18,7 +18,7 @@
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",
         "symfony/finder": "^5.4|^6.0|^7.0",
         "symfony/http-kernel": "^5.4|^6.0|^7.0",
-        "twig/twig": "^2.15.3|^3.4.3",
+        "twig/twig": "^2.15.3|~3.8.0",
         "symfony/deprecation-contracts": "^2.0|^3.0"
     },
     "require-dev": {

--- a/src/StimulusBundle/src/Helper/StimulusHelper.php
+++ b/src/StimulusBundle/src/Helper/StimulusHelper.php
@@ -27,9 +27,7 @@ final class StimulusHelper
     public function __construct(?Environment $twig)
     {
         // Twig needed just for its escaping mechanism
-        $this->twig = $twig ?? new Environment(new ArrayLoader(), [
-            'use_yield' => true,
-        ]);
+        $this->twig = $twig ?? new Environment(new ArrayLoader());
     }
 
     public function createStimulusAttributes(): StimulusAttributes

--- a/src/StimulusBundle/tests/Dto/StimulusAttributesTest.php
+++ b/src/StimulusBundle/tests/Dto/StimulusAttributesTest.php
@@ -24,9 +24,7 @@ final class StimulusAttributesTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader(), [
-            'use_yield' => true,
-        ]));
+        $this->stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
     }
 
     public function testAddAction(): void

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -31,7 +31,7 @@
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
         "symfony/property-access": "^5.4|^6.0|^7.0",
-        "twig/twig": "^2.14.7|^3.0.4"
+        "twig/twig": "^2.14.7|~3.8.0"
     },
     "require-dev": {
         "symfony/console": "^5.4|^6.0|^7.0",

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -133,9 +133,7 @@ final class ComponentAttributesTest extends TestCase
             'data-live-data-value' => '{}',
         ]);
 
-        $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader(), [
-            'use_yield' => true,
-        ]));
+        $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
         $stimulusAttributes->addController('foo', ['name' => 'ryan', 'some_array' => ['a', 'b']]);
         $attributes = $attributes->defaults($stimulusAttributes);
 
@@ -160,9 +158,7 @@ final class ComponentAttributesTest extends TestCase
             'data-action' => 'live#foo',
         ]);
 
-        $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader(), [
-            'use_yield' => true,
-        ]));
+        $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
         $stimulusAttributes->addAction('foo', 'barMethod');
         $attributes = $attributes->defaults([...$stimulusAttributes]);
 


### PR DESCRIPTION
As Symfony Twig Bridge & Twig Bundle have decided to skip Twig 3.9 for now, we should do the same, as testing and/or maintaining a compatible version would be really hard without the bundle support.

https://github.com/symfony/twig-bridge/commit/2abddb106523c53aebfe075c04a9d01bc8cdc5b4 
https://github.com/symfony/twig-bundle/commit/23a02ff1693c2c76a4fd55eae83704048d1e93e7


Update: 

Twig 3.9 introduce a major change in the way templates are rendered, and to fully test/fix our compatibility, we need to wait Bridge and Bundle to allow Twig 3.9

In the meantime, please do not set "use_yield = true" as we are not ready yet.

This is something that has a major impact on TwigComponent and LiveComponent, and we'll probably need some changes on the CI / test suite to handle both modes.



---

Pull Request (compatibility - wip) : https://github.com/symfony/ux/pull/1487 (help welcomed)
Issue: https://github.com/symfony/ux/issues/1390 
Twig PR : https://github.com/twigphp/Twig/pull/3950
