### PR TITLE
[Doc] Fix some syntax issues in Typed docs

### DIFF
--- a/src/Typed/doc/index.rst
+++ b/src/Typed/doc/index.rst
@@ -54,7 +54,7 @@ The main usage of Symfony UX Typed is to use its Stimulus controller to initiali
     </div>
 
 
-That's it! Typed now shows the messages defined in the `strings` argument.
+That's it! Typed now shows the messages defined in the ``strings`` argument.
 You can customize the way those messages are typed.
 Parameters are exactly the same as for the `typed library`_
 
@@ -73,8 +73,6 @@ Parameters are exactly the same as for the `typed library`_
             cursorChar: '✨'
         }) }}></span>
     </div>
-
-.. note::
 
 Extend the JavaScript Controller
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | -
| License       | MIT

Fixes these errors:

```
Error while processing "note" directive:
"Content expected, none found." in file "index" at line 80

Found invalid reference "strings` argument in file "index"
```