### PR TITLE
[Live] Add signature overload for on and off methods of component

### DIFF
--- a/src/LiveComponent/assets/dist/Component/index.d.ts
+++ b/src/LiveComponent/assets/dist/Component/index.d.ts
@@ -1,8 +1,24 @@
 import { BackendInterface } from '../Backend/Backend';
 import ValueStore from './ValueStore';
+import BackendRequest from '../Backend/BackendRequest';
 import { ElementDriver } from './ElementDriver';
 import { PluginInterface } from './plugins/PluginInterface';
 import BackendResponse from '../Backend/BackendResponse';
+type MaybePromise<T = void> = T | Promise<T>;
+export type ComponentHooks = {
+    'connect': (component: Component) => MaybePromise;
+    'disconnect': (component: Component) => MaybePromise;
+    'request:started': (requestConfig: any) => MaybePromise;
+    'render:finished': (component: Component) => MaybePromise;
+    'response:error': (backendResponse: BackendResponse, controls: {
+        displayError: boolean;
+    }) => MaybePromise;
+    'loading.state.started': (element: HTMLElement, request: BackendRequest) => MaybePromise;
+    'loading.state.finished': (element: HTMLElement) => MaybePromise;
+    'model:set': (model: string, value: any, component: Component) => MaybePromise;
+};
+export type ComponentHookName = keyof ComponentHooks;
+export type ComponentHookCallback<T extends string = ComponentHookName> = T extends ComponentHookName ? ComponentHooks[T] : (...args: any[]) => MaybePromise;
 export default class Component {
     readonly element: HTMLElement;
     readonly name: string;
@@ -30,8 +46,8 @@ export default class Component {
     addPlugin(plugin: PluginInterface): void;
     connect(): void;
     disconnect(): void;
-    on(hookName: string, callback: (...args: any[]) => void): void;
-    off(hookName: string, callback: (...args: any[]) => void): void;
+    on<T extends string | ComponentHookName = ComponentHookName>(hookName: T, callback: ComponentHookCallback<T>): void;
+    off<T extends string | ComponentHookName = ComponentHookName>(hookName: T, callback: ComponentHookCallback<T>): void;
     set(model: string, value: any, reRender?: boolean, debounce?: number | boolean): Promise<BackendResponse>;
     getData(model: string): any;
     action(name: string, args?: any, debounce?: number | boolean): Promise<BackendResponse>;
@@ -55,3 +71,4 @@ export default class Component {
     _updateFromParentProps(props: any): void;
 }
 export declare function proxifyComponent(component: Component): Component;
+export {};

--- a/src/LiveComponent/assets/dist/HookManager.d.ts
+++ b/src/LiveComponent/assets/dist/HookManager.d.ts
@@ -1,6 +1,6 @@
 export default class {
     private hooks;
-    register(hookName: string, callback: () => void): void;
-    unregister(hookName: string, callback: () => void): void;
+    register(hookName: string, callback: (...args: any[]) => void): void;
+    unregister(hookName: string, callback: (...args: any[]) => void): void;
     triggerHook(hookName: string, ...args: any[]): void;
 }

--- a/src/LiveComponent/assets/dist/PollingDirector.d.ts
+++ b/src/LiveComponent/assets/dist/PollingDirector.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import Component from './Component';
 export default class {
     component: Component;
@@ -7,7 +6,7 @@ export default class {
         actionName: string;
         duration: number;
     }>;
-    pollingIntervals: NodeJS.Timer[];
+    pollingIntervals: number[];
     constructor(component: Component);
     addPoll(actionName: string, duration: number): void;
     startAllPolling(): void;

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2625,7 +2625,7 @@ class PollingDirector {
                 this.component.action(actionName, {}, 0);
             };
         }
-        const timer = setInterval(() => {
+        const timer = window.setInterval(() => {
             callback();
         }, duration);
         this.pollingIntervals.push(timer);

--- a/src/LiveComponent/assets/src/HookManager.ts
+++ b/src/LiveComponent/assets/src/HookManager.ts
@@ -1,13 +1,13 @@
 export default class {
     private hooks: Map<string, Array<(...args: any[]) => void>> = new Map();
 
-    register(hookName: string, callback: () => void): void {
+    register(hookName: string, callback: (...args: any[]) => void): void {
         const hooks = this.hooks.get(hookName) || [];
         hooks.push(callback);
         this.hooks.set(hookName, hooks);
     }
 
-    unregister(hookName: string, callback: () => void): void {
+    unregister(hookName: string, callback: (...args: any[]) => void): void {
         const hooks = this.hooks.get(hookName) || [];
         const index = hooks.indexOf(callback);
         if (index === -1) {

--- a/src/LiveComponent/assets/src/PollingDirector.ts
+++ b/src/LiveComponent/assets/src/PollingDirector.ts
@@ -4,7 +4,7 @@ export default class {
     component: Component;
     isPollingActive = true;
     polls: Array<{ actionName: string; duration: number }>;
-    pollingIntervals: NodeJS.Timer[] = [];
+    pollingIntervals: number[] = [];
 
     constructor(component: Component) {
         this.component = component;
@@ -55,7 +55,7 @@ export default class {
             };
         }
 
-        const timer = setInterval(() => {
+        const timer = window.setInterval(() => {
             callback();
         }, duration);
         this.pollingIntervals.push(timer);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | no
| Issues        |
| License       | MIT

Following some feedback in #1676. This PR only affects TypeScript typing.

Provides automatic typing for the `on` and `off` events of a component, depending on the event's name. Also changes the return type allowed from an event listener to allow passing an asynchronous function. This is a pretty common thing to do (the need to use `await`), but TypeScript/linters will often yell at you for doing so if the event listener does not expect a `Promise` to be returned.

(also fixed a typing issue with `NodeJS.Timer` being used instead of `number`)