### PR TITLE
[LiveComponent] Throw exception for typed LiveProps as interfaces

### DIFF
--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -496,6 +496,10 @@ final class LiveComponentHydrator
             }
         }
 
+        if (interface_exists($classType)) {
+            throw new \LogicException(sprintf('Cannot dehydrate value typed as interface "%s" on component "%s". Change this to a concrete type that can be dehydrated. Or set the hydrateWith/dehydrateWith options in LiveProp or set "useSerializerForHydration: true" on the LiveProp to use the serializer.', get_debug_type($value), $parentObject::class));
+        }
+
         $dehydratedObjectValues = [];
         foreach ((new PropertyInfoExtractor([new ReflectionExtractor()]))->getProperties($classType) as $property) {
             $propertyValue = $this->propertyAccessor->getValue($value, $property);
@@ -538,6 +542,10 @@ final class LiveComponentHydrator
             if ($extension->supports($className)) {
                 return $extension->hydrate($value, $className);
             }
+        }
+
+        if (interface_exists($className)) {
+            throw new \LogicException(sprintf('Cannot hydrate value typed as interface "%s" on component "%s". Change this to a concrete type that can be hydrated. Or set the hydrateWith/dehydrateWith options in LiveProp or set "useSerializerForHydration: true" on the LiveProp to use the serializer.', $className, $component::class));
         }
 
         if (\is_array($value)) {

--- a/src/LiveComponent/tests/Fixtures/Dto/SimpleDto.php
+++ b/src/LiveComponent/tests/Fixtures/Dto/SimpleDto.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Dto;
+
+class SimpleDto implements SimpleDtoInterface
+{
+}

--- a/src/LiveComponent/tests/Fixtures/Dto/SimpleDtoInterface.php
+++ b/src/LiveComponent/tests/Fixtures/Dto/SimpleDtoInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Dto;
+
+interface SimpleDtoInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Issues        | Fix #1590
| License       | MIT

Check is done just after the hydration extensions are called, to allow userland implementations.