### PR TITLE
[Live] override data collector & debug command

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/property-access": "^5.4.5|^6.0|^7.0",
-        "symfony/ux-twig-component": "^2.8",
+        "symfony/ux-twig-component": "^2.17",
         "twig/twig": "^3.8.0"
     },
     "require-dev": {
@@ -38,6 +38,7 @@
         "doctrine/orm": "^2.9.4",
         "doctrine/persistence": "^2.5.2|^3.0",
         "phpdocumentor/reflection-docblock": "5.x-dev",
+        "symfony/console": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",
         "symfony/expression-language": "^5.4|^6.0|^7.0",
         "symfony/form": "^5.4|^6.0|^7.0",

--- a/src/LiveComponent/src/Command/LiveComponentDebugCommand.php
+++ b/src/LiveComponent/src/Command/LiveComponentDebugCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Command;
+
+use Symfony\UX\TwigComponent\Command\TwigComponentDebugCommand;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LiveComponentDebugCommand extends TwigComponentDebugCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setAliases(['debug:live-component']);
+    }
+}

--- a/src/LiveComponent/src/DataCollector/LiveComponentDataCollector.php
+++ b/src/LiveComponent/src/DataCollector/LiveComponentDataCollector.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\DataCollector;
+
+use Symfony\UX\TwigComponent\DataCollector\TwigComponentDataCollector;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class LiveComponentDataCollector extends TwigComponentDataCollector
+{
+    public function getName(): string
+    {
+        return 'live_component';
+    }
+}

--- a/src/LiveComponent/src/DependencyInjection/Compiler/DebugLiveComponentPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/DebugLiveComponentPass.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\UX\LiveComponent\Command\LiveComponentDebugCommand;
+use Symfony\UX\LiveComponent\DataCollector\LiveComponentDataCollector;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class DebugLiveComponentPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('ux.twig_component.data_collector')) {
+            return;
+        }
+
+        $container->getDefinition('ux.twig_component.data_collector')
+            ->setClass(LiveComponentDataCollector::class)
+            ->clearTag('data_collector')
+            ->addTag('data_collector', [
+                'template' => '@LiveComponent/Collector/live_component.html.twig',
+                'id' => 'live_component',
+                'priority' => 256,
+            ]);
+
+        $container->getDefinition('ux.twig_component.command.debug')
+            ->setClass(LiveComponentDebugCommand::class)
+            ->addTag('console.command', ['command' => 'debug:live-component'])
+        ;
+    }
+}

