### PR TITLE
[LiveComponent] Add modifier option to LiveProp

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.17.0
+
+-   Add `modifier` option in `LiveProp` so options can be modified at runtime.
+
 ## 2.16.0
 
 -   LiveComponents is now stable and no longer experimental 🥳

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3450,6 +3450,53 @@ the change of one specific key::
         }
     }
 
+Set LiveProp Options Dynamically
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.17
+
+    The ``modifier`` option was added in LiveComponents 2.17.
+
+
+If you need to configure a LiveProp's options dynamically, you can use the ``modifier`` option to use a custom
+method in your component that returns a modified version of your LiveProp::
+
+
+    #[AsLiveComponent]
+    class ProductSearch
+    {
+        #[LiveProp(writable: true, modifier: 'modifyAddedDate')]
+        public ?\DateTimeImmutable $addedDate = null;
+
+        #[LiveProp]
+        public string $dateFormat = 'Y-m-d';
+
+        // ...
+
+        public function modifyAddedDate(LiveProp $prop): LiveProp
+        {
+            return $prop->withFormat($this->dateFormat);
+        }
+    }
+
+Then, when using your component in a template, you can change the date format used for ``$addedDate``:
+
+.. code-block:: twig
+
+    {{ component('ProductSearch', {
+        dateFormat: 'd/m/Y'
+    }) }}
+
+
+All ``LiveProp::with*`` methods are immutable, so you need to use their return value as your new LiveProp.
+
+.. caution::
+
+    Avoid relying on props that also use a modifier in other modifiers methods. For example, if the ``$dateFormat``
+    property above also had a ``modifier`` option, then it wouldn't be safe to reference it from the ``modifyAddedDate``
+    modifier method. This is because the ``$dateFormat`` property may not have been hydrated by this point.
+
+
 Debugging Components
 --------------------
 

--- a/src/LiveComponent/src/Attribute/LiveProp.php
+++ b/src/LiveComponent/src/Attribute/LiveProp.php
@@ -101,10 +101,19 @@ final class LiveProp
          * in the URL.
          */
         private bool $url = false,
