### PR TITLE
[Translator] Clean code to suppress warnings

### DIFF
--- a/src/Translator/assets/src/formatters/formatter.ts
+++ b/src/Translator/assets/src/formatters/formatter.ts
@@ -62,10 +62,7 @@ export function format(id: string, parameters: Record<string, string | number> =
     if (/^\|+$/.test(id)) {
         parts = id.split('|');
     } else {
-        const matches = id.match(/(?:\|\||[^|])+/g);
-        if (matches !== null) {
-            parts = matches;
-        }
+        parts = id.match(/(?:\|\||[^|])+/g) || [];
     }
 
     const intervalRegex = /^(?<interval>({\s*(-?\d+(\.\d+)?[\s*,\s*\-?\d+(.\d+)?]*)\s*})|(?<left_delimiter>[[\]])\s*(?<left>-Inf|-?\d+(\.\d+)?)\s*,\s*(?<right>\+?Inf|-?\d+(\.\d+)?)\s*(?<right_delimiter>[[\]]))\s*(?<message>.*?)$/s;
@@ -74,31 +71,31 @@ export function format(id: string, parameters: Record<string, string | number> =
     for (let part of parts) {
         part = part.trim().replace(/\|\|/g, '|');
 
-        let matches = part.match(intervalRegex);
-        if (matches !== null) {
+        const matches = part.match(intervalRegex);
+        if (matches) {
+            /**
+             * @type {interval: string, left_delimiter: string, left: string, right_delimiter: string, right: string, message: string}
+             */
+            const matchGroups: { [p: string]: string } = matches.groups || {};
             if (matches[2]) {
                 for (const n of matches[3].split(',')) {
                     if (number === Number(n)) {
-                        return strtr(matches.groups!['message'], parameters);
+                        return strtr(matchGroups.message, parameters);
                     }
                 }
             } else {
-                const leftNumber = '-Inf' === matches.groups!['left'] ? Number.NEGATIVE_INFINITY : Number(matches.groups!['left']);
-                const rightNumber = ['Inf', '+Inf'].includes(matches.groups!['right']) ? Number.POSITIVE_INFINITY : Number(matches.groups!['right']);
+                const leftNumber = '-Inf' === matchGroups.left ? Number.NEGATIVE_INFINITY : Number(matchGroups.left);
+                const rightNumber = ['Inf', '+Inf'].includes(matchGroups.right) ? Number.POSITIVE_INFINITY : Number(matchGroups.right);
 
-                if (('[' === matches.groups!['left_delimiter'] ? number >= leftNumber : number > leftNumber)
-                    && (']' === matches.groups!['right_delimiter'] ? number <= rightNumber : number < rightNumber)
+                if (('[' === matchGroups.left_delimiter ? number >= leftNumber : number > leftNumber)
+                    && (']' === matchGroups.right_delimiter ? number <= rightNumber : number < rightNumber)
                 ) {
-                    return strtr(matches.groups!['message'], parameters);
+                    return strtr(matchGroups.message, parameters);
                 }
             }
         } else {
-            matches = part.match(/^\w+:\s*(.*?)$/);
-            if (matches !== null) {
-                standardRules.push(matches[1]);
-            } else {
-                standardRules.push(part);
-            }
+            const ruleMatch = part.match(/^\w+:\s*(.*?)$/);
+            standardRules.push(ruleMatch ? ruleMatch[1] : part);
         }
     }
 

--- a/src/Translator/assets/src/translator.ts
+++ b/src/Translator/assets/src/translator.ts
@@ -25,6 +25,7 @@ export type ParametersOf<M, D extends DomainType> = M extends Message<infer Tran
         : never
     : never;
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface Message<Translations extends TranslationsType, Locale extends LocaleType> {
     id: string;
     translations: {


### PR DESCRIPTION
I've had enough of those TS warnings 😅 

```console
/home/runner/work/ux/ux/src/Translator/assets/src/formatters/formatter.ts
  82:38   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  86:47   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  86:107  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  87:62   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  87:124  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  89:30   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  90:33   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  92:34   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/home/runner/work/ux/ux/src/Translator/assets/src/translator.ts
  28:26  warning  'Translations' is defined but never used  @typescript-eslint/no-unused-vars
```

(ex: https://github.com/symfony/ux/actions/runs/7951722335/job/21705480408)

--

The tests are green, but if someone want to checkproof ? 