### PR TITLE
[TwigComponent] Fix invalid docs

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1225,8 +1225,8 @@ If no variants match, you can define a default set of classes to apply:
                 lg: 'rounded-lg',
             }
         },
-        defaultsVariants: {
-            rounded: 'rounded-md',
+        defaultVariants: {
+            rounded: 'md',
         }
     }) %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Issues        | -
| License       | MIT

There was a typo in the documentation. Furthermore the example was wrong which leads to an `An exception has been thrown during the rendering of a template ("Warning: Undefined array key "rounded-md"").` exception.