### PR TITLE
[Icons] `Icon` changes

### DIFF
--- a/src/Icons/src/Icon.php
+++ b/src/Icons/src/Icon.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\UX\Icons\Svg;
+namespace Symfony\UX\Icons;
 
 /**
  * @author Simon André <smn.andre@gmail.com>
  *
  * @internal
  */
-final class Icon implements \Stringable, \Serializable
+final class Icon implements \Stringable
 {
     /**
      * Transforms a valid icon ID into an icon name.
@@ -191,16 +191,6 @@ final class Icon implements \Stringable, \Serializable
     public function __toString(): string
     {
         return $this->toHtml();
-    }
-
-    public function serialize(): string
-    {
-        return serialize([$this->innerSvg, $this->attributes]);
-    }
-
-    public function unserialize(string $data): void
-    {
-        [$this->innerSvg, $this->attributes] = unserialize($data);
     }
 
     public function __serialize(): array

--- a/src/Icons/src/IconCacheWarmer.php
+++ b/src/Icons/src/IconCacheWarmer.php
@@ -13,7 +13,6 @@ namespace Symfony\UX\Icons;
 
 use Symfony\UX\Icons\Exception\IconNotFoundException;
 use Symfony\UX\Icons\Registry\CacheIconRegistry;
-use Symfony\UX\Icons\Svg\Icon;
 use Symfony\UX\Icons\Twig\IconFinder;
 
 /**

--- a/src/Icons/src/IconRegistryInterface.php
+++ b/src/Icons/src/IconRegistryInterface.php
@@ -12,7 +12,6 @@
 namespace Symfony\UX\Icons;
 
 use Symfony\UX\Icons\Exception\IconNotFoundException;
-use Symfony\UX\Icons\Svg\Icon;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/Icons/src/Iconify.php
+++ b/src/Icons/src/Iconify.php
@@ -17,7 +17,6 @@ use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
-use Symfony\UX\Icons\Svg\Icon;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/Icons/src/Registry/CacheIconRegistry.php
+++ b/src/Icons/src/Registry/CacheIconRegistry.php
@@ -13,8 +13,8 @@ namespace Symfony\UX\Icons\Registry;
 
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
+use Symfony\UX\Icons\Icon;
 use Symfony\UX\Icons\IconRegistryInterface;
-use Symfony\UX\Icons\Svg\Icon;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/Icons/src/Registry/ChainIconRegistry.php
+++ b/src/Icons/src/Registry/ChainIconRegistry.php
@@ -12,8 +12,8 @@
 namespace Symfony\UX\Icons\Registry;
 
 use Symfony\UX\Icons\Exception\IconNotFoundException;
+use Symfony\UX\Icons\Icon;
 use Symfony\UX\Icons\IconRegistryInterface;
-use Symfony\UX\Icons\Svg\Icon;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/Icons/src/Registry/IconifyOnDemandRegistry.php
+++ b/src/Icons/src/Registry/IconifyOnDemandRegistry.php
@@ -12,9 +12,9 @@
 namespace Symfony\UX\Icons\Registry;
 
 use Symfony\UX\Icons\Exception\IconNotFoundException;
+use Symfony\UX\Icons\Icon;
 use Symfony\UX\Icons\Iconify;
 use Symfony\UX\Icons\IconRegistryInterface;
-use Symfony\UX\Icons\Svg\Icon;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/Icons/src/Registry/LocalSvgIconRegistry.php
+++ b/src/Icons/src/Registry/LocalSvgIconRegistry.php
@@ -13,8 +13,8 @@ namespace Symfony\UX\Icons\Registry;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
+use Symfony\UX\Icons\Icon;
 use Symfony\UX\Icons\IconRegistryInterface;
-use Symfony\UX\Icons\Svg\Icon;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/Icons/tests/Unit/IconRendererTest.php
+++ b/src/Icons/tests/Unit/IconRendererTest.php
@@ -13,9 +13,9 @@ namespace Symfony\UX\Icons\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
+use Symfony\UX\Icons\Icon;
 use Symfony\UX\Icons\IconRegistryInterface;
 use Symfony\UX\Icons\IconRenderer;
-use Symfony\UX\Icons\Svg\Icon;
 use Symfony\UX\Icons\Tests\Util\InMemoryIconRegistry;
 
 /**

--- a/src/Icons/tests/Unit/IconTest.php
+++ b/src/Icons/tests/Unit/IconTest.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\UX\Icons\Tests\Unit\Svg;
+namespace Symfony\UX\Icons\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\UX\Icons\Svg\Icon;
+use Symfony\UX\Icons\Icon;
 
 final class IconTest extends TestCase
 {
@@ -274,5 +274,12 @@ final class IconTest extends TestCase
             ['foo' => 'foobar'],
             ['foo' => 'foobar', 'baz' => 'qux'],
         ];
+    }
+
+    public function testSerialize(): void
+    {
+        $icon = new Icon('foo', ['bar' => 'baz']);
+
+        $this->assertEquals($icon, unserialize(serialize($icon)));
     }
 }

--- a/src/Icons/tests/Unit/Registry/InMemoryIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/InMemoryIconRegistryTest.php
@@ -13,7 +13,7 @@ namespace Symfony\UX\Icons\Tests\Unit\Registry;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
-use Symfony\UX\Icons\Svg\Icon;
+use Symfony\UX\Icons\Icon;
 use Symfony\UX\Icons\Tests\Util\InMemoryIconRegistry;
 
 /**

--- a/src/Icons/tests/Unit/Registry/LocalSvgIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/LocalSvgIconRegistryTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\UX\Icons\Tests\Unit\Registry;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\UX\Icons\Icon;
 use Symfony\UX\Icons\Registry\LocalSvgIconRegistry;
-use Symfony\UX\Icons\Svg\Icon;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/src/Icons/tests/Util/InMemoryIconRegistry.php
+++ b/src/Icons/tests/Util/InMemoryIconRegistry.php
@@ -12,8 +12,8 @@
 namespace Symfony\UX\Icons\Tests\Util;
 
 use Symfony\UX\Icons\Exception\IconNotFoundException;
+use Symfony\UX\Icons\Icon;
 use Symfony\UX\Icons\IconRegistryInterface;
-use Symfony\UX\Icons\Svg\Icon;
 
 /**
  * @author Simon André <smn.andre@gmail.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | n/a
| License       | MIT

1. Removed `Serializable` from `Icon` (this isn't needed unless I'm mistaken)
2. I moved `Icon` up a level (this is a personal preference). @smnandre did you have plans for more classes in the `Svg` namespace?
