### PR TITLE
[DX] Show component name in multiple elements error

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2104,7 +2104,9 @@ class Component {
             }
         }
         catch (error) {
-            console.error('There was a problem with the component HTML returned:');
+            console.error(`There was a problem with the '${this.name}' component HTML returned:`, {
+                id: this.id
+            });
             throw error;
         }
         this.externalMutationTracker.handlePendingChanges();

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -363,8 +363,9 @@ export default class Component {
                 throw new Error('A live component template must contain a single root controller element.');
             }
         } catch (error) {
-            console.error('There was a problem with the component HTML returned:');
-
+            console.error(`There was a problem with the '${this.name}' component HTML returned:`, {
+                id: this.id
+            });
             throw error;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Issues        | N/A
| License       | MIT

If a page contains multiple components and one of them renders multiple elements, identifying the Component helps troubleshooting.
- Should we output the element ID as well?
