### PR TITLE
[Doc] Added a missing reference in Live Component docs

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2943,6 +2943,7 @@ component:
     model: when the child model changes, the parent model will also change.
 
 .. _data-model:
+.. _update-parent-model:
 
 Updating a Parent Model from a Child
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | -
| License       | MIT

Fixes this error:

```
Found invalid reference "update-parent-model" in file "index"
```