### PR TITLE
[LiveComponent] Add the `live.component` service tag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,6 +128,8 @@ jobs:
                 dependency-versions: ${{ matrix.dependency-version }}
 
             - name: ${{ matrix.component }} Tests
+              env:
+                  SYMFONY_DEPRECATIONS_HELPER: 'max[total]=999999'
               working-directory: "src/${{ matrix.component }}"
               run: vendor/bin/simple-phpunit
 

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -37,6 +37,7 @@
         "doctrine/doctrine-bundle": "^2.4.3",
         "doctrine/orm": "^2.9.4",
         "doctrine/persistence": "^2.5.2|^3.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^5.1",
         "phpdocumentor/reflection-docblock": "5.x-dev",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",
         "symfony/expression-language": "^5.4|^6.0|^7.0",

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3561,6 +3561,59 @@ Debugging Components
 Need to list or debug some component issues.
 The `Twig Component debug command`_ can help you.
 
+
+Registering Live Components manually
+------------------------------------
+
+.. versionadded:: 2.17
+
+    The ``live.component`` tag has been introduced in LiveComponents 2.17.
+
+Sometimes you might need to register your Live Components manually. This can be useful if you want to provide a live component
+along with a bundle. To do this, you can use the ``live.component`` tag:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        services:
+            # ...
+            app.component.product_search:
+                class: App\Components\ProductSearch
+                # ...
+                tags:
+                    - { name: 'live.component', key: 'ProductSearch', template: 'product_search.html.twig' }
+
+    .. code-block:: xml
+
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+            <service id="app.component.product_search" class="App\Components\ProductSearch">
+                <!-- ... -->
+                <tag name="live.component" key="ProductSearch" template="product_search.html.twig" />
+            </service>
+        </container>
+
+    .. code-block:: php
+
+        use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+        return static function (ContainerConfigurator $container): void {
+            $services = $container->services();
+            $services
+                ->set('app.component.product_search', App\Component\ProductSearch::class)
+                // ...
+                ->tag('live.component', ['key' => 'product_search', 'template' => '@App/product_search.html.twig'])
+            ;
+        };
+
+
 Test Helper
 -----------
 

--- a/src/LiveComponent/src/DependencyInjection/Compiler/LiveComponentTagPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/LiveComponentTagPass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @author Jacob Tobiasz <jakub.tobiasz@icloud.com>
+ *
+ * @internal
+ */
+final class LiveComponentTagPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('live.component') as $id => $tags) {
+            foreach ($tags as $tag) {
+                $liveComponentService = $container->getDefinition($id);
+                $liveComponentService->addTag('twig.component', [
+                    'key' => $tag['key'] ?? throw new InvalidArgumentException('The "key" attribute is required for the "live.component" tag.'),
+                    'template' => $tag['template'] ?? throw new InvalidArgumentException('The "template" attribute is required for the "live.component" tag.'),
+                    'expose_public_props' => $tag['expose_public_props'] ?? true,
+                    'attributes_var' => $tag['attributes_var'] ?? 'attributes',
+                    'default_action' => $tag['default_action'] ?? null,
+                    'live' => true,
+                    'csrf' => $tag['csrf'] ?? true,
+                    'route' => $tag['route'] ?? 'ux_live_component',
+                    'method' => $tag['method'] ?? 'post',
+                    'url_reference_type' => $tag['url_reference_type'] ?? UrlGeneratorInterface::ABSOLUTE_PATH,
+                ]);
+                $liveComponentService->addTag('controller.service_arguments');
+            }
+        }
+    }
+}

