### PR TITLE
[TwigComponent] Render in PostRenderEvent

### DIFF
--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -50,7 +50,8 @@ class TwigComponentDebugCommand extends Command
             ->setDefinition([
                 new InputArgument('name', InputArgument::OPTIONAL, 'A component name or part of the component name'),
             ])
-            ->setHelp(<<<'EOF'
+            ->setHelp(
+                <<<'EOF'
 The <info>%command.name%</info> display all the Twig components in your application.
 
 To list all components:

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -220,10 +220,7 @@ final class ComponentFactory
         return null !== $this->componentTemplateFinder->findAnonymousComponentTemplate($name);
     }
 
-    /**
-     * @return never
-     */
-    private function throwUnknownComponentException(string $name): void
+    private function throwUnknownComponentException(string $name): never
     {
         $message = sprintf('Unknown component "%s".', $name);
         $lowerName = strtolower($name);

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -72,7 +72,7 @@ final class ComponentRenderer implements ComponentRendererInterface
         }
 
         try {
-            return $this->twig->loadTemplate(
+            return $content = $this->twig->loadTemplate(
                 $this->twig->getTemplateClass($event->getTemplate()),
                 $event->getTemplate(),
                 $event->getTemplateIndex(),
@@ -80,7 +80,7 @@ final class ComponentRenderer implements ComponentRendererInterface
         } finally {
             $mounted = $this->componentStack->pop();
 
-            $event = new PostRenderEvent($mounted);
+            $event = new PostRenderEvent($mounted, $content ?? null);
             $this->dispatcher->dispatch($event);
         }
     }

--- a/src/TwigComponent/src/Event/PostRenderEvent.php
+++ b/src/TwigComponent/src/Event/PostRenderEvent.php
@@ -19,12 +19,26 @@ final class PostRenderEvent extends Event
     /**
      * @internal
      */
-    public function __construct(private MountedComponent $mounted)
-    {
+    public function __construct(
+        private MountedComponent $mounted,
+        private ?string $content = null,
+    ) {
     }
 
     public function getMountedComponent(): MountedComponent
     {
         return $this->mounted;
+    }
+
+    /**
+     * The rendered content of the component.
+     *
+     * (not available for the `embedded` components)
+     *
+     * @internal
+     */
+    public function getContent(): ?string
+    {
+        return $this->content;
     }
 }

--- a/src/TwigComponent/src/Test/InteractsWithTwigComponents.php
+++ b/src/TwigComponent/src/Test/InteractsWithTwigComponents.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\TwigComponent\Test;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -39,12 +40,13 @@ trait InteractsWithTwigComponents
         $blocks = array_filter(array_merge($blocks, ['content' => $content]));
 
         if (!$blocks) {
-            return new RenderedComponent(self::getContainer()->get('twig')
-                ->createTemplate('{{ component(name, data) }}')
-                ->render([
-                    'name' => $name,
-                    'data' => $data,
-                ])
+            return new RenderedComponent(
+                self::getContainer()->get('twig')
+                    ->createTemplate('{{ component(name, data) }}')
+                    ->render([
+                        'name' => $name,
+                        'data' => $data,
+                    ])
             );
         }
 
@@ -56,7 +58,8 @@ trait InteractsWithTwigComponents
 
         $template .= '{% endcomponent %}';
 
-        return new RenderedComponent(self::getContainer()->get('twig')
+        return new RenderedComponent(
+            self::getContainer()->get('twig')
             ->createTemplate($template)
             ->render([
                 'data' => $data,

--- a/src/TwigComponent/tests/Unit/EventListener/TwigComponentLoggerListenerTest.php
+++ b/src/TwigComponent/tests/Unit/EventListener/TwigComponentLoggerListenerTest.php
@@ -46,7 +46,7 @@ class TwigComponentLoggerListenerTest extends TestCase
         $mounted = new MountedComponent('foo', new \stdClass(), new ComponentAttributes([]));
         $eventE = new PreRenderEvent($mounted, new ComponentMetadata(['template' => 'bar']), []);
         $logger->onPreRender($eventE);
-        $eventF = new PostRenderEvent($mounted);
+        $eventF = new PostRenderEvent($mounted, 'fooBar');
         $logger->onPostRender($eventF);
 
         $this->assertSame([$eventA, $eventB, $eventC, $eventD, $eventE, $eventF], array_column($logger->getEvents(), 0));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| License       | MIT

Pass the rendered content in the Event
(not available for the `embedded` components)

Similar to what's done in HttpFramework with the ResponseEvent