### PR TITLE
Prepping 2.16 changelogs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # UPGRADE
 
+## FROM 2.15 to 2.16
+
+-   **Live Components**: Change `data-action-name` attribute to `data-live-action-param`
+    and change action arguments to be passed as individual `data-live-` attributes #1418.
+    See [LiveComponents CHANGELOG](https://github.com/symfony/ux/blob/2.x/src/LiveComponent/CHANGELOG.md#2160)
+    for more details.
+
+-   **Live Components**: Remove the `|prevent` modifier and place it on the `data-action`
+    instead - e.g. `data-action="live#action:prevent"`.
+
+-   **Live Components**: Change `data-event` attributes to `data-live-event-param` #1418.
+
 ## FROM 2.14 to 2.15
 
 -   **Live Components**: Change `data-live-id` attributes to `id` #1484.

--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.16.0
+
+-   Missing translations added for many languages #1527 #1528 #1535
+
 ## 2.15.0
 
 -   Add doctrine/orm 3 support #1468

--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## 2.16.0
 
+-   LiveComponents is now stable and no longer experimental 🥳
 -   [BC BREAK] The `data-action-name` attribute behavior was removed in favor of
     using Stimulus "action parameters" and `data-live-action-param`. This is a
     breaking change if you were using the `data-action-name` attribute directly
-    in your templates.
+    in your templates. #1418
 
     To upgrade your application, follow these changes:
 
@@ -44,9 +45,14 @@
 -   [BC BREAK] The `data-event` attribute was removed in favor of using Stimulus
     "action parameters": rename `data-event` to `data-live-event-param`. Additionally,
     if you were passing arguments to the event name, use action parameter attributes
-    for those as well - e.g. `data-live-foo-param="bar"`.
+    for those as well - e.g. `data-live-foo-param="bar"`. #1418
 
--   Reverted setting `ignoreActiveValue: true` in Idiomorph
+-   Reverted setting `ignoreActiveValue: true` in Idiomorph #1548
+-   New placeholder macro to generate defer/lazy skeleton #1532
+-   improve TestLiveComponent::actingAs() #1461
+-   Drop Twig 2 support #1436
+-   Add better error message when hydrating dates #1431
+-   Store TemplateMap in build_dir #1525
 
 ## 2.15.0
 

--- a/src/Translator/CHANGELOG.md
+++ b/src/Translator/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## UNRELEASED
+## 2.16.0
 
--   Increase version range of `intl-messageformat` to `^10.5.11`, in order tou se a faster implementation of ICU messages parsing.
+-   Increase version range of `intl-messageformat` to `^10.5.11`, in order to see
+    a faster implementation of ICU messages parsing. #1443
 
 ## 2.13.2
 

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.16.0
+
+-   Introduce CVA to style TwigComponent #1416
+-   Drop Twig 2 support #1436
+-   Fix full context is stored in profiler #1552
+
 ## 2.15.0
 
 -   Add the ability to render specific attributes from the `attributes` variable #1442


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

Time for our end-of-month release.

And since the last release 9 days ago... this is packed!

* ✅ Live Components stable
* ✅ CVA #1416

... and many other goodies and fixes. Cool 😎 

This release DOES contain a few BC breaks in Live Components (the last ones!) that will affect many / most applications. See the CHANGELOG for LiveComponents for details.