### PR TITLE
[Icon] Console theme: reference the webite + improve icon readability

### DIFF
--- a/src/Icons/src/Command/ImportIconCommand.php
+++ b/src/Icons/src/Command/ImportIconCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\Icons\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -64,7 +65,7 @@ final class ImportIconCommand extends Command
 
             [$fullName, $prefix, $name] = $matches;
 
-            $io->comment(sprintf('Importing <info>%s</info>...', $fullName));
+            $io->comment(sprintf('Importing %s...', $fullName));
 
             try {
                 $svg = $this->iconify->fetchSvg($prefix, $name);
@@ -75,13 +76,17 @@ final class ImportIconCommand extends Command
                 continue;
             }
 
+            $cursor = new Cursor($output);
+            $cursor->moveUp(2);
+
             $this->registry->add(sprintf('%s/%s', $prefix, $name), $svg);
 
             $license = $this->iconify->metadataFor($prefix)['license'];
 
             $io->text(sprintf(
-                "Imported <info>%s</info> (License: <href=%s>%s</>), render with <comment>{{ ux_icon('%s') }}</comment>.",
-                $fullName,
+                " <fg=bright-green;options=bold>✓</> Imported <fg=bright-white;bg=black>%s:</><fg=bright-magenta;bg=black;options>%s</> (License: <href=%s>%s</>). Render with: <comment>{{ ux_icon('%s') }}</comment>",
+                $prefix,
+                $name,
                 $license['url'],
                 $license['title'],
                 $fullName,

--- a/src/Icons/tests/Integration/Command/ImportIconCommandTest.php
+++ b/src/Icons/tests/Integration/Command/ImportIconCommandTest.php
@@ -46,7 +46,7 @@ final class ImportIconCommandTest extends KernelTestCase
         $this->executeConsoleCommand('ux:icons:import uiw:dashboard')
             ->assertSuccessful()
             ->assertOutputContains('Importing uiw:dashboard')
-            ->assertOutputContains("Imported uiw:dashboard (License: MIT), render with {{ ux_icon('uiw:dashboard') }}")
+            ->assertOutputContains("Imported uiw:dashboard (License: MIT). Render with: {{ ux_icon('uiw:dashboard') }}")
         ;
 
         $this->assertFileExists($expectedFile);


### PR DESCRIPTION
Currently:
<img width="763" alt="Capture d’écran 2024-03-10 à 05 04 02" src="https://github.com/symfony/ux/assets/1359581/e1032de4-57a2-4f69-a87e-836f6d31d551">


I'd suggest one of those... Open to debate :) 

<img width="767" alt="Capture d’écran 2024-03-10 à 05 27 26" src="https://github.com/symfony/ux/assets/1359581/d5d742ab-9e34-48ff-9b92-b09a57965c64">

<img width="894" alt="Capture d’écran 2024-03-10 à 05 26 32" src="https://github.com/symfony/ux/assets/1359581/4fe7beb9-8873-4d6d-bf90-dfd0aeb88417">
