### PR TITLE
[LiveComponent] Fix collections hydration with serializer

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.17.0
 
 -   Add `modifier` option in `LiveProp` so options can be modified at runtime.
+-   Fix collections hydration with serializer in LiveComponents
 
 ## 2.16.0
 

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -256,11 +256,22 @@ final class LiveComponentHydrator
                 throw new \LogicException(sprintf('The LiveProp "%s" on component "%s" has "useSerializerForHydration: true", but the given serializer does not implement DenormalizerInterface.', $propMetadata->getName(), $parentObject::class));
             }
 
-            if (null === $propMetadata->getType()) {
+            if ($propMetadata->collectionValueType()) {
+                $builtInType = $propMetadata->collectionValueType()->getBuiltinType();
+                if (Type::BUILTIN_TYPE_OBJECT === $builtInType) {
+                    $type = $propMetadata->collectionValueType()->getClassName().'[]';
+                } else {
+                    $type = $builtInType.'[]';
+                }
+            } else {
+                $type = $propMetadata->getType();
+            }
+
+            if (null === $type) {
                 throw new \LogicException(sprintf('The "%s::%s" object should be hydrated with the Serializer, but no type could be guessed.', $parentObject::class, $propMetadata->getName()));
             }
 
-            return $this->serializer->denormalize($value, $propMetadata->getType(), 'json', $propMetadata->serializationContext());
+            return $this->serializer->denormalize($value, $type, 'json', $propMetadata->serializationContext());
         }
 
         if ($propMetadata->collectionValueType() && Type::BUILTIN_TYPE_OBJECT === $propMetadata->collectionValueType()->getBuiltinType()) {

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -1031,6 +1031,42 @@ final class LiveComponentHydratorTest extends KernelTestCase
             ;
         }];
 
+        yield 'Collection: using serializer (de)hydrates correctly' => [function () {
+            return HydrationTest::create(new class() {
+                /** @var \Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Temperature[] */
+                #[LiveProp(useSerializerForHydration: true)]
+                public array $temperatures = [];
+
+                /**
+                 * @var string[]
+                 */
+                #[LiveProp(useSerializerForHydration: true)]
+                public array $tags = [];
+            })
+                ->mountWith([
+                    'temperatures' => [
+                        new Temperature(10, 'C'),
+                        new Temperature(20, 'C'),
+                    ],
+                    'tags' => ['foo', 'bar'],
+                ])
+                ->assertDehydratesTo([
+                    'temperatures' => [
+                        ['degrees' => 10, 'uom' => 'C'],
+                        ['degrees' => 20, 'uom' => 'C'],
+                    ],
+                    'tags' => ['foo', 'bar'],
+                ])
+                ->assertObjectAfterHydration(function (object $object) {
+                    self::assertSame(10, $object->temperatures[0]->degrees);
+                    self::assertSame('C', $object->temperatures[0]->uom);
+                    self::assertSame(20, $object->temperatures[1]->degrees);
+                    self::assertSame('C', $object->temperatures[1]->uom);
+                    self::assertSame(['foo', 'bar'], $object->tags);
+                })
+            ;
+        }];
+
         yield 'Updating non-writable path is rejected' => [function () {
             $product = new ProductFixtureEntity();
             $product->name = 'original name';


### PR DESCRIPTION
| Q            | A   |
|--------------|-----|
| Bug fix?     | yes |
| New feature? | no  |
| Issues       | N/A |
| License      | MIT |

Hello!

I encountered issues when trying to hydrate a `LiveProp` as a collection of objects, using the Symfony Serializer.

Given `phpdocumentor/reflection-dockblock` is installed in the project, and I have the following component:

```php

#[AsLiveComponent]
class MyComponent
{
    /**
     * @var MyDto[] 
     */
    #[LiveProp(useSerializerForHydration: true)]
    public array $prop = [];
}
```

Then I should be able to hydrate `$prop` as a collection of `MyDto`. 

However, the `LiveComponentHydrator` doesn't consider the collection type when `useSerializerForHydration` is enabled, and tries to deserialize to `array` type, throwing the following exception:
```
Symfony\Component\Serializer\Exception\NotNormalizableValueException : Could not denormalize object of type "array", no supporting normalizer found.
```

So here is a proposal to fix the issue.

Cheers!
