### PR TITLE
[LazyImage] Abstract image content fetching

### DIFF
--- a/src/LazyImage/doc/index.rst
+++ b/src/LazyImage/doc/index.rst
@@ -99,9 +99,37 @@ blurred, data-uri thumbnail of the image:
 
 The ``data_uri_thumbnail`` function receives 3 arguments:
 
--  the server path to the image to generate the data-uri thumbnail for ;
+-  the path to the image to generate the data-uri thumbnail for ;
 -  the width of the BlurHash to generate
 -  the height of the BlurHash to generate
+
+Customizing images fetching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, ``data_uri_thumbnail`` fetches images using the `file_get_contents`_ function.
+It works well for local files, but you may want to customize it to fetch images from a remote server, `Flysystem`_, etc.
+
+To do so you can create a invokable class, the first argument is the filename to fetch:
+
+.. ::
+
+    namespace App\BlurHash;
+
+    class FetchImageContent
+    {
+        public function __invoke(string $filename): string
+        {
+            // Your custom implementation here to fetch the image content
+        }
+    }
+
+Then you must configure the service in your Symfony configuration:
+
+.. code-block:: yaml
+
+    # config/packages/lazy_image.yaml
+    lazy_image:
+        fetch_image_content: 'App\BlurHash\FetchImageContent'
 
 Performance considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -190,3 +218,5 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`BlurHash implementation`: https://blurha.sh
 .. _`StimulusBundle`: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
+.. _`file_get_contents`: https://www.php.net/manual/en/function.file-get-contents.php
+.. _`Flysystem`: https://flysystem.thephpleague.com

--- a/src/LazyImage/src/DependencyInjection/Configuration.php
+++ b/src/LazyImage/src/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ final class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('cache')->end()
+                ->scalarNode('fetch_image_content')->defaultNull()->end()
             ->end()
         ;
 

--- a/src/LazyImage/src/DependencyInjection/LazyImageExtension.php
+++ b/src/LazyImage/src/DependencyInjection/LazyImageExtension.php
@@ -46,13 +46,24 @@ class LazyImageExtension extends Extension implements PrependExtensionInterface
 
         $container
             ->setDefinition('lazy_image.blur_hash', new Definition(BlurHash::class))
-            ->setArgument(0, new Reference('lazy_image.image_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
+            ->setArguments([
+                new Reference('lazy_image.image_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                null, // $cache
+                null, // $fetchImageContent
+            ])
         ;
 
         if (isset($config['cache'])) {
             $container
                 ->getDefinition('lazy_image.blur_hash')
                 ->setArgument(1, new Reference($config['cache']))
+            ;
+        }
+
+        if (isset($config['fetch_image_content'])) {
+            $container
+                ->getDefinition('lazy_image.blur_hash')
+                ->setArgument(2, new Reference($config['fetch_image_content']))
             ;
         }
 

--- a/src/LazyImage/tests/Fixtures/BlurHash/LoggedFetchImageContent.php
+++ b/src/LazyImage/tests/Fixtures/BlurHash/LoggedFetchImageContent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\UX\LazyImage\Tests\Fixtures\BlurHash;
+
+final class LoggedFetchImageContent
+{
+    public array $logs = [];
+
+    public function __invoke(string $filename): string
+    {
+        $this->logs[] = $filename;
+
+        return file_get_contents($filename);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #1773 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Hi,

This PR is a proposal for #1773, logic to fetch content image is now customizable thanks to closure, meaning that an end-user can use whatever solution he wants to fetch the image content (HttpClient, Flysystem, ...).

I'm not 100% about the `Closure::fromCallable(new Reference($config['fetch_image_content']))` tho