### PR TITLE
[LiveComponent] Add a note about render:finished event

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -905,6 +905,11 @@ component system from Stimulus:
         }
     }
 
+.. note::
+
+    The ``render:started`` and ``render:finished`` events are only dispatched
+    when the component is **re**-rendered (via an action or a model change).
+
 The following hooks are available (along with the arguments that are passed):
 
 * ``connect`` args ``(component: Component)``


### PR DESCRIPTION
The `render:finished` event is not dispatched when the component is initially rendered in Twig

As a couple of users have missed this information while reading the documentation, I suggest a little admonition to emphasis it :)
