### PR TITLE
[TwigComponent] fix typo in compoundVariants documentation

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1167,12 +1167,12 @@ when multiple other variant conditions are met.
                 lg: 'text-lg',
             }
         },
-        compoundVariants: {
-            // if colors=red AND size = (md or lg), add the `font-bold` class
-            colors: ['red'],
+        compoundVariants: [{
+            // if color = red AND size = (md or lg), add the `font-bold` class
+            color: ['red'],
             size: ['md', 'lg'],
             class: 'font-bold'
-        }
+        }]
     }) %}
 
     <div class="{{ alert.apply({color, size}) }}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Issues        | -
| License       | MIT

I think there is a typo in the documentation in the compoundVariants part, and it made me confused a little. The example in the doc was throwing `An exception has been thrown during the rendering of a template ("Warning: foreach() argument must be of type array|object, string given").`
