### PR TITLE
[Autocomplete] Fix tests for ORM 3.0

### DIFF
--- a/src/Autocomplete/src/Doctrine/EntityMetadata.php
+++ b/src/Autocomplete/src/Doctrine/EntityMetadata.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\Autocomplete\Doctrine;
 
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
@@ -75,8 +76,14 @@ class EntityMetadata
     public function getAssociationMetadata(string $propertyName): array
     {
         if (\array_key_exists($propertyName, $this->metadata->associationMappings)) {
-            // Cast to array, because in doctrine/orm:^3.0; $metadata will be an AssociationMapping object
-            return (array) $this->metadata->associationMappings[$propertyName];
+            $associationMapping = $this->metadata->associationMappings[$propertyName];
+
+            // Doctrine ORM 3.0
+            if (class_exists(AssociationMapping::class) && $associationMapping instanceof AssociationMapping) {
+                return $associationMapping->toArray();
+            }
+
+            return $associationMapping;
         }
 
         throw new \InvalidArgumentException(sprintf('The "%s" field does not exist in the "%s" entity.', $propertyName, $this->metadata->getName()));

--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\Autocomplete\Tests\Fixtures;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\ORM\Mapping\AssociationMapping;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -100,7 +101,7 @@ final class Kernel extends BaseKernel
             'auto_refresh_proxies' => false,
         ]);
 
-        $c->extension('doctrine', [
+        $config = [
             'dbal' => ['url' => '%env(resolve:DATABASE_URL)%'],
             'orm' => [
                 'auto_generate_proxy_classes' => true,
@@ -115,7 +116,14 @@ final class Kernel extends BaseKernel
                     ],
                 ],
             ],
-        ]);
+        ];
+        if (class_exists(AssociationMapping::class)) {
+            // Doctrine ORM >= 3.0
+            $config['orm']['controller_resolver'] = [
+                'auto_mapping' => true,
+            ];
+        }
+        $c->extension('doctrine', $config);
 
         $c->extension('security', [
             'password_hashers' => [


### PR DESCRIPTION
* leverage Metadata::toArray to keep the "type" data
* lighten some over-specific tests
* document some changes
* fix deprecation 

Make the CI green again