### PR TITLE
Build reproductible TemplateMap

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -256,7 +256,11 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             ->setArguments(['%kernel.cache_dir%/'.self::TEMPLATES_MAP_FILENAME]);
 
         $container->register('ux.live_component.twig.cache_warmer', TemplateCacheWarmer::class)
-            ->setArguments([new Reference('twig.template_iterator'), self::TEMPLATES_MAP_FILENAME])
+            ->setArguments([
+                new Reference('twig.template_iterator'),
+                self::TEMPLATES_MAP_FILENAME,
+                '%kernel.secret%',
+            ])
             ->addTag('kernel.cache_warmer');
     }
 

--- a/src/LiveComponent/src/Twig/TemplateCacheWarmer.php
+++ b/src/LiveComponent/src/Twig/TemplateCacheWarmer.php
@@ -22,15 +22,18 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
  */
 final class TemplateCacheWarmer implements CacheWarmerInterface
 {
-    public function __construct(private \IteratorAggregate $templateIterator, private readonly string $cacheFilename)
-    {
+    public function __construct(
+        private readonly \IteratorAggregate $templateIterator,
+        private readonly string $cacheFilename,
+        private readonly string $secret,
+    ) {
     }
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
         $map = [];
         foreach ($this->templateIterator as $item) {
-            $map[bin2hex(random_bytes(16))] = $item;
+            $map[hash('xxh128', $item.$this->secret)] = $item;
         }
 
         (new PhpArrayAdapter($cacheDir.'/'.$this->cacheFilename, new NullAdapter()))->warmUp(['map' => $map]);

--- a/src/LiveComponent/src/Twig/TemplateMap.php
+++ b/src/LiveComponent/src/Twig/TemplateMap.php
@@ -28,7 +28,7 @@ final class TemplateMap
         $this->map = (new PhpArrayAdapter($cacheFile, new NullAdapter()))->getItem('map')->get();
     }
 
-    public function resolve(string $obscuredName)
+    public function resolve(string $obscuredName): string
     {
         return $this->map[$obscuredName] ?? throw new \RuntimeException(sprintf('Cannot find a template matching "%s". Cache may be corrupt.', $obscuredName));
     }

--- a/src/LiveComponent/tests/Unit/Twig/TemplateCacheWarmerTest.php
+++ b/src/LiveComponent/tests/Unit/Twig/TemplateCacheWarmerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Unit\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\UX\LiveComponent\Twig\TemplateCacheWarmer;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class TemplateCacheWarmerTest extends TestCase
+{
+    private string $cacheDir;
+    private string $cacheFile;
+    private TemplateCacheWarmer $templateCacheWarmer;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir ??= sys_get_temp_dir();
+        $this->cacheFile ??= $this->cacheDir.'/cache_file';
+        if (file_exists($this->cacheFile)) {
+            unlink($this->cacheFile);
+        }
+        $this->templateCacheWarmer ??= new TemplateCacheWarmer(
+            new \ArrayObject(['template1', 'template2']),
+            'cache_file',
+            'secret'
+        );
+    }
+
+    public function testWarmUpCreatesCacheFile(): void
+    {
+        $this->assertFileDoesNotExist($this->cacheFile);
+
+        $this->templateCacheWarmer->warmUp($this->cacheDir);
+
+        $this->assertFileExists($this->cacheFile);
+    }
+
+    public function testWarmUpCreatesCorrectCacheContent(): void
+    {
+        $this->templateCacheWarmer->warmUp($this->cacheDir);
+        $adapter = new PhpArrayAdapter($this->cacheFile, new NullAdapter());
+        $item = $adapter->getItem('map');
+
+        $this->assertSame(
+            [
+                hash('xxh128', 'template1secret') => 'template1',
+                hash('xxh128', 'template2secret') => 'template2',
+            ],
+            $item->get()
+        );
+    }
+
+    public function testWarmUpCreatesReproductibleTemplateMap(): void
+    {
+        $this->templateCacheWarmer->warmUp($this->cacheDir);
+        $adapter = new PhpArrayAdapter($this->cacheFile, new NullAdapter());
+        $map1 = $adapter->getItem('map')->get();
+
+        $this->templateCacheWarmer->warmUp($this->cacheDir);
+        $adapter = new PhpArrayAdapter($this->cacheFile, new NullAdapter());
+        $map2 = $adapter->getItem('map')->get();
+
+        $this->assertSame($map1, $map2);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Issues        | Fix #1493
| License       | MIT

(prevent crashes when a LiveComponent has to work before/after a cache clear)

See https://github.com/symfony/ux/issues/1493