### PR TITLE
[Icons] allow configuring multiple local directories and optionally prefixing them

### DIFF
--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -44,6 +44,25 @@ icon will be used.
             - %kernel.project_dir%/assets/icons
             - %kernel.project_dir%/vendor/your-vendor/your-bundle/assets/icons
 
+.. tip::
+
+    You can suffix the path with ``@<alias>`` to use a prefix. For example, let's say you
+    have the ``fortawesome/font-awesome`` composer package installed and you want to use
+    the ``fa`` prefix:
+
+    .. code-block:: yaml
+
+        ux_icons:
+            icon_dir:
+                # ...
+                - %kernel.project_dir%/vendor/fortawesome/font-awesome/svgs@fa
+
+    Now, you can use the ``fa:icon-name`` syntax to render icons from the FontAwesome set:
+
+    .. code-block:: html+twig
+
+        {{ ux_icon('fa:solid:adjust', {class: 'w-4 h-4'}) }} <!-- renders "vendor/fortawesome/font-awesome/svgs/solid/adjust.svg" -->
+
 Icons On-Demand
 ~~~~~~~~~~~~~~~
 
@@ -146,6 +165,7 @@ Full Default Configuration
         # The local directory('s) where icons are stored.
         # Order matters as the first directory to contain the icon will be used.
         # The first directory will be used to store imported icons.
+        # Suffix with "@<alias>" to use a prefix.
         icon_dir:
 
             # Default:

--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -27,9 +27,22 @@ No icons are provided by this package but there are several ways to include and 
 Local SVG Icons
 ~~~~~~~~~~~~~~~
 
-Add your svg icons to the ``assets/icons/`` directory and commit them.
+Add your svg icons to the configured local icon directory (``assets/icons/`` by default) and commit them.
 The name of the file is used as the _name_ of the icon (``name.svg`` will be named ``name``).
 If located in a subdirectory, the _name_ will be ``sub-dir:name``.
+
+Multiple Directories
+^^^^^^^^^^^^^^^^^^^^
+
+You can configure multiple directories to search for icons. The first directory to contain the
+icon will be used.
+
+.. code-block:: yaml
+
+    ux_icons:
+        icon_dir:
+            - %kernel.project_dir%/assets/icons
+            - %kernel.project_dir%/vendor/your-vendor/your-bundle/assets/icons
 
 Icons On-Demand
 ~~~~~~~~~~~~~~~
@@ -130,8 +143,13 @@ Full Default Configuration
 .. code-block:: yaml
 
     ux_icons:
-        # The local directory where icons are stored.
-        icon_dir: '%kernel.project_dir%/assets/icons'
+        # The local directory('s) where icons are stored.
+        # Order matters as the first directory to contain the icon will be used.
+        # The first directory will be used to store imported icons.
+        icon_dir:
+
+            # Default:
+            - %kernel.project_dir%/assets/icons
 
         # Default attributes to add to all icons.
         default_icon_attributes:

--- a/src/Icons/src/DependencyInjection/UXIconsExtension.php
+++ b/src/Icons/src/DependencyInjection/UXIconsExtension.php
@@ -37,12 +37,30 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
                 ->arrayNode('icon_dir')
                     ->beforeNormalization()
                         ->ifString()
