### PR TITLE
[WIP][Autocomplete] Adding morph support for Turbo & overhauling process

### DIFF
--- a/src/Autocomplete/assets/dist/controller.d.ts
+++ b/src/Autocomplete/assets/dist/controller.d.ts
@@ -50,4 +50,6 @@ export default class extends Controller {
     private onMutations;
     private createOptionsDataStructure;
     private areOptionsEquivalent;
+    private beforeMorphElement;
+    private beforeMorphAttribute;
 }

--- a/src/Autocomplete/assets/dist/controller.d.ts
+++ b/src/Autocomplete/assets/dist/controller.d.ts
@@ -34,6 +34,7 @@ export default class extends Controller {
     private isObserving;
     private hasLoadedChoicesPreviously;
     private originalOptions;
+    private parentElement;
     initialize(): void;
     connect(): void;
     initializeTomSelect(): void;

--- a/ux.symfony.com/src/Form/TimeForAMealForm.php
+++ b/ux.symfony.com/src/Form/TimeForAMealForm.php
@@ -14,6 +14,7 @@ namespace App\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class TimeForAMealForm extends AbstractType
 {
@@ -23,6 +24,9 @@ class TimeForAMealForm extends AbstractType
             ->add('foods', FoodAutocompleteField::class)
             ->add('name', TextType::class, [
                 'label' => 'What should we call this meal?',
+                'constraints' => [
+                    new NotBlank(),
+                ],
             ])
         ;
     }

--- a/ux.symfony.com/templates/base.html.twig
+++ b/ux.symfony.com/templates/base.html.twig
@@ -11,6 +11,8 @@
             <link rel="canonical" href="{{ meta.canonical }}">
         {% endif %}
         <meta name="view-transition" content="same-origin" />
+        <meta name="turbo-refresh-method" content="morph">
+        <meta name="turbo-refresh-scroll" content="preserve">
         <link rel="icon" href="/favicon.ico" sizes="48x48">
         <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">

--- a/ux.symfony.com/templates/ux_packages/autocomplete.html.twig
+++ b/ux.symfony.com/templates/ux_packages/autocomplete.html.twig
@@ -31,7 +31,7 @@
 
 {% block demo_content %}
     {# The frame is used just to keep the form submit all in one place: it feels nice #}
-    <turbo-frame id="autocomplete-demo-form">
+    <div id="autocomplete-demo-form">
         {% for message in app.flashes('autocomplete_success') %}
             <div class="alert alert-success" data-turbo-cache="false">{{ message }}</div>
         {% endfor %}
@@ -41,7 +41,7 @@
 
             {{ form_row(form.name) }}
 
-            <button type="submit" class="btn btn-primary">Let's Nom!</button>
+            <button type="submit" class="btn btn-primary" formnovalidate>Let's Nom!</button>
         {{ form_end(form) }}
-    </turbo-frame>
+    </div>
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Issues        | Fix #1500
| License       | MIT

This is WIP. The goal is to, during morphing, do both of the following:

1) Prevent morphing from removing any manual DOM changes made by TomSelect (which we want to keep)
2) Notice any changes (e.g. the underlying `<option>` elements change) that would require a TomSelect "reset" and doing that reset.

There are lot of permutations to get right, especially with (2), like making sure that both single & multiple `<select>` work as well as TomSelect used on an `<input>`.

Cheers!