### PR TITLE
[Icons] Add Search Command

### DIFF
--- a/src/Icons/config/iconify.php
+++ b/src/Icons/config/iconify.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\UX\Icons\Command\ImportIconCommand;
 use Symfony\UX\Icons\Command\LockIconsCommand;
+use Symfony\UX\Icons\Command\SearchIconCommand;
 use Symfony\UX\Icons\Iconify;
 use Symfony\UX\Icons\Registry\IconifyOnDemandRegistry;
 
@@ -39,11 +40,17 @@ return static function (ContainerConfigurator $container): void {
             ->tag('console.command')
 
         ->set('.ux_icons.command.lock', LockIconsCommand::class)
-        ->args([
-            service('.ux_icons.iconify'),
-            service('.ux_icons.local_svg_icon_registry'),
-            service('.ux_icons.icon_finder'),
-        ])
-        ->tag('console.command')
+            ->args([
+                service('.ux_icons.iconify'),
+                service('.ux_icons.local_svg_icon_registry'),
+                service('.ux_icons.icon_finder'),
+            ])
+            ->tag('console.command')
+
+        ->set('.ux_icons.command.search', SearchIconCommand::class)
+            ->args([
+                service('.ux_icons.iconify'),
+            ])
+            ->tag('console.command')
     ;
 };

--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -126,6 +126,56 @@ Icon Set                    Icons License    Prefix      Example
 
 To see the full list of available icon sets, visit `ux.symfony.com/icons`_.
 
+Search Icon sets
+~~~~~~~~~~~~~~~~
+
+You can use the ``ux:icons:search`` command to search for icon sets, or to find
+the prefix of a specific icon set:
+
+.. code-block:: terminal
+
+    $ php bin/console ux:icons:search tabler
+
+     -------------- ------- --------- -------- --------------
+      Icon set       Icons   License   Prefix   Example
+     -------------- ------- --------- -------- --------------
+      Tabler Icons    5219   MIT       tabler   tabler:alien
+     -------------- ------- --------- -------- --------------
+
+    Search "arrow" in Tabler Icons icons:
+
+     php bin/console ux:icons:search tabler arrow
+
+Search Icons
+~~~~~~~~~~~~
+
+You can also search for icons within a specific icon set. To search for "arrow"
+icons in the "Tabler Icons" set, use the following command:
+
+.. code-block:: terminal
+
+    $ php bin/console ux:icons:search tabler arrow
+
+    Searching Tabler Icons icons "arrow"...
+    Found 64 icons.
+     ------------------------------------------ ------------------------------------------
+      tabler:archery-arrow                       tabler:arrow-autofit-up
+      tabler:arrow-back                          tabler:arrow-back-up
+      tabler:arrow-badge-down                    tabler:arrow-badge-up
+      tabler:arrow-badge-up-filled               tabler:arrow-bar-both
+      tabler:arrow-bar-down                      tabler:arrow-bar-left
+      tabler:arrow-bar-right                     tabler:arrow-bar-to-up
+      tabler:arrow-bar-up                        tabler:arrow-bear-left
+      tabler:arrow-big-down                      tabler:arrow-big-down-filled
+      tabler:arrow-big-down-line                 tabler:arrow-big-left
+      tabler:arrow-big-left-filled               tabler:arrow-big-left-line
+      tabler:arrow-big-right                     tabler:arrow-big-right-filled
+      tabler:arrow-big-right-line                tabler:arrow-big-up
+     ------------------------------------------ ------------------------------------------
+
+     Page 1/3. Continue? (yes/no) [yes]:
+     >
+
 HTML Syntax
 ~~~~~~~~~~~
 

