### PR TITLE
[Site] fix: hide IconSearchBox on mobile when AppHeader is open

### DIFF
--- a/ux.symfony.com/assets/styles/components/_IconSearch.scss
+++ b/ux.symfony.com/assets/styles/components/_IconSearch.scss
@@ -6,6 +6,10 @@
 
 }
 
+.AppHeader.open + main .IconSearchBox {
+  position: unset;
+}
+
 .IconSearchBox {
   position: sticky;
   top: 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #... 
| License       | MIT

(Issue 1711 - 3)
When the AppHeader in the icon page on mobile the IconSearchBox is undesirably visible. This PR aims to hide it.