### PR TITLE
[Site] Fix input range colors

### DIFF
--- a/ux.symfony.com/assets/styles/_variables.scss
+++ b/ux.symfony.com/assets/styles/_variables.scss
@@ -18,3 +18,6 @@ $primary: #222 !default;
 $size-unit: calc(8px + 1.5625vw);
 
 $font-family-monospace: var(--font-family-code);
+
+$form-range-track-bg: var(--bs-body-bg);
+$form-range-thumb-bg: var(--bs-secondary-color);

--- a/ux.symfony.com/assets/styles/vendor/_bootstrap.scss
+++ b/ux.symfony.com/assets/styles/vendor/_bootstrap.scss
@@ -37,12 +37,3 @@
   }
 
 }
-
-
-.form-range::-moz-range-track {
-  background: var(--bs-secondary-bg-subtle);
-}
-
-.form-range::-moz-range-thumb {
-  background: var(--bs-secondary-color);
-}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Following https://github.com/symfony/ux/pull/1743#issuecomment-2064316267, removing the custom CSS and configuring Bootstrap variables made the `.form-range` displays correctly in both Chrome and Firefox:

<img width="1528" alt="image" src="https://github.com/symfony/ux/assets/2103975/0a45fa49-5ff4-4da2-869d-16e875eef20c">

<img width="1433" alt="image" src="https://github.com/symfony/ux/assets/2103975/f2065757-3e27-45e1-9e4f-e471603e9118">