--- a/src/LiveComponent/src/LiveComponentBundle.php
+++ b/src/LiveComponent/src/LiveComponentBundle.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\UX\LiveComponent\DependencyInjection\Compiler\ComponentDefaultActionPass;
+use Symfony\UX\LiveComponent\DependencyInjection\Compiler\DebugLiveComponentPass;
 use Symfony\UX\LiveComponent\DependencyInjection\Compiler\OptionalDependencyPass;
 
 /**
@@ -29,6 +30,7 @@ final class LiveComponentBundle extends Bundle
         // must run before Symfony\Component\Serializer\DependencyInjection\SerializerPass
         $container->addCompilerPass(new OptionalDependencyPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 100);
         $container->addCompilerPass(new ComponentDefaultActionPass());
+        $container->addCompilerPass(new DebugLiveComponentPass(), priority: 100);
     }
 
     public function getPath(): string

--- a/src/LiveComponent/templates/Collector/live_component.html.twig
+++ b/src/LiveComponent/templates/Collector/live_component.html.twig
@@ -1,0 +1,1 @@
+{% extends '@TwigComponent/Collector/twig_component.html.twig' %}

--- a/src/LiveComponent/tests/Functional/Command/LiveComponentDebugCommandTest.php
+++ b/src/LiveComponent/tests/Functional/Command/LiveComponentDebugCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Functional\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LiveComponentDebugCommandTest extends KernelTestCase
+{
+    public function testWithNoComponent(): void
+    {
+        $commandTester = $this->createCommandTester();
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $display = $commandTester->getDisplay();
+
+        $this->assertStringContainsString('Component', $display);
+        $this->assertStringContainsString('Class', $display);
+        $this->assertStringContainsString('Template', $display);
+        $this->assertStringContainsString('Type', $display);
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        return new CommandTester($application->find('debug:twig-component'));
+    }
+}

--- a/src/TwigComponent/config/debug.php
+++ b/src/TwigComponent/config/debug.php
@@ -9,13 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\UX\TwigComponent\DependencyInjection\Loader\Configurator;
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\UX\TwigComponent\Command\TwigComponentDebugCommand;
 use Symfony\UX\TwigComponent\DataCollector\TwigComponentDataCollector;
 use Symfony\UX\TwigComponent\EventListener\TwigComponentLoggerListener;
-
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -35,5 +33,16 @@ return static function (ContainerConfigurator $container) {
             'template' => '@TwigComponent/Collector/twig_component.html.twig',
             'id' => 'twig_component',
             'priority' => 256,
-        ]);
+        ])
+
+        ->set('ux.twig_component.command.debug', TwigComponentDebugCommand::class)
+        ->args([
+            param('twig.default_path'),
+            service('ux.twig_component.component_factory'),
+            service('twig'),
+            param('ux.twig_component.class_component_map'),
+            param('ux.twig_component.anonymous_template_directory'),
+        ])
+        ->tag('console.command')
+    ;
 };

--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\UX\TwigComponent\Command;
 
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -28,7 +27,6 @@ use Symfony\UX\TwigComponent\ComponentMetadata;
 use Symfony\UX\TwigComponent\Twig\PropsNode;
 use Twig\Environment;
 
-#[AsCommand(name: 'debug:twig-component', description: 'Display components and them usages for an application')]
 class TwigComponentDebugCommand extends Command
 {
     private readonly string $anonymousDirectory;
@@ -42,6 +40,16 @@ class TwigComponentDebugCommand extends Command
     ) {
         parent::__construct();
         $this->anonymousDirectory = $anonymousDirectory ?? 'components';
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'debug:twig-component';
+    }
+
+    public static function getDefaultDescription(): ?string
+    {
+        return 'Display components and their usages for an application';
     }
 
     protected function configure(): void

--- a/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
+++ b/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
@@ -25,6 +25,8 @@ use Twig\Error\LoaderError;
 
 /**
  * @author Simon André <smn.andre@gmail.com>
+ *
+ * @internal
  */
 class TwigComponentDataCollector extends AbstractDataCollector implements LateDataCollectorInterface
 {

--- a/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
+++ b/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
@@ -80,8 +80,9 @@ final class TwigComponentPass implements CompilerPassInterface
         $factoryDefinition->setArgument(4, $componentConfig);
         $factoryDefinition->setArgument(5, $componentClassMap);
 
-        $debugCommandDefinition = $container->findDefinition('ux.twig_component.command.debug');
-        $debugCommandDefinition->setArgument(3, $componentClassMap);
+        if ($container->hasDefinition('ux.twig_component.command.debug')) {
+            $container->setParameter('ux.twig_component.class_component_map', $componentClassMap);
+        }
     }
 
     private function findMatchingDefaults(string $className, array $componentDefaults): ?array

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -22,10 +22,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
-use Symfony\UX\TwigComponent\Command\TwigComponentDebugCommand;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentRenderer;
 use Symfony\UX\TwigComponent\ComponentRendererInterface;
@@ -111,22 +109,13 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
             ->setDecoratedService(new Reference('twig.configurator.environment'))
             ->setArguments([new Reference('ux.twig_component.twig.environment_configurator.inner')]);
 
-        $container->register('ux.twig_component.command.debug', TwigComponentDebugCommand::class)
-            ->setArguments([
-                new Parameter('twig.default_path'),
-                new Reference('ux.twig_component.component_factory'),
-                new Reference('twig'),
-                class_exists(AbstractArgument::class) ? new AbstractArgument(sprintf('Added in %s.', TwigComponentPass::class)) : [],
-                $config['anonymous_template_directory'],
-            ])
-            ->addTag('console.command')
-        ;
-
         $container->setAlias('console.command.stimulus_component_debug', 'ux.twig_component.command.debug')
             ->setDeprecated('symfony/ux-twig-component', '2.13', '%alias_id%');
 
         if ($container->getParameter('kernel.debug')) {
             $loader->load('debug.php');
+
+            $container->setParameter('ux.twig_component.anonymous_template_directory', $config['anonymous_template_directory']);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | n/a
| License       | MIT

When live component is installed, swap the debug command and data collector to a live component version.

This refactor enables us to add additional live-component specific details to both the debug command and the profiler.

Helps with #1720.