### PR TITLE
[TwigComponent] Allow input props to have the same name as context variables

### DIFF
--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -117,8 +117,9 @@ final class ComponentRenderer implements ComponentRendererInterface
             // first so values can be overridden
             $context,
             // add the context in a separate variable to keep track
-            // of what is coming from outside the component
-            ['__context' => $context],
+            // of what is coming from outside the component, excluding props
+            // as they override initial context values
+            ['__context' => array_diff_key($context, $props)],
             // keep reference to old context
             ['outerScope' => $context],
             // add the component as "this"
@@ -180,7 +181,7 @@ final class ComponentRenderer implements ComponentRendererInterface
             $name = $attribute->name ?? (str_starts_with($method->name, 'get') ? lcfirst(substr($method->name, 3)) : $method->name);
 
             if ($method->getNumberOfRequiredParameters()) {
-                throw new \LogicException(sprintf('Cannot use %s on methods with required parameters (%s::%s).', ExposeInTemplate::class, $component::class, $method->name));
+                throw new \LogicException(sprintf('Cannot use "%s" on methods with required parameters (%s::%s).', ExposeInTemplate::class, $component::class, $method->name));
             }
 
             if ($attribute->destruct) {

--- a/src/TwigComponent/src/Twig/PropsNode.php
+++ b/src/TwigComponent/src/Twig/PropsNode.php
@@ -57,7 +57,7 @@ class PropsNode extends Node
             if (!$this->hasNode($name)) {
                 $compiler
                     ->indent()
-                    ->write('throw new \Twig\Error\RuntimeError("'.$name.' should be defined for component '.$this->getTemplateName().'");')
+                    ->write('throw new \Twig\Error\RuntimeError("'.$name.' should be defined for component '.$this->getTemplateName().'.");')
                     ->write("\n")
                     ->outdent()
                     ->write('}')
@@ -100,18 +100,13 @@ class PropsNode extends Node
             $compiler
                 ->write('if (isset($context[\'__context\'][\''.$name.'\'])) {')
                 ->raw("\n")
-                ->write('$contextValue = $context[\'__context\'][\''.$name.'\'];')
-                ->raw("\n")
-                ->write('$propsValue = $context[\''.$name.'\'];')
-                ->raw("\n")
-                ->write('if ($contextValue === $propsValue) {')
-                ->raw("\n")
+                ->indent()
                 ->write('$context[\''.$name.'\'] = ')
                 ->subcompile($this->getNode($name))
                 ->raw(";\n")
+                ->outdent()
                 ->write('}')
                 ->raw("\n")
-                ->write('}')
             ;
         }
     }

--- a/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_input_prop_with_same_name_in_context.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_input_prop_with_same_name_in_context.html.twig
@@ -1,0 +1,5 @@
+{% set message = 'bar' %}
+
+<twig:Message :message="message">
+    <p>Hey!</p>
+</twig:Message>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -204,6 +204,13 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('<p>foo</p>', $output);
     }
 
+    public function testComponentPropsOverwriteContextValueWithInputProp(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_input_prop_with_same_name_in_context.html.twig');
+
+        $this->assertStringContainsString('<p>bar</p>', $output);
+    }
+
     public function testComponentPropsWithTrailingComma(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_props_trailing_comma.html.twig');


### PR DESCRIPTION
| Q            | A   |
|--------------|-----|
| Bug fix?     | yes |
| New feature? | no  |
| Issues       | -   |
| License      | MIT |

It looks like #1652 introduced an issue with input props and parent context.

If:
- A component prop has the same name as a variable in the parent context
- The context variable is used to set the prop value as an input prop
- The component is rendered with the embed strategy

Then, the default value of the prop is used instead of the one passed to the component.

Example: 

```twig
{# templates/components/Hello.html.twig #}

{% props name = 'John' %}
<div {{ attributes }}>
    Hello {{ name }}!
</div>
```

### Render embedded

```twig
{% set name = 'Bryan' %}
<twig:Hello :name="name"></twig:Hello>
```

Wrong output: 
```html
<div>
    Hello John!
</div>
```

### Render with function

```twig
{% set name = 'Bryan' %}
<twig:Hello :name="name" />
```

Correct output: 
```html
<div>
    Hello Bryan!
</div>
```


