### PR TITLE
[TwigComponent] ingore content when printed as string 

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -70,6 +70,16 @@ class TwigPreLexer
                 }
             }
 
+            // ignore content when printed as string, see #1021
+            if ($this->consume('{{ "')) {
+                $output .= $this->consumeUntil('" }}');
+                $this->consume('" }}');
+
+                if ($this->position === $this->length) {
+                    break;
+                }
+            }
+
             if ($this->consume('{% embed')) {
                 $inTwigEmbed = true;
                 $output .= '{% embed';

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -366,5 +366,14 @@ final class TwigPreLexerTest extends TestCase
             '<twig:foobar bar="baz" {{ ...attr }}>content</twig:foobar>',
             '{% component \'foobar\' with { bar: \'baz\', ...attr } %}{% block content %}content{% endblock %}{% endcomponent %}',
         ];
+        yield 'ignore_printed_component' => [
+            '{{ "<twig:Alert/>" }} <twig:Alert/>',
+            '<twig:Alert/> {{ component(\'Alert\') }}',
+        ];
+
+        yield 'file_ended_with_printed_component' => [
+            '{{ "<twig:Alert/>" }}',
+            '<twig:Alert/>',
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Issues        | Fix #1021 
| License       | MIT

When a component is displayed as a character string, it should not be transformed. This is particularly useful for code generation, as described in issue 

this solution needs to be improved to handle various complex cases, for example, the possibility of taking into account filters such as “raw” etc... and that of not taking into account spaces between “{{” and the character string, for example.

I'd be delighted to have some guidance in this direction, but for now here's a quick fix
