### PR TITLE
[Site] fix: AppHeader top spacing on mobile

### DIFF
--- a/ux.symfony.com/assets/styles/components/_Banner.scss
+++ b/ux.symfony.com/assets/styles/components/_Banner.scss
@@ -9,6 +9,10 @@
   position: relative;
 }
 
+.Banner:has(+ .App .AppHeader.open) {
+  display: none;
+}
+
 .BannerInner {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #...
| License       | MIT

The Banner caused the an unwanted space for the opened AppHeader on mobile. This PR tries to fix this by undisplaying the Banner when the AppHeader is open.