### PR TITLE
[TwigComponent] Fix configuration namespace end with "\"

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1579,10 +1579,10 @@ controls how components are named and where their templates live:
             #    - templates will live in "components/"
             #        Alert => templates/components/Alert.html.twig
             #        Button:Primary => templates/components/Button/Primary.html.twig
-            App\Twig\Components: components/
+            App\Twig\Components\: components/
 
             # long form
-            App\Pizza\Components:
+            App\Pizza\Components\:
                 template_directory: components/pizza
                 # component names will have an extra "Pizza:" prefix
                 #    App\Pizza\Components\Alert => Pizza:Alert


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

Fix the doc configuration about multi namespaces as the tree builder define.

https://github.com/symfony/ux/blob/0f8b952f08862caf7ed76b2b5b93b6b5bfe6227f/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php#L157-L159

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
