### PR TITLE
#1770 [Autocomplete] Ignore the ExtraLazyChoiceLoader if the parent $loader is null

### DIFF
--- a/src/Autocomplete/src/Form/BaseEntityAutocompleteType.php
+++ b/src/Autocomplete/src/Form/BaseEntityAutocompleteType.php
@@ -38,6 +38,10 @@ final class BaseEntityAutocompleteType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $choiceLoader = static function (Options $options, $loader) {
+            if (null === $loader) {
+                return null;
+            }
+            
             return new ExtraLazyChoiceLoader($loader);
         };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| Issues        | Fix #1770 
| License       | MIT

When a custom autoload field class is created and `choices` option is passed, an error occurs: `Symfony\UX\Autocomplete\Form\ChoiceList\Loader\ExtraLazyChoiceLoader::__construct(): Argument #1 ($decorated) must be of type Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface, null given`.

This should fix the problem, described in #1770.