### PR TITLE
[Doc] Remove the --dir option in debug:twig-component command

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -118,7 +118,7 @@ and any other components by running:
 
 .. code-block:: terminal
 
-    $ php bin/console debug:twig-component --dir=bar
+    $ php bin/console debug:twig-component
 
 Take a moment to fist pump - then come back!
 
@@ -1598,7 +1598,7 @@ Debugging Components
 As your application grows, you'll eventually have a lot of components.
 This command will help you to debug some components issues.
 First, the debug:twig-component command lists all your application components
-who live in ``templates/components``:
+that live in ``templates/components/``:
 
 .. code-block:: terminal
 
@@ -1614,15 +1614,7 @@ who live in ``templates/components``:
     | foo:Anonymous | Anonymous component         | components/foo/Anonymous.html.twig |      |
     +---------------+-----------------------------+------------------------------------+------+
 
-If you have some components that don't live in ``templates/components/``,
-but in ``templates/bar`` for example, you can pass an option:
-
-.. code-block:: terminal
-
-    $ php bin/console debug:twig-component --dir=bar
-
-And the name of some component to this argument to print the
-component details:
+Pass the name of some component as an argument to print its details:
 
 .. code-block:: terminal
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | -
| License       | MIT

I tried adding the `--dir` option and the command showed an error: `The "--dir" option does not exist.`

Looking at the source code, it looks like this option doesn't exist:

https://github.com/symfony/ux/blob/4b3fcaea426d7493e7151c97ba63697be0cc5061/src/TwigComponent/src/Command/TwigComponentDebugCommand.php#L47-L66