### PR TITLE
[Icons] Fix Icon aliases not found

### DIFF
--- a/src/Icons/src/Iconify.php
+++ b/src/Icons/src/Iconify.php
@@ -61,14 +61,19 @@ final class Iconify
             throw new IconNotFoundException(sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $name));
         }
 
+        $nameArg = $name;
+        if (isset($data['aliases'][$name])) {
+            $name = $data['aliases'][$name]['parent'];
+        }
+
         if (!isset($data['icons'][$name]['body'])) {
-            throw new IconNotFoundException(sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $name));
+            throw new IconNotFoundException(sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $nameArg));
         }
 
         $height = $data['icons'][$name]['height'] ?? $data['height'] ?? $this->sets()[$prefix]['height'] ?? null;
         $width = $data['icons'][$name]['width'] ?? $data['width'] ?? $this->sets()[$prefix]['width'] ?? null;
         if (null === $width && null === $height) {
-            throw new \RuntimeException(sprintf('The icon "%s:%s" does not have a width or height.', $prefix, $name));
+            throw new \RuntimeException(sprintf('The icon "%s:%s" does not have a width or height.', $prefix, $nameArg));
         }
 
         return new Icon($data['icons'][$name]['body'], [

--- a/src/Icons/tests/Integration/RenderIconsInTwigTest.php
+++ b/src/Icons/tests/Integration/RenderIconsInTwigTest.php
@@ -38,4 +38,17 @@ final class RenderIconsInTwigTest extends KernelTestCase
             trim($output)
         );
     }
+
+    public function testRenderAliasIcons(): void
+    {
+        $templateIcon = '<twig:ux:icon name="flowbite:close-outline" />';
+        $outputIcon = self::getContainer()->get(Environment::class)->createTemplate($templateIcon)->render();
+
+        $templateAlias = '<twig:ux:icon name="flowbite:x-outline" />';
+        $outputAlias = self::getContainer()->get(Environment::class)->createTemplate($templateAlias)->render();
+
+        $expected = '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L17.94 6M18 18L6.06 6"/></svg>';
+        $this->assertSame($outputIcon, $expected);
+        $this->assertSame($outputIcon, $outputAlias);
+    }
 }

--- a/src/Icons/tests/Unit/IconifyTest.php
+++ b/src/Icons/tests/Unit/IconifyTest.php
@@ -50,6 +50,37 @@ class IconifyTest extends TestCase
         $this->assertEquals($icon->getAttributes(), ['viewBox' => '0 0 24 24']);
     }
 
+    public function testFetchIconByAlias(): void
+    {
+        $iconify = new Iconify(
+            cache: new NullAdapter(),
+            endpoint: 'https://example.com',
+            http: new MockHttpClient([
+                new JsonMockResponse([
+                    'bi' => [],
+                ]),
+                new JsonMockResponse([
+                    'aliases' => [
+                        'foo' => [
+                            'parent' => 'bar',
+                        ],
+                    ],
+                    'icons' => [
+                        'bar' => [
+                            'body' => '<path d="M0 0h24v24H0z" fill="none"/>',
+                            'height' => 24,
+                        ],
+                    ],
+                ]),
+            ]),
+        );
+
+        $icon = $iconify->fetchIcon('bi', 'foo');
+
+        $this->assertEquals($icon->getInnerSvg(), '<path d="M0 0h24v24H0z" fill="none"/>');
+        $this->assertEquals($icon->getAttributes(), ['viewBox' => '0 0 24 24']);
+    }
+
     public function testFetchIconThrowsWhenIconSetDoesNotExists(): void
     {
         $iconify = new Iconify(new NullAdapter(), 'https://example.com', new MockHttpClient(new JsonMockResponse([])));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Issues        | Fix #1721
| License       | MIT

I'm adding a dedicated functional test because aliases will require specific attention/code regarding automatic class generation.


Update: other CS fails fixed in https://github.com/symfony/ux/pull/1725 