### PR TITLE
[Chartjs] Improve Y axis formatting example

### DIFF
--- a/src/Chartjs/doc/index.rst
+++ b/src/Chartjs/doc/index.rst
@@ -185,6 +185,8 @@ custom Stimulus controller:
             console.log(event.detail.config);
 
             // For instance you can format Y axis
+            // To avoid overriding existing config, you should distinguish 3 cases:
+            // # 1. No existing scales config => add a new scales config
             event.detail.config.options.scales = {
                 y: {
                     ticks: {
@@ -192,6 +194,20 @@ custom Stimulus controller:
                             /* ... */
                         },
                     },
+                },
+            };
+            // # 2. Existing scales config without Y axis config => add new Y axis config
+            event.detail.config.options.scales.y = {
+                ticks: {
+                    callback: function (value, index, values) {
+                        /* ... */
+                    },
+                },
+            };
+            // # 3. Existing Y axis config => update it
+            event.detail.config.options.scales.y.ticks = {
+                callback: function (value, index, values) {
+                    /* ... */
                 },
             };
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | misleading doc fix
| New feature?  | no
| Issues        | see description
| License       | MIT

Code example in the doc does not just format Y axis, it overrides existing `scales` configuration.

```js
// For instance you can format Y axis
event.detail.config.options.scales = {
    y: {
        ticks: {
            callback: function (value, index, values) {
                /* ... */
            },
        },
    },
};
```

This code formats the y-axis and keeps an existing `scales` config untouched, but requires an existing Y axis config.

```js
// For instance you can format Y axis
event.detail.config.options.scales.y.ticks = {
    callback: function (value, index, values) {
        /* ... */
    }
};
```