+
+        /**
+         * A hook that will be called when this LiveProp is used.
+         *
+         * Allows to modify the LiveProp options depending on the context. The
+         * original LiveProp attribute instance will be passed as an argument to
+         * it.
+         *
+         * @var string|null
+         */
+        private string|null $modifier = null,
     ) {
-        if ($this->useSerializerForHydration && ($this->hydrateWith || $this->dehydrateWith)) {
-            throw new \InvalidArgumentException('Cannot use useSerializerForHydration with hydrateWith or dehydrateWith.');
-        }
+        self::validateHydrationStrategy($this);
     }
 
     /**
@@ -117,6 +126,14 @@ final class LiveProp
         }
 
         return \in_array(self::IDENTITY, $this->writable, true);
+    }
+
+    public function withWritable(bool|array $writable): self
+    {
+        $clone = clone $this;
+        $clone->writable = $writable;
+
+        return $clone;
     }
 
     /**
@@ -141,12 +158,32 @@ final class LiveProp
         return $this->hydrateWith ? trim($this->hydrateWith, '()') : null;
     }
 
+    public function withHydrateWith(?string $hydrateWith): self
+    {
+        $clone = clone $this;
+        $clone->hydrateWith = $hydrateWith;
+
+        self::validateHydrationStrategy($clone);
+
+        return $clone;
+    }
+
     /**
      * @internal
      */
     public function dehydrateMethod(): ?string
     {
         return $this->dehydrateWith ? trim($this->dehydrateWith, '()') : null;
+    }
+
+    public function withDehydrateWith(?string $dehydrateWith): self
+    {
+        $clone = clone $this;
+        $clone->dehydrateWith = $dehydrateWith;
+
+        self::validateHydrationStrategy($clone);
+
+        return $clone;
     }
 
     /**
@@ -157,12 +194,32 @@ final class LiveProp
         return $this->useSerializerForHydration;
     }
 
+    public function withUseSerializerForHydration(bool $userSerializerForHydration): self
+    {
+        $clone = clone $this;
+        $clone->useSerializerForHydration = $userSerializerForHydration;
+
+        self::validateHydrationStrategy($clone);
+
+        return $clone;
+    }
+
     /**
      * @internal
      */
     public function serializationContext(): array
     {
         return $this->serializationContext;
+    }
+
+    public function withSerializationContext(array $serializationContext): self
+    {
+        $clone = clone $this;
+        $clone->serializationContext = $serializationContext;
+
+        self::validateHydrationStrategy($clone);
+
+        return $clone;
     }
 
     /**
@@ -181,9 +238,25 @@ final class LiveProp
         return $this->fieldName;
     }
 
+    public function withFieldName(?string $fieldName): self
+    {
+        $clone = clone $this;
+        $clone->fieldName = $fieldName;
+
+        return $clone;
+    }
+
     public function format(): ?string
     {
         return $this->format;
+    }
+
+    public function withFormat(?string $format): self
+    {
+        $clone = clone $this;
+        $clone->format = $format;
+
+        return $clone;
     }
 
     public function acceptUpdatesFromParent(): bool
@@ -196,8 +269,36 @@ final class LiveProp
         return $this->onUpdated;
     }
 
+    public function withOnUpdated(string|array|null $onUpdated): self
+    {
+        $clone = clone $this;
+        $clone->onUpdated = $onUpdated;
+
+        return $clone;
+    }
+
     public function url(): bool
     {
         return $this->url;
+    }
+
+    public function withUrl(bool $url): self
+    {
+        $clone = clone $this;
+        $clone->url = $url;
+
+        return $clone;
+    }
+
+    public function modifier(): string|null
+    {
+        return $this->modifier;
+    }
+
+    private static function validateHydrationStrategy(self $liveProp): void
+    {
+        if ($liveProp->useSerializerForHydration && ($liveProp->hydrateWith || $liveProp->dehydrateWith)) {
+            throw new \InvalidArgumentException('Cannot use useSerializerForHydration with hydrateWith or dehydrateWith.');
+        }
     }
 }

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -227,6 +227,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
                 new Reference('request_stack'),
                 new Reference('ux.live_component.metadata_factory'),
                 new Reference('ux.live_component.query_string_props_extractor'),
+                new Reference('property_accessor'),
             ])
             ->addTag('kernel.event_subscriber');
 

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -63,7 +63,7 @@ final class LiveComponentHydrator
         $takenFrontendPropertyNames = [];
 
         $dehydratedProps = new DehydratedProps();
-        foreach ($componentMetadata->getAllLivePropsMetadata() as $propMetadata) {
+        foreach ($componentMetadata->getAllLivePropsMetadata($component) as $propMetadata) {
             $propertyName = $propMetadata->getName();
             $frontendName = $propMetadata->calculateFieldName($component, $propertyName);
 
@@ -143,8 +143,9 @@ final class LiveComponentHydrator
         $attributes = new ComponentAttributes($dehydratedOriginalProps->getPropValue(self::ATTRIBUTES_KEY, []));
         $dehydratedOriginalProps->removePropValue(self::ATTRIBUTES_KEY);
 
-        foreach ($componentMetadata->getAllLivePropsMetadata() as $propMetadata) {
+        foreach ($componentMetadata->getAllLivePropsMetadata($component) as $propMetadata) {
             $frontendName = $propMetadata->calculateFieldName($component, $propMetadata->getName());
+
             if (!$dehydratedOriginalProps->hasPropValue($frontendName)) {
                 // this property was not sent, so skip
                 // even if this has writable paths, if no identity is sent,

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
@@ -25,6 +25,10 @@ class LiveComponentMetadata
         /** @var LivePropMetadata[] */
         private array $livePropsMetadata,
     ) {
+        uasort(
+            $this->livePropsMetadata,
+            static fn (LivePropMetadata $a, LivePropMetadata $b) => $a->hasModifier() <=> $b->hasModifier()
+        );
     }
 
     public function getComponentMetadata(): ComponentMetadata
