### PR TITLE
[TwigComponent] Fix full context is stored in profiler

### DIFF
--- a/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
+++ b/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
@@ -124,7 +124,6 @@ class TwigComponentDataCollector extends AbstractDataCollector implements LateDa
                     'is_embed' => $event->isEmbedded(),
                     'input_props' => $mountedComponent->getInputProps(),
                     'attributes' => $mountedComponent->getAttributes()->all(),
-                    'variables' => $event->getVariables(),
                     'template_index' => $event->getTemplateIndex(),
                     'component' => $mountedComponent->getComponent(),
                     'depth' => \count($ongoingRenders),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix [#1540](https://github.com/symfony/ux/issues/1540)
| License       | MIT

As `$event->getVariables()` get the full context for non-embed components, this led to huge data stored for every component called during the request. (see [#1540](https://github.com/symfony/ux/issues/1540))

As this is internal data, and the "variables" was not used in the profiler, I believe we should consider this a bug and simply remove it.
