### PR TITLE
[Autocomplete] Fix grouped options order

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -195,11 +195,9 @@ class default_1 extends Controller {
     }
     createOptionsDataStructure(selectElement) {
         return Array.from(selectElement.options).map((option) => {
-            const optgroup = option.closest('optgroup');
             return {
                 value: option.value,
                 text: option.text,
-                group: optgroup ? optgroup.label : null,
             };
         });
     }
@@ -216,7 +214,7 @@ class default_1 extends Controller {
         if (filteredOriginalOptions.length !== filteredNewOptions.length) {
             return false;
         }
-        const normalizeOption = (option) => `${option.value}-${option.text}-${option.group}`;
+        const normalizeOption = (option) => `${option.value}-${option.text}`;
         const originalOptionsSet = new Set(filteredOriginalOptions.map(normalizeOption));
         const newOptionsSet = new Set(filteredNewOptions.map(normalizeOption));
         return (originalOptionsSet.size === newOptionsSet.size &&
@@ -250,6 +248,40 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
             this.tomSelect.setTextboxValue('');
         },
         closeAfterSelect: true,
+        onOptionAdd: (value, data) => {
+            let parentElement = this.tomSelect.input;
+            let optgroupData = null;
+            const optgroup = data[this.tomSelect.settings.optgroupField];
+            if (optgroup && this.tomSelect.optgroups) {
+                optgroupData = this.tomSelect.optgroups[optgroup];
+                if (optgroupData) {
+                    const optgroupElement = parentElement.querySelector(`optgroup[label="${optgroupData.label}"]`);
+                    if (optgroupElement) {
+                        parentElement = optgroupElement;
+                    }
+                }
+            }
+            const optionElement = document.createElement('option');
+            optionElement.value = value;
+            optionElement.text = data[this.tomSelect.settings.labelField];
+            const optionOrder = data['$order'];
+            let orderedOption = null;
+            for (const [, tomSelectOption] of Object.entries(this.tomSelect.options)) {
+                if (tomSelectOption['$order'] === optionOrder) {
+                    orderedOption = parentElement.querySelector(`:scope > option[value="${tomSelectOption[this.tomSelect.settings.valueField]}"]`);
+                    break;
+                }
+            }
+            if (orderedOption) {
+                orderedOption.insertAdjacentElement('afterend', optionElement);
+            }
+            else if (optionOrder >= 0) {
+                parentElement.append(optionElement);
+            }
+            else {
+                parentElement.prepend(optionElement);
+            }
+        },
     };
     if (!this.selectElement && !this.urlValue) {
         config.shouldLoad = () => false;

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -264,10 +264,10 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
             const optionElement = document.createElement('option');
             optionElement.value = value;
             optionElement.text = data[this.tomSelect.settings.labelField];
-            const optionOrder = data['$order'];
+            const optionOrder = data.$order;
             let orderedOption = null;
             for (const [, tomSelectOption] of Object.entries(this.tomSelect.options)) {
-                if (tomSelectOption['$order'] === optionOrder) {
+                if (tomSelectOption.$order === optionOrder) {
                     orderedOption = parentElement.querySelector(`:scope > option[value="${tomSelectOption[this.tomSelect.settings.valueField]}"]`);
                     break;
                 }

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -182,11 +182,11 @@ export default class extends Controller {
                 optionElement.value = value;
                 optionElement.text = data[this.tomSelect.settings.labelField];
 
-                const optionOrder = data['$order'];
+                const optionOrder = data.$order;
                 let orderedOption = null;
 
                 for (const [, tomSelectOption] of Object.entries(this.tomSelect.options)) {
-                    if (tomSelectOption['$order'] === optionOrder) {
+                    if (tomSelectOption.$order === optionOrder) {
                         orderedOption = parentElement.querySelector(
                             `:scope > option[value="${tomSelectOption[this.tomSelect.settings.valueField]}"]`
                         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,7 +2856,7 @@ __metadata:
     vitest-canvas-mock: "npm:^0.3.3"
   peerDependencies:
     "@hotwired/stimulus": ^3.0.0
-    chart.js: ^4.0
+    chart.js: ^3.4.1 || ^4.0
   languageName: unknown
   linkType: soft
 
@@ -2987,7 +2987,7 @@ __metadata:
     svelte: "npm:^3.0 || ^4.0"
   peerDependencies:
     "@hotwired/stimulus": ^3.0.0
-    svelte: ^4.0
+    svelte: ^3.0 || ^4.0
   languageName: unknown
   linkType: soft
 
@@ -3042,7 +3042,7 @@ __metadata:
     "@hotwired/turbo": "npm:^7.1.0 || ^8.0"
   peerDependencies:
     "@hotwired/stimulus": ^3.0.0
-    "@hotwired/turbo": ^8.0
+    "@hotwired/turbo": ^7.1.1 || ^8.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,7 +2856,7 @@ __metadata:
     vitest-canvas-mock: "npm:^0.3.3"
   peerDependencies:
     "@hotwired/stimulus": ^3.0.0
-    chart.js: ^3.4.1 || ^4.0
+    chart.js: ^4.0
   languageName: unknown
   linkType: soft
 
@@ -2987,7 +2987,7 @@ __metadata:
     svelte: "npm:^3.0 || ^4.0"
   peerDependencies:
     "@hotwired/stimulus": ^3.0.0
-    svelte: ^3.0 || ^4.0
+    svelte: ^4.0
   languageName: unknown
   linkType: soft
 
@@ -3042,7 +3042,7 @@ __metadata:
     "@hotwired/turbo": "npm:^7.1.0 || ^8.0"
   peerDependencies:
     "@hotwired/stimulus": ^3.0.0
-    "@hotwired/turbo": ^7.1.1 || ^8.0
+    "@hotwired/turbo": ^8.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1616 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

The bug is being caused by TomSelect not preserving the order of the option elements in the select as we select the options in the dropdown. In this case, the MutationObserver callback uses the optgroup element as a parameter to "store" the group (if any) to which the option belongs. However, once the option is selected, it no longer has an optgroup as its parentElement (a problem caused by the aforementioned bug).

As I see it, there is no need to "store" the option's group since, in any case, all <option> elements usually have a unique [value], and even if not, it will still work as expected.

A callback was added for options added through [addOption](https://github.com/orchidjs/tom-select/blob/69180fa9e79060060f1824fbde85537579d0005d/src/tom-select.ts#L1636), but the caveat is that it needs the parameter user_created=true to trigger the 'option_add' event.