### PR TITLE
[Chart.js] add view-value-change event

### DIFF
--- a/src/Chartjs/CHANGELOG.md
+++ b/src/Chartjs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.17.0
+
+-   Add `chartjs:view-value-change` event #1605
+
 ## 2.15.0
 
 -   Remove restriction that prevented Chart.js 3.9 #1518

--- a/src/Chartjs/assets/dist/controller.js
+++ b/src/Chartjs/assets/dist/controller.js
@@ -34,8 +34,13 @@ class default_1 extends Controller {
     }
     viewValueChanged() {
         if (this.chart) {
-            this.chart.data = this.viewValue.data;
-            this.chart.options = this.viewValue.options;
+            const viewValue = { data: this.viewValue.data, options: this.viewValue.options };
+            if (Array.isArray(viewValue.options) && 0 === viewValue.options.length) {
+                viewValue.options = {};
+            }
+            this.dispatchEvent('view-value-change', viewValue);
+            this.chart.data = viewValue.data;
+            this.chart.options = viewValue.options;
             this.chart.update();
             const parentElement = this.element.parentElement;
             if (parentElement && this.chart.options.responsive) {

--- a/src/Chartjs/assets/src/controller.ts
+++ b/src/Chartjs/assets/src/controller.ts
@@ -59,8 +59,14 @@ export default class extends Controller {
      */
     viewValueChanged(): void {
         if (this.chart) {
-            this.chart.data = this.viewValue.data;
-            this.chart.options = this.viewValue.options;
+            const viewValue = { data: this.viewValue.data, options: this.viewValue.options };
+            if (Array.isArray(viewValue.options) && 0 === viewValue.options.length) {
+                viewValue.options = {};
+            }
+            this.dispatchEvent('view-value-change', viewValue);
+            this.chart.data = viewValue.data;
+            this.chart.options = viewValue.options;
+
             this.chart.update();
 
             // Updating the chart seems to sometimes result in a chart that is

--- a/src/Chartjs/assets/test/controller.test.ts
+++ b/src/Chartjs/assets/test/controller.test.ts
@@ -46,7 +46,7 @@ const startChartTest = async (canvasHtml: string): Promise<{ canvas: HTMLCanvasE
     });
 
     if (!chart) {
-        throw 'Missing TomSelect instance';
+        throw 'Missing ChartJS instance';
     }
 
     return { canvas: canvasElement, chart };
@@ -102,6 +102,33 @@ describe('ChartjsController', () => {
 
         await waitFor(() => {
             expect(chart.options.showLines).toBe(true);
+        });
+    });
+
+    it('will update when the view data changes without options', async () => {
+        let viewValueChangeCallCount = 0;
+
+        document.body.addEventListener('chartjs:view-value-change', (event: any) => {
+            viewValueChangeCallCount++;
+            event.detail.options.showLines = true;
+        });
+
+        const { chart, canvas } = await startChartTest(`
+           <canvas
+               data-testid='canvas'
+               data-controller='check chartjs'
+               data-chartjs-view-value="&#x7B;&quot;type&quot;&#x3A;&quot;line&quot;,&quot;data&quot;&#x3A;&#x7B;&quot;labels&quot;&#x3A;&#x5B;&quot;January&quot;,&quot;February&quot;,&quot;March&quot;,&quot;April&quot;,&quot;May&quot;,&quot;June&quot;,&quot;July&quot;&#x5D;,&quot;datasets&quot;&#x3A;&#x5B;&#x7B;&quot;label&quot;&#x3A;&quot;My&#x20;First&#x20;dataset&quot;,&quot;backgroundColor&quot;&#x3A;&quot;rgb&#x28;255,&#x20;99,&#x20;132&#x29;&quot;,&quot;borderColor&quot;&#x3A;&quot;rgb&#x28;255,&#x20;99,&#x20;132&#x29;&quot;,&quot;data&quot;&#x3A;&#x5B;0,10,5,2,20,30,45&#x5D;&#x7D;&#x5D;&#x7D;,&quot;options&quot;&#x3A;&#x5B;&#x5D;&#x7D;"
+           ></canvas>
+       `);
+
+        expect(chart.options.showLines).toBeUndefined();
+        // change label: January -> NewDataJanuary
+        const currentViewValue = JSON.parse('{"type":"line","data":{"labels":["NewDataJanuary","February","March","April","May","June","July"],"datasets":[{"label":"My First dataset","backgroundColor":"rgb(255, 99, 132)","borderColor":"rgb(255, 99, 132)","data":[0,10,5,2,20,30,45]}]},"options":[]}');
+        canvas.dataset.chartjsViewValue = JSON.stringify(currentViewValue);
+
+        await waitFor(() => {
+            expect(chart.options.showLines).toBe(true);
+            expect(viewValueChangeCallCount).toBe(1);
         });
     });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

I was following this tutorial https://ux.symfony.com/demos/live-component/chartjs and everything works fine until I want to modify the `y` axis label.

i read about this documentation that I can extend the default behaviour https://symfony.com/bundles/ux-chartjs/current/index.html#extend-the-default-behavior

it works on the initial chart render, but when I change some values the chart gets re-render, and the scale options that I added on `pre-connect` event get overwritten by `$chart->setOptions([...])`, when I tried to remove `$chart->setOptions([...])` on PHP code completely to use the options fully from `pre-connect`, and I got this error

```
Uncaught TypeError: Stimulus Value "symfony--ux-chartjs--chart.viewValue" - Cannot convert undefined or null to object
```

hence I propose to introduce a new event that makes it able to add additional options while we are still using `$chart->setOptions([...])` everytime the chart gets re-rendered

this is also fixed on `viewValueChanged` method if no `$chart->setOptions([...])` provided
