### PR TITLE
[Icons] Improve cache warmup by looking at every string

### DIFF
--- a/src/Icons/config/iconify.php
+++ b/src/Icons/config/iconify.php
@@ -25,6 +25,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->set('.ux_icons.iconify', Iconify::class)
             ->args([
+                service('cache.system'),
                 abstract_arg('endpoint'),
                 service('http_client')->nullOnInvalid(),
             ])

--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -115,6 +115,22 @@ In production, you can pre-warm the cache by running the following command:
 
 This command looks in all your twig templates for ``ux_icon`` calls and caches the icons it finds.
 
+.. caution::
+
+    Icons that have a name built dynamically will not be cached. It's advised to have the icon
+    name as a string literal in your templates.
+
+    .. code-block:: twig
+
+        {# This will be cached #}
+        {{ ux_icon('flag-fr') }}
+
+        {# This will NOT be cached #}
+        {{ ux_icon('flag-' ~ locale) }}
+
+        {% set flags = {fr: 'flag-fr', de: 'flag-de'} %} {# both "flag-fr" and "flag-de" will be cached #}
+        {{ ux_icon(flags[locale]) }}
+
 .. note::
 
     During development, if you modify an icon, you will need to clear the cache (``bin/console cache:clear``)

--- a/src/Icons/src/Command/WarmCacheCommand.php
+++ b/src/Icons/src/Command/WarmCacheCommand.php
@@ -45,7 +45,6 @@ final class WarmCacheCommand extends Command
                     $io->writeln(sprintf(' Warmed icon <comment>%s</comment>.', $name));
                 }
             },
-            onFailure: fn (string $name) => $io->warning(sprintf('Icon <comment>%s</comment> not found.', $name))
         );
 
         $io->success('Icon cache warmed.');

--- a/src/Icons/src/DependencyInjection/UXIconsExtension.php
+++ b/src/Icons/src/DependencyInjection/UXIconsExtension.php
@@ -91,7 +91,7 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
             $loader->load('iconify.php');
 
             $container->getDefinition('.ux_icons.iconify')
-                ->setArgument(0, $mergedConfig['iconify']['endpoint'])
+                ->setArgument(1, $mergedConfig['iconify']['endpoint'])
             ;
         }
 

--- a/src/Icons/src/Twig/IconFinder.php
+++ b/src/Icons/src/Twig/IconFinder.php
@@ -38,11 +38,7 @@ final class IconFinder
         foreach ($this->files($this->twig->getLoader()) as $file) {
             $contents = file_get_contents($file);
 
-            if (preg_match_all('#ux_icon\(["\']([\w:-]+)["\']#', $contents, $matches)) {
-                $found[] = $matches[1];
-            }
-
-            if (preg_match_all('#name=["\']([\w:-]+)["\']#', $contents, $matches)) {
+            if (preg_match_all('#["\']([\w:-]+)["\']#', $contents, $matches)) {
                 $found[] = $matches[1];
             }
         }

--- a/src/Icons/tests/Fixtures/templates/template2.html.twig
+++ b/src/Icons/tests/Fixtures/templates/template2.html.twig
@@ -1,3 +1,5 @@
+{% set icon = 'flag:eu-4x3' %}
+
 {{ ux_icon('something:invalid') }}
 {{ ux_icon('invalid') }}
 {{ ux_icon('iconamoon:invalid') }}

--- a/src/Icons/tests/Integration/Command/WarmCacheCommandTest.php
+++ b/src/Icons/tests/Integration/Command/WarmCacheCommandTest.php
@@ -29,6 +29,7 @@ final class WarmCacheCommandTest extends KernelTestCase
             ->assertOutputContains('Warmed icon user.')
             ->assertOutputContains('Warmed icon sub:check.')
             ->assertOutputContains('Warmed icon iconamoon:3d-duotone.')
+            ->assertOutputContains('Warmed icon flag:eu-4x3.')
             ->assertOutputContains('Icon cache warmed.')
         ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | n/a
| License       | MIT

Improve working with dynamic icon names (inspired by https://v2.tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html)

```twig
{# This will be cached #}
{{ ux_icon('flag-fr') }}

{# This will NOT be cached #}
{{ ux_icon('flag-' ~ locale) }}

{% set flags = {fr: 'flag-fr', de: 'flag-de'} %} {# both "flag-fr" and "flag-de" will be cached #}
{{ ux_icon(flags[locale]) }}
```

Closes #1601