### PR TITLE
[Autocomplete] Command make:autocomplete-field output a doc compliant class

### DIFF
--- a/src/Autocomplete/src/Maker/MakeAutocompleteField.php
+++ b/src/Autocomplete/src/Maker/MakeAutocompleteField.php
@@ -28,7 +28,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
-use Symfony\UX\Autocomplete\Form\ParentEntityAutocompleteType;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
@@ -121,7 +121,7 @@ EOF)
             AbstractType::class,
             OptionsResolver::class,
             AsEntityAutocompleteField::class,
-            ParentEntityAutocompleteType::class,
+            BaseEntityAutocompleteType::class,
         ]);
 
         $variables = new MakerAutocompleteVariables(

--- a/src/Autocomplete/src/Maker/skeletons/AutocompleteField.tpl.php
+++ b/src/Autocomplete/src/Maker/skeletons/AutocompleteField.tpl.php
@@ -1,6 +1,5 @@
 <?php
 
-use Symfony\Bundle\MakerBundle\Str;
 use Symfony\UX\Autocomplete\Maker\MakerAutocompleteVariables;
 
 /** @var MakerAutocompleteVariables $variables */
@@ -16,24 +15,23 @@ namespace <?php echo $namespace; ?>;
 #[AsEntityAutocompleteField]
 class <?php echo $class_name; ?> extends AbstractType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'class' => <?php echo $variables->entityClassDetails->getShortName(); ?>::class,
             'placeholder' => 'Choose a <?php echo $variables->entityClassDetails->getShortName(); ?>',
-            //'choice_label' => 'name',
+            // 'choice_label' => 'name',
 
-<?php if ($variables->repositoryClassDetails) { ?>
-            'query_builder' => function(<?php echo $variables->repositoryClassDetails->getShortName(); ?> $<?php echo Str::asLowerCamelCase($variables->repositoryClassDetails->getShortName()); ?>) {
-                return $<?php echo Str::asLowerCamelCase($variables->repositoryClassDetails->getShortName()); ?>->createQueryBuilder('<?php echo Str::asLowerCamelCase($variables->entityClassDetails->getShortName()); ?>');
-            },
-<?php } ?>
-            //'security' => 'ROLE_SOMETHING',
+            // choose which fields to use in the search
+            // if not passed, *all* fields are used
+            // 'searchable_fields' => ['name'],
+
+            // 'security' => 'ROLE_SOMETHING',
         ]);
     }
 
     public function getParent(): string
     {
-        return ParentEntityAutocompleteType::class;
+        return BaseEntityAutocompleteType::class;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | n/a 
| License       | MIT

The `make:autocomplete-field` command outputs a bad formatted file with a deprecated Parent and a query_builder.
I replaced the parent and removed the query_builder line just like in the doc.

