### PR TITLE
[TwigComponent] Fix LiveComponent namespace mapping

### DIFF
--- a/src/TwigComponent/src/Twig/TemplateNameParser.php
+++ b/src/TwigComponent/src/Twig/TemplateNameParser.php
@@ -11,21 +11,24 @@
 
 namespace Symfony\UX\TwigComponent\Twig;
 
+/**
+ * @internal
+ */
 final class TemplateNameParser
 {
     /**
-     * Copied from Twig\Loader\FilesystemLoader, and adjusted to needs for this class (no namespace returned).
+     * Copied from Twig\Loader\FilesystemLoader, and adjusted to needs for this class.
      *
      * @see \Twig\Loader\FilesystemLoader::parseName
      */
-    public static function parse(string $name): mixed
+    public static function parse(string $name): string
     {
-        if (isset($name[0]) && '@' == $name[0]) {
-            if (false === $pos = strpos($name, '/')) {
+        if (str_starts_with($name, '@')) {
+            if (!str_contains($name, '/')) {
                 throw new \LogicException(sprintf('Malformed namespaced template name "%s" (expecting "@namespace/template_name").', $name));
             }
 
-            return substr($name, $pos + 1);
+            return $name;
         }
 
         return $name;

--- a/src/TwigComponent/tests/Unit/Twig/TemplateNameParserTest.php
+++ b/src/TwigComponent/tests/Unit/Twig/TemplateNameParserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\TwigComponent\Twig\TemplateNameParser;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+class TemplateNameParserTest extends TestCase
+{
+    /**
+     * @dataProvider provideParse
+     */
+    public function testParse(string $name, string $parsedName): void
+    {
+        $this->assertSame($parsedName, TemplateNameParser::parse($name));
+    }
+
+    public function testParseThrowsExceptionWhenInvalidName(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Malformed namespaced template name "@foo" (expecting "@namespace/template_name").');
+        TemplateNameParser::parse('@foo');
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: string}>
+     */
+    public static function provideParse(): iterable
+    {
+        yield ['foo', 'foo'];
+        yield ['foo/bar', 'foo/bar'];
+        yield ['@Admin/foo', '@Admin/foo'];
+        yield ['Admin/foo', 'Admin/foo'];
+    }
+}


### PR DESCRIPTION
I believe this modification fix #1754

**Original problem**

If you render a template @Acme/dashboard.html.twig, embedded Components (live or twig) referenced wrong template (dashboard.html.twig here), making LiveComponent impossible to rerender (this file beeing not referenced in the TemplateMap).

This behaviour was introduced in #1082 (and worked then). But i'm convinced all the work/changes made by Ryan to fix the embed bug (#1247 and related) made this obselete (and in this particular situation even originates a bug)

All tests are green, and i'd like to test it more heavily... but before that : do you think this is a bug fix or is there some kind of BC break here?

