### PR TITLE
[Autocomplete] Fix regression where placeholder change didn't cause a reset

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -199,6 +199,14 @@ class default_1 extends Controller {
     areOptionsEquivalent(newOptions) {
         const filteredOriginalOptions = this.originalOptions.filter((option) => option.value !== '');
         const filteredNewOptions = newOptions.filter((option) => option.value !== '');
+        const originalPlaceholderOption = this.originalOptions.find((option) => option.value === '');
+        const newPlaceholderOption = newOptions.find((option) => option.value === '');
+        console.log(originalPlaceholderOption, newPlaceholderOption);
+        if (originalPlaceholderOption &&
+            newPlaceholderOption &&
+            originalPlaceholderOption.text !== newPlaceholderOption.text) {
+            return false;
+        }
         if (filteredOriginalOptions.length !== filteredNewOptions.length) {
             return false;
         }

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -429,6 +429,17 @@ export default class extends Controller {
         const filteredOriginalOptions = this.originalOptions.filter((option) => option.value !== '');
         const filteredNewOptions = newOptions.filter((option) => option.value !== '');
 
+        const originalPlaceholderOption = this.originalOptions.find((option) => option.value === '');
+        const newPlaceholderOption = newOptions.find((option) => option.value === '');
+        console.log(originalPlaceholderOption, newPlaceholderOption);
+        if (
+            originalPlaceholderOption &&
+            newPlaceholderOption &&
+            originalPlaceholderOption.text !== newPlaceholderOption.text
+        ) {
+            return false;
+        }
+
         if (filteredOriginalOptions.length !== filteredNewOptions.length) {
             return false;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | None
| License       | MIT

Introduced here - https://github.com/symfony/ux/pull/1502/files#diff-655bee3f1f3d92a2b984a8599df80a4f31a842d5f04fd3d186f8e3161ce49c0bR429 - when fixing the bug:

> A) If there was no empty <option value""> element, then each time a value was selected, it incorrectly looked like the options had changed, triggering a reset. This is because TomSelect adds a `<option value="">` is there was not one at the start.