### PR TITLE
[Site] Leveraging Turbo 8 on ux.symfony.com

### DIFF
--- a/ux.symfony.com/assets/controllers.json
+++ b/ux.symfony.com/assets/controllers.json
@@ -87,7 +87,7 @@
         "@symfony/ux-turbo": {
             "turbo-core": {
                 "enabled": true,
-                "fetch": "lazy"
+                "fetch": "eager"
             },
             "mercure-turbo-stream": {
                 "enabled": true,

--- a/ux.symfony.com/importmap.php
+++ b/ux.symfony.com/importmap.php
@@ -102,7 +102,7 @@ return [
         'version' => '2.0.2',
     ],
     '@hotwired/turbo' => [
-        'version' => '7.3.0',
+        'version' => '8.0.2',
     ],
     'typed.js' => [
         'version' => '2.0.16',

--- a/ux.symfony.com/templates/base.html.twig
+++ b/ux.symfony.com/templates/base.html.twig
@@ -10,6 +10,7 @@
         {% if meta.canonical|default %}
             <link rel="canonical" href="{{ meta.canonical }}">
         {% endif %}
+        <meta name="view-transition" content="same-origin" />
         <link rel="icon" href="/favicon.ico" sizes="48x48">
         <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

That's all that's needed to use Turbo 8 + view transitions + instaclick-style preloading.


https://github.com/symfony/ux/assets/121003/881dbe3e-5e6c-476b-bf2d-3da836501c18
