### PR TITLE
[Site] Fix input range color

### DIFF
--- a/ux.symfony.com/assets/styles/_variables.scss
+++ b/ux.symfony.com/assets/styles/_variables.scss
@@ -19,5 +19,5 @@ $size-unit: calc(8px + 1.5625vw);
 
 $font-family-monospace: var(--font-family-code);
 
-$form-range-track-bg: var(--bs-body-bg);
+$form-range-track-bg: #111315ab;
 $form-range-thumb-bg: var(--bs-secondary-color);


### PR DESCRIPTION
Previous value made it impossible to use without a background (ex: charts JS demo)
