### PR TITLE
[Twig] allow stringable objects as attribute values

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -41,6 +41,10 @@ final class ComponentAttributes implements \IteratorAggregate, \Countable
             function (string $carry, string $key) {
                 $value = $this->attributes[$key];
 
+                if ($value instanceof \Stringable) {
+                    $value = (string) $value;
+                }
+
                 if (!\is_scalar($value) && null !== $value) {
                     throw new \LogicException(sprintf('A "%s" prop was passed when creating the component. No matching "%s" property or mount() argument was found, so we attempted to use this as an HTML attribute. But, the value is not a scalar (it\'s a %s). Did you mean to pass this to your component or is there a typo on its name?', $key, $key, get_debug_type($value)));
                 }
@@ -69,6 +73,10 @@ final class ComponentAttributes implements \IteratorAggregate, \Countable
     {
         if (null === $value = $this->attributes[$attribute] ?? null) {
             return null;
+        }
+
+        if ($value instanceof \Stringable) {
+            $value = (string) $value;
         }
 
         if (!\is_string($value)) {

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -27,7 +27,12 @@ final class ComponentAttributesTest extends TestCase
     {
         $attributes = new ComponentAttributes([
             'class' => 'foo',
-            'style' => 'color:black;',
+            'style' => new class() {
+                public function __toString(): string
+                {
+                    return 'color:black;';
+                }
+            },
             'value' => '',
             'autofocus' => true,
         ]);
@@ -210,7 +215,15 @@ final class ComponentAttributesTest extends TestCase
 
     public function testRenderingSingleAttributeExcludesFromString(): void
     {
-        $attributes = new ComponentAttributes(['attr1' => 'value1', 'attr2' => 'value2']);
+        $attributes = new ComponentAttributes([
+            'attr1' => new class() {
+                public function __toString(): string
+                {
+                    return 'value1';
+                }
+            },
+            'attr2' => 'value2',
+        ]);
 
         $this->assertSame('value1', $attributes->render('attr1'));
         $this->assertSame(' attr2="value2"', (string) $attributes);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | n/a
| License       | MIT

Allows passing a stringable objects as attribute values.

```twig
{# currently #}
<twig:Form :action="stringableUriObject"> {# error because stringableUriObject isn't scalar #}

{# with this PR #}
<twig:Form :action="stringableUriObject"> {# auto converts stringableUriObject to string #}
```