### PR TITLE
Allow debuging components with union typed props

### DIFF
--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -255,9 +255,14 @@ EOF
             $propertyName = $property->getName();
 
             if ($metadata->isPublicPropsExposed() && $property->isPublic()) {
-                $visibility = $property->getType()?->getName();
+                $type = $property->getType();
+                if ($type instanceof \ReflectionNamedType) {
+                    $typeName = $type->getName();
+                } else {
+                    $typeName = (string) $type;
+                }
                 $value = $property->getDefaultValue();
-                $propertyDisplay = $visibility.' $'.$propertyName.(null !== $value ? ' = '.json_encode($value) : '');
+                $propertyDisplay = $typeName.' $'.$propertyName.(null !== $value ? ' = '.json_encode($value) : '');
                 $properties[$property->name] = $propertyDisplay;
             }
 

--- a/src/TwigComponent/tests/Fixtures/Component/UnionTypeProps.php
+++ b/src/TwigComponent/tests/Fixtures/Component/UnionTypeProps.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent(name: 'union_type_props', exposePublicProps: true)]
+final class UnionTypeProps
+{
+    public string|bool $prop1;
+}

--- a/src/TwigComponent/tests/Integration/Command/TwigComponentDebugCommandTest.php
+++ b/src/TwigComponent/tests/Integration/Command/TwigComponentDebugCommandTest.php
@@ -141,7 +141,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('primary = true', $display);
     }
 
-    public function testWithoutPublicPros(): void
+    public function testWithoutPublicProps(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'no_public_props']);
@@ -171,6 +171,20 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringNotContainsString('prop2', $display);
         $this->assertStringContainsString('customProp3', $display);
         $this->assertStringNotContainsString('prop3', $display);
+    }
+
+    public function testWithUnionTypeProps(): void
+    {
+        $commandTester = $this->createCommandTester();
+        $commandTester->execute(['name' => 'union_type_props']);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $display = $commandTester->getDisplay();
+
+        $this->tableDisplayCheck($display);
+        $this->assertStringContainsString('string|bool', $display);
+        $this->assertStringContainsString('prop1', $display);
     }
 
     private function createCommandTester(): CommandTester


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Issues        | N.A.
| License       | MIT

When a component has a property with an union type, the debug command crash with `Attempted to call an undefined method named "getName" of class "ReflectionUnionType"`. This fix the issue.
