### PR TITLE
[LiveComponent] set LiveArg value to null if empty string

### DIFF
--- a/src/LiveComponent/src/Attribute/LiveArg.php
+++ b/src/LiveComponent/src/Attribute/LiveArg.php
@@ -11,44 +11,49 @@
 
 namespace Symfony\UX\LiveComponent\Attribute;
 
-/**
- * An attribute to configure a LiveArg (custom argument passed to a LiveAction).
- *
- * @see https://symfony.com/bundles/ux-live-component/current/index.html#actions-arguments
- *
- * @author Tomas Norkūnas <norkunas.tom@gmail.com>
- */
-#[\Attribute(\Attribute::TARGET_PARAMETER)]
-final class LiveArg
-{
-    public function __construct(
-        /**
-         * @param string|null $name The name of the argument received by the LiveAction
-         */
-        public ?string $name = null,
-    ) {
-    }
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
+use Symfony\UX\LiveComponent\ValueResolver\LiveArgValueResolver;
 
+if (class_exists(ValueResolver::class)) {
     /**
-     * @internal
+     * An attribute to configure a LiveArg (custom argument passed to a LiveAction).
      *
-     * @return array<string, string>
+     * @see https://symfony.com/bundles/ux-live-component/current/index.html#actions-arguments
+     *
+     * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+     * @author Jannes Drijkoningen <jannesdrijkoningen@gmail.com>
      */
-    public static function liveArgs(object $component, string $action): array
+    #[\Attribute(\Attribute::TARGET_PARAMETER)]
+    final class LiveArg extends ValueResolver
     {
-        $method = new \ReflectionMethod($component, $action);
-        $liveArgs = [];
-
-        foreach ($method->getParameters() as $parameter) {
-            foreach ($parameter->getAttributes(self::class) as $liveArg) {
-                /** @var LiveArg $attr */
-                $attr = $liveArg->newInstance();
-                $parameterName = $parameter->getName();
-
-                $liveArgs[$parameterName] = $attr->name ?? $parameterName;
-            }
+        public function __construct(
+            /**
+             * @param string|null $name The name of the argument received by the LiveAction
+             */
+            public ?string $name = null,
+            bool $disabled = false,
+            string $resolver = LiveArgValueResolver::class,
+        ) {
+            parent::__construct($resolver, $disabled);
         }
-
-        return $liveArgs;
+    }
+} else {
+    /**
+     * An attribute to configure a LiveArg (custom argument passed to a LiveAction).
+     *
+     * @see https://symfony.com/bundles/ux-live-component/current/index.html#actions-arguments
+     *
+     * @author Tomas Norkūnas <norkunas.tom@gmail.com>
+     */
+    #[\Attribute(\Attribute::TARGET_PARAMETER)]
+    final class LiveArg
+    {
+        public function __construct(
+            /**
+             * @param string|null $name The name of the argument received by the LiveAction
+             */
+            public ?string $name = null,
+        ) {
+        }
     }
 }

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -47,6 +47,7 @@ use Symfony\UX\LiveComponent\Util\LiveComponentStack;
 use Symfony\UX\LiveComponent\Util\LiveControllerAttributesCreator;
 use Symfony\UX\LiveComponent\Util\QueryStringPropsExtractor;
 use Symfony\UX\LiveComponent\Util\TwigAttributeHelperFactory;
+use Symfony\UX\LiveComponent\ValueResolver\LiveArgValueResolver;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentRenderer;
 
@@ -261,6 +262,9 @@ final class LiveComponentExtension extends Extension implements PrependExtension
                 '%kernel.secret%',
             ])
             ->addTag('kernel.cache_warmer');
+
+        $container->register(LiveArgValueResolver::class, LiveArgValueResolver::class)
+            ->addTag('controller.argument_value_resolver', ['priority' => 0]);
     }
 
     private function isAssetMapperAvailable(ContainerBuilder $container): bool

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -13,7 +13,6 @@ namespace Symfony\UX\LiveComponent\EventListener;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Exception\JsonException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -29,10 +28,10 @@ use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
-use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadataFactory;
 use Symfony\UX\LiveComponent\Util\LiveControllerAttributesCreator;
+use Symfony\UX\LiveComponent\Util\LiveRequestDataParser;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentMetadata;
 use Symfony\UX\TwigComponent\ComponentRenderer;
@@ -116,7 +115,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
 
         if ('_batch' === $action) {
             // use batch controller
-            $data = $this->parseDataFor($request);
+            $data = LiveRequestDataParser::parseDataFor($request);
 
             $request->attributes->set('_controller', 'ux.live_component.batch_action_controller');
             $request->attributes->set('serviceId', $metadata->getServiceId());
@@ -195,61 +194,6 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
                 $action,
             ]);
         }
