### PR TITLE
[Icons] Rework cache warm

### DIFF
--- a/src/Icons/config/services.php
+++ b/src/Icons/config/services.php
@@ -50,15 +50,16 @@ return static function (ContainerConfigurator $container): void {
             ])
             ->tag('twig.runtime')
 
-        ->set('.ux_icons.twig_icon_finder', IconFinder::class)
+        ->set('.ux_icons.icon_finder', IconFinder::class)
             ->args([
                 service('twig'),
+                abstract_arg('icon_dir'),
             ])
 
         ->set('.ux_icons.cache_warmer', IconCacheWarmer::class)
             ->args([
                 service('.ux_icons.cache_icon_registry'),
-                service('.ux_icons.twig_icon_finder'),
+                service('.ux_icons.icon_finder'),
             ])
 
         ->set('.ux_icons.command.warm_cache', WarmCacheCommand::class)

--- a/src/Icons/src/DependencyInjection/UXIconsExtension.php
+++ b/src/Icons/src/DependencyInjection/UXIconsExtension.php
@@ -87,6 +87,10 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
             ])
         ;
 
+        $container->getDefinition('.ux_icons.icon_finder')
+            ->setArgument(1, $mergedConfig['icon_dir'])
+        ;
+
         $container->getDefinition('.ux_icons.icon_renderer')
             ->setArgument(1, $mergedConfig['default_icon_attributes'])
         ;

--- a/src/Icons/src/Twig/IconFinder.php
+++ b/src/Icons/src/Twig/IconFinder.php
@@ -24,8 +24,10 @@ use Twig\Loader\LoaderInterface;
  */
 final class IconFinder
 {
-    public function __construct(private Environment $twig)
-    {
+    public function __construct(
+        private Environment $twig,
+        private string $iconDirectory,
+    ) {
     }
 
     /**
@@ -35,42 +37,48 @@ final class IconFinder
     {
         $found = [];
 
-        foreach ($this->files($this->twig->getLoader()) as $file) {
-            $contents = file_get_contents($file);
+        // https://regex101.com/r/WGa4iF/1
+        $token = '[a-z0-9]+(?:-[a-z0-9]+)*';
+        $pattern = "#(?:'$token:$token')|(?:\"$token:$token\")#i";
 
-            if (preg_match_all('#["\']([\w:-]+)["\']#', $contents, $matches)) {
-                $found[] = $matches[1];
+        // Extract icon names from strings in app templates
+        foreach ($this->templateFiles($this->twig->getLoader()) as $file) {
+            $contents = file_get_contents($file);
+            if (preg_match_all($pattern, $contents, $matches)) {
+                $found[] = array_map(fn ($res) => trim($res, '"\''), $matches[0]);
+            }
+        }
+        $found = array_merge(...$found);
+
+        // Extract prefix-less SVG files from the root of the icon directory
+        if (is_dir($this->iconDirectory)) {
+            $icons = (new Finder())->files()->in($this->iconDirectory)->depth(0)->name('*.svg');
+            foreach ($icons as $icon) {
+                $found[] = $icon->getBasename('.svg');
             }
         }
 
-        return array_unique(array_merge(...$found));
+        return array_unique($found);
     }
 
     /**
      * @return string[]
      */
-    private function files(LoaderInterface $loader): iterable
+    private function templateFiles(LoaderInterface $loader): iterable
     {
-        $files = [];
-
         if ($loader instanceof FilesystemLoader) {
+            $paths = [];
             foreach ($loader->getNamespaces() as $namespace) {
-                foreach ($loader->getPaths($namespace) as $path) {
-                    foreach ((new Finder())->files()->in($path)->name('*.twig') as $file) {
-                        $file = (string) $file;
-                        if (!\in_array($file, $files, true)) {
-                            yield $file;
-                        }
-
-                        $files[] = $file;
-                    }
-                }
+                $paths = [...$paths, ...$loader->getPaths($namespace)];
+            }
+            foreach ((new Finder())->files()->in($paths)->name('*.twig') as $file) {
+                yield (string) $file;
             }
         }
 
         if ($loader instanceof ChainLoader) {
             foreach ($loader->getLoaders() as $subLoader) {
-                yield from $this->files($subLoader);
+                yield from $this->templateFiles($subLoader);
             }
         }
     }


### PR DESCRIPTION
The warm cache took a lot of time because

- the regexp was very open (due to the non-prefix icon names)
- twig templates were listed multiple times (due to the namespace system)

And a looot of false positives caused lot of cache locks for nothing.

On ux.symfony.com project with this component, the PR make the icons detected from 1000+ to 1 :)
And the command is now way quicker to run.

The prefix-less icons are warmed by simply listing the SVG at the root of the asset/icons directory





