### PR TITLE
[Autocomplete] Use `choice_value` in the `WrappedEntityTypeAutocompleter` in `EntityAutocompleteField`

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.17.0
+
+-   Allow `choice_value` option in entity autocomplete fields #1723
+
 ## 2.16.0
 
 -   Missing translations added for many languages #1527 #1528 #1535

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -100,6 +100,16 @@ final class WrappedEntityTypeAutocompleter implements OptionsAwareEntityAutocomp
 
     public function getValue(object $entity): string
     {
+        $choiceValue = $this->getFormOption('choice_value');
+
+        if (\is_string($choiceValue) || $choiceValue instanceof PropertyPathInterface) {
+            return $this->propertyAccessor->getValue($entity, $choiceValue);
+        }
+
+        if ($choiceValue instanceof \Closure) {
+            return $choiceValue($entity);
+        }
+
         return $this->getEntityMetadata()->getIdValue($entity);
     }
 

--- a/src/Autocomplete/tests/Fixtures/Entity/Category.php
+++ b/src/Autocomplete/tests/Fixtures/Entity/Category.php
@@ -26,6 +26,9 @@ class Category
     #[ORM\Column()]
     private ?string $name = null;
 
+    #[ORM\Column()]
+    private ?string $code = null;
+
     #[ORM\OneToMany(mappedBy: 'category', targetEntity: Product::class)]
     private Collection $products;
 
@@ -49,6 +52,18 @@ class Category
         $this->name = $name;
 
         return $this;
+    }
+
+    public function setCode(string $code): self
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
     }
 
     /**

--- a/src/Autocomplete/tests/Fixtures/Factory/CategoryFactory.php
+++ b/src/Autocomplete/tests/Fixtures/Factory/CategoryFactory.php
@@ -39,8 +39,10 @@ final class CategoryFactory extends ModelFactory
 {
     protected function getDefaults(): array
     {
+        $name = self::faker()->name();
         return [
-            'name' => self::faker()->text(),
+            'name' => $name,
+            'code' => strtolower(str_replace(' ', '_', $name)),
         ];
     }
 

--- a/src/Autocomplete/tests/Fixtures/Form/CategoryWithCallbackAsCustomValue.php
+++ b/src/Autocomplete/tests/Fixtures/Form/CategoryWithCallbackAsCustomValue.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixtures\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Category;
+
+#[AsEntityAutocompleteField]
+class CategoryWithCallbackAsCustomValue extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'class' => Category::class,
+            'placeholder' => 'What should we eat?',
+            'choice_value' => function (?Category $category): ?string {
+                return $category?->getCode();
+            },
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return BaseEntityAutocompleteType::class;
+    }
+}

--- a/src/Autocomplete/tests/Fixtures/Form/CategoryWithPropertyNameAsCustomValue.php
+++ b/src/Autocomplete/tests/Fixtures/Form/CategoryWithPropertyNameAsCustomValue.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixtures\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Category;
+
+#[AsEntityAutocompleteField]
+class CategoryWithPropertyNameAsCustomValue extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'class' => Category::class,
+            'placeholder' => 'What should we eat?',
+            'choice_value' => 'code',
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return BaseEntityAutocompleteType::class;
+    }
+}

--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -13,6 +13,8 @@ namespace Symfony\UX\Autocomplete\Tests\Fixtures;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\Mapping\AssociationMapping;
+use Fixtures\Form\CategoryWithCallbackAsCustomValue;
+use Fixtures\Form\CategoryWithPropertyNameAsCustomValue;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -179,6 +181,16 @@ final class Kernel extends BaseKernel
 
         $services->alias('public.ux.autocomplete.make_autocomplete_field', 'ux.autocomplete.make_autocomplete_field')
             ->public();
+
+        $services->set(CategoryWithPropertyNameAsCustomValue::class)
+            ->tag('ux.entity_autocomplete_field')
+            ->public()
+        ;
+
+        $services->set(CategoryWithCallbackAsCustomValue::class)
+            ->tag('ux.entity_autocomplete_field')
+            ->public()
+        ;
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void

--- a/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
+++ b/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
@@ -101,4 +101,30 @@ class FieldAutocompleterTest extends KernelTestCase
             ->assertJsonMatches('length(results)', 5)
         ;
     }
+
+    public function testItUsesTheCustomStringValue(): void
+    {
+        $category = CategoryFactory::createOne(['code' => 'foo']);
+
+        $this->browser()
+            ->throwExceptions()
+            ->get('/test/autocomplete/category_with_property_name_as_custom_value?query=foo')
+            ->assertSuccessful()
+            ->assertJsonMatches('results[0].value', 'foo')
+            ->assertJsonMatches('results[0].text', $category->getName())
+        ;
+    }
+
+    public function testItUsesTheCustomCallbackValue(): void
+    {
+        $category = CategoryFactory::createOne(['code' => 'foo']);
+
+        $this->browser()
+            ->throwExceptions()
+            ->get('/test/autocomplete/category_with_callback_as_custom_value?query=foo')
+            ->assertSuccessful()
+            ->assertJsonMatches('results[0].value', 'foo')
+            ->assertJsonMatches('results[0].text', $category->getName())
+        ;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | 
| License       | MIT

Currently despite setting the `choice_value` the `\Symfony\UX\Autocomplete\Form\WrappedEntityTypeAutocompleter` uses the id value of the entity. This PR allows to override the autocomplete result value in the entity autocomplete fields.