### PR TITLE
[CI] Freeze Foundry 1.37

### DIFF
--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -50,7 +50,7 @@
         "symfony/uid": "^6.3|^7.0",
         "twig/twig": "^2.14.7|^3.0.4",
         "zenstruck/browser": "^1.1",
-        "zenstruck/foundry": "^1.33"
+        "zenstruck/foundry": "1.37.*"
     },
     "conflict": {
         "doctrine/orm": "2.9.0 || 2.9.1"

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -50,7 +50,7 @@
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",
         "symfony/validator": "^5.4|^6.0|^7.0",
         "zenstruck/browser": "^1.2.0",
-        "zenstruck/foundry": "^1.33"
+        "zenstruck/foundry": "1.37.*"
     },
     "conflict": {
         "symfony/config": "<5.4.0"


### PR DESCRIPTION
To keep the tests green on the CI, I suggest we stay on Foundry 1.37

Since 1.38, deprecations are triggered to prepare the 2.0, but they make the CI fail on Autocomplete and LiveComponent

We'll release the constraint when we can handle the migration :)

WDYT @kbond ?