-
-        // read the action arguments from the request, unless they're already set (batch sub-requests)
-        $actionArguments = $request->attributes->get('_component_action_args', $this->parseDataFor($request)['args']);
-        // extra variables to be made available to the controller
-        // (for "actions" only)
-        foreach (LiveArg::liveArgs($component, $action) as $parameter => $arg) {
-            if (isset($actionArguments[$arg])) {
-                $request->attributes->set($parameter, $actionArguments[$arg]);
-            }
-        }
-    }
-
-    /**
-     * @return array{
-     *     data: array,
-     *     args: array,
-     *     actions: array
-     *     // has "fingerprint" and "tag" string key, keyed by component id
-     *     children: array
-     *     propsFromParent: array
-     * }
-     */
-    private static function parseDataFor(Request $request): array
-    {
-        if (!$request->attributes->has('_live_request_data')) {
-            if ($request->query->has('props')) {
-                $liveRequestData = [
-                    'props' => self::parseJsonFromQuery($request, 'props'),
-                    'updated' => self::parseJsonFromQuery($request, 'updated'),
-                    'args' => [],
-                    'actions' => [],
-                    'children' => self::parseJsonFromQuery($request, 'children'),
-                    'propsFromParent' => self::parseJsonFromQuery($request, 'propsFromParent'),
-                ];
-            } else {
-                try {
-                    $requestData = json_decode($request->request->get('data'), true, 512, \JSON_BIGINT_AS_STRING | \JSON_THROW_ON_ERROR);
-                } catch (\JsonException $e) {
-                    throw new JsonException('Could not decode request body.', $e->getCode(), $e);
-                }
-
-                $liveRequestData = [
-                    'props' => $requestData['props'] ?? [],
-                    'updated' => $requestData['updated'] ?? [],
-                    'args' => $requestData['args'] ?? [],
-                    'actions' => $requestData['actions'] ?? [],
-                    'children' => $requestData['children'] ?? [],
-                    'propsFromParent' => $requestData['propsFromParent'] ?? [],
-                ];
-            }
-
-            $request->attributes->set('_live_request_data', $liveRequestData);
-        }
-
-        return $request->attributes->get('_live_request_data');
     }
 
     public function onKernelView(ViewEvent $event): void
@@ -354,34 +298,22 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
         $metadataFactory = $this->container->get(LiveComponentMetadataFactory::class);
         \assert($metadataFactory instanceof LiveComponentMetadataFactory);
 
+        $liveRequestData = LiveRequestDataParser::parseDataFor($request);
         $componentAttributes = $hydrator->hydrate(
             $component,
-            $this->parseDataFor($request)['props'],
-            $this->parseDataFor($request)['updated'],
+            $liveRequestData['props'],
+            $liveRequestData['updated'],
             $metadataFactory->getMetadata($componentName),
-            $this->parseDataFor($request)['propsFromParent']
+            $liveRequestData['propsFromParent']
         );
 
         $mountedComponent = new MountedComponent($componentName, $component, $componentAttributes);
 
         $mountedComponent->addExtraMetadata(
             InterceptChildComponentRenderSubscriber::CHILDREN_FINGERPRINTS_METADATA_KEY,
-            $this->parseDataFor($request)['children']
+            $liveRequestData['children']
         );
 
         return $mountedComponent;
-    }
-
-    private static function parseJsonFromQuery(Request $request, string $key): array
-    {
-        if (!$request->query->has($key)) {
-            return [];
-        }
-
-        try {
-            return json_decode($request->query->get($key), true, 512, \JSON_THROW_ON_ERROR);
-        } catch (\JsonException $exception) {
-            throw new JsonException(sprintf('Invalid JSON on query string %s.', $key), 0, $exception);
-        }
     }
 }

