### PR TITLE
[TwigComponent] Remove wrongly added configuration

### DIFF
--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -155,7 +155,7 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                         ->always(function ($v) {
                             foreach ($v as $namespace => $defaults) {
                                 if (!str_ends_with($namespace, '\\')) {
-                                    throw new InvalidConfigurationException(sprintf('The twig_component.defaults namespace "%s" is invalid: it must end in a "\"', $namespace));
+                                    throw new InvalidConfigurationException(sprintf('The twig_component.defaults namespace "%s" is invalid: it must end in a "\".', $namespace));
                                 }
                             }
 
@@ -181,9 +181,6 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                 ->end()
                 ->scalarNode('anonymous_template_directory')
                     ->info('Defaults to `components`')
-                ->end()
-                ->scalarNode('controllers_json')
-                    ->defaultValue('%kernel.project_dir%/assets/controllers.json')
                 ->end()
             ->end();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #... 
| License       | MIT

This configuration parameter has been added by mistake in https://github.com/symfony/ux/commit/0284c0a51dd3b5be1a1b7bfe34b53aae61cf33c2#diff-d57f69d9cc81e78af30634d1b88a735542ffb1c98c782269abb604a85b727ce1R189-R191

I checked everywhere in this component and there is no usage of it

(it seems to come from a Stimulus config copy/paste during the 6.4 ~~chaos~~ rush)