@@ -35,9 +39,11 @@ class LiveComponentMetadata
     /**
      * @return LivePropMetadata[]
      */
-    public function getAllLivePropsMetadata(): array
+    public function getAllLivePropsMetadata(object $component): iterable
     {
-        return $this->livePropsMetadata;
+        foreach ($this->livePropsMetadata as $livePropMetadata) {
+            yield $livePropMetadata->withModifier($component);
+        }
     }
 
     /**
@@ -60,9 +66,9 @@ class LiveComponentMetadata
         return array_intersect_key($inputProps, array_flip($propNames));
     }
 
-    public function hasQueryStringBindings(): bool
+    public function hasQueryStringBindings($component): bool
     {
-        foreach ($this->getAllLivePropsMetadata() as $livePropMetadata) {
+        foreach ($this->getAllLivePropsMetadata($component) as $livePropMetadata) {
             if ($livePropMetadata->queryStringMapping()) {
                 return true;
             }

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
@@ -107,8 +107,7 @@ class LiveComponentMetadataFactory implements ResetInterface
             $infoType,
             $isTypeBuiltIn,
             $isTypeNullable,
-            $collectionValueType,
-            $liveProp->url()
+            $collectionValueType
         );
     }
 

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -103,11 +103,11 @@ class LiveControllerAttributesCreator
             $attributesCollection->setRequestMethod($requestMethod);
         }
 
-        if ($liveMetadata->hasQueryStringBindings()) {
+        if ($liveMetadata->hasQueryStringBindings($mounted->getComponent())) {
             $queryMapping = [];
-            foreach ($liveMetadata->getAllLivePropsMetadata() as $livePropMetadata) {
+            foreach ($liveMetadata->getAllLivePropsMetadata($mounted->getComponent()) as $livePropMetadata) {
                 if ($livePropMetadata->queryStringMapping()) {
-                    $frontendName = $livePropMetadata->calculateFieldName($mounted, $livePropMetadata->getName());
+                    $frontendName = $livePropMetadata->calculateFieldName($mounted->getComponent(), $livePropMetadata->getName());
                     $queryMapping[$frontendName] = ['name' => $frontendName];
                 }
             }

--- a/src/LiveComponent/src/Util/QueryStringPropsExtractor.php
+++ b/src/LiveComponent/src/Util/QueryStringPropsExtractor.php
@@ -40,7 +40,7 @@ final class QueryStringPropsExtractor
         }
         $data = [];
 
-        foreach ($metadata->getAllLivePropsMetadata() as $livePropMetadata) {
+        foreach ($metadata->getAllLivePropsMetadata($component) as $livePropMetadata) {
             if ($livePropMetadata->queryStringMapping()) {
                 $frontendName = $livePropMetadata->calculateFieldName($component, $livePropMetadata->getName());
                 if (null !== ($value = $query[$frontendName] ?? null)) {

--- a/src/LiveComponent/tests/Fixtures/Component/ComponentWithUrlBoundProps.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ComponentWithUrlBoundProps.php
@@ -38,4 +38,23 @@ class ComponentWithUrlBoundProps
 
     #[LiveProp(fieldName: 'field6', url: true)]
     public ?string $prop6 = null;
+
+    #[LiveProp(fieldName: 'getProp7Name()', url: true)]
+    public ?string $prop7 = null;
+
+    #[LiveProp(modifier: 'modifyProp8')]
+    public ?string $prop8 = null;
+
+    #[LiveProp]
+    public ?bool $prop8InUrl = false;
+
+    public function getProp7Name(): string
+    {
+        return 'field7';
+    }
+
+    public function modifyProp8(LiveProp $prop): LiveProp
+    {
+        return $prop->withUrl($this->prop8InUrl);
+    }
 }

--- a/src/LiveComponent/tests/Fixtures/templates/components/component_with_url_bound_props.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/component_with_url_bound_props.html.twig
@@ -5,4 +5,6 @@
     Prop4: {{ prop4 }}
     Prop5: address: {{ prop5.address ?? '' }} city: {{ prop5.city ?? '' }}
     Prop6: {{ prop6 }}
+    Prop7: {{ prop7 }}
+    Prop8: {{ prop8 }}
 </div>

--- a/src/LiveComponent/tests/Fixtures/templates/render_component_with_url_bound_props.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/render_component_with_url_bound_props.html.twig
@@ -1,1 +1,3 @@
-{{ component('component_with_url_bound_props') }}
+{{ component('component_with_url_bound_props', {
+    prop8InUrl: true
+}) }}

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -151,6 +151,8 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
             'prop3' => ['name' => 'prop3'],
             'prop5' => ['name' => 'prop5'],
             'field6' => ['name' => 'field6'],
+            'field7' => ['name' => 'field7'],
+            'prop8' => ['name' => 'prop8'],
         ];
 
         $this->assertEquals($expected, $queryMapping);

--- a/src/LiveComponent/tests/Functional/EventListener/QueryStringInitializerSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/QueryStringInitializerSubscriberTest.php
@@ -21,7 +21,8 @@ class QueryStringInitializerSubscriberTest extends KernelTestCase
     public function testQueryStringPropsInitialization()
     {
         $this->browser()
-            ->get('/render-template/render_component_with_url_bound_props?prop1=foo&prop2=42&prop3[]=foo&prop3[]=bar&prop4=unbound&prop5[address]=foo&prop5[city]=bar&field6=foo')
+            ->throwExceptions()
+            ->get('/render-template/render_component_with_url_bound_props?prop1=foo&prop2=42&prop3[]=foo&prop3[]=bar&prop4=unbound&prop5[address]=foo&prop5[city]=bar&field6=foo&field7=foo&prop8=foo')
             ->assertSuccessful()
             ->assertContains('Prop1: foo')
             ->assertContains('Prop2: 42')
@@ -29,6 +30,8 @@ class QueryStringInitializerSubscriberTest extends KernelTestCase
             ->assertContains('Prop4:')
             ->assertContains('Prop5: address: foo city: bar')
             ->assertContains('Prop6: foo')
+            ->assertContains('Prop7: foo')
+            ->assertContains('Prop8: foo')
         ;
     }
 }

--- a/src/LiveComponent/tests/Functional/Metadata/LiveComponentMetadataFactoryTest.php
+++ b/src/LiveComponent/tests/Functional/Metadata/LiveComponentMetadataFactoryTest.php
@@ -41,5 +41,9 @@ class LiveComponentMetadataFactoryTest extends KernelTestCase
         $this->assertTrue($propsMetadataByName['prop5']->queryStringMapping());
 
         $this->assertTrue($propsMetadataByName['prop6']->queryStringMapping());
+
+        $this->assertTrue($propsMetadataByName['prop7']->queryStringMapping());
+
+        $this->assertFalse($propsMetadataByName['prop8']->queryStringMapping());
     }
 }

--- a/src/LiveComponent/tests/Unit/Metadata/LiveComponentMetadataTest.php
+++ b/src/LiveComponent/tests/Unit/Metadata/LiveComponentMetadataTest.php
@@ -22,10 +22,10 @@ class LiveComponentMetadataTest extends TestCase
     public function testGetOnlyPropsThatAcceptUpdatesFromParent()
     {
         $propMetadatas = [
-            new LivePropMetadata('noUpdateFromParent1', new LiveProp(updateFromParent: false), null, false, false, null, false),
-            new LivePropMetadata('noUpdateFromParent2', new LiveProp(updateFromParent: false), null, false, false, null, false),
-            new LivePropMetadata('yesUpdateFromParent1', new LiveProp(updateFromParent: true), null, false, false, null, false),
-            new LivePropMetadata('yesUpdateFromParent2', new LiveProp(updateFromParent: true), null, false, false, null, false),
+            new LivePropMetadata('noUpdateFromParent1', new LiveProp(updateFromParent: false), null, false, false, null),
+            new LivePropMetadata('noUpdateFromParent2', new LiveProp(updateFromParent: false), null, false, false, null),
+            new LivePropMetadata('yesUpdateFromParent1', new LiveProp(updateFromParent: true), null, false, false, null),
+            new LivePropMetadata('yesUpdateFromParent2', new LiveProp(updateFromParent: true), null, false, false, null),
         ];
         $liveComponentMetadata = new LiveComponentMetadata(new ComponentMetadata([]), $propMetadatas);
         $inputProps = [

--- a/src/LiveComponent/tests/Unit/Metadata/LivePropMetadataTest.php
+++ b/src/LiveComponent/tests/Unit/Metadata/LivePropMetadataTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Unit\Metadata;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\Metadata\LivePropMetadata;
+
+class LivePropMetadataTest extends TestCase
+{
+    public function testWithModifier()
+    {
+        $liveProp = new LiveProp(modifier: 'modifyProp');
+        $livePropMetadata = new LivePropMetadata('propWithModifier', $liveProp, null, false, false, null);
+
+        $component = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['modifyProp'])
+            ->getMock();
+
+        $component
+            ->expects($this->once())
+            ->method('modifyProp')
+            ->with($liveProp)
+            ->willReturn($liveProp->withFieldName('customField'));
+
+        $livePropMetadata = $livePropMetadata->withModifier($component);
+
+        $this->assertEquals('customField', $livePropMetadata->calculateFieldName($component, 'propWithModifier'));
+    }
+
+    public function testWithModifierThrowsErrorIfNoMethodExistsInComponent()
+    {
+        $liveProp = new LiveProp(modifier: 'modifyProp');
+        $livePropMetadata = new LivePropMetadata('propWithModifier', $liveProp, null, false, false, null);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Method ".*::modifyProp\(\)" given in LiveProp "modifier" does not exist\./');
+
+        $livePropMetadata->withModifier(new \stdClass());
+    }
+
+    public function testWithModifierThrowsAnErrorIfModifierMethodDoesNotReturnLiveProp()
+    {
+        $liveProp = new LiveProp(modifier: 'modifyProp');
+        $livePropMetadata = new LivePropMetadata('propWithModifier', $liveProp, null, false, false, null);
+
+        $component = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['modifyProp'])
+            ->getMock();
+
+        $component
+            ->expects($this->once())
+            ->method('modifyProp')
+            ->willReturn(false);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches(sprintf('/Method ".*::modifyProp\(\)" should return an instance of "%s" \(given: "bool"\)\./', preg_quote(LiveProp::class)));
+        $livePropMetadata->withModifier($component);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | N/A
| License       | MIT

Hi!

Following discussions in [#1396](https://github.com/symfony/ux/pull/1396#discussion_r1471304150), here is a proposal to allow a `LiveProp` to be modified at runtime.

The feature adds a `modifier` option to `LiveProp`, so users can use a custom method to modify the `LiveProp`'s options
depending on the context. 

This context could be a service, or even another prop within the component. 

### Usage

Here is the example given in the doc: 

```php
#[AsLiveComponent]
class ProductSearch
{
    #[LiveProp(writable: true, modifier: 'modifyAddedDate')]
    public ?\DateTimeImmutable $addedDate;

    #[LiveProp]
    public string $dateFormat = 'Y-m-d';

    // ...

    public function modifyAddedDate(LiveProp $prop): LiveProp
    {
        return $prop->withFormat($this->dateFormat);
    }
}
```

```twig
{{ component('ProductSearch', {
    dateFormat: 'd/m/Y'
}) }}
```

### Changes overview

First, we have to make the `LiveProp` attribute editable in some way. I opted out for immutable methods, so caching is preserved when applicable.

Then add a `LivePropMetadata::withModifier(object $component)` method that returns a new instance modified by the user-defined method. This is called in a few places, similarly to `LiveComponentMetadata::calculateFieldName()`.  

The tricky part is component hydration. If we use props in modifiers to change other `LiveProp` options, they have to be hydrated before the modifier is applied. This is only useful for options related to hydration, but it concerns most of them... The trick is to sort metadata, so modified ones are hydrated at the end.