--- a/src/LiveComponent/src/LiveComponentBundle.php
+++ b/src/LiveComponent/src/LiveComponentBundle.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\UX\LiveComponent\DependencyInjection\Compiler\ComponentDefaultActionPass;
+use Symfony\UX\LiveComponent\DependencyInjection\Compiler\LiveComponentTagPass;
 use Symfony\UX\LiveComponent\DependencyInjection\Compiler\OptionalDependencyPass;
 
 /**
@@ -28,6 +29,7 @@ final class LiveComponentBundle extends Bundle
     {
         // must run before Symfony\Component\Serializer\DependencyInjection\SerializerPass
         $container->addCompilerPass(new OptionalDependencyPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 100);
+        $container->addCompilerPass(new LiveComponentTagPass(), priority: 100);
         $container->addCompilerPass(new ComponentDefaultActionPass());
     }
 

--- a/src/LiveComponent/tests/Integration/DependencyInjection/Compiler/LiveComponentTagPassTest.php
+++ b/src/LiveComponent/tests/Integration/DependencyInjection/Compiler/LiveComponentTagPassTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Integration\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\UX\LiveComponent\DependencyInjection\Compiler\LiveComponentTagPass;
+
+final class LiveComponentTagPassTest extends AbstractCompilerPassTestCase
+{
+    public function testAddingTwigComponentTagToServicesTaggedWithLiveComponentTag(): void
+    {
+        $liveComponent = new Definition();
+        $liveComponent->addTag('live.component', ['key' => 'foo', 'template' => 'bar']);
+
+        $this->setDefinition('my_live_component', $liveComponent);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'my_live_component',
+            'twig.component',
+            [
+                'key' => 'foo',
+                'template' => 'bar',
+                'expose_public_props' => true,
+                'attributes_var' => 'attributes',
+                'default_action' => null,
+                'live' => true,
+                'csrf' => true,
+                'route' => 'ux_live_component',
+                'method' => 'post',
+                'url_reference_type' => UrlGeneratorInterface::ABSOLUTE_PATH,
+            ]
+        );
+    }
+
+    public function testOverridingTagAttributesWithLiveComponentTag(): void
+    {
+        $liveComponent = new Definition();
+        $liveComponent->addTag('live.component', [
+            'key' => 'foo',
+            'template' => 'bar',
+            'expose_public_props' => false,
+            'attributes_var' => 'custom_attributes',
+            'default_action' => 'customAction',
+            'csrf' => false,
+            'route' => 'custom_route',
+            'method' => 'get',
+            'url_reference_type' => UrlGeneratorInterface::ABSOLUTE_URL,
+        ]);
+
+        $this->setDefinition('my_live_component', $liveComponent);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'my_live_component',
+            'twig.component',
+            [
+                'key' => 'foo',
+                'template' => 'bar',
+                'expose_public_props' => false,
+                'attributes_var' => 'custom_attributes',
+                'default_action' => 'customAction',
+                'live' => true,
+                'csrf' => false,
+                'route' => 'custom_route',
+                'method' => 'get',
+                'url_reference_type' => UrlGeneratorInterface::ABSOLUTE_URL,
+            ]
+        );
+    }
+
+    public function testThrowingExceptionWhenKeyIsNotPresentOnLiveComponentTag(): void
+    {
+        $liveComponent = new Definition();
+        $liveComponent->addTag('live.component', ['template' => 'bar']);
+
+        $this->setDefinition('my_live_component', $liveComponent);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "key" attribute is required for the "live.component" tag');
+
+        $this->compile();
+    }
+
+    public function testThrowingExceptionWhenTemplateIsNotPresentOnLiveComponentTag(): void
+    {
+        $liveComponent = new Definition();
+        $liveComponent->addTag('live.component', ['key' => 'foo']);
+
+        $this->setDefinition('my_live_component', $liveComponent);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "template" attribute is required for the "live.component" tag');
+
+        $this->compile();
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new LiveComponentTagPass());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | n/a
| License       | MIT

Currently we've been forced to use `twig.component` tag to configure live components manually. It required a lot of boilerplate code and sometimes could cause some issues when a new attribute has appeared (we faced with it once or twice in Sylius). So, the idea is to add a `live.component` service tag, which will be translated into `twig.component` tag 🕺🏻.

> Time spent on this feature has been sponsored by [Commerce Weavers](https://commerceweavers.com/) ♥️.