### PR TITLE
[Twig] Handle aria-* attribute boolean values

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -51,6 +51,10 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
                     $value = (string) $value;
                 }
 
+                if (\is_bool($value) && str_starts_with($key, 'aria-')) {
+                    $value = $value ? 'true' : 'false';
+                }
+
                 if (!\is_scalar($value) && null !== $value) {
                     throw new \LogicException(sprintf('A "%s" prop was passed when creating the component. No matching "%s" property or mount() argument was found, so we attempted to use this as an HTML attribute. But, the value is not a scalar (it\'s a %s). Did you mean to pass this to your component or is there a typo on its name?', $key, $key, get_debug_type($value)));
                 }
@@ -83,6 +87,10 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
 
         if ($value instanceof \Stringable) {
             $value = (string) $value;
+        }
+
+        if (\is_bool($value) && str_starts_with($attribute, 'aria-')) {
+            $value = $value ? 'true' : 'false';
         }
 
         if (!\is_string($value)) {

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -258,4 +258,30 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(' class="baz"', (string) $attributes->nested('title')->nested('span'));
         $this->assertSame('', (string) $attributes->nested('invalid'));
     }
+
+    public function testConvertBooleanAriaAttributeValues(): void
+    {
+        $attributes = new ComponentAttributes([
+            'aria-foo' => true,
+            'aria-bar' => false,
+            'aria-true' => 'true',
+            'aria-false' => 'false',
+            'aria-foobar' => 'foobar',
+            'aria-number' => '1',
+        ]);
+
+        $this->assertStringContainsString('aria-foo="true"', (string) $attributes);
+        $this->assertStringContainsString('aria-bar="false"', (string) $attributes);
+        $this->assertStringContainsString('aria-true="true"', (string) $attributes);
+        $this->assertStringContainsString('aria-false="false"', (string) $attributes);
+        $this->assertStringContainsString('aria-foobar="foobar"', (string) $attributes);
+        $this->assertStringContainsString('aria-number="1"', (string) $attributes);
+
+        $this->assertSame('true', $attributes->render('aria-foo'));
+        $this->assertSame('false', $attributes->render('aria-bar'));
+        $this->assertSame('true', $attributes->render('aria-true'));
+        $this->assertSame('false', $attributes->render('aria-false'));
+        $this->assertSame('foobar', $attributes->render('aria-foobar'));
+        $this->assertSame('1', $attributes->render('aria-number'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #1701 
| License       | MIT

Convert aria-* boolean attributes to their expected string values.
