### PR TITLE
[Twig] allow compound variant value to be string

### DIFF
--- a/src/TwigComponent/src/CVA.php
+++ b/src/TwigComponent/src/CVA.php
@@ -77,6 +77,10 @@ final class CVA
                         break;
                     }
 
+                    if (!\is_array($compoundValues)) {
+                        $compoundValues = [$compoundValues];
+                    }
+
                     if (!\in_array($recipes[$compoundName], $compoundValues)) {
                         $isCompound = false;
                         break;

--- a/src/TwigComponent/tests/Unit/CVATest.php
+++ b/src/TwigComponent/tests/Unit/CVATest.php
@@ -221,7 +221,7 @@ class CVATest extends TestCase
                 ],
                 'compounds' => [
                     [
-                        'colors' => ['primary'],
+                        'colors' => 'primary',
                         'sizes' => ['sm'],
                         'class' => 'text-red-500',
                     ],
@@ -361,7 +361,7 @@ class CVATest extends TestCase
                 'compounds' => [
                     [
                         'colors' => ['danger', 'secondary'],
-                        'sizes' => ['sm'],
+                        'sizes' => 'sm',
                         'class' => 'text-red-500',
                     ],
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | n/a
| License       | MIT

According to https://cva.style/docs/getting-started/variants#compound-variants, the compound variant values can be strings.

/cc @WebMamba