### PR TITLE
fix: Changed getParent to BaseEntityAutocompleteType instead of depre…

### DIFF
--- a/src/Autocomplete/src/Maker/MakeAutocompleteField.php
+++ b/src/Autocomplete/src/Maker/MakeAutocompleteField.php
@@ -28,7 +28,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
-use Symfony\UX\Autocomplete\Form\ParentEntityAutocompleteType;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>

--- a/src/Autocomplete/src/Maker/MakeAutocompleteField.php
+++ b/src/Autocomplete/src/Maker/MakeAutocompleteField.php
@@ -121,7 +121,7 @@ EOF)
             AbstractType::class,
             OptionsResolver::class,
             AsEntityAutocompleteField::class,
-            ParentEntityAutocompleteType::class,
+            BaseEntityAutocompleteType::class,
         ]);
 
         $variables = new MakerAutocompleteVariables(

--- a/src/Autocomplete/src/Maker/skeletons/AutocompleteField.tpl.php
+++ b/src/Autocomplete/src/Maker/skeletons/AutocompleteField.tpl.php
@@ -34,6 +34,6 @@ class <?php echo $class_name; ?> extends AbstractType
 
     public function getParent(): string
     {
-        return ParentEntityAutocompleteType::class;
+        return BaseEntityAutocompleteType::class;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Issues        | 
| License       | MIT

if you create a new class with the make:autocomplete command, it still use the deprecated class "ParentEntityAutocompleteType" for getParent() return. 
It was deprecated in 93355877d69f95b36479956f430f44b57ae8faf1 

This pull request changes it to the new class "BaseEntityAutocompleteType" in the template