--- a/src/Icons/src/Command/SearchIconCommand.php
+++ b/src/Icons/src/Command/SearchIconCommand.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Cursor;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Helper\TableCellStyle;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\UX\Icons\Iconify;
+
+/**
+ * A console command to search icons and icon sets from ux.symfony.com.
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ *
+ * @internal
+ */
+#[AsCommand(
+    name: 'ux:icons:search',
+    description: 'Search icons and icon sets from ux.symfony.com',
+)]
+final class SearchIconCommand extends Command
+{
+    public function __construct(private Iconify $iconify)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('prefix', InputArgument::REQUIRED, 'Prefix or name of the icon set (ex: bootstrap, fa, tabler)')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Name of the icon (leave empty to search for sets)')
+            ->setHelp(
+                <<<EOF
+The <info>%command.name%</info> command search icon sets and icons from ux.symfony.com
+
+To search for <comment>icon sets</comment>, pass the prefix or name of the icon set (or a part of it):
+
+  <info>php %command.full_name% bootstrap</info>
+  <info>php %command.full_name% material</info>
+
+To search for <comment>icons</comment>, pass the prefix of the icon set and the name of the icon:
+
+  <info>php %command.full_name% bootstrap star</info>
+
+EOF
+            );
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        if (null === $input->getArgument('prefix')) {
+            $io = new SymfonyStyle($input, $output);
+            if ($prefix = $io->ask('Prefix or name of the icon set (ex: bootstrap, fa, tabler)')) {
+                $input->setArgument('prefix', $prefix);
+            }
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $prefix = $input->getArgument('prefix');
+        $name = $input->getArgument('name');
+
+        $iconSets = $this->findIconSets($prefix);
+
+        if (null === $name) {
+            $this->renderIconSetTable($io, $iconSets);
+            if (1 === \count($iconSets)) {
+                $iconSet = reset($iconSets);
+                $searchTerm = 'arrow';
+                $io->writeln(sprintf('Search <comment>"%s"</comment> in <comment>%s</comment> icons:', $searchTerm, $iconSet['name']));
+                $io->newLine();
+                $io->writeln(' '.sprintf('php bin/console <comment>ux:icons:search %s %s</comment>', $iconSet['prefix'], $searchTerm));
+                $io->newLine();
+            }
+
+            return Command::SUCCESS;
+        }
+
+        if (false === $iconSet = reset($iconSets)) {
+            $io->error(sprintf('No icon sets found for prefix "%s".', $prefix));
+
+            return Command::INVALID;
+        }
+
+        if (1 < \count($iconSets) && $prefix !== $iconSet['prefix']) {
+            $choices = array_combine(array_keys($iconSets), array_column($iconSets, 'name'));
+            $choice = $io->choice('Select an icon set', array_values($choices));
+            if (!$choice || false === $prefix = array_search($choice, $choices, true)) {
+                $io->error('No icon set selected.');
+
+                return Command::INVALID;
+            }
+            $iconSet = $iconSets[$prefix];
+        }
+
+        $io->write(sprintf('Searching <comment>%s</comment> icons "<comment>%s</comment>"...', $iconSet['name'], $name));
+        try {
+            $results = $this->iconify->searchIcons($prefix, $name);
+        } catch (\Throwable $e) {
+            $io->write(' <fg=bright-red;options=bold>✗</>');
+            $io->error('An error occurred while searching for icons.');
+            if ($io->isVerbose()) {
+                $io->writeln($e->getMessage());
+                if ($io->isDebug()) {
+                    $io->writeln($e->getTraceAsString());
+                }
+            }
+
+            return Command::FAILURE;
+        }
+        $io->newLine();
+
+        $icons = $results['icons'] ?? [];
+        sort($icons);
+        $iconPages = array_chunk($icons, 24);
+        $nbPages = \count($iconPages);
+
+        $cursor = new Cursor($output);
+        $io->writeln(sprintf('Found <info>%d</info> icons.', \count($icons)));
+        foreach ($iconPages as $page => $iconPage) {
+            $this->renderIconTable($io, $prefix, $name, $iconPage);
+            if ($page + 1 === $nbPages) {
+                break;
+            }
+            if (!$io->confirm(sprintf('Page <comment>%d</comment>/<comment>%d</comment>. Continue?', $page + 1, $nbPages))) {
+                break;
+            }
+            $cursor->moveUp(5)->clearLineAfter();
+        }
+        $io->newLine();
+        $io->writeln(sprintf('See all the <comment>%s</comment> icons on: https://ux.symfony.com/icons?set=%s', $prefix, $prefix));
+        $io->newLine();
+
+        return Command::SUCCESS;
+    }
+
+    private function renderIconTable(SymfonyStyle $io, string $prefix, string $name, array $icons): void
+    {
+        $table = new Table($io);
+        $table->setStyle('symfony-style-guide');
+        $table->setColumnWidths([40, 40]);
+        foreach ($icons as $i => $icon) {
+            $icons[$i] = str_replace($name, '<fg=bright-blue>'.$name.'</>', $icon);
+        }
+        $table->addRows(array_chunk($icons, 2));
+        $table->render();
+    }
+
+    private function renderIconSetTable(SymfonyStyle $io, array $iconSets): void
+    {
+        $results = [];
+        foreach ($iconSets as $prefix => $iconSet) {
+            $results[] = [
+                $iconSet['name'] ?? $prefix,
+                new TableCell($iconSet['total'], [
+                    'style' => new TableCellStyle(['align' => 'right']),
+                ]),
+                $iconSet['license']['title'] ?? '',
+                $iconSet['prefix'],
+                $this->formatIcon($io, $prefix.':'.$iconSet['samples'][0], false),
+            ];
+        }
+        $io->table(['Icon set', 'Icons', 'License', 'Prefix', 'Example'], $results);
+    }
+
+    private function findIconSets(string $query): array
+    {
+        $iconSets = [];
+        $query = mb_strtolower($query);
+        foreach ($this->iconify->getIconSets() as $prefix => $iconSet) {
+            if (!str_contains($prefix, $query) && !str_contains(mb_strtolower($iconSet['name']), $query)) {
+                continue;
+            }
+            $iconSets[$prefix] = [...$iconSet, 'prefix' => $prefix];
+        }
+
+        return $iconSets;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if (!$input->mustSuggestArgumentValuesFor('prefix')) {
+            return;
+        }
+
+        $prefixes = array_keys($this->iconify->getIconSets());
+        if ($input->getArgument('prefix')) {
+            $prefixes = array_filter($prefixes, fn ($prefix) => str_contains($prefix, $input->getArgument('prefix')));
+        }
+
+        $suggestions->suggestValues($prefixes);
+    }
+
+    private function formatIcon(OutputInterface $output, string $icon, bool $padding = true): string
+    {
+        if (!$output->getFormatter()->hasStyle('icon-prefix')) {
+            $output->getFormatter()->setStyle('icon-prefix', new OutputFormatterStyle('bright-white', 'black'));
+        }
+        if (!$output->getFormatter()->hasStyle('icon-name')) {
+            $output->getFormatter()->setStyle('icon-name', new OutputFormatterStyle('bright-magenta', 'black'));
+        }
+
+        [$prefix, $name] = explode(':', $icon.':');
+        $padding = $padding ? ' ' : '';
+
+        return sprintf('<icon-prefix>%s%s:</><icon-name>%s%s</>', $padding, $prefix, $name, $padding);
+    }
+}

