### PR TITLE
[TwigComponent] Fix typo in the documentation

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -333,7 +333,7 @@ close tag, it's passed to your component template as the block called
 
 .. code-block:: html+twig
 
-    <div {{ attributes.defaults({ class: 'alert alert'~ type }) }}">
+    <div {{ attributes.defaults({ class: 'alert alert-'~ type }) }}">
         {% block content %}{% endblock %}
     </div>
 
@@ -825,7 +825,7 @@ We already have a generic ``Alert`` component, so let's re-use it:
 .. code-block:: html+twig
 
     {# templates/components/Alert.html.twig #}
-    <div {{ attributes.defaults({ class: 'alert alert'~ type }) }}">
+    <div {{ attributes.defaults({ class: 'alert alert-'~ type }) }}">
         {% block content %}{% endblock %}
     </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Fix a small typo in the documentation (will render the Alert correctly as _alert alert-success_ instead of _alert alertsuccess_)
