### PR TITLE
[Icons] Test IconRenderer 

### DIFF
--- a/src/Icons/src/IconRenderer.php
+++ b/src/Icons/src/IconRenderer.php
@@ -19,12 +19,20 @@ namespace Symfony\UX\Icons;
 final class IconRenderer
 {
     public function __construct(
-        private IconRegistryInterface $registry,
-        private array $defaultIconAttributes = [],
+        private readonly IconRegistryInterface $registry,
+        private readonly array $defaultIconAttributes = [],
     ) {
     }
 
     /**
+     * Renders an icon.
+     *
+     * Provided attributes are merged with the default attributes.
+     * Existing icon attributes are then merged with those new attributes.
+     *
+     * Precedence order:
+     *   Icon file < Renderer configuration < Renderer invocation
+     *
      * @param array<string,string|bool> $attributes
      */
     public function renderIcon(string $name, array $attributes = []): string

--- a/src/Icons/tests/Integration/RenderIconsInTwigTest.php
+++ b/src/Icons/tests/Integration/RenderIconsInTwigTest.php
@@ -23,7 +23,8 @@ final class RenderIconsInTwigTest extends KernelTestCase
     {
         $output = self::getContainer()->get(Environment::class)->render('template1.html.twig');
 
-        $this->assertSame(<<<HTML
+        $this->assertSame(
+            <<<HTML
             <ul class="svg">
                 <li id="first"><svg viewBox="0 0 24 24" fill="currentColor" class="h-8 w-8"><path fill-rule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clip-rule="evenodd"></path></svg></li>
                 <li id="second"><svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6"><path fill-rule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clip-rule="evenodd"></path></svg></li>

--- a/src/Icons/tests/Unit/IconRendererTest.php
+++ b/src/Icons/tests/Unit/IconRendererTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Icons\Exception\IconNotFoundException;
+use Symfony\UX\Icons\IconRegistryInterface;
+use Symfony\UX\Icons\IconRenderer;
+use Symfony\UX\Icons\Svg\Icon;
+use Symfony\UX\Icons\Tests\Util\InMemoryIconRegistry;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+class IconRendererTest extends TestCase
+{
+    public function testRenderIcon(): void
+    {
+        $registry = $this->createRegistry([
+            'user' => '<circle ',
+        ]);
+        $iconRenderer = new IconRenderer($registry);
+
+        $icon = $iconRenderer->renderIcon('user');
+
+        $this->assertStringContainsString('<svg', $icon);
+        $this->assertStringContainsString('<circle', $icon);
+    }
+
+    public function testRenderIconThrowsExceptionWhenIconNotFound(): void
+    {
+        $registry = $this->createRegistry([]);
+        $iconRenderer = new IconRenderer($registry);
+
+        $this->expectException(IconNotFoundException::class);
+
+        $iconRenderer->renderIcon('foo');
+    }
+
+    public function testRenderIconThrowsExceptionWhenAttributesAreInvalid(): void
+    {
+        $registry = $this->createRegistry(['foo' => '<path d="M0 0L12 12"/>']);
+        $iconRenderer = new IconRenderer($registry);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $iconRenderer->renderIcon('foo', [1, 2, null]);
+    }
+
+    public function testRenderIconWithAttributes(): void
+    {
+        $registry = $this->createRegistry([
+            'foo' => '<path d="M0 0L12 12"/>',
+        ]);
+        $iconRenderer = new IconRenderer($registry);
+        $attributes = ['viewBox' => '0 0 24 24', 'class' => 'icon', 'id' => 'FooBar'];
+
+        $svg = $iconRenderer->renderIcon('foo', $attributes);
+
+        $this->assertSame('<svg viewBox="0 0 24 24" class="icon" id="FooBar"><path d="M0 0L12 12"/></svg>', $svg);
+    }
+
+    public function testRenderIconWithDefaultAttributes(): void
+    {
+        $registry = $this->createRegistry([
+            'foo' => '<path d="M0 0L12 12"/>',
+        ]);
+        $iconRenderer = new IconRenderer($registry, ['viewBox' => '0 0 24 24', 'class' => 'icon']);
+
+        $svg = $iconRenderer->renderIcon('foo');
+
+        $this->assertSame('<svg viewBox="0 0 24 24" class="icon"><path d="M0 0L12 12"/></svg>', $svg);
+    }
+
+    /**
+     * @dataProvider provideAttributesWithDefaultAttributesCases
+     */
+    public function testRenderIconWithAttributesAndDefaultAttributes($iconAttrs, $defaultAttrs, $renderAttr, $expectedTag): void
+    {
+        $registry = $this->createRegistry([
+            'foo' => ['', $iconAttrs],
+        ]);
+        $iconRenderer = new IconRenderer($registry, $defaultAttrs);
+
+        $svg = $iconRenderer->renderIcon('foo', $renderAttr);
+        $this->assertStringStartsWith($expectedTag, $svg);
+    }
+
+    public static function provideAttributesWithDefaultAttributesCases()
+    {
+        yield 'no_attributes' => [
+            [],
+            [],
+            [],
+            '<svg>',
+        ];
+        yield 'icon_attributes_are_used' => [
+            ['id' => 'icon'],
+            [],
+            [],
+            '<svg id="icon">',
+        ];
+        yield 'default_attributes_are_used' => [
+            [],
+            ['id' => 'default'],
+            [],
+            '<svg id="default">',
+        ];
+        yield 'render_attributes_are_used' => [
+            [],
+            [],
+            ['id' => 'render'],
+            '<svg id="render">',
+        ];
+        yield 'default_attributes_take_precedence_on_icon' => [
+            ['id' => 'icon'],
+            ['id' => 'default'],
+            [],
+            '<svg id="default">',
+        ];
+        yield 'default_attributes_are_merged_with_icon_attributes' => [
+            ['id' => 'icon', 'foo' => 'bar'],
+            ['id' => 'default', 'baz' => 'qux'],
+            [],
+            '<svg id="default" foo="bar" baz="qux">',
+        ];
+        yield 'render_attributes_take_precedence_on_default' => [
+            [],
+            ['id' => 'default'],
+            ['id' => 'render'],
+            '<svg id="render">',
+        ];
+        yield 'render_attributes_are_merged_with_default_attributes' => [
+            [],
+            ['id' => 'default', 'foo' => 'bar'],
+            ['id' => 'render', 'baz' => 'qux'],
+            '<svg id="render" foo="bar" baz="qux">',
+        ];
+        yield 'render_attributes_take_precedence_on_icon' => [
+            ['id' => 'icon'],
+            [],
+            ['id' => 'render'],
+            '<svg id="render">',
+        ];
+        yield 'render_attributes_are_merged_with_icon_attributes' => [
+            ['id' => 'icon', 'foo' => 'bar'],
+            [],
+            ['id' => 'render', 'baz' => 'qux'],
+            '<svg id="render" foo="bar" baz="qux">',
+        ];
+    }
+
+    private function createRegistry(array $icons): IconRegistryInterface
+    {
+        $registryIcons = [];
+        foreach ($icons as $name => $data) {
+            $data = (array) $data;
+            if (array_is_list($data)) {
+                $data = ['innerSvg' => $data[0], 'attributes' => $data[1] ?? []];
+            }
+            $registryIcons[$name] = new Icon(...$data);
+        }
+
+        return new InMemoryIconRegistry($registryIcons);
+    }
+}

--- a/src/Icons/tests/Unit/Registry/InMemoryIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/InMemoryIconRegistryTest.php
@@ -13,8 +13,8 @@ namespace Symfony\UX\Icons\Tests\Unit\Registry;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
-use Symfony\UX\Icons\Registry\InMemoryIconRegistry;
 use Symfony\UX\Icons\Svg\Icon;
+use Symfony\UX\Icons\Tests\Util\InMemoryIconRegistry;
 
 /**
  * @author Simon André <smn.andre@gmail.com>

--- a/src/Icons/tests/Util/InMemoryIconRegistry.php
+++ b/src/Icons/tests/Util/InMemoryIconRegistry.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\UX\Icons\Registry;
+namespace Symfony\UX\Icons\Tests\Util;
 
 use Symfony\UX\Icons\Exception\IconNotFoundException;
 use Symfony\UX\Icons\IconRegistryInterface;


### PR DESCRIPTION
Create tests for the IconRenderer

Add internal docblock to clarify the attributes precedence

(+ one CS fix passing by)

-- 

+ moved the InMemoryRegistrey in the `tests` directory

As @kbond  says, it won't be used by final users so it's better there
