### PR TITLE
[TwigComponent] attributes.has() method

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -193,6 +193,11 @@ final class ComponentAttributes implements \IteratorAggregate, \Countable
         return new \ArrayIterator($this->attributes);
     }
 
+    public function has(string $attribute): bool
+    {
+        return array_key_exists($attribute, $this->attributes);
+    }
+
     public function count(): int
     {
         return \count($this->attributes);

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -224,4 +224,11 @@ final class ComponentAttributesTest extends TestCase
 
         $attributes->render('attr1');
     }
+    
+    public function testCanCheckIfAttributeExists(): void
+    {
+        $attributes = new ComponentAttributes(['foo' => 'bar']);
+
+        $this->assertTrue($attributes->has('foo'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| Issues        | -
| License       | MIT

Provide a `ComponentAttributes::has()` function to be able to check via `{{ attributes.has('foo') }}` whether the attribute has been passed. 

I would like to show the use case in the following example. Using `attributes.has('href')`, I check whether the TwigComponent has set an 'href' attribute when it is called. If so, an `<a>` tag should be rendered, otherwise a `<button>` tag.

```twig
{# templates/components/Button.html.twig #}
{% set element = attributes.has('href') ? 'a' : 'button' %}

<{{ element }} {{ attributes }}>
    {% block content %}{% endblock %}
</{{ element }}>
```

