### PR TITLE
[Site] Fix TomSelect select colors in dark mode

### DIFF
--- a/ux.symfony.com/assets/styles/vendor/_tom-select.scss
+++ b/ux.symfony.com/assets/styles/vendor/_tom-select.scss
@@ -1,5 +1,5 @@
 .ts-dropdown, .ts-control, .ts-control input {
-  color: var(--bs-body-color);
+  color: var(--bs-body-color) !important;
 }
 
 .ts-dropdown, .ts-dropdown.form-control, .ts-dropdown.form-select {

--- a/ux.symfony.com/templates/liveDemoBase.html.twig
+++ b/ux.symfony.com/templates/liveDemoBase.html.twig
@@ -68,7 +68,6 @@
 
 {% block aside %}
     <aside style="background-color: var(--bs-secondary-bg-subtle);" class="mt-5">
-
         <twig:PrevNextDemo demo="{{ demo }}" />
-    </aside>>
+    </aside>
 {% endblock %}


### PR DESCRIPTION
Fix this bug i had on my todo for a loong time 😶 

![image](https://github.com/symfony/ux/assets/1359581/e31ad727-3c3c-4e52-93ba-2086bc55e2be)


(and remove a little closing tag trying to outsmart everyone)
