### PR TITLE
[Twig] boolean (true) CVA variants

### DIFF
--- a/src/TwigComponent/src/CVA.php
+++ b/src/TwigComponent/src/CVA.php
@@ -26,8 +26,8 @@ final class CVA
 {
     /**
      * @var string|list<string|null>|null
-     * @var array<string, array<string, string|list<string|null>>|null the array should have the following format [variantCategory => [variantName => classes]]
-     *                                                ex: ['colors' => ['primary' => 'bleu-8000', 'danger' => 'red-800 text-bold'], 'size' => [...]]
+     * @var array<string, string|list<string>|array<string, string|list<string|null>>|null the array should have the following format [variantCategory => [variantName => classes]]
+     *                                                                                     ex: ['colors' => ['primary' => 'bleu-8000', 'danger' => 'red-800 text-bold'], 'size' => [...]]
      * @var array<array<string, string|array<string>>> the array should have the following format ['variantsCategory' => ['variantName', 'variantName'], 'class' => 'text-red-500']
      * @var array<string, string>|null
      */
@@ -53,6 +53,14 @@ final class CVA
         }
 
         foreach ($recipes as $recipeName => $recipeValue) {
+            if (isset($this->variants[$recipeName]) && (\is_string($this->variants[$recipeName]) || (\is_array($this->variants[$recipeName]) && array_is_list($this->variants[$recipeName])))) {
+                if (true === $recipeValue) {
+                    $classes .= ' '.implode(' ', (array) $this->variants[$recipeName]);
+                }
+
+                continue;
+            }
+
             if (!isset($this->variants[$recipeName][$recipeValue])) {
                 continue;
             }

--- a/src/TwigComponent/tests/Fixtures/templates/class_merge.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/class_merge.html.twig
@@ -1,1 +1,2 @@
 <twig:Alert color='red' size='lg' class='dark:bg-gray-600'/>
+<twig:Alert color='red' size='lg' class='dark:bg-gray-600' disabled />

--- a/src/TwigComponent/tests/Fixtures/templates/components/Alert.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/Alert.html.twig
@@ -1,4 +1,4 @@
-{% props color = 'blue', size = 'md' %}
+{% props color = 'blue', size = 'md', disabled = false %}
 
 {% set alert = cva({
         base: ['alert'],
@@ -18,7 +18,8 @@
                 sm: 'rounded-sm',
                 md: 'rounded-md',
                 lg: 'rounded-lg',
-            }
+            },
+            disabled: 'disable',
         },
         compoundVariants: [{
             color: ['red'],
@@ -30,6 +31,6 @@
         }
 }) %}
 
-<div class="{{ alert.apply({color, size}, attributes.render('class'), 'flex p-4') }}">
+<div class="{{ alert.apply({color, size, disabled}, attributes.render('class'), 'flex p-4') }}">
     ...
 </div>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -261,6 +261,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $output = self::getContainer()->get(Environment::class)->render('class_merge.html.twig');
 
         $this->assertStringContainsString('class="alert alert-red alert-lg font-semibold rounded-md dark:bg-gray-600 flex p-4"', $output);
+        $this->assertStringContainsString('class="alert alert-red alert-lg disable font-semibold rounded-md dark:bg-gray-600 flex p-4"', $output);
     }
 
     private function renderComponent(string $name, array $data = []): string

--- a/src/TwigComponent/tests/Unit/CVATest.php
+++ b/src/TwigComponent/tests/Unit/CVATest.php
@@ -167,6 +167,90 @@ class CVATest extends TestCase
             'font-semibold border rounded text-primary text-sm',
         ];
 
+        yield 'boolean string variants true' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => 'disable',
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => true],
+            'text-primary disable',
+        ];
+
+        yield 'boolean string variants false' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => 'disable',
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => false],
+            'text-primary',
+        ];
+
+        yield 'boolean string variants missing' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => 'disable',
+                ],
+            ],
+            ['colors' => 'primary'],
+            'text-primary',
+        ];
+
+        yield 'boolean list variants true' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => ['disable', 'opacity-50'],
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => true],
+            'text-primary disable opacity-50',
+        ];
+
+        yield 'boolean list variants false' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => ['disable', 'opacity-50'],
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => false],
+            'text-primary',
+        ];
+
+        yield 'boolean list variants missing' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => ['disable', 'opacity-50'],
+                ],
+            ],
+            ['colors' => 'primary'],
+            'text-primary',
+        ];
+
         yield 'simple variants as array' => [
             [
                 'base' => 'font-semibold border rounded',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #1614
| License       | MIT

This is an attempt to solve #1614. As discussed in that issue, it seems like only a `true` should be valid. Because of this, I opted for the variant value(s) to be a `string` or `list<string>` - this is used when the recipe value is `true`. Examples:


```twig
{% props size = 'md', disabled = false %}

{% set button = cva({
    variants: {
        size: {
            sm: 'alert-sm',
            md: 'alert-md',
            lg: 'alert-lg',
        },
        disabled: 'opacity-50 cursor-not-allowed',
        disabled: ['opacity-50', 'cursor-not-allowed'], {# also valid #}
    },
}) %}

<button class="{{ button.apply({size, disabled}, attributes.render('class'), 'flex p-4') }}">
    ...
</button>
```

**TODO**
- [ ] docs
- [ ] changelog