### PR TITLE
[TwigComponent] Fix aria attribute cannot be removed

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -51,17 +51,17 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
                     $value = (string) $value;
                 }
 
-                if (\is_bool($value) && str_starts_with($key, 'aria-')) {
-                    $value = $value ? 'true' : 'false';
-                }
-
                 if (!\is_scalar($value) && null !== $value) {
-                    throw new \LogicException(sprintf('A "%s" prop was passed when creating the component. No matching "%s" property or mount() argument was found, so we attempted to use this as an HTML attribute. But, the value is not a scalar (it\'s a %s). Did you mean to pass this to your component or is there a typo on its name?', $key, $key, get_debug_type($value)));
+                    throw new \LogicException(sprintf('A "%s" prop was passed when creating the component. No matching "%s" property or mount() argument was found, so we attempted to use this as an HTML attribute. But, the value is not a scalar (it\'s a "%s"). Did you mean to pass this to your component or is there a typo on its name?', $key, $key, get_debug_type($value)));
                 }
 
                 if (null === $value) {
                     trigger_deprecation('symfony/ux-twig-component', '2.8.0', 'Passing "null" as an attribute value is deprecated and will throw an exception in 3.0.');
                     $value = true;
+                }
+
+                if (true === $value && str_starts_with($key, 'aria-')) {
+                    $value = 'true';
                 }
 
                 return match ($value) {
@@ -89,12 +89,12 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
             $value = (string) $value;
         }
 
-        if (\is_bool($value) && str_starts_with($attribute, 'aria-')) {
-            $value = $value ? 'true' : 'false';
+        if (true === $value && str_starts_with($attribute, 'aria-')) {
+            $value = 'true';
         }
 
         if (!\is_string($value)) {
-            throw new \LogicException(sprintf('Can only get string attributes (%s is a %s).', $attribute, get_debug_type($value)));
+            throw new \LogicException(sprintf('Can only get string attributes (%s is a "%s").', $attribute, get_debug_type($value)));
         }
 
         $this->rendered[$attribute] = true;

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -259,29 +259,31 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame('', (string) $attributes->nested('invalid'));
     }
 
-    public function testConvertBooleanAriaAttributeValues(): void
+    public function testConvertTrueAriaAttributeValue(): void
     {
         $attributes = new ComponentAttributes([
-            'aria-foo' => true,
             'aria-bar' => false,
+            'aria-foo' => true,
             'aria-true' => 'true',
             'aria-false' => 'false',
             'aria-foobar' => 'foobar',
             'aria-number' => '1',
         ]);
 
+        $this->assertStringNotContainsString('aria-bar', (string) $attributes);
         $this->assertStringContainsString('aria-foo="true"', (string) $attributes);
-        $this->assertStringContainsString('aria-bar="false"', (string) $attributes);
         $this->assertStringContainsString('aria-true="true"', (string) $attributes);
         $this->assertStringContainsString('aria-false="false"', (string) $attributes);
         $this->assertStringContainsString('aria-foobar="foobar"', (string) $attributes);
         $this->assertStringContainsString('aria-number="1"', (string) $attributes);
 
         $this->assertSame('true', $attributes->render('aria-foo'));
-        $this->assertSame('false', $attributes->render('aria-bar'));
         $this->assertSame('true', $attributes->render('aria-true'));
         $this->assertSame('false', $attributes->render('aria-false'));
         $this->assertSame('foobar', $attributes->render('aria-foobar'));
         $this->assertSame('1', $attributes->render('aria-number'));
+
+        $this->expectException(\LogicException::class);
+        $attributes->render('aria-bar');
     }
 }


### PR DESCRIPTION
Handle only "true" (the original need) and restore using false to remove an attribute

cf #1709 and #1797  