### PR TITLE
[Turbo] add options to EventSource Mercure

### DIFF
--- a/src/Turbo/assets/dist/turbo_stream_controller.d.ts
+++ b/src/Turbo/assets/dist/turbo_stream_controller.d.ts
@@ -3,11 +3,13 @@ export default class extends Controller {
     static values: {
         topic: StringConstructor;
         hub: StringConstructor;
+        eventSourceOptions: ObjectConstructor;
     };
     es: EventSource | undefined;
     url: string | undefined;
     readonly topicValue: string;
     readonly hubValue: string;
+    readonly eventSourceOptionsValue: object;
     readonly hasHubValue: boolean;
     readonly hasTopicValue: boolean;
     initialize(): void;

--- a/src/Turbo/assets/dist/turbo_stream_controller.js
+++ b/src/Turbo/assets/dist/turbo_stream_controller.js
@@ -16,7 +16,7 @@ class default_1 extends Controller {
     }
     connect() {
         if (this.url) {
-            this.es = new EventSource(this.url);
+            this.es = new EventSource(this.url, this.eventSourceOptionsValue);
             connectStreamSource(this.es);
         }
     }
@@ -30,6 +30,7 @@ class default_1 extends Controller {
 default_1.values = {
     topic: String,
     hub: String,
+    eventSourceOptions: Object,
 };
 
 export { default_1 as default };

--- a/src/Turbo/assets/src/turbo_stream_controller.ts
+++ b/src/Turbo/assets/src/turbo_stream_controller.ts
@@ -17,12 +17,14 @@ export default class extends Controller {
     static values = {
         topic: String,
         hub: String,
+        eventSourceOptions: Object,
     };
     es: EventSource | undefined;
     url: string | undefined;
 
     declare readonly topicValue: string;
     declare readonly hubValue: string;
+    declare readonly eventSourceOptionsValue: object;
     declare readonly hasHubValue: boolean;
     declare readonly hasTopicValue: boolean;
 
@@ -40,7 +42,7 @@ export default class extends Controller {
 
     connect() {
         if (this.url) {
-            this.es = new EventSource(this.url);
+            this.es = new EventSource(this.url, this.eventSourceOptionsValue);
             connectStreamSource(this.es);
         }
     }

--- a/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
+++ b/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
@@ -46,7 +46,7 @@ final class TurboStreamListenRenderer implements TurboStreamListenRendererInterf
         $this->stimulusHelper = $stimulus;
     }
 
-    public function renderTurboStreamListen(Environment $env, $topic): string
+    public function renderTurboStreamListen(Environment $env, $topic, array $eventSourceOptions = []): string
     {
         if (\is_object($topic)) {
             $class = $topic::class;
@@ -61,11 +61,13 @@ final class TurboStreamListenRenderer implements TurboStreamListenRendererInterf
             $topic = sprintf(Broadcaster::TOPIC_PATTERN, rawurlencode($topic), '{id}');
         }
 
+        $params = ['topic' => $topic, 'hub' => $this->hub->getPublicUrl()];
+        if ($eventSourceOptions) {
+            $params['eventSourceOptions'] = $eventSourceOptions;
+        }
+
         $stimulusAttributes = $this->stimulusHelper->createStimulusAttributes();
-        $stimulusAttributes->addController(
-            'symfony/ux-turbo/mercure-turbo-stream',
-            ['topic' => $topic, 'hub' => $this->hub->getPublicUrl()]
-        );
+        $stimulusAttributes->addController('symfony/ux-turbo/mercure-turbo-stream', $params);
 
         return (string) $stimulusAttributes;
     }

--- a/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
+++ b/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
@@ -46,6 +46,10 @@ final class TurboStreamListenRenderer implements TurboStreamListenRendererInterf
         $this->stimulusHelper = $stimulus;
     }
 
+    /**
+     * @param string|object $topic
+     * @param array<string,mixed> $eventSourceOptions
+     */
     public function renderTurboStreamListen(Environment $env, $topic, array $eventSourceOptions = []): string
     {
         if (\is_object($topic)) {

--- a/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
+++ b/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
@@ -47,7 +47,7 @@ final class TurboStreamListenRenderer implements TurboStreamListenRendererInterf
     }
 
     /**
-     * @param string|object $topic
+     * @param string|object       $topic
      * @param array<string,mixed> $eventSourceOptions
      */
     public function renderTurboStreamListen(Environment $env, $topic, array $eventSourceOptions = []): string

--- a/src/Turbo/src/Twig/TurboStreamListenRendererInterface.php
+++ b/src/Turbo/src/Twig/TurboStreamListenRendererInterface.php
@@ -21,7 +21,7 @@ use Twig\Environment;
 interface TurboStreamListenRendererInterface
 {
     /**
-     * @param string|object $topic
+     * @param string|object       $topic
      * @param array<string,mixed> $eventSourceOptions
      */
     public function renderTurboStreamListen(Environment $env, $topic, array $eventSourceOptions = []): string;

--- a/src/Turbo/src/Twig/TurboStreamListenRendererInterface.php
+++ b/src/Turbo/src/Twig/TurboStreamListenRendererInterface.php
@@ -23,5 +23,5 @@ interface TurboStreamListenRendererInterface
     /**
      * @param string|object $topic
      */
-    public function renderTurboStreamListen(Environment $env, $topic): string;
+    public function renderTurboStreamListen(Environment $env, $topic, array $eventSourceOptions): string;
 }

--- a/src/Turbo/src/Twig/TurboStreamListenRendererInterface.php
+++ b/src/Turbo/src/Twig/TurboStreamListenRendererInterface.php
@@ -22,6 +22,7 @@ interface TurboStreamListenRendererInterface
 {
     /**
      * @param string|object $topic
+     * @param array<string,mixed> $eventSourceOptions
      */
-    public function renderTurboStreamListen(Environment $env, $topic, array $eventSourceOptions): string;
+    public function renderTurboStreamListen(Environment $env, $topic, array $eventSourceOptions = []): string;
 }

--- a/src/Turbo/src/Twig/TwigExtension.php
+++ b/src/Turbo/src/Twig/TwigExtension.php
@@ -37,6 +37,7 @@ final class TwigExtension extends AbstractExtension
 
     /**
      * @param object|string $topic
+     * @param array<string,mixed> $eventSourceOptions
      */
     public function turboStreamListen(Environment $env, $topic, ?string $transport = null, array $eventSourceOptions = []): string
     {

--- a/src/Turbo/src/Twig/TwigExtension.php
+++ b/src/Turbo/src/Twig/TwigExtension.php
@@ -36,7 +36,7 @@ final class TwigExtension extends AbstractExtension
     }
 
     /**
-     * @param object|string $topic
+     * @param string|object       $topic
      * @param array<string,mixed> $eventSourceOptions
      */
     public function turboStreamListen(Environment $env, $topic, ?string $transport = null, array $eventSourceOptions = []): string

--- a/src/Turbo/src/Twig/TwigExtension.php
+++ b/src/Turbo/src/Twig/TwigExtension.php
@@ -38,7 +38,7 @@ final class TwigExtension extends AbstractExtension
     /**
      * @param object|string $topic
      */
-    public function turboStreamListen(Environment $env, $topic, ?string $transport = null): string
+    public function turboStreamListen(Environment $env, $topic, ?string $transport = null, array $eventSourceOptions = []): string
     {
         $transport = $transport ?? $this->default;
 
@@ -46,6 +46,6 @@ final class TwigExtension extends AbstractExtension
             throw new \InvalidArgumentException(sprintf('The Turbo stream transport "%s" doesn\'t exist.', $transport));
         }
 
-        return $this->turboStreamListenRenderers->get($transport)->renderTurboStreamListen($env, $topic);
+        return $this->turboStreamListenRenderers->get($transport)->renderTurboStreamListen($env, $topic, $eventSourceOptions);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | n/a
| Issues        | Fix #291 
| License       | MIT

To prevent 401 with Mercure & Turbo stream on different domain, add an options for EventSource is required.
Exemple of code:
```twig
<div id="messages" {{ turbo_stream_listen('https://example.com/books/1', eventSourceOptions = {withCredentials: true}) }}</div>
```