### PR TITLE
[LazyImage] Re-add forgotten twig.runtime

### DIFF
--- a/src/LazyImage/src/DependencyInjection/LazyImageExtension.php
+++ b/src/LazyImage/src/DependencyInjection/LazyImageExtension.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\UX\LazyImage\BlurHash\BlurHash;
 use Symfony\UX\LazyImage\BlurHash\BlurHashInterface;
 use Symfony\UX\LazyImage\Twig\BlurHashExtension;
+use Symfony\UX\LazyImage\Twig\BlurHashRuntime;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
@@ -40,7 +41,6 @@ class LazyImageExtension extends Extension implements PrependExtensionInterface
             $container
                 ->setDefinition('lazy_image.image_manager', new Definition(ImageManager::class))
                 ->addArgument(BlurHash::intervention3() ? Driver::class : [])
-                ->setPublic(false)
             ;
         }
 
@@ -60,9 +60,13 @@ class LazyImageExtension extends Extension implements PrependExtensionInterface
 
         $container
             ->setDefinition('twig.extension.blur_hash', new Definition(BlurHashExtension::class))
-            ->addArgument(new Reference('lazy_image.blur_hash'))
             ->addTag('twig.extension')
-            ->setPublic(false)
+        ;
+
+        $container
+            ->setDefinition('twig.runtime.blur_hash', new Definition(BlurHashRuntime::class))
+            ->addArgument(new Reference('lazy_image.blur_hash'))
+            ->addTag('twig.runtime')
         ;
     }
 

--- a/src/LazyImage/src/Twig/BlurHashExtension.php
+++ b/src/LazyImage/src/Twig/BlurHashExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\UX\LazyImage\Twig;
 
-use Symfony\UX\LazyImage\BlurHash\BlurHashInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -22,28 +21,9 @@ use Twig\TwigFunction;
  */
 class BlurHashExtension extends AbstractExtension
 {
-    private $blurHash;
-
-    public function __construct(BlurHashInterface $blurHash)
+    public function getFunctions(): iterable
     {
-        $this->blurHash = $blurHash;
-    }
-
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('data_uri_thumbnail', [$this, 'createDataUriThumbnail']),
-            new TwigFunction('blur_hash', [$this, 'blurHash']),
-        ];
-    }
-
-    public function createDataUriThumbnail(string $filename, int $width, int $height, int $encodingWidth = 75, int $encodingHeight = 75): string
-    {
-        return $this->blurHash->createDataUriThumbnail($filename, $width, $height, $encodingWidth, $encodingHeight);
-    }
-
-    public function blurHash(string $filename, int $encodingWidth = 75, int $encodingHeight = 75): string
-    {
-        return $this->blurHash->encode($filename, $encodingWidth, $encodingHeight);
+        yield new TwigFunction('data_uri_thumbnail', [BlurHashRuntime::class, 'createDataUriThumbnail']);
+        yield new TwigFunction('blur_hash', [BlurHashRuntime::class, 'blurHash']);
     }
 }

--- a/src/LazyImage/src/Twig/BlurHashRuntime.php
+++ b/src/LazyImage/src/Twig/BlurHashRuntime.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LazyImage\Twig;
+
+use Symfony\UX\LazyImage\BlurHash\BlurHashInterface;
+use Twig\Extension\RuntimeExtensionInterface;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class BlurHashRuntime implements RuntimeExtensionInterface
+{
+    public function __construct(
+        private BlurHashInterface $blurHash,
+    ) {
+    }
+
+    public function createDataUriThumbnail(string $filename, int $width, int $height, int $encodingWidth = 75, int $encodingHeight = 75): string
+    {
+        return $this->blurHash->createDataUriThumbnail($filename, $width, $height, $encodingWidth, $encodingHeight);
+    }
+
+    public function blurHash(string $filename, int $encodingWidth = 75, int $encodingHeight = 75): string
+    {
+        return $this->blurHash->encode($filename, $encodingWidth, $encodingHeight);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Hi!

It looks like the Twig Runtime has been removed in #1766 while processing my review, so let's add it back :)