### PR TITLE
[LiveComponent] hide property-info deprecations in Symfony 7.1

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -43,7 +43,7 @@
         "symfony/form": "^5.4|^6.0|^7.0",
         "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/options-resolver": "^5.4|^6.0|^7.0",
-        "symfony/phpunit-bridge": "^6.0|^7.0",
+        "symfony/phpunit-bridge": "^6.1|^7.0",
         "symfony/property-info": "^5.4|^6.0|^7.0",
         "symfony/security-bundle": "^5.4|^6.0|^7.0",
         "symfony/serializer": "^5.4|^6.0|^7.0",

--- a/src/LiveComponent/phpunit.xml.dist
+++ b/src/LiveComponent/phpunit.xml.dist
@@ -18,7 +18,7 @@
         <server name="KERNEL_CLASS" value="Symfony\UX\LiveComponent\Tests\Fixtures\Kernel"/>
         <server name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data.db"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
-        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;ignoreFile=./tests/baseline-ignore"/>
     </php>
 
     <testsuites>

--- a/src/LiveComponent/tests/baseline-ignore
+++ b/src/LiveComponent/tests/baseline-ignore
@@ -1,0 +1,5 @@
+%Since symfony/property-info 7.1: The "Symfony\\Component\\PropertyInfo\\Extractor\\ReflectionExtractor::getTypes\(\)".+%
+%Since symfony/property-info 7.1: The "Symfony\\Component\\PropertyInfo\\Extractor\\PhpStanExtractor::getTypes\(\)".+%
+%Since symfony/property-info 7.1: The "Symfony\\Component\\PropertyInfo\\Extractor\\PhpDocExtractor::getTypes\(\)".+%
+%Since symfony/property-info 7.1: The "Symfony\\Component\\PropertyInfo\\PropertyInfoExtractor::getTypes\(\)".+%
+%Since symfony/property-info 7.1: The "Symfony\\Component\\PropertyInfo\\Type" class is deprecated..+%


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | n/a
| License       | MIT

This fixes the LiveComponent CI on 7.1.