### PR TITLE
Fix typo on only and without methods documentation

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1025,13 +1025,13 @@ Extract specific attributes and discard the rest:
 
 .. code-block:: html+twig
 
+    {# render component #}
+    {{ component('MyComponent', { class: 'foo', style: 'color:red' }) }}
+
     {# templates/components/MyComponent.html.twig #}
     <div{{ attributes.only('class') }}>
       My Component!
     </div>
-
-    {# render component #}
-    {{ component('MyComponent', { class: 'foo', style: 'color:red' }) }}
 
     {# renders as: #}
     <div class="foo">
@@ -1045,13 +1045,13 @@ Exclude specific attributes:
 
 .. code-block:: html+twig
 
+    {# render component #}
+    {{ component('MyComponent', { class: 'foo', style: 'color:red' }) }}
+
     {# templates/components/MyComponent.html.twig #}
     <div{{ attributes.without('class') }}>
       My Component!
     </div>
-
-    {# render component #}
-    {{ component('MyComponent', { class: 'foo', style: 'color:red' }) }}
 
     {# renders as: #}
     <div style="color:red">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Issues        | 
| License       | MIT

There are two typos in the `only` and `without` examples.
The intermediate representation still have the style and the classes attributes respectively.