### PR TITLE
[LiveComponent] Add Events listening infos in Profiler and DebugCommand

### DIFF
--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -18,9 +18,11 @@ use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 use Symfony\UX\TwigComponent\ComponentFactory;
@@ -49,6 +51,11 @@ class TwigComponentDebugCommand extends Command
         $this
             ->setDefinition([
                 new InputArgument('name', InputArgument::OPTIONAL, 'A component name or part of the component name'),
+                new InputOption(
+                    name: 'listening',
+                    mode: InputOption::VALUE_REQUIRED,
+                    description: 'Filter components list to display only those listening to the given action'
+                ),
             ])
             ->setHelp(
                 <<<'EOF'
@@ -83,7 +90,7 @@ EOF
             return Command::SUCCESS;
         }
 
-        $components = $this->findComponents();
+        $components = $this->findComponents($input->getOption('listening'));
         $this->displayComponentsTable($io, $components);
 
         return Command::SUCCESS;
@@ -128,14 +135,19 @@ EOF
     /**
      * @return array<string, ComponentMetadata>
      */
-    private function findComponents(): array
+    private function findComponents(?string $listeningFilter): array
     {
         $components = [];
         foreach ($this->componentClassMap as $class => $name) {
-            $components[$name] ??= $this->componentFactory->metadataFor($name);
+            if (null === $listeningFilter || \in_array($listeningFilter, $this->resolveEventsListening($class))) {
+                $components[$name] ??= $this->componentFactory->metadataFor($name);
+            }
         }
-        foreach ($this->findAnonymousComponents() as $name => $template) {
-            $components[$name] ??= $this->componentFactory->metadataFor($name);
+
+        if (null === $listeningFilter) {
+            foreach ($this->findAnonymousComponents() as $name => $template) {
+                $components[$name] ??= $this->componentFactory->metadataFor($name);
+            }
         }
 
         return $components;
@@ -195,6 +207,14 @@ EOF
             ['Public Props', $metadata->get('expose_public_props') ? 'Yes' : 'No'],
             ['Properties', implode("\n", $this->getComponentProperties($metadata))],
         ]);
+
+        $eventsListened = $this->resolveEventsListening($metadata->get('class'));
+        if ($eventsListened) {
+            $table->addRows([
+                new TableSeparator(),
+                ['Listening to', implode("\n", $eventsListened)],
+            ]);
+        }
 
         $logMethod = function (\ReflectionMethod $m) {
             $params = array_map(
@@ -313,5 +333,14 @@ EOF
         }
 
         return $properties;
+    }
+
+    private function resolveEventsListening(string $class): array
+    {
+        if (class_exists(AsLiveComponent::class)) {
+            return array_column(AsLiveComponent::liveListeners($class), 'event');
+        }
+
+        return [];
     }
 }

--- a/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
+++ b/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\TwigComponent\Event\PostRenderEvent;
 use Symfony\UX\TwigComponent\Event\PreRenderEvent;
 use Symfony\UX\TwigComponent\EventListener\TwigComponentLoggerListener;
@@ -115,6 +116,9 @@ class TwigComponentDataCollector extends AbstractDataCollector implements LateDa
                     'template_path' => $this->resolveTemplatePath($metadata->getTemplate()), // defer ? lazy ?
                     'render_count' => 0,
                     'render_time' => 0,
+                    'listening' => class_exists(AsLiveComponent::class) ?
+                        array_column(AsLiveComponent::liveListeners($componentClass), 'event') :
+                        [],
                 ];
 
                 $renderId = spl_object_id($mountedComponent);

--- a/src/TwigComponent/templates/Collector/twig_component.html.twig
+++ b/src/TwigComponent/templates/Collector/twig_component.html.twig
@@ -234,6 +234,9 @@
                         {% else %}
                             <span class=text-muted">{{ component.template }}</span>
                         {% endif %}
+                        {% if component.listening is not empty %}
+                            <pre class="sf-dump"><span class="text-muted">Listening to {{ component.listening|join(', ') }}</span></pre>
+                        {% endif %}
                     </td>
                     <td class="cell-right">{{ component.render_count }}</td>
                     <td class="cell-right">
@@ -285,18 +288,18 @@
                     </tr>
                 </thead>
                 <tbody id="render-{{ loop.index }}--details">
-                    <tr class="{{ not render.input_props|default ? 'opacity-50' }}">
-                        <th scope="row">Input props</th>
-                        <td colspan="3">{{ profiler_dump(render.input_props) }}</td>
-                    </tr>
-                    <tr class="{{ not render.attributes|default ? 'opacity-50' }}">
-                        <th scope="row">Attributes</th>
-                        <td colspan="3">{{ profiler_dump(render.attributes) }}</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">Component</th>
-                        <td colspan="3">{{ profiler_dump(render.component) }}</td>
-                    </tr>
+                <tr class="{{ not render.input_props|default ? 'opacity-50' }}">
+                    <th scope="row">Input props</th>
+                    <td colspan="3">{{ profiler_dump(render.input_props) }}</td>
+                </tr>
+                <tr class="{{ not render.attributes|default ? 'opacity-50' }}">
+                    <th scope="row">Attributes</th>
+                    <td colspan="3">{{ profiler_dump(render.attributes) }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Component</th>
+                    <td colspan="3">{{ profiler_dump(render.component) }}</td>
+                </tr>
                 </tbody>
             </table>
         {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | No issue
| License       | MIT

Hello,

First of all, thank you for your work and dedication.

Playing with LiveComponents on my spare time, I have a SPA using several events to communicate between components.
In several occasion, it took me a little time to find out bugs in my application concerning these events.

That's why I propose these small enhancements for debug concerning events in LiveComponent :
1) In TwigComponentDebugCommand, allow to filter components by the events they are listening to :
```bash
bin/console debug:twig-component --listening buyEvent
```

2) Still in TwigComponentDebugCommand, when displaying a unique Component, add a line to display the events it listens to, if any :
![Capture d’écran du 2024-04-11 16-22-41](https://github.com/symfony/ux/assets/16019969/072e4937-3cca-42c6-bead-03c6a5190f37)

3) In Profiler, add a line to display the events it listens to, if any :
![Capture d’écran du 2024-04-11 16-28-02](https://github.com/symfony/ux/assets/16019969/df7b90b7-ea52-4828-adc2-ef6969f93f99)


What do you think of it ? I will add test in a second time.
