### PR TITLE
[Twig] Resolving boolean as variant keys

### DIFF
--- a/src/TwigComponent/src/CVA.php
+++ b/src/TwigComponent/src/CVA.php
@@ -94,6 +94,9 @@ final class CVA
 
         // Resolve recipes against variants
         foreach ($recipes as $recipeName => $recipeValue) {
+            if (\is_bool($recipeValue)) {
+                $recipeValue = $recipeValue ? 'true' : 'false';
+            }
             $recipeClasses = $this->variants[$recipeName][$recipeValue] ?? [];
             $classes = [...$classes, ...(array) $recipeClasses];
         }

--- a/src/TwigComponent/tests/Unit/CVATest.php
+++ b/src/TwigComponent/tests/Unit/CVATest.php
@@ -449,6 +449,134 @@ class CVATest extends TestCase
             [],
             'font-semibold border rounded text-primary text-sm rounded-md',
         ];
+
+        yield 'boolean string variants true / true' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => [
+                        'true' => 'disable',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => true],
+            'text-primary disable',
+        ];
+
+        yield 'boolean string variants true / false' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => [
+                        'true' => 'disable',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => false],
+            'text-primary',
+        ];
+
+        yield 'boolean string variants false / true' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => [
+                        'false' => 'disable',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => true],
+            'text-primary',
+        ];
+
+        yield 'boolean string variants false / false' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => [
+                        'false' => 'disable',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => false],
+            'text-primary disable',
+        ];
+
+        yield 'boolean string variants missing' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => [
+                        'true' => 'disable',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary'],
+            'text-primary',
+        ];
+
+        yield 'boolean list variants true' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => [
+                        'true' => ['disable', 'opacity-50'],
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => true],
+            'text-primary disable opacity-50',
+        ];
+
+        yield 'boolean list variants false' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => [
+                        'true' => ['disable', 'opacity-50'],
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'disabled' => false],
+            'text-primary',
+        ];
+
+        yield 'boolean list variants missing' => [
+            [
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'disabled' => [
+                        'true' => ['disable', 'opacity-50'],
+                    ],
+                ],
+            ],
+            ['colors' => 'primary'],
+            'text-primary',
+        ];
     }
 
     /**


### PR DESCRIPTION
After some "back and forth", we agreed on the following behaviour. I hope this will match your needs :) 

This PR allows users to pass real boolean when calling the component, to match string-boolean defined in the CVA definition.

Based on the work of @kbond in #1647  to fix #1614 

```twig
{# templates/components/Button.html.twig #}

{% props color = 'blue', giant = false %}
{% set button = cva({
  base: 'button',
  variants: {
      color: {
          blue: 'btn-blue',
          green: 'btn-red',
      },
      giant: {
          true: 'btn-giant',
      }
  }
}) %}

<button class="{{ button.apply({color, giant}, attributes.render('class')) }}">
   {{ label }}
</button>
```

Then the 3 following calls should be equivalent

```twig

{# String value #}
<twig:Button color="blue" giant="true"  label="Save" />

{# Boolean value #}
<twig:Button color="blue" giant="{{ true }}"  label="Save" />

{# Boolean expression #}
<twig:Button color="blue" giant="{{ 2 > 1 }}"  label="Save" />
```

