### PR TITLE
[Autocomplete] Fix 2 bugs where TomSelect would reset when not necessary

### DIFF
--- a/src/Autocomplete/assets/test/controller.test.ts
+++ b/src/Autocomplete/assets/test/controller.test.ts
@@ -815,4 +815,46 @@ describe('AutocompleteController', () => {
         });
         expect(getSelectedValues()).toEqual(['2', '3']);
     });
+
+    it('does not trigger a reset when the style of "multiple" attribute changes', async () => {
+        const { container } = await startAutocompleteTest(`
+            <select multiple data-testid='main-element' data-controller='autocomplete'>
+                <option value=''>Select dogs</option>
+                <option value='1'>dog1</option>
+                <option value='2'>dog2</option>
+                <option value='3'>dog3</option>
+            </select>
+        `);
+
+        let wasReset = false;
+        container.addEventListener('autocomplete:before-reset', () => {
+            wasReset = true;
+        });
+
+        const selectElement = getByTestId(container, 'main-element') as HTMLSelectElement;
+        selectElement.setAttribute('multiple', 'multiple');
+        // wait for the mutation observe
+        await shortDelay(10);
+        expect(wasReset).toBe(false);
+    });
+
+    it('does not trigger a reset based on the extra, empty select', async () => {
+        const { container, tomSelect } = await startAutocompleteTest(`
+            <select data-testid='main-element' data-controller='autocomplete'>
+                <option value='1'>dog1</option>
+                <option value='2'>dog2</option>
+                <option value='3'>dog3</option>
+            </select>
+        `);
+
+        let wasReset = false;
+        container.addEventListener('autocomplete:before-reset', () => {
+            wasReset = true;
+        });
+
+        tomSelect.addItem('2');
+        // wait for the mutation observe
+        await shortDelay(10);
+        expect(wasReset).toBe(false);
+    });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1499
| License       | MIT

Hi!

The Autocomplete component "resets" the TomSelect instance under certain situations:

* A) The underlying `<option>` elements have changed
* B) The `<select>` changed its `multiple` attribute

Both of these situations had a bug:

* A) If there was no empty `<option value"">` element, then each time a value was selected, it incorrectly looked like the options had changed, triggering a reset.
* B) If the `<select multiple>` attribute was used without the `multiple="multiple"`, it would incorrectly look like the multiple value was changing, when in fact it was just varying between these 2 valid formats.

In both cases, when combined with LiveComponents, an infinite loop was triggered. That's because, as part of the reset process, when we recreate the TomSelect instance, we "select" the original value. This triggers a `change` event, causing LiveComponents to re-render. On its own , that's fine. But the re-render would trigger one of the bugs above, which would trigger another reset and another re-render.

Cheers!
