### PR TITLE
[LiveComponent] Store TemplateMap in `build_dir`

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -253,7 +253,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
         ;
 
         $container->register('ux.live_component.twig.template_mapper', TemplateMap::class)
-            ->setArguments(['%kernel.cache_dir%/'.self::TEMPLATES_MAP_FILENAME]);
+            ->setArguments(['%kernel.build_dir%/'.self::TEMPLATES_MAP_FILENAME]);
 
         $container->register('ux.live_component.twig.cache_warmer', TemplateCacheWarmer::class)
             ->setArguments([

--- a/src/LiveComponent/src/Twig/TemplateCacheWarmer.php
+++ b/src/LiveComponent/src/Twig/TemplateCacheWarmer.php
@@ -36,7 +36,8 @@ final class TemplateCacheWarmer implements CacheWarmerInterface
             $map[hash('xxh128', $item.$this->secret)] = $item;
         }
 
-        (new PhpArrayAdapter($cacheDir.'/'.$this->cacheFilename, new NullAdapter()))->warmUp(['map' => $map]);
+        $cacheFile = sprintf('%s%s%s', $buildDir ?? $cacheDir, DIRECTORY_SEPARATOR, $this->cacheFilename);
+        PhpArrayAdapter::create($cacheFile, new NullAdapter())->warmUp(['map' => $map]);
 
         return [];
     }

--- a/src/LiveComponent/src/Twig/TemplateMap.php
+++ b/src/LiveComponent/src/Twig/TemplateMap.php
@@ -21,11 +21,14 @@ use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
  */
 final class TemplateMap
 {
+    /**
+     * @var array<string, string> Map of <obscured name> => <template name>
+     */
     private readonly array $map;
 
     public function __construct(string $cacheFile)
     {
-        $this->map = (new PhpArrayAdapter($cacheFile, new NullAdapter()))->getItem('map')->get();
+        $this->map = PhpArrayAdapter::create($cacheFile, new NullAdapter())->getItem('map')->get();
     }
 
     public function resolve(string $obscuredName): string
@@ -35,8 +38,7 @@ final class TemplateMap
 
     public function obscuredName(string $templateName): string
     {
-        $obscuredName = array_search($templateName, $this->map, true);
-        if (false === $obscuredName) {
+        if (false === $obscuredName = array_search($templateName, $this->map, true)) {
             throw new \RuntimeException(sprintf('Cannot find a match for template "%s". Cache may be corrupt.', $templateName));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1522
| License       | MIT

Per default `build_dir` = `cache_dir` so that won't change a thing for most of installs.

But in projects with a distinct build directory, this PR fixes a bug where `cache:clear` did not create the file. (cf #1522)