### PR TITLE
[Site] Update RegistrationForm.html.twig use form_end instead of html form 

### DIFF
--- a/ux.symfony.com/templates/components/RegistrationForm.html.twig
+++ b/ux.symfony.com/templates/components/RegistrationForm.html.twig
@@ -21,6 +21,6 @@
             >Register</button>
 
             {{ form_rest(form) }}
-        </form>
+        {{ form_end(form) }}
     {% endif %}
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | n/a
| License       | MIT

- Use `{{ form_end(form) }}` instead of `</form>`