--- a/src/LiveComponent/src/Util/LiveRequestDataParser.php
+++ b/src/LiveComponent/src/Util/LiveRequestDataParser.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Util;
+
+use Symfony\Component\HttpFoundation\Exception\JsonException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @internal
+ */
+final class LiveRequestDataParser
+{
+    /**
+     * @return array{
+     *     data: array,
+     *     args: array,
+     *     actions: array
+     *     // has "fingerprint" and "tag" string key, keyed by component id
+     *     children: array
+     *     propsFromParent: array
+     * }
+     */
+    public static function parseDataFor(Request $request): array
+    {
+        if (!$request->attributes->has('_live_request_data')) {
+            if ($request->query->has('props')) {
+                $liveRequestData = [
+                    'props' => self::parseJsonFromQuery($request, 'props'),
+                    'updated' => self::parseJsonFromQuery($request, 'updated'),
+                    'args' => [],
+                    'actions' => [],
+                    'children' => self::parseJsonFromQuery($request, 'children'),
+                    'propsFromParent' => self::parseJsonFromQuery($request, 'propsFromParent'),
+                ];
+            } else {
+                try {
+                    $requestData = json_decode($request->request->get('data'), true, 512, \JSON_BIGINT_AS_STRING | \JSON_THROW_ON_ERROR);
+                } catch (\JsonException $e) {
+                    throw new JsonException('Could not decode request body.', $e->getCode(), $e);
+                }
+
+                $liveRequestData = [
+                    'props' => $requestData['props'] ?? [],
+                    'updated' => $requestData['updated'] ?? [],
+                    'args' => $requestData['args'] ?? [],
+                    'actions' => $requestData['actions'] ?? [],
+                    'children' => $requestData['children'] ?? [],
+                    'propsFromParent' => $requestData['propsFromParent'] ?? [],
+                ];
+            }
+
+            $request->attributes->set('_live_request_data', $liveRequestData);
+        }
+
+        return $request->attributes->get('_live_request_data');
+    }
+
+    private static function parseJsonFromQuery(Request $request, string $key): array
+    {
+        if (!$request->query->has($key)) {
+            return [];
+        }
+
+        try {
+            return json_decode($request->query->get($key), true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new JsonException(sprintf('Invalid JSON on query string %s.', $key), 0, $exception);
+        }
+    }
+}

--- a/src/LiveComponent/src/ValueResolver/LiveArgValueResolver.php
+++ b/src/LiveComponent/src/ValueResolver/LiveArgValueResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\ValueResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+if (interface_exists(ValueResolverInterface::class)) {
+    /**
+     * @author Jannes Drijkoningen <jannesdrijkoningen@gmail.com>
+     *
+     * @internal
+     */
+    class LiveArgValueResolver implements ValueResolverInterface
+    {
+        use LiveArgValueResolverTrait {
+            resolve as resolveArgument;
+        }
+
+        public function resolve(Request $request, ArgumentMetadata $argument): iterable
+        {
+            if (!$this->supports($argument)) {
+                return [];
+            }
+
+            return $this->resolveArgument($request, $argument);
+        }
+    }
+} else {
+    /**
+     * @author Jannes Drijkoningen <jannesdrijkoningen@gmail.com>
+     *
+     * @internal
+     *
+     * @deprecated should be removed when Symfony 6.1 is no longer supported
+     */
+    class LiveArgValueResolver implements ArgumentValueResolverInterface
+    {
+        use LiveArgValueResolverTrait {
+            supports as supportsArgument;
+        }
+
+        public function supports(Request $request, ArgumentMetadata $argument): bool
+        {
+            return $this->supportsArgument($argument);
+        }
+    }
+}

--- a/src/LiveComponent/src/ValueResolver/LiveArgValueResolverTrait.php
+++ b/src/LiveComponent/src/ValueResolver/LiveArgValueResolverTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\ValueResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Util\LiveRequestDataParser;
+
+/**
+ * @author Jannes Drijkoningen <jannesdrijkoningen@gmail.com>
+ *
+ * @internal
+ *
+ * @deprecated should be moved to LiveArgValueResolver when support for Symfony 6.1 is dropped.
+ */
+trait LiveArgValueResolverTrait
+{
+    public function supports(ArgumentMetadata $argument): bool
+    {
+        /** @var LiveArg|null $options */
+        $options = $argument->getAttributes(LiveArg::class, ArgumentMetadata::IS_INSTANCEOF)[0] ?? null;
+        if (null === $options) {
+            return false;
+        }
+
+        return !property_exists($options, 'disabled') || !$options->disabled;
+    }
+
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        /** @var LiveArg $options */
+        $options = $argument->getAttributes(LiveArg::class, ArgumentMetadata::IS_INSTANCEOF)[0];
+
+        $values = $request->attributes->get(
+            '_component_action_args',
+            LiveRequestDataParser::parseDataFor($request)['args']
+        );
+
+        $argumentName = $options->name ?? $argument->getName();
+        $value = $values[$argumentName] ?? null;
+
+        if ('' === $value && $argument->isNullable() && !str_contains($argument->getType(), 'string')) {
+            $value = null;
+        }
+
+        return [$value];
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Component/Component6.php
+++ b/src/LiveComponent/tests/Fixtures/Component/Component6.php
@@ -37,15 +37,25 @@ class Component6
     #[LiveProp]
     public $arg3;
 
+    #[LiveProp]
+    public $arg4;
+
+    #[LiveProp]
+    public $arg5;
+
     #[LiveAction]
     public function inject(
         #[LiveArg] string $arg1,
         #[LiveArg] int $arg2,
         #[LiveArg('custom')] float $arg3,
+        #[LiveArg] ?int $arg4,
+        #[LiveArg] string $arg5,
     ) {
         $this->called = true;
         $this->arg1 = $arg1;
         $this->arg2 = $arg2;
         $this->arg3 = $arg3;
+        $this->arg4 = $arg4;
+        $this->arg5 = $arg5;
     }
 }

--- a/src/LiveComponent/tests/Fixtures/templates/components/component6.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/component6.html.twig
@@ -2,4 +2,6 @@
     Arg1: {{ this.called ? this.arg1 : 'not provided' }}
     Arg2: {{ this.called ? this.arg2 : 'not provided' }}
     Arg3: {{ this.called ? this.arg3 : 'not provided' }}
+    Arg4: {{ this.called ? (this.arg4 ?? 'null') : 'not provided' }}
+    Arg5: {{ this.called ? (this.arg5 is empty ? 'empty-string' : '') : 'not provided' }}
 </div>

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -449,7 +449,13 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         $dehydrated = $this->dehydrateComponent($this->mountComponent('component6'));
         $token = null;
 
-        $arguments = ['arg1' => 'hello', 'arg2' => 666, 'custom' => '33.3'];
+        $arguments = [
+            'arg1' => 'hello',
+            'arg2' => 666,
+            'custom' => '33.3',
+            'arg4' => '',
+            'arg5' => '',
+        ];
         $this->browser()
             ->throwExceptions()
             ->post('/_components/component6', [
@@ -464,6 +470,8 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ->assertContains('Arg1: not provided')
             ->assertContains('Arg2: not provided')
             ->assertContains('Arg3: not provided')
+            ->assertContains('Arg4: not provided')
+            ->assertContains('Arg5: not provided')
             ->use(function (Crawler $crawler) use (&$token) {
                 // get a valid token to use for actions
                 $token = $crawler->filter('div')->first()->attr('data-live-csrf-value');
@@ -482,6 +490,8 @@ final class LiveComponentSubscriberTest extends KernelTestCase
             ->assertContains('Arg1: hello')
             ->assertContains('Arg2: 666')
             ->assertContains('Arg3: 33.3')
+            ->assertContains('Arg4: null')
+            ->assertContains('Arg5: empty-string')
         ;
     }
 

--- a/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
+++ b/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
@@ -61,18 +61,32 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertStringContainsString('Arg1: not provided', $testComponent->render());
         $this->assertStringContainsString('Arg2: not provided', $testComponent->render());
         $this->assertStringContainsString('Arg3: not provided', $testComponent->render());
+        $this->assertStringContainsString('Arg4: not provided', $testComponent->render());
+        $this->assertStringContainsString('Arg5: not provided', $testComponent->render());
         $this->assertNull($testComponent->component()->arg1);
         $this->assertNull($testComponent->component()->arg2);
         $this->assertNull($testComponent->component()->arg3);
+        $this->assertNull($testComponent->component()->arg4);
+        $this->assertNull($testComponent->component()->arg5);
 
-        $testComponent->call('inject', ['arg1' => 'hello', 'arg2' => 666, 'custom' => '33.3']);
+        $testComponent->call('inject', [
+            'arg1' => 'hello',
+            'arg2' => 666,
+            'custom' => '33.3',
+            'arg4' => '',
+            'arg5' => '',
+        ]);
 
         $this->assertStringContainsString('Arg1: hello', $testComponent->render());
         $this->assertStringContainsString('Arg2: 666', $testComponent->render());
         $this->assertStringContainsString('Arg3: 33.3', $testComponent->render());
+        $this->assertStringContainsString('Arg4: null', $testComponent->render());
+        $this->assertStringContainsString('Arg5: empty-string', $testComponent->render());
         $this->assertSame('hello', $testComponent->component()->arg1);
         $this->assertSame(666, $testComponent->component()->arg2);
         $this->assertSame(33.3, $testComponent->component()->arg3);
+        $this->assertNull($testComponent->component()->arg4);
+        $this->assertSame('', $testComponent->component()->arg5);
     }
 
     public function testCanEmitEvent(): void


### PR DESCRIPTION
Checks the type to see if the argument is nullable and is not a string, if so, and an empty string is provided, the value will be overwritten to null. This should be backwards compatible since before users were manually casting to string "null" in this case.

| Q             | A
| ------------- | ---
| Bug fix?      | kinda?
| New feature?  | kinda?
| Issues        | Fix #1691
| License       | MIT

Includes type information in the `LiveArg` attribute, this type information is then used in the controller subscriber of `LiveAction` to convert empty strings (`"`") to `null`, only when `null` is accepted **and** the types does not allow `string`.
