### PR TITLE
[LazyImage] Cache BlurHash, close #2

### DIFF
--- a/src/LazyImage/composer.json
+++ b/src/LazyImage/composer.json
@@ -36,6 +36,7 @@
     "require-dev": {
         "intervention/image": "^2.5",
         "kornrunner/blurhash": "^1.1",
+        "symfony/cache-contracts": "^2.2",
         "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/phpunit-bridge": "^5.2|^6.0|^7.0",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",

--- a/src/LazyImage/doc/index.rst
+++ b/src/LazyImage/doc/index.rst
@@ -103,10 +103,27 @@ The ``data_uri_thumbnail`` function receives 3 arguments:
 -  the width of the BlurHash to generate
 -  the height of the BlurHash to generate
 
+Performance considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 You should try to generate small BlurHash images as generating the image
 can be CPU-intensive. Instead, you can rely on the browser scaling
 abilities by generating a small image and using the ``width`` and
 ``height`` HTML attributes to scale up the image.
+
+You can also configure a cache pool to store the generated BlurHash,
+this way you can avoid generating the same BlurHash multiple times:
+
+.. code-block:: yaml
+
+    # config/packages/lazy_image.yaml
+    framework:
+        cache:
+            pools:
+                cache.lazy_image: cache.adapter.redis # or any other cache adapter depending on your needs
+
+    lazy_image:
+        cache: cache.lazy_image # the cache pool to use
 
 Extend the default behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/LazyImage/src/BlurHash/BlurHash.php
+++ b/src/LazyImage/src/BlurHash/BlurHash.php
@@ -21,11 +21,9 @@ use kornrunner\Blurhash\Blurhash as BlurhashEncoder;
  */
 class BlurHash implements BlurHashInterface
 {
-    private $imageManager;
-
-    public function __construct(?ImageManager $imageManager = null)
-    {
-        $this->imageManager = $imageManager;
+    public function __construct(
+        private ?ImageManager $imageManager = null,
+    ) {
     }
 
     public function createDataUriThumbnail(string $filename, int $width, int $height, int $encodingWidth = 75, int $encodingHeight = 75): string

--- a/src/LazyImage/src/BlurHash/CachedBlurHash.php
+++ b/src/LazyImage/src/BlurHash/CachedBlurHash.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LazyImage\BlurHash;
+
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * Decorate a BlurHashInterface to cache the result of the encoding, for performance purposes.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @final
+ */
+class CachedBlurHash implements BlurHashInterface
+{
+    public function __construct(
+        private BlurHashInterface $blurHash,
+        private CacheInterface $cache,
+    ) {
+    }
+
+    public function createDataUriThumbnail(string $filename, int $width, int $height, int $encodingWidth = 75, int $encodingHeight = 75): string
+    {
+        return $this->blurHash->createDataUriThumbnail($filename, $width, $height, $encodingWidth, $encodingHeight);
+    }
+
+    public function encode(string $filename, int $encodingWidth = 75, int $encodingHeight = 75): string
+    {
+        return $this->cache->get(
+            'blurhash.'.hash('xxh3', $filename.$encodingWidth.$encodingHeight),
+            fn () => $this->blurHash->encode($filename, $encodingWidth, $encodingHeight)
+        );
+    }
+}

--- a/src/LazyImage/src/DependencyInjection/Configuration.php
+++ b/src/LazyImage/src/DependencyInjection/Configuration.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LazyImage\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('ux_lazy_image');
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode
+            ->children()
+                ->scalarNode('cache')->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #2 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Hi everyone, this PR is a proposal for #2, the second oldest issue on this repository 🤯 

I've also though about decorates the `BlurHashInterface` if option `cache` is set, this way we don't modify the current `BlurHash`. Let me know what is preferred :) 