### PR TITLE
[Site] adjust external link config

### DIFF
--- a/ux.symfony.com/src/Service/CommonMark/ConverterFactory.php
+++ b/ux.symfony.com/src/Service/CommonMark/ConverterFactory.php
@@ -38,6 +38,9 @@ final class ConverterFactory
                     'generator' => 'https://github.com/symfony/ux/issues/%d',
                 ],
             ],
+            'external_link' => [
+                'internal_hosts' => ['/(^|\.)symfony\.com$/'],
+            ],
         ]);
 
         $converter->getEnvironment()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | n/a
| License       | MIT

Don't mark any `*symfony.com` link as _external_.
