### PR TITLE
upgrading mercure and specifying database options

### DIFF
--- a/ux.symfony.com/mercure/.platform.app.yaml
+++ b/ux.symfony.com/mercure/.platform.app.yaml
@@ -7,7 +7,7 @@ build:
 
 variables:
     env:
-        MERCURE_TRANSPORT_URL: bolt:///app/.local/database.db
+        MERCURE_TRANSPORT_URL: bolt:///app/.local/mercure.db?size=1000&cleanup_frequency=0.5
         # Defined as platform.sh vars
         # MERCURE_PUBLISHER_JWT_KEY: ''
         # MERCURE_SUBSCRIBER_JWT_KEY: ''
@@ -33,4 +33,4 @@ hooks:
         set -e -x
 
         curl -s https://get.symfony.com/cloud/configurator | (>&2 bash)
-        curl -s -H 'Accept: application/octet-stream' -J -L "https://github.com/dunglas/mercure/releases/download/v0.13.0/mercure_0.13.0_Linux_x86_64.tar.gz" | tar -C /app/ -zxpf -
+        curl -s -H 'Accept: application/octet-stream' -J -L "https://github.com/dunglas/mercure/releases/download/v0.15.9/mercure_Linux_x86_64.tar.gz" | tar -C /app/ -zxpf -


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

Our Mercure Bolt database is filling up - the history cleanup - https://mercure.rocks/docs/hub/config#bolt-adapter - doesn't seem to be happening, possibly due to missing options or an out-of-date mercure.