--- a/src/Icons/src/Iconify.php
+++ b/src/Icons/src/Iconify.php
@@ -94,6 +94,23 @@ final class Iconify
         return $content;
     }
 
+    public function getIconSets(): array
+    {
+        return $this->sets()->getArrayCopy();
+    }
+
+    public function searchIcons(string $prefix, string $query)
+    {
+        $response = $this->http->request('GET', '/search', [
+            'query' => [
+                'query' => $query,
+                'prefix' => $prefix,
+            ],
+        ]);
+
+        return new \ArrayObject($response->toArray());
+    }
+
     private function sets(): \ArrayObject
     {
         return $this->sets ??= $this->cache->get('ux-iconify-sets', function () {

--- a/src/Icons/tests/Integration/Command/SearchIconCommandTest.php
+++ b/src/Icons/tests/Integration/Command/SearchIconCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons\Tests\Integration\Command;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Console\Test\InteractsWithConsole;
+
+/**
+ * @author Simon Andreé <smn.andre@gmail.com>
+ */
+final class SearchIconCommandTest extends KernelTestCase
+{
+    use InteractsWithConsole;
+
+    public function testSearchWithPrefix(): void
+    {
+        $this->consoleCommand('ux:icons:search lucide')
+            ->execute()
+            ->assertSuccessful()
+            ->assertOutputContains('Icon set')
+            ->assertOutputContains('Lucide')
+            ->assertOutputContains('Icons')
+            ->assertOutputContains('License')
+            ->assertOutputContains('ISC')
+            ->assertOutputContains('Prefix')
+            ->assertOutputContains('lucide')
+            ->assertOutputContains('Example')
+            ->assertOutputContains('lucide:')
+            ->assertOutputContains('php bin/console ux:icons:search lucide');
+    }
+
+    public function testSearchWithPrefixMatchingMultipleSet(): void
+    {
+        $this->consoleCommand('ux:icons:search box')
+            ->execute()
+            ->assertSuccessful()
+            ->assertOutputContains('BoxIcons')
+            ->assertOutputContains('bx ')
+            ->assertOutputContains('BoxIcons Solid')
+            ->assertOutputContains('bxs ')
+            ->assertOutputContains('BoxIcons Logo')
+            ->assertOutputContains('bxl ')
+            ->assertStatusCode(0);
+    }
+
+    public function testSearchWithPrefixName(): void
+    {
+        $this->consoleCommand('ux:icons:search lucide arrow')
+            ->execute()
+            ->assertSuccessful()
+            ->assertOutputContains('Searching Lucide icons "arrow"...')
+            ->assertOutputContains('lucide:arrow-')
+            ->assertOutputContains('lucide:circle-arrow')
+            ->assertOutputContains('See all the lucide icons')
+            ->assertOutputContains('https://ux.symfony.com/icons?set=lucide')
+            ->assertStatusCode(0);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | 
| License       | MIT

Allow to search for icon sets (by prefix / name) and icons (paginated lists)


```console
# Search icon set matching "boo"
php bin/console ux:icons:search boo
```

```console
# Search icons in the Lucide set matching "arr"
php bin/console ux:icons:search lucide arr
```


| Search | Search Set | Search Set |
| -- | -- | -- | 
| ![iconsearch23](https://github.com/symfony/ux/assets/1359581/35993d18-9722-4ccc-8d1f-4ecfc4b7d518) | ![iconsearch24](https://github.com/symfony/ux/assets/1359581/f48344b8-8894-4d37-b731-59154f5d8a37) | ![iconsearch25](https://github.com/symfony/ux/assets/1359581/e7ed804a-3a93-4b0e-ad27-67d6f221c286) |

| Icons | Icons | Icons |
| -- | -- | -- | 
| ![iconsearch27](https://github.com/symfony/ux/assets/1359581/fa8e8a0b-8830-4681-a91d-18009a5a7ac8) | ![iconsearch29](https://github.com/symfony/ux/assets/1359581/4138cbd3-89e5-4db6-b33e-6f033269745e) | ![iconsearch28](https://github.com/symfony/ux/assets/1359581/b86d83b4-bc15-4644-a31e-2c86cb5c2309) |


