### PR TITLE
Update error message with `php bin/console`

### DIFF
--- a/src/StimulusBundle/src/AssetMapper/AutoImportLocator.php
+++ b/src/StimulusBundle/src/AssetMapper/AutoImportLocator.php
@@ -64,7 +64,7 @@ class AutoImportLocator
 
         $entry = $this->importMapConfigReader->findRootImportMapEntry($path);
         if (!$entry) {
-            throw new \LogicException(sprintf('The autoimport "%s" could not be found in importmap.php. Try running "importmap:require %s".', $path, $path));
+            throw new \LogicException(sprintf('The autoimport "%s" could not be found in importmap.php. Try running "php bin/console importmap:require %s".', $path, $path));
         }
 
         return new MappedControllerAutoImport($path, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Issues        | no
| License       | MIT

During my testing of Symfony/UX, I encountered the 'Try running "importmap:require %s"' message. I think it could be more precise to add php bin/console to help people :)