-                        ->then(static function ($v) { return [$v]; })
+                        ->then(static fn ($v) => [$v])
+                    ->end()
+                    ->beforeNormalization()
+                        ->always(function (array $values) {
+                            $ret = [];
+
+                            foreach ($values as $value) {
+                                if (2 === \count($parts = explode('@', $value, 2))) {
+                                    $ret[$parts[1]] = $parts[0];
+
+                                    continue;
+                                }
+
+                                $ret[] = $value;
+                            }
+
+                            return $ret;
+                        })
                     ->end()
                     ->info(<<<EOF
                         The local directory('s) where icons are stored.
                         Order matters as the first directory to contain the icon will be used.
                         The first directory will be used to store imported icons.
+                        Suffix with "@<alias>" to use a prefix.
                         EOF)
                     ->scalarPrototype()->end()
                     ->defaultValue(['%kernel.project_dir%/assets/icons'])

--- a/src/Icons/src/DependencyInjection/UXIconsExtension.php
+++ b/src/Icons/src/DependencyInjection/UXIconsExtension.php
@@ -34,9 +34,18 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
 
         $rootNode
             ->children()
-                ->scalarNode('icon_dir')
-                    ->info('The local directory where icons are stored.')
-                    ->defaultValue('%kernel.project_dir%/assets/icons')
+                ->arrayNode('icon_dir')
+                    ->beforeNormalization()
+                        ->ifString()
+                        ->then(static function ($v) { return [$v]; })
+                    ->end()
+                    ->info(<<<EOF
+                        The local directory('s) where icons are stored.
+                        Order matters as the first directory to contain the icon will be used.
+                        The first directory will be used to store imported icons.
+                        EOF)
+                    ->scalarPrototype()->end()
+                    ->defaultValue(['%kernel.project_dir%/assets/icons'])
                 ->end()
                 ->variableNode('default_icon_attributes')
                     ->info('Default attributes to add to all icons.')

--- a/src/Icons/src/Registry/LocalSvgIconRegistry.php
+++ b/src/Icons/src/Registry/LocalSvgIconRegistry.php
@@ -23,22 +23,28 @@ use Symfony\UX\Icons\Svg\Icon;
  */
 final class LocalSvgIconRegistry implements IconRegistryInterface
 {
-    public function __construct(private string $iconDir)
+    /**
+     * @param string[] $iconDirs
+     */
+    public function __construct(private array $iconDirs)
     {
     }
 
     public function get(string $name): Icon
     {
-        if (!file_exists($filename = sprintf('%s/%s.svg', $this->iconDir, str_replace(':', '/', $name)))) {
-            throw new IconNotFoundException(sprintf('The icon "%s" (%s) does not exist.', $name, $filename));
+        foreach ($this->iconDirs as $dir) {
+            if (file_exists($filename = sprintf('%s/%s.svg', $dir, str_replace(':', '/', $name)))) {
+                return Icon::fromFile($filename);
+            }
         }
 
-        return Icon::fromFile($filename);
+        throw new IconNotFoundException(sprintf('The svg file for icon "%s" does not exist.', $name));
     }
 
     public function add(string $name, string $svg): void
     {
-        $filename = sprintf('%s/%s.svg', $this->iconDir, $name);
+        $dir = $this->iconDirs[0] ?? throw new \LogicException('No local icon directory configured.');
+        $filename = sprintf('%s/%s.svg', $dir, $name);
 
         (new Filesystem())->dumpFile($filename, $svg);
     }

--- a/src/Icons/src/Registry/LocalSvgIconRegistry.php
+++ b/src/Icons/src/Registry/LocalSvgIconRegistry.php
@@ -32,7 +32,11 @@ final class LocalSvgIconRegistry implements IconRegistryInterface
 
     public function get(string $name): Icon
     {
-        foreach ($this->iconDirs as $dir) {
+        foreach ($this->iconDirs as $key => $dir) {
+            if (!is_numeric($key) && str_starts_with($name, $key.':')) {
+                $name = substr($name, \strlen($key) + 1);
+            }
+
             if (file_exists($filename = sprintf('%s/%s.svg', $dir, str_replace(':', '/', $name)))) {
                 return Icon::fromFile($filename);
             }
@@ -43,7 +47,7 @@ final class LocalSvgIconRegistry implements IconRegistryInterface
 
     public function add(string $name, string $svg): void
     {
-        $dir = $this->iconDirs[0] ?? throw new \LogicException('No local icon directory configured.');
+        $dir = $this->iconDirs[array_key_first($this->iconDirs)] ?? throw new \LogicException('No local icon directory configured.');
         $filename = sprintf('%s/%s.svg', $dir, $name);
 
         (new Filesystem())->dumpFile($filename, $svg);

--- a/src/Icons/tests/Fixtures/TestKernel.php
+++ b/src/Icons/tests/Fixtures/TestKernel.php
@@ -49,7 +49,10 @@ final class TestKernel extends Kernel
         ]);
 
         $c->extension('ux_icons', [
-            'icon_dir' => '%kernel.project_dir%/tests/Fixtures/icons',
+            'icon_dir' => [
+                '%kernel.project_dir%/tests/Fixtures/icons',
+                '%kernel.project_dir%/tests/Fixtures/icons2',
+            ],
         ]);
 
         $c->services()->set('logger', NullLogger::class);

--- a/src/Icons/tests/Fixtures/TestKernel.php
+++ b/src/Icons/tests/Fixtures/TestKernel.php
@@ -52,6 +52,7 @@ final class TestKernel extends Kernel
             'icon_dir' => [
                 '%kernel.project_dir%/tests/Fixtures/icons',
                 '%kernel.project_dir%/tests/Fixtures/icons2',
+                '%kernel.project_dir%/tests/Fixtures/icons3@fa',
             ],
         ]);
 

--- a/src/Icons/tests/Fixtures/icons2/arrow.svg
+++ b/src/Icons/tests/Fixtures/icons2/arrow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" d="M18.4 10.6C16.55 9 14.15 8 11.5 8c-4.65 0-8.58 3.03-9.96 7.22L3.9 16a8.002 8.002 0 0 1 7.6-5.5c1.95 0 3.73.72 5.12 1.88L13 16h9V7z"/></svg>

--- a/src/Icons/tests/Fixtures/icons3/solid/thing.svg
+++ b/src/Icons/tests/Fixtures/icons3/solid/thing.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" d="M18.4 10.6C16.55 9 14.15 8 11.5 8c-4.65 0-8.58 3.03-9.96 7.22L3.9 16a8.002 8.002 0 0 1 7.6-5.5c1.95 0 3.73.72 5.12 1.88L13 16h9V7z"/></svg>

--- a/src/Icons/tests/Fixtures/templates/template2.html.twig
+++ b/src/Icons/tests/Fixtures/templates/template2.html.twig
@@ -2,3 +2,4 @@
 {{ ux_icon('invalid') }}
 {{ ux_icon('iconamoon:invalid') }}
 {{ ux_icon('arrow') }}
+{{ ux_icon('fa:solid:thing') }}

--- a/src/Icons/tests/Fixtures/templates/template2.html.twig
+++ b/src/Icons/tests/Fixtures/templates/template2.html.twig
@@ -1,3 +1,4 @@
 {{ ux_icon('something:invalid') }}
 {{ ux_icon('invalid') }}
 {{ ux_icon('iconamoon:invalid') }}
+{{ ux_icon('arrow') }}

--- a/src/Icons/tests/Integration/Command/WarmCacheCommandTest.php
+++ b/src/Icons/tests/Integration/Command/WarmCacheCommandTest.php
@@ -29,6 +29,7 @@ final class WarmCacheCommandTest extends KernelTestCase
             ->assertOutputContains('Warmed icon user.')
             ->assertOutputContains('Warmed icon sub:check.')
             ->assertOutputContains('Warmed icon iconamoon:3d-duotone.')
+            ->assertOutputContains('Warmed icon arrow.')
             ->assertOutputContains('Icon cache warmed.')
         ;
     }

--- a/src/Icons/tests/Integration/Command/WarmCacheCommandTest.php
+++ b/src/Icons/tests/Integration/Command/WarmCacheCommandTest.php
@@ -30,6 +30,7 @@ final class WarmCacheCommandTest extends KernelTestCase
             ->assertOutputContains('Warmed icon sub:check.')
             ->assertOutputContains('Warmed icon iconamoon:3d-duotone.')
             ->assertOutputContains('Warmed icon arrow.')
+            ->assertOutputContains('Warmed icon fa:solid:thing.')
             ->assertOutputContains('Icon cache warmed.')
         ;
     }

--- a/src/Icons/tests/Unit/Registry/LocalSvgIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/LocalSvgIconRegistryTest.php
@@ -84,6 +84,6 @@ final class LocalSvgIconRegistryTest extends TestCase
 
     private function registry(): LocalSvgIconRegistry
     {
-        return new LocalSvgIconRegistry(__DIR__.'/../../Fixtures/svg');
+        return new LocalSvgIconRegistry([__DIR__.'/../../Fixtures/svg']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Issues        | n/a
| License       | MIT

Configure multiple paths:

```yaml
ux_icons:
    icon_dir:
        - %kernel.project_dir%/assets/icons
        - %kernel.project_dir%/vendor/your-vendor/your-bundle/assets/icons
```

Additionally, you can suffix the path with `@<alias>` to add a prefix for icons in this directory:

```yaml
ux_icons:
    icon_dir:
        # ...
        - %kernel.project_dir%/vendor/fortawesome/font-awesome/svgs@fa
```

Now you can render icons in this directory by prefixing the name with `fa:`:

```twig
{{ ux_icon('fa:solid:adjust', {class: 'w-4 h-4'}) }} <!-- renders "vendor/fortawesome/font-awesome/svgs/solid/adjust.svg" -->
```
