### PR TITLE
Drop ESLint and Prettier for Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,47 @@
+{
+    "files": {
+        "ignore": ["**/composer.json"]
+    },
+    "linter": {
+        "rules": {
+            "suspicious": {
+                "noExplicitAny": "off",
+                "noEmptyBlockStatements": "off"
+            },
+            "complexity": {
+                "noStaticOnlyClass": "off",
+                "noForEach": "off"
+            },
+            "style": {
+                "noParameterAssign": "off"
+            },
+            "performance": {
+                "noDelete": "off"
+            }
+        }
+    },
+    "formatter": {
+        "lineWidth": 120,
+        "indentStyle": "space",
+        "indentWidth": 4
+    },
+    "javascript": {
+        "formatter": {
+            "trailingComma": "es5",
+            "bracketSameLine": true,
+            "quoteStyle": "single"
+        }
+    },
+    "overrides": [
+        {
+            "include": ["*.svelte"],
+            "linter": {
+                "rules": {
+                    "style": {
+                        "useConst": "off"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,73 +1,28 @@
 {
     "private": true,
-    "workspaces": [
-        "src/*/assets"
-    ],
+    "workspaces": ["src/*/assets"],
     "scripts": {
         "build": "node bin/build_javascript.js && node bin/build_styles.js",
         "test": "bin/run-vitest-all.sh",
-        "lint": "yarn workspaces run eslint src test",
-        "format": "prettier src/*/assets/src/*.ts src/*/assets/test/*.js {,src/*/}*.{json,md} --write",
-        "check-lint": "yarn lint --no-fix",
-        "check-format": "yarn format --no-write --check"
+        "lint": "yarn workspaces run biome lint src test --apply",
+        "format": "biome format src/*/assets/src/*.ts src/*/assets/test/*.js {,src/*/}*.{json,md} --write",
+        "check-lint": "yarn workspaces run biome lint src test",
+        "check-format": "biome format src/*/assets/src/*.ts src/*/assets/test/*.js {,src/*/}*.{json,md}"
     },
     "devDependencies": {
         "@babel/core": "^7.15.8",
         "@babel/preset-env": "^7.15.8",
         "@babel/preset-react": "^7.15.8",
         "@babel/preset-typescript": "^7.15.8",
+        "@biomejs/biome": "^1.7.3",
         "@rollup/plugin-commonjs": "^23.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
         "@rollup/plugin-typescript": "^10.0.0",
         "@symfony/stimulus-testing": "^2.0.1",
-        "@typescript-eslint/eslint-plugin": "^5.2.0",
-        "@typescript-eslint/parser": "^5.2.0",
         "clean-css-cli": "^5.6.2",
-        "eslint": "^8.1.0",
-        "eslint-config-prettier": "^8.0.0",
-        "prettier": "^2.2.1",
         "rollup": "^3.7.0",
         "tslib": "^2.3.1",
         "typescript": "^4.4.4",
         "vitest": "^0.34.6"
-    },
-    "eslintConfig": {
-        "root": true,
-        "parser": "@typescript-eslint/parser",
-        "plugins": [
-            "@typescript-eslint"
-        ],
-        "extends": [
-            "eslint:recommended",
-            "prettier",
-            "plugin:@typescript-eslint/eslint-recommended",
-            "plugin:@typescript-eslint/recommended"
-        ],
-        "rules": {
-            "@typescript-eslint/no-explicit-any": "off",
-            "@typescript-eslint/no-empty-function": "off",
-            "@typescript-eslint/ban-ts-comment": "off",
-            "quotes": [
-                "error",
-                "single"
-            ]
-        },
-        "env": {
-            "browser": true
-        },
-        "overrides": [
-            {
-                "files": [
-                    "src/*/assets/test/**/*.ts"
-                ]
-            }
-        ]
-    },
-    "prettier": {
-        "printWidth": 120,
-        "trailingComma": "es5",
-        "tabWidth": 4,
-        "bracketSameLine": true,
-        "singleQuote": true
     }
 }

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -106,10 +106,10 @@ class default_1 extends Controller {
         if (!this.hasPreloadValue) {
             return 'focus';
         }
-        if (this.preloadValue == 'false') {
+        if (this.preloadValue === 'false') {
             return false;
         }
-        if (this.preloadValue == 'true') {
+        if (this.preloadValue === 'true') {
             return true;
         }
         return this.preloadValue;
@@ -260,12 +260,8 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
             };
         },
         render: {
-            item: function (item) {
-                return `<div>${item.text}</div>`;
-            },
-            option: function (item) {
-                return `<div>${item.text}</div>`;
-            },
+            item: (item) => `<div>${item.text}</div>`,
+            option: (item) => `<div>${item.text}</div>`,
         },
     });
     return __classPrivateFieldGet(this, _default_1_instances, "m", _default_1_createTomSelect).call(this, config);
@@ -298,18 +294,10 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
             return query.length >= 3;
         },
         optgroupField: 'group_by',
-        score: function (search) {
-            return function (item) {
-                return 1;
-            };
-        },
+        score: (search) => (item) => 1,
         render: {
-            option: function (item) {
-                return `<div>${item.text}</div>`;
-            },
-            item: function (item) {
-                return `<div>${item.text}</div>`;
-            },
+            option: (item) => `<div>${item.text}</div>`,
+            item: (item) => `<div>${item.text}</div>`,
             loading_more: () => {
                 return `<div class="loading-more-results">${this.loadingMoreTextValue}</div>`;
             },

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 import TomSelect from 'tom-select';
-import { TPluginHash } from 'tom-select/dist/types/contrib/microplugin';
-import { RecursivePartial, TomSettings, TomTemplates, TomLoadCallback } from 'tom-select/dist/types/types';
+import type { TPluginHash } from 'tom-select/dist/types/contrib/microplugin';
+import type { RecursivePartial, TomSettings, TomTemplates, TomLoadCallback } from 'tom-select/dist/types/types';
 
 export interface AutocompletePreConnectOptions {
     options: any;
@@ -175,12 +175,8 @@ export default class extends Controller {
                 };
             },
             render: {
-                item: function (item: any) {
-                    return `<div>${item.text}</div>`;
-                },
-                option: function (item: any) {
-                    return `<div>${item.text}</div>`;
-                },
+                item: (item: any) => `<div>${item.text}</div>`,
+                option: (item: any) => `<div>${item.text}</div>`,
             },
         });
 
@@ -231,18 +227,10 @@ export default class extends Controller {
             },
             optgroupField: 'group_by',
             // avoid extra filtering after results are returned
-            score: function (search: string) {
-                return function (item: any) {
-                    return 1;
-                };
-            },
+            score: (search: string) => (item: any) => 1,
             render: {
-                option: function (item: any) {
-                    return `<div>${item.text}</div>`;
-                },
-                item: function (item: any) {
-                    return `<div>${item.text}</div>`;
-                },
+                option: (item: any) => `<div>${item.text}</div>`,
+                item: (item: any) => `<div>${item.text}</div>`,
                 loading_more: (): string => {
                     return `<div class="loading-more-results">${this.loadingMoreTextValue}</div>`;
                 },
@@ -312,11 +300,11 @@ export default class extends Controller {
             return 'focus';
         }
 
-        if (this.preloadValue == 'false') {
+        if (this.preloadValue === 'false') {
             return false;
         }
 
-        if (this.preloadValue == 'true') {
+        if (this.preloadValue === 'true') {
             return true;
         }
 

--- a/src/Autocomplete/assets/test/controller.test.ts
+++ b/src/Autocomplete/assets/test/controller.test.ts
@@ -7,16 +7,15 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
 
 import { Application } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import AutocompleteController, {
-    AutocompleteConnectOptions,
-    AutocompletePreConnectOptions,
+    type AutocompleteConnectOptions,
+    type AutocompletePreConnectOptions,
 } from '../src/controller';
 import userEvent from '@testing-library/user-event';
-import TomSelect from 'tom-select';
+import type TomSelect from 'tom-select';
 import createFetchMock from 'vitest-fetch-mock';
 import { vi } from 'vitest';
 

--- a/src/Chartjs/assets/dist/controller.js
+++ b/src/Chartjs/assets/dist/controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 import { registerables, Chart } from 'chart.js';
 
-if (registerables != undefined) {
+if (registerables) {
     Chart.register(...registerables);
 }
 let isChartInitialized = false;
@@ -48,7 +48,7 @@ class default_1 extends Controller {
             const parentElement = this.element.parentElement;
             if (parentElement && this.chart.options.responsive) {
                 const originalWidth = parentElement.style.width;
-                parentElement.style.width = parentElement.offsetWidth + 1 + 'px';
+                parentElement.style.width = `${parentElement.offsetWidth + 1}px`;
                 setTimeout(() => {
                     parentElement.style.width = originalWidth;
                 }, 0);

--- a/src/Chartjs/assets/src/controller.ts
+++ b/src/Chartjs/assets/src/controller.ts
@@ -7,13 +7,11 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
 import { Chart, registerables } from 'chart.js';
 
 // ChartJs 3.x
-if (registerables != undefined) {
+if (registerables) {
     Chart.register(...registerables);
 }
 
@@ -80,7 +78,7 @@ export default class extends Controller {
             const parentElement = this.element.parentElement;
             if (parentElement && this.chart.options.responsive) {
                 const originalWidth = parentElement.style.width;
-                parentElement.style.width = parentElement.offsetWidth + 1 + 'px';
+                parentElement.style.width = `${parentElement.offsetWidth + 1}px`;
                 setTimeout(() => {
                     parentElement.style.width = originalWidth;
                 }, 0);

--- a/src/Chartjs/assets/test/controller.test.ts
+++ b/src/Chartjs/assets/test/controller.test.ts
@@ -7,7 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
 
 import { Application } from '@hotwired/stimulus';
 import { waitFor } from '@testing-library/dom';

--- a/src/Chartjs/assets/test/setup.js
+++ b/src/Chartjs/assets/test/setup.js
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import 'vitest-canvas-mock';
 // eslint-disable-next-line
 global.ResizeObserver = require('resize-observer-polyfill');

--- a/src/Cropperjs/assets/src/controller.ts
+++ b/src/Cropperjs/assets/src/controller.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
 import Cropper from 'cropperjs';
 import CropEvent = Cropper.CropEvent;

--- a/src/Cropperjs/assets/test/controller.test.ts
+++ b/src/Cropperjs/assets/test/controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
@@ -41,7 +39,7 @@ const dataToJsonAttribute = (data: any) => {
 }
 
 describe('CropperjsController', () => {
-    let container: any;
+    let container: HTMLElement;
 
     beforeEach(() => {
         container = mountDOM(`

--- a/src/Dropzone/assets/dist/controller.js
+++ b/src/Dropzone/assets/dist/controller.js
@@ -47,7 +47,7 @@ class default_1 extends Controller {
         const reader = new FileReader();
         reader.addEventListener('load', (event) => {
             this.previewImageTarget.style.display = 'block';
-            this.previewImageTarget.style.backgroundImage = 'url("' + event.target.result + '")';
+            this.previewImageTarget.style.backgroundImage = `url("${event.target.result}")`;
         });
         reader.readAsDataURL(file);
     }

--- a/src/Dropzone/assets/src/controller.ts
+++ b/src/Dropzone/assets/src/controller.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
@@ -89,7 +87,7 @@ export default class extends Controller {
 
         reader.addEventListener('load', (event: any) => {
             this.previewImageTarget.style.display = 'block';
-            this.previewImageTarget.style.backgroundImage = 'url("' + event.target.result + '")';
+            this.previewImageTarget.style.backgroundImage = `url("${event.target.result}")`;
         });
 
         reader.readAsDataURL(file);

--- a/src/Dropzone/assets/test/controller.test.ts
+++ b/src/Dropzone/assets/test/controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import user from '@testing-library/user-event';
@@ -31,7 +29,7 @@ const startStimulus = () => {
 };
 
 describe('DropzoneController', () => {
-    let container;
+    let container: HTMLElement;
 
     beforeEach(() => {
         container = mountDOM(`
@@ -87,7 +85,9 @@ describe('DropzoneController', () => {
 
         // Attach a listener to ensure the event is dispatched
         let dispatched = false;
-        getByTestId(container, 'container').addEventListener('dropzone:clear', () => (dispatched = true));
+        getByTestId(container, 'container').addEventListener('dropzone:clear', () => {
+            dispatched = true;
+        });
 
         // Manually show preview
         getByTestId(container, 'input').style.display = 'none';
@@ -111,7 +111,9 @@ describe('DropzoneController', () => {
 
         // Attach a listener to ensure the event is dispatched
         let dispatched = null;
-        getByTestId(container, 'container').addEventListener('dropzone:change', (event) => (dispatched = event));
+        getByTestId(container, 'container').addEventListener('dropzone:change', (event) => {
+            dispatched = event;
+        });
 
         // Select the file
         const input = getByTestId(container, 'input');

--- a/src/LazyImage/assets/src/controller.ts
+++ b/src/LazyImage/assets/src/controller.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {

--- a/src/LazyImage/assets/test/controller.test.ts
+++ b/src/LazyImage/assets/test/controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
@@ -33,7 +31,7 @@ const startStimulus = () => {
 };
 
 describe('LazyImageController', () => {
-    let container;
+    let container: HTMLElement;
 
     beforeEach(() => {
         container = mountDOM(`

--- a/src/LiveComponent/assets/dist/Backend/RequestBuilder.d.ts
+++ b/src/LiveComponent/assets/dist/Backend/RequestBuilder.d.ts
@@ -1,4 +1,4 @@
-import { BackendAction, ChildrenFingerprints } from './Backend';
+import type { BackendAction, ChildrenFingerprints } from './Backend';
 export default class {
     private url;
     private method;

--- a/src/LiveComponent/assets/dist/Component/ElementDriver.d.ts
+++ b/src/LiveComponent/assets/dist/Component/ElementDriver.d.ts
@@ -1,4 +1,4 @@
-import LiveControllerDefault from '../live_controller';
+import type LiveControllerDefault from '../live_controller';
 export interface ElementDriver {
     getModelName(element: HTMLElement): string | null;
     getComponentProps(): any;

--- a/src/LiveComponent/assets/dist/Component/UnsyncedInputsTracker.d.ts
+++ b/src/LiveComponent/assets/dist/Component/UnsyncedInputsTracker.d.ts
@@ -1,5 +1,5 @@
-import { ElementDriver } from './ElementDriver';
-import Component from './index';
+import type { ElementDriver } from './ElementDriver';
+import type Component from './index';
 export default class {
     private readonly component;
     private readonly modelElementResolver;

--- a/src/LiveComponent/assets/dist/Component/index.d.ts
+++ b/src/LiveComponent/assets/dist/Component/index.d.ts
@@ -1,13 +1,13 @@
-import { BackendInterface } from '../Backend/Backend';
+import type { BackendInterface } from '../Backend/Backend';
 import ValueStore from './ValueStore';
-import BackendRequest from '../Backend/BackendRequest';
-import { ElementDriver } from './ElementDriver';
-import { PluginInterface } from './plugins/PluginInterface';
+import type BackendRequest from '../Backend/BackendRequest';
+import type { ElementDriver } from './ElementDriver';
+import type { PluginInterface } from './plugins/PluginInterface';
 import BackendResponse from '../Backend/BackendResponse';
 type MaybePromise<T = void> = T | Promise<T>;
 export type ComponentHooks = {
-    'connect': (component: Component) => MaybePromise;
-    'disconnect': (component: Component) => MaybePromise;
+    connect: (component: Component) => MaybePromise;
+    disconnect: (component: Component) => MaybePromise;
     'request:started': (requestConfig: any) => MaybePromise;
     'render:finished': (component: Component) => MaybePromise;
     'response:error': (backendResponse: BackendResponse, controls: {

--- a/src/LiveComponent/assets/dist/Component/plugins/ChildComponentPlugin.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/ChildComponentPlugin.d.ts
@@ -1,5 +1,5 @@
-import Component from '../../Component';
-import { PluginInterface } from './PluginInterface';
+import type Component from '../../Component';
+import type { PluginInterface } from './PluginInterface';
 export default class implements PluginInterface {
     private readonly component;
     private parentModelBindings;

--- a/src/LiveComponent/assets/dist/Component/plugins/LazyPlugin.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/LazyPlugin.d.ts
@@ -1,5 +1,5 @@
-import { PluginInterface } from './PluginInterface';
-import Component from '../index';
+import type { PluginInterface } from './PluginInterface';
+import type Component from '../index';
 export default class implements PluginInterface {
     private intersectionObserver;
     attachToComponent(component: Component): void;

--- a/src/LiveComponent/assets/dist/Component/plugins/LoadingPlugin.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/LoadingPlugin.d.ts
@@ -1,7 +1,7 @@
-import { Directive } from '../../Directive/directives_parser';
-import BackendRequest from '../../Backend/BackendRequest';
-import Component from '../../Component';
-import { PluginInterface } from './PluginInterface';
+import { type Directive } from '../../Directive/directives_parser';
+import type BackendRequest from '../../Backend/BackendRequest';
+import type Component from '../../Component';
+import type { PluginInterface } from './PluginInterface';
 interface ElementLoadingDirectives {
     element: HTMLElement | SVGElement;
     directives: Directive[];

--- a/src/LiveComponent/assets/dist/Component/plugins/PageUnloadingPlugin.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/PageUnloadingPlugin.d.ts
@@ -1,5 +1,5 @@
-import Component from '../index';
-import { PluginInterface } from './PluginInterface';
+import type Component from '../index';
+import type { PluginInterface } from './PluginInterface';
 export default class implements PluginInterface {
     private isConnected;
     attachToComponent(component: Component): void;

--- a/src/LiveComponent/assets/dist/Component/plugins/PluginInterface.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/PluginInterface.d.ts
@@ -1,4 +1,4 @@
-import Component from '../index';
+import type Component from '../index';
 export interface PluginInterface {
     attachToComponent(component: Component): void;
 }

--- a/src/LiveComponent/assets/dist/Component/plugins/PollingPlugin.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/PollingPlugin.d.ts
@@ -1,5 +1,5 @@
-import Component from '../index';
-import { PluginInterface } from './PluginInterface';
+import type Component from '../index';
+import type { PluginInterface } from './PluginInterface';
 export default class implements PluginInterface {
     private element;
     private pollingDirector;

--- a/src/LiveComponent/assets/dist/Component/plugins/QueryStringPlugin.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/QueryStringPlugin.d.ts
@@ -1,5 +1,5 @@
-import Component from '../index';
-import { PluginInterface } from './PluginInterface';
+import type Component from '../index';
+import type { PluginInterface } from './PluginInterface';
 interface QueryMapping {
     name: string;
 }

--- a/src/LiveComponent/assets/dist/Component/plugins/SetValueOntoModelFieldsPlugin.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/SetValueOntoModelFieldsPlugin.d.ts
@@ -1,5 +1,5 @@
-import Component from '../index';
-import { PluginInterface } from './PluginInterface';
+import type Component from '../index';
+import type { PluginInterface } from './PluginInterface';
 export default class implements PluginInterface {
     attachToComponent(component: Component): void;
     private synchronizeValueOfModelFields;

--- a/src/LiveComponent/assets/dist/Component/plugins/ValidatedFieldsPlugin.d.ts
+++ b/src/LiveComponent/assets/dist/Component/plugins/ValidatedFieldsPlugin.d.ts
@@ -1,5 +1,5 @@
-import Component from '../index';
-import { PluginInterface } from './PluginInterface';
+import type Component from '../index';
+import type { PluginInterface } from './PluginInterface';
 export default class implements PluginInterface {
     attachToComponent(component: Component): void;
     private handleModelSet;

--- a/src/LiveComponent/assets/dist/ComponentRegistry.d.ts
+++ b/src/LiveComponent/assets/dist/ComponentRegistry.d.ts
@@ -1,4 +1,4 @@
-import Component from './Component';
+import type Component from './Component';
 export declare const resetRegistry: () => void;
 export declare const registerComponent: (component: Component) => void;
 export declare const unregisterComponent: (component: Component) => void;

--- a/src/LiveComponent/assets/dist/Directive/directives_parser.d.ts
+++ b/src/LiveComponent/assets/dist/Directive/directives_parser.d.ts
@@ -6,8 +6,6 @@ export interface Directive {
     action: string;
     args: string[];
     modifiers: DirectiveModifier[];
-    getString: {
-        (): string;
-    };
+    getString: () => string;
 }
 export declare function parseDirectives(content: string | null): Directive[];

--- a/src/LiveComponent/assets/dist/Directive/get_model_binding.d.ts
+++ b/src/LiveComponent/assets/dist/Directive/get_model_binding.d.ts
@@ -1,4 +1,4 @@
-import { Directive } from './directives_parser';
+import type { Directive } from './directives_parser';
 export interface ModelBinding {
     modelName: string;
     innerModelName: string | null;

--- a/src/LiveComponent/assets/dist/PollingDirector.d.ts
+++ b/src/LiveComponent/assets/dist/PollingDirector.d.ts
@@ -1,4 +1,4 @@
-import Component from './Component';
+import type Component from './Component';
 export default class {
     component: Component;
     isPollingActive: boolean;

--- a/src/LiveComponent/assets/dist/dom_utils.d.ts
+++ b/src/LiveComponent/assets/dist/dom_utils.d.ts
@@ -1,6 +1,6 @@
-import ValueStore from './Component/ValueStore';
-import { Directive } from './Directive/directives_parser';
-import Component from './Component';
+import type ValueStore from './Component/ValueStore';
+import { type Directive } from './Directive/directives_parser';
+import type Component from './Component';
 export declare function getValueFromElement(element: HTMLElement, valueStore: ValueStore): string | string[] | null | boolean;
 export declare function setValueOnElement(element: HTMLElement, value: any): void;
 export declare function getAllModelDirectiveFromElements(element: HTMLElement): Directive[];

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 import Component from './Component';
-import { BackendInterface } from './Backend/Backend';
+import { type BackendInterface } from './Backend/Backend';
 export { Component };
 export { getComponent } from './ComponentRegistry';
 export interface LiveEvent extends CustomEvent {

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -10,7 +10,7 @@ function parseDirectives(content) {
     let currentArguments = [];
     let currentModifiers = [];
     let state = 'action';
-    const getLastActionName = function () {
+    const getLastActionName = () => {
         if (currentActionName) {
             return currentActionName;
         }
@@ -19,7 +19,7 @@ function parseDirectives(content) {
         }
         return directives[directives.length - 1].action;
     };
-    const pushInstruction = function () {
+    const pushInstruction = () => {
         directives.push({
             action: currentActionName,
             args: currentArguments,
@@ -34,11 +34,11 @@ function parseDirectives(content) {
         currentModifiers = [];
         state = 'action';
     };
-    const pushArgument = function () {
+    const pushArgument = () => {
         currentArguments.push(currentArgumentValue.trim());
         currentArgumentValue = '';
     };
-    const pushModifier = function () {
+    const pushModifier = () => {
         if (currentArguments.length > 1) {
             throw new Error(`The modifier "${currentActionName}()" does not support multiple arguments.`);
         }
@@ -121,9 +121,7 @@ function normalizeModelName(model) {
     return (model
         .replace(/\[]$/, '')
         .split('[')
-        .map(function (s) {
-        return s.replace(']', '');
-    })
+        .map((s) => s.replace(']', ''))
         .join('.'));
 }
 
@@ -135,33 +133,31 @@ function getElementAsTagText(element) {
 
 let componentMapByElement = new WeakMap();
 let componentMapByComponent = new Map();
-const registerComponent = function (component) {
+const registerComponent = (component) => {
     componentMapByElement.set(component.element, component);
     componentMapByComponent.set(component, component.name);
 };
-const unregisterComponent = function (component) {
+const unregisterComponent = (component) => {
     componentMapByElement.delete(component.element);
     componentMapByComponent.delete(component);
 };
-const getComponent = function (element) {
-    return new Promise((resolve, reject) => {
-        let count = 0;
-        const maxCount = 10;
-        const interval = setInterval(() => {
-            const component = componentMapByElement.get(element);
-            if (component) {
-                clearInterval(interval);
-                resolve(component);
-            }
-            count++;
-            if (count > maxCount) {
-                clearInterval(interval);
-                reject(new Error(`Component not found for element ${getElementAsTagText(element)}`));
-            }
-        }, 5);
-    });
-};
-const findComponents = function (currentComponent, onlyParents, onlyMatchName) {
+const getComponent = (element) => new Promise((resolve, reject) => {
+    let count = 0;
+    const maxCount = 10;
+    const interval = setInterval(() => {
+        const component = componentMapByElement.get(element);
+        if (component) {
+            clearInterval(interval);
+            resolve(component);
+        }
+        count++;
+        if (count > maxCount) {
+            clearInterval(interval);
+            reject(new Error(`Component not found for element ${getElementAsTagText(element)}`));
+        }
+    }, 5);
+});
+const findComponents = (currentComponent, onlyParents, onlyMatchName) => {
     const components = [];
     componentMapByComponent.forEach((componentName, component) => {
         if (onlyParents && (currentComponent === component || !component.element.contains(currentComponent.element))) {
@@ -174,7 +170,7 @@ const findComponents = function (currentComponent, onlyParents, onlyMatchName) {
     });
     return components;
 };
-const findChildren = function (currentComponent) {
+const findChildren = (currentComponent) => {
     const children = [];
     componentMapByComponent.forEach((componentName, component) => {
         if (currentComponent === component) {
@@ -199,7 +195,7 @@ const findChildren = function (currentComponent) {
     });
     return children;
 };
-const findParent = function (currentComponent) {
+const findParent = (currentComponent) => {
     let parentElement = currentComponent.element.parentElement;
     while (parentElement) {
         const component = componentMapByElement.get(parentElement);
@@ -220,7 +216,7 @@ function getValueFromElement(element, valueStore) {
                 if (Array.isArray(modelValue)) {
                     return getMultipleCheckboxValue(element, modelValue);
                 }
-                else if (Object(modelValue) === modelValue) {
+                if (Object(modelValue) === modelValue) {
                     return getMultipleCheckboxValue(element, Object.values(modelValue));
                 }
             }
@@ -254,14 +250,14 @@ function setValueOnElement(element, value) {
             return;
         }
         if (element.type === 'radio') {
-            element.checked = element.value == value;
+            element.checked = element.value === value;
             return;
         }
         if (element.type === 'checkbox') {
             if (Array.isArray(value)) {
                 let valueFound = false;
                 value.forEach((val) => {
-                    if (val == element.value) {
+                    if (val === element.value) {
                         valueFound = true;
                     }
                 });
@@ -269,7 +265,7 @@ function setValueOnElement(element, value) {
             }
             else {
                 if (element.hasAttribute('value')) {
-                    element.checked = element.value == value;
+                    element.checked = element.value === value;
                 }
                 else {
                     element.checked = value;
@@ -280,7 +276,7 @@ function setValueOnElement(element, value) {
     }
     if (element instanceof HTMLSelectElement) {
         const arrayWrappedValue = [].concat(value).map((value) => {
-            return value + '';
+            return `${value}`;
         });
         Array.from(element.options).forEach((option) => {
             option.selected = arrayWrappedValue.includes(option.value);
@@ -366,7 +362,7 @@ function htmlToElement(html) {
     }
     return child;
 }
-const getMultipleCheckboxValue = function (element, currentValues) {
+const getMultipleCheckboxValue = (element, currentValues) => {
     const finalValues = [...currentValues];
     const value = inputValue(element);
     const index = currentValues.indexOf(value);
@@ -381,9 +377,7 @@ const getMultipleCheckboxValue = function (element, currentValues) {
     }
     return finalValues;
 };
-const inputValue = function (element) {
-    return element.dataset.value ? element.dataset.value : element.value;
-};
+const inputValue = (element) => element.dataset.value ? element.dataset.value : element.value;
 
 function getDeepData(data, propertyPath) {
     const { currentLevelData, finalKey } = parseDeepData(data, propertyPath);
@@ -392,7 +386,7 @@ function getDeepData(data, propertyPath) {
     }
     return currentLevelData[finalKey];
 }
-const parseDeepData = function (data, propertyPath) {
+const parseDeepData = (data, propertyPath) => {
     const finalData = JSON.parse(JSON.stringify(data));
     let currentLevelData = finalData;
     const parts = propertyPath.split('.');
@@ -1325,7 +1319,7 @@ function normalizeAttributesForComparison(element) {
     });
 }
 
-const syncAttributes = function (fromEl, toEl) {
+const syncAttributes = (fromEl, toEl) => {
     for (let i = 0; i < fromEl.attributes.length; i++) {
         const attr = fromEl.attributes[i];
         toEl.setAttribute(attr.name, attr.value);
@@ -1420,7 +1414,7 @@ function executeMorphdom(rootFromElement, rootToElement, modifiedFieldElements, 
                     fromEl.innerHTML = toEl.innerHTML;
                     return true;
                 }
-                if (fromEl.parentElement && fromEl.parentElement.hasAttribute('data-skip-morph')) {
+                if (fromEl.parentElement?.hasAttribute('data-skip-morph')) {
                     return false;
                 }
                 return !fromEl.hasAttribute('data-live-ignore');
@@ -1981,13 +1975,13 @@ class Component {
         return this.unsyncedInputsTracker.getUnsyncedModels();
     }
     emit(name, data, onlyMatchingComponentsNamed = null) {
-        return this.performEmit(name, data, false, onlyMatchingComponentsNamed);
+        this.performEmit(name, data, false, onlyMatchingComponentsNamed);
     }
     emitUp(name, data, onlyMatchingComponentsNamed = null) {
-        return this.performEmit(name, data, true, onlyMatchingComponentsNamed);
+        this.performEmit(name, data, true, onlyMatchingComponentsNamed);
     }
     emitSelf(name, data) {
-        return this.doEmit(name, data);
+        this.doEmit(name, data);
     }
     performEmit(name, data, emitUp, matchingName) {
         const components = findComponents(this, emitUp, matchingName);
@@ -2410,7 +2404,7 @@ class LoadingPlugin {
             if (!isLoading) {
                 return;
             }
-            delay = modifier.value ? parseInt(modifier.value) : 200;
+            delay = modifier.value ? Number.parseInt(modifier.value) : 200;
         });
         validModifiers.set('action', (modifier) => {
             if (!modifier.value) {
@@ -2516,7 +2510,7 @@ class LoadingPlugin {
         });
     }
 }
-const parseLoadingAction = function (action, isLoading) {
+const parseLoadingAction = (action, isLoading) => {
     switch (action) {
         case 'show':
             return isLoading ? 'show' : 'hide';
@@ -2655,7 +2649,7 @@ class PollingPlugin {
                 switch (modifier.name) {
                     case 'delay':
                         if (modifier.value) {
-                            duration = parseInt(modifier.value);
+                            duration = Number.parseInt(modifier.value);
                         }
                         break;
                     default:
@@ -2722,7 +2716,7 @@ function getModelBinding (modelDirective) {
                 shouldRender = false;
                 break;
             case 'debounce':
-                debounce = modifier.value ? parseInt(modifier.value) : true;
+                debounce = modifier.value ? Number.parseInt(modifier.value) : true;
                 break;
             default:
                 throw new Error(`Unknown modifier "${modifier.name}" in data-model="${modelDirective.getString()}".`);
@@ -2783,8 +2777,10 @@ function fromQueryString(search) {
         return {};
     const insertDotNotatedValueIntoData = (key, value, data) => {
         const [first, second, ...rest] = key.split('.');
-        if (!second)
-            return (data[key] = value);
+        if (!second) {
+            data[key] = value;
+            return value;
+        }
         if (data[first] === undefined) {
             data[first] = Number.isNaN(Number.parseInt(second)) ? {} : [];
         }
@@ -2987,7 +2983,7 @@ class LiveControllerDefault extends Controller {
                 }
             });
             validModifiers.set('debounce', (modifier) => {
-                debounce = modifier.value ? parseInt(modifier.value) : true;
+                debounce = modifier.value ? Number.parseInt(modifier.value) : true;
             });
             validModifiers.set('files', (modifier) => {
                 if (!modifier.value) {

--- a/src/LiveComponent/assets/dist/morphdom.d.ts
+++ b/src/LiveComponent/assets/dist/morphdom.d.ts
@@ -1,2 +1,2 @@
-import ExternalMutationTracker from './Rendering/ExternalMutationTracker';
+import type ExternalMutationTracker from './Rendering/ExternalMutationTracker';
 export declare function executeMorphdom(rootFromElement: HTMLElement, rootToElement: HTMLElement, modifiedFieldElements: Array<HTMLElement>, getElementValue: (element: HTMLElement) => any, externalMutationTracker: ExternalMutationTracker): void;

--- a/src/LiveComponent/assets/src/Backend/RequestBuilder.ts
+++ b/src/LiveComponent/assets/src/Backend/RequestBuilder.ts
@@ -1,4 +1,4 @@
-import { BackendAction, ChildrenFingerprints } from './Backend';
+import type { BackendAction, ChildrenFingerprints } from './Backend';
 
 export default class {
     private url: string;

--- a/src/LiveComponent/assets/src/Component/ElementDriver.ts
+++ b/src/LiveComponent/assets/src/Component/ElementDriver.ts
@@ -1,5 +1,5 @@
 import {getModelDirectiveFromElement} from '../dom_utils';
-import LiveControllerDefault from '../live_controller';
+import type LiveControllerDefault from '../live_controller';
 
 export interface ElementDriver {
     getModelName(element: HTMLElement): string|null;

--- a/src/LiveComponent/assets/src/Component/UnsyncedInputsTracker.ts
+++ b/src/LiveComponent/assets/src/Component/UnsyncedInputsTracker.ts
@@ -1,6 +1,6 @@
-import {ElementDriver} from './ElementDriver';
+import type {ElementDriver} from './ElementDriver';
 import {elementBelongsToThisComponent} from '../dom_utils';
-import Component from './index';
+import type Component from './index';
 
 export default class {
     private readonly component: Component;

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -1,13 +1,13 @@
-import { BackendAction, BackendInterface } from '../Backend/Backend';
+import type { BackendAction, BackendInterface } from '../Backend/Backend';
 import ValueStore from './ValueStore';
 import { normalizeModelName } from '../string_utils';
-import BackendRequest from '../Backend/BackendRequest';
+import type BackendRequest from '../Backend/BackendRequest';
 import { elementBelongsToThisComponent, getValueFromElement, htmlToElement } from '../dom_utils';
 import { executeMorphdom } from '../morphdom';
 import UnsyncedInputsTracker from './UnsyncedInputsTracker';
-import { ElementDriver } from './ElementDriver';
+import type { ElementDriver } from './ElementDriver';
 import HookManager from '../HookManager';
-import { PluginInterface } from './plugins/PluginInterface';
+import type { PluginInterface } from './plugins/PluginInterface';
 import BackendResponse from '../Backend/BackendResponse';
 import ExternalMutationTracker from '../Rendering/ExternalMutationTracker';
 import { findComponents, registerComponent, unregisterComponent } from '../ComponentRegistry';
@@ -17,8 +17,8 @@ declare const Turbo: any;
 type MaybePromise<T = void> = T | Promise<T>;
 
 export type ComponentHooks = {
-    'connect': (component: Component) => MaybePromise,
-    'disconnect': (component: Component) => MaybePromise,
+    connect: (component: Component) => MaybePromise,
+    disconnect: (component: Component) => MaybePromise,
     'request:started': (requestConfig: any) => MaybePromise,
     'render:finished': (component: Component) => MaybePromise,
     'response:error': (backendResponse: BackendResponse, controls: { displayError: boolean }) => MaybePromise,
@@ -199,15 +199,15 @@ export default class Component {
     }
 
     emit(name: string, data: any, onlyMatchingComponentsNamed: string|null = null): void {
-        return this.performEmit(name, data, false, onlyMatchingComponentsNamed);
+        this.performEmit(name, data, false, onlyMatchingComponentsNamed);
     }
 
     emitUp(name: string, data: any, onlyMatchingComponentsNamed: string|null = null): void {
-        return this.performEmit(name, data, true, onlyMatchingComponentsNamed);
+        this.performEmit(name, data, true, onlyMatchingComponentsNamed);
     }
 
     emitSelf(name: string, data: any): void {
-        return this.doEmit(name, data);
+        this.doEmit(name, data);
     }
 
     private performEmit(name: string, data: any, emitUp: boolean, matchingName: string|null): void {

--- a/src/LiveComponent/assets/src/Component/plugins/ChildComponentPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/ChildComponentPlugin.ts
@@ -1,7 +1,7 @@
-import Component from '../../Component';
-import { PluginInterface } from './PluginInterface';
-import { ChildrenFingerprints } from '../../Backend/Backend';
-import getModelBinding, { ModelBinding } from '../../Directive/get_model_binding';
+import type Component from '../../Component';
+import type { PluginInterface } from './PluginInterface';
+import type { ChildrenFingerprints } from '../../Backend/Backend';
+import getModelBinding, { type ModelBinding } from '../../Directive/get_model_binding';
 import { getAllModelDirectiveFromElements } from '../../dom_utils';
 import { findChildren, findParent } from '../../ComponentRegistry';
 

--- a/src/LiveComponent/assets/src/Component/plugins/LazyPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/LazyPlugin.ts
@@ -1,5 +1,5 @@
-import {PluginInterface} from './PluginInterface';
-import Component from '../index';
+import type {PluginInterface} from './PluginInterface';
+import type Component from '../index';
 
 export default class implements PluginInterface {
     private intersectionObserver:  IntersectionObserver | null = null;

--- a/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
@@ -1,13 +1,13 @@
 import {
-    Directive,
-    DirectiveModifier,
+    type Directive,
+    type DirectiveModifier,
     parseDirectives
 } from '../../Directive/directives_parser';
 import { elementBelongsToThisComponent } from '../../dom_utils';
 import { combineSpacedArray } from '../../string_utils';
-import BackendRequest from '../../Backend/BackendRequest';
-import Component from '../../Component';
-import { PluginInterface } from './PluginInterface';
+import type BackendRequest from '../../Backend/BackendRequest';
+import type Component from '../../Component';
+import type { PluginInterface } from './PluginInterface';
 
 interface ElementLoadingDirectives {
     element: HTMLElement|SVGElement,
@@ -68,7 +68,7 @@ export default class implements PluginInterface {
             if (!isLoading) {
                 return;
             }
-            delay = modifier.value ? parseInt(modifier.value) : 200;
+            delay = modifier.value ? Number.parseInt(modifier.value) : 200;
         });
         validModifiers.set('action', (modifier: DirectiveModifier) => {
             if (!modifier.value) {
@@ -211,7 +211,7 @@ export default class implements PluginInterface {
     }
 }
 
-const parseLoadingAction = function (action: string, isLoading: boolean) {
+const parseLoadingAction = (action: string, isLoading: boolean) => {
     switch (action) {
         case 'show':
             return isLoading ? 'show' : 'hide';

--- a/src/LiveComponent/assets/src/Component/plugins/PageUnloadingPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/PageUnloadingPlugin.ts
@@ -1,5 +1,5 @@
-import Component from '../index';
-import { PluginInterface } from './PluginInterface';
+import type Component from '../index';
+import type { PluginInterface } from './PluginInterface';
 
 export default class implements PluginInterface {
     private isConnected = false;

--- a/src/LiveComponent/assets/src/Component/plugins/PluginInterface.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/PluginInterface.ts
@@ -1,4 +1,4 @@
-import Component from '../index';
+import type Component from '../index';
 
 export interface PluginInterface {
     attachToComponent(component: Component): void;

--- a/src/LiveComponent/assets/src/Component/plugins/PollingPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/PollingPlugin.ts
@@ -1,7 +1,7 @@
-import Component from '../index';
+import type Component from '../index';
 import { parseDirectives } from '../../Directive/directives_parser';
 import PollingDirector from '../../PollingDirector';
-import { PluginInterface } from './PluginInterface';
+import type { PluginInterface } from './PluginInterface';
 
 export default class implements PluginInterface {
     private element: Element;
@@ -49,7 +49,7 @@ export default class implements PluginInterface {
                 switch (modifier.name) {
                     case 'delay':
                         if (modifier.value) {
-                            duration = parseInt(modifier.value);
+                            duration = Number.parseInt(modifier.value);
                         }
 
                          break;

--- a/src/LiveComponent/assets/src/Component/plugins/QueryStringPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/QueryStringPlugin.ts
@@ -1,5 +1,5 @@
-import Component from '../index';
-import { PluginInterface } from './PluginInterface';
+import type Component from '../index';
+import type { PluginInterface } from './PluginInterface';
 import { UrlUtils, HistoryStrategy } from '../../url_utils';
 
 interface QueryMapping {

--- a/src/LiveComponent/assets/src/Component/plugins/SetValueOntoModelFieldsPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/SetValueOntoModelFieldsPlugin.ts
@@ -1,11 +1,11 @@
-import Component from '../index';
+import type Component from '../index';
 import {
     elementBelongsToThisComponent,
     getModelDirectiveFromElement,
     getValueFromElement,
     setValueOnElement
 } from '../../dom_utils';
-import { PluginInterface } from './PluginInterface';
+import type { PluginInterface } from './PluginInterface';
 
 /**
  * Handles setting the "value" onto data-model fields automatically from the data store.

--- a/src/LiveComponent/assets/src/Component/plugins/ValidatedFieldsPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/ValidatedFieldsPlugin.ts
@@ -1,6 +1,6 @@
-import Component from '../index';
-import ValueStore from '../ValueStore';
-import { PluginInterface } from './PluginInterface';
+import type Component from '../index';
+import type ValueStore from '../ValueStore';
+import type { PluginInterface } from './PluginInterface';
 
 export default class implements PluginInterface {
     attachToComponent(component: Component): void {

--- a/src/LiveComponent/assets/src/ComponentRegistry.ts
+++ b/src/LiveComponent/assets/src/ComponentRegistry.ts
@@ -1,4 +1,4 @@
-import Component from './Component';
+import type Component from './Component';
 import getElementAsTagText from './Util/getElementAsTagText';
 
 let componentMapByElement = new WeakMap<HTMLElement, Component>();
@@ -7,23 +7,23 @@ let componentMapByElement = new WeakMap<HTMLElement, Component>();
  */
 let componentMapByComponent = new Map<Component, string>();
 
-export const resetRegistry = function () {
+export const resetRegistry = () => {
     componentMapByElement = new WeakMap<HTMLElement, Component>();
     componentMapByComponent = new Map<Component, string>();
 };
 
-export const registerComponent = function (component: Component) {
+export const registerComponent = (component: Component) => {
     componentMapByElement.set(component.element, component);
     componentMapByComponent.set(component, component.name);
 };
 
-export const unregisterComponent = function (component: Component) {
+export const unregisterComponent = (component: Component) => {
     componentMapByElement.delete(component.element);
     componentMapByComponent.delete(component);
 };
 
-export const getComponent = function (element: HTMLElement): Promise<Component> {
-    return new Promise((resolve, reject) => {
+export const getComponent = (element: HTMLElement): Promise<Component> =>
+    new Promise((resolve, reject) => {
         let count = 0;
         const maxCount = 10;
         const interval = setInterval(() => {
@@ -40,16 +40,15 @@ export const getComponent = function (element: HTMLElement): Promise<Component> 
             }
         }, 5);
     });
-};
 
 /**
  * Returns a filtered list of all the currently-registered components
  */
-export const findComponents = function (
+export const findComponents = (
     currentComponent: Component,
     onlyParents: boolean,
     onlyMatchName: string | null
-): Component[] {
+): Component[] => {
     const components: Component[] = [];
     componentMapByComponent.forEach((componentName: string, component: Component) => {
         if (onlyParents && (currentComponent === component || !component.element.contains(currentComponent.element))) {
@@ -69,7 +68,7 @@ export const findComponents = function (
 /**
  * Returns an array of components that are direct children of the given component.
  */
-export const findChildren = function (currentComponent: Component): Component[] {
+export const findChildren = (currentComponent: Component): Component[] => {
     const children: Component[] = [];
     componentMapByComponent.forEach((componentName: string, component: Component) => {
         if (currentComponent === component) {
@@ -103,7 +102,7 @@ export const findChildren = function (currentComponent: Component): Component[] 
     return children;
 };
 
-export const findParent = function (currentComponent: Component): Component | null {
+export const findParent = (currentComponent: Component): Component | null => {
     // recursively traverse the node tree up to find a parent
     let parentElement = currentComponent.element.parentElement;
     while (parentElement) {

--- a/src/LiveComponent/assets/src/Directive/directives_parser.ts
+++ b/src/LiveComponent/assets/src/Directive/directives_parser.ts
@@ -29,7 +29,7 @@ export interface Directive {
      * Any modifiers applied to the action
      */
     modifiers: DirectiveModifier[];
-    getString: { (): string };
+    getString: () => string;
 }
 
 /**
@@ -56,7 +56,7 @@ export function parseDirectives(content: string|null): Directive[] {
     let currentModifiers: { name: string, value: string | null }[] = [];
     let state = 'action';
 
-    const getLastActionName = function() {
+    const getLastActionName = () => {
         if (currentActionName) {
             return currentActionName;
         }
@@ -67,7 +67,7 @@ export function parseDirectives(content: string|null): Directive[] {
 
         return directives[directives.length - 1].action;
     }
-    const pushInstruction = function() {
+    const pushInstruction = () => {
         directives.push({
             action: currentActionName,
             args: currentArguments,
@@ -84,14 +84,14 @@ export function parseDirectives(content: string|null): Directive[] {
         currentModifiers = [];
         state = 'action';
     }
-    const pushArgument = function() {
+    const pushArgument = () => {
         // value is trimmed to avoid space after ","
         // "foo, bar"
         currentArguments.push(currentArgumentValue.trim());
         currentArgumentValue = '';
     }
 
-    const pushModifier = function() {
+    const pushModifier = () => {
         if (currentArguments.length > 1) {
             throw new Error(`The modifier "${currentActionName}()" does not support multiple arguments.`)
         }

--- a/src/LiveComponent/assets/src/Directive/get_model_binding.ts
+++ b/src/LiveComponent/assets/src/Directive/get_model_binding.ts
@@ -1,4 +1,4 @@
-import {Directive} from './directives_parser';
+import type {Directive} from './directives_parser';
 
 export interface ModelBinding {
     modelName: string,
@@ -32,7 +32,7 @@ export default function(modelDirective: Directive): ModelBinding {
                 break;
 
             case 'debounce':
-                debounce = modifier.value ? parseInt(modifier.value) : true;
+                debounce = modifier.value ? Number.parseInt(modifier.value) : true;
 
                 break;
             default:

--- a/src/LiveComponent/assets/src/PollingDirector.ts
+++ b/src/LiveComponent/assets/src/PollingDirector.ts
@@ -1,4 +1,4 @@
-import Component from './Component';
+import type Component from './Component';
 
 export default class {
     component: Component;

--- a/src/LiveComponent/assets/src/data_manipulation_utils.ts
+++ b/src/LiveComponent/assets/src/data_manipulation_utils.ts
@@ -9,7 +9,7 @@ export function getDeepData(data: any, propertyPath: string) {
 }
 
 // post.user.username
-const parseDeepData = function (data: any, propertyPath: string) {
+const parseDeepData = (data: any, propertyPath: string) => {
     const finalData = JSON.parse(JSON.stringify(data));
 
     let currentLevelData = finalData;
@@ -69,13 +69,13 @@ export function setDeepData(data: any, propertyPath: string, value: any): any {
             throw new Error(
                 `The model name ${propertyPath} was never initialized. Did you forget to add exposed={"${lastPart}"} to its LiveProp?`
             );
-        } else {
-            throw new Error(
-                `The model name "${propertyPath}" was never initialized. Did you forget to expose "${lastPart}" as a LiveProp? Available models values are: ${
-                    Object.keys(data).length > 0 ? Object.keys(data).join(', ') : '(none)'
-                }`
-            );
         }
+
+        throw new Error(
+            `The model name "${propertyPath}" was never initialized. Did you forget to expose "${lastPart}" as a LiveProp? Available models values are: ${
+                Object.keys(data).length > 0 ? Object.keys(data).join(', ') : '(none)'
+            }`
+        );
     }
 
     currentLevelData[finalKey] = value;

--- a/src/LiveComponent/assets/src/dom_utils.ts
+++ b/src/LiveComponent/assets/src/dom_utils.ts
@@ -1,7 +1,7 @@
-import ValueStore from './Component/ValueStore';
-import { Directive, parseDirectives } from './Directive/directives_parser';
+import type ValueStore from './Component/ValueStore';
+import { type Directive, parseDirectives } from './Directive/directives_parser';
 import { normalizeModelName } from './string_utils';
-import Component from './Component';
+import type Component from './Component';
 import { findChildren } from './ComponentRegistry';
 import getElementAsTagText from './Util/getElementAsTagText';
 
@@ -22,7 +22,8 @@ export function getValueFromElement(element: HTMLElement, valueStore: ValueStore
                 const modelValue = valueStore.get(modelNameData.action);
                 if (Array.isArray(modelValue)) {
                     return getMultipleCheckboxValue(element, modelValue);
-                } else if (Object(modelValue) === modelValue) {
+                }
+                if (Object(modelValue) === modelValue) {
                     // we might get objects of values from forms, like {'1': 'foo', '2': 'bar'}
                     // this occurs in symfony forms with expanded ChoiceType when first checked options get unchecked
                     return getMultipleCheckboxValue(element, Object.values(modelValue));
@@ -78,7 +79,7 @@ export function setValueOnElement(element: HTMLElement, value: any): void {
         }
 
         if (element.type === 'radio') {
-            element.checked = element.value == value;
+            element.checked = element.value === value;
 
             return;
         }
@@ -90,7 +91,7 @@ export function setValueOnElement(element: HTMLElement, value: any): void {
                 // want the "includes" to be "fuzzy".
                 let valueFound = false;
                 value.forEach((val) => {
-                    if (val == element.value) {
+                    if (val === element.value) {
                         valueFound = true;
                     }
                 });
@@ -99,7 +100,7 @@ export function setValueOnElement(element: HTMLElement, value: any): void {
             } else {
                 if (element.hasAttribute('value')) {
                     // if the checkbox has a value="", then check if it matches
-                    element.checked = element.value == value;
+                    element.checked = element.value === value;
                 } else {
                     // no value, treat it like a boolean
                     element.checked = value;
@@ -112,7 +113,7 @@ export function setValueOnElement(element: HTMLElement, value: any): void {
 
     if (element instanceof HTMLSelectElement) {
         const arrayWrappedValue = [].concat(value).map((value) => {
-            return value + '';
+            return `${value}`;
         });
 
         Array.from(element.options).forEach((option) => {
@@ -256,7 +257,7 @@ export function htmlToElement(html: string): HTMLElement {
     return child;
 }
 
-const getMultipleCheckboxValue = function (element: HTMLInputElement, currentValues: Array<string>): Array<string> {
+const getMultipleCheckboxValue = (element: HTMLInputElement, currentValues: Array<string>): Array<string> => {
     const finalValues = [...currentValues];
     const value = inputValue(element);
     const index = currentValues.indexOf(value);
@@ -278,6 +279,5 @@ const getMultipleCheckboxValue = function (element: HTMLInputElement, currentVal
     return finalValues;
 };
 
-const inputValue = function (element: HTMLInputElement): string {
-    return element.dataset.value ? element.dataset.value : element.value;
-};
+const inputValue = (element: HTMLInputElement): string =>
+    element.dataset.value ? element.dataset.value : element.value;

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -1,15 +1,15 @@
 import { Controller } from '@hotwired/stimulus';
-import { parseDirectives, DirectiveModifier } from './Directive/directives_parser';
+import { parseDirectives, type DirectiveModifier } from './Directive/directives_parser';
 import { getModelDirectiveFromElement, getValueFromElement, elementBelongsToThisComponent } from './dom_utils';
 import Component, { proxifyComponent } from './Component';
-import Backend, { BackendInterface } from './Backend/Backend';
+import Backend, { type BackendInterface } from './Backend/Backend';
 import { StimulusElementDriver } from './Component/ElementDriver';
 import LoadingPlugin from './Component/plugins/LoadingPlugin';
 import ValidatedFieldsPlugin from './Component/plugins/ValidatedFieldsPlugin';
 import PageUnloadingPlugin from './Component/plugins/PageUnloadingPlugin';
 import PollingPlugin from './Component/plugins/PollingPlugin';
 import SetValueOntoModelFieldsPlugin from './Component/plugins/SetValueOntoModelFieldsPlugin';
-import { PluginInterface } from './Component/plugins/PluginInterface';
+import type { PluginInterface } from './Component/plugins/PluginInterface';
 import getModelBinding from './Directive/get_model_binding';
 import QueryStringPlugin from './Component/plugins/QueryStringPlugin';
 import ChildComponentPlugin from './Component/plugins/ChildComponentPlugin';
@@ -148,7 +148,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
                 }
             });
             validModifiers.set('debounce', (modifier: DirectiveModifier) => {
-                debounce = modifier.value ? parseInt(modifier.value) : true;
+                debounce = modifier.value ? Number.parseInt(modifier.value) : true;
             });
             validModifiers.set('files', (modifier: DirectiveModifier) => {
                 if (!modifier.value) {

--- a/src/LiveComponent/assets/src/morphdom.ts
+++ b/src/LiveComponent/assets/src/morphdom.ts
@@ -2,9 +2,9 @@ import { cloneHTMLElement, getModelDirectiveFromElement, setValueOnElement } fro
 // @ts-ignore
 import { Idiomorph } from 'idiomorph/dist/idiomorph.esm.js';
 import { normalizeAttributesForComparison } from './normalize_attributes_for_comparison';
-import ExternalMutationTracker from './Rendering/ExternalMutationTracker';
+import type ExternalMutationTracker from './Rendering/ExternalMutationTracker';
 
-const syncAttributes = function (fromEl: Element, toEl: Element): void {
+const syncAttributes = (fromEl: Element, toEl: Element): void => {
     for (let i = 0; i < fromEl.attributes.length; i++) {
         const attr = fromEl.attributes[i];
         toEl.setAttribute(attr.name, attr.value);
@@ -206,7 +206,7 @@ export function executeMorphdom(
                     return true;
                 }
                 // if parent's innerHTML was replaced, skip morphing on child
-                if (fromEl.parentElement && fromEl.parentElement.hasAttribute('data-skip-morph')) {
+                if (fromEl.parentElement?.hasAttribute('data-skip-morph')) {
                     return false;
                 }
 

--- a/src/LiveComponent/assets/src/string_utils.ts
+++ b/src/LiveComponent/assets/src/string_utils.ts
@@ -39,9 +39,7 @@ export function normalizeModelName(model: string): string {
             .replace(/\[]$/, '')
             .split('[')
             // ['object', 'foo', 'bar', 'ya']
-            .map(function (s) {
-                return s.replace(']', '');
-            })
+            .map((s) => s.replace(']', ''))
             .join('.')
     );
 }

--- a/src/LiveComponent/assets/src/url_utils.ts
+++ b/src/LiveComponent/assets/src/url_utils.ts
@@ -85,7 +85,10 @@ function fromQueryString(search: string) {
         const [first, second, ...rest] = key.split('.');
 
         // We're at a leaf node, let's make the assigment...
-        if (!second) return (data[key] = value);
+        if (!second) {
+            data[key] = value;
+            return value;
+        }
 
         // This is where we fill in empty arrays/objects along the way to the assigment...
         if (data[first] === undefined) {

--- a/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
+++ b/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
@@ -182,8 +182,10 @@ describe('buildRequest', () => {
     const getFileList = (length = 1) => {
         const blob = new Blob([''], { type: 'text/html' });
         // @ts-ignore This is a mock and those are needed to mock a File object
+        // biome-ignore lint/complexity/useLiteralKeys: This is a mock and those are needed to mock a File object
         blob['lastModifiedDate'] = '';
         // @ts-ignore This is a mock and those are needed to mock a File object
+        // biome-ignore lint/complexity/useLiteralKeys: This is a mock and those are needed to mock a File object
         blob['name'] = 'filename';
         const file = <File>blob;
         const fileList: FileList = {
@@ -205,7 +207,7 @@ describe('buildRequest', () => {
             {},
             {},
             {},
-            { 'file': getFileList()}
+            { file: getFileList()}
         );
 
         expect(url).toEqual('/_components');
@@ -230,7 +232,7 @@ describe('buildRequest', () => {
             {},
             {},
             {},
-            { 'file[]': getFileList(3), 'otherFile': getFileList()}
+            { 'file[]': getFileList(3), otherFile: getFileList()}
         );
 
         expect(url).toEqual('/_components');

--- a/src/LiveComponent/assets/test/Component/index.test.ts
+++ b/src/LiveComponent/assets/test/Component/index.test.ts
@@ -1,9 +1,9 @@
 import Component, { proxifyComponent } from '../../src/Component';
-import {BackendAction, BackendInterface} from '../../src/Backend/Backend';
+import type {BackendAction, BackendInterface} from '../../src/Backend/Backend';
 import BackendRequest from '../../src/Backend/BackendRequest';
 import { Response } from 'node-fetch';
 import { waitFor } from '@testing-library/dom';
-import BackendResponse from '../../src/Backend/BackendResponse';
+import type BackendResponse from '../../src/Backend/BackendResponse';
 import { noopElementDriver } from '../tools';
 
 interface MockBackend extends BackendInterface {
@@ -51,7 +51,7 @@ describe('Component class', () => {
             // set model but no re-render
             const promise = component.set('firstName', 'Ryan', false);
             // when this promise IS finally resolved, set the flag to true
-            promise.then((response) => backendResponse = response);
+            promise.then((response) => { backendResponse = response });
             // it should not have happened yet
             expect(backendResponse).toBeNull();
 

--- a/src/LiveComponent/assets/test/ComponentRegistry.test.ts
+++ b/src/LiveComponent/assets/test/ComponentRegistry.test.ts
@@ -6,7 +6,7 @@ import {
     findComponents,
 } from '../src/ComponentRegistry';
 import BackendRequest from '../src/Backend/BackendRequest';
-import { BackendInterface } from '../src/Backend/Backend';
+import type { BackendInterface } from '../src/Backend/Backend';
 import { Response } from 'node-fetch';
 import { noopElementDriver } from './tools';
 

--- a/src/LiveComponent/assets/test/Directive/directives_parser.test.ts
+++ b/src/LiveComponent/assets/test/Directive/directives_parser.test.ts
@@ -1,6 +1,6 @@
-import {Directive, parseDirectives} from '../../src/Directive/directives_parser';
+import {type Directive, parseDirectives} from '../../src/Directive/directives_parser';
 
-const assertDirectiveEquals = function(actual: Directive, expected: any) {
+const assertDirectiveEquals = (actual: Directive, expected: any) => {
     // normalize this so that it doesn't trip up the comparison
     const getString = () => 'foo';
     actual.getString = getString;

--- a/src/LiveComponent/assets/test/controller/action.test.ts
+++ b/src/LiveComponent/assets/test/controller/action.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { createTest, initComponent, shutdownTests } from '../tools';
 import { getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';

--- a/src/LiveComponent/assets/test/controller/basic.test.ts
+++ b/src/LiveComponent/assets/test/controller/basic.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {createTest, initComponent, shutdownTests, startStimulus} from '../tools';
 import { htmlToElement } from '../../src/dom_utils';
 import Component from '../../src/Component';

--- a/src/LiveComponent/assets/test/controller/child-model.test.ts
+++ b/src/LiveComponent/assets/test/controller/child-model.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { createTest, initComponent, shutdownTests } from '../tools';
 import {getByTestId, waitFor} from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';

--- a/src/LiveComponent/assets/test/controller/child.test.ts
+++ b/src/LiveComponent/assets/test/controller/child.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {
     createTestForExistingComponent,
     createTest,

--- a/src/LiveComponent/assets/test/controller/dispatch-event.test.ts
+++ b/src/LiveComponent/assets/test/controller/dispatch-event.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {createTest, initComponent, shutdownTests} from '../tools';
 
 describe('LiveController Event Dispatching Tests', () => {

--- a/src/LiveComponent/assets/test/controller/emit.test.ts
+++ b/src/LiveComponent/assets/test/controller/emit.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {createTest, initComponent, shutdownTests} from '../tools';
 import { getByText, waitFor } from '@testing-library/dom';
 

--- a/src/LiveComponent/assets/test/controller/error.test.ts
+++ b/src/LiveComponent/assets/test/controller/error.test.ts
@@ -7,11 +7,9 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { createTest, initComponent, shutdownTests } from '../tools';
 import { getByText, waitFor } from '@testing-library/dom';
-import BackendResponse from '../../src/Backend/BackendResponse';
+import type BackendResponse from '../../src/Backend/BackendResponse';
 
 const getErrorElement = (): Element|null => {
     return document.getElementById('live-component-error');

--- a/src/LiveComponent/assets/test/controller/loading.test.ts
+++ b/src/LiveComponent/assets/test/controller/loading.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {createTest, initComponent, shutdownTests} from '../tools';
 import {getByTestId, getByText, waitFor} from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';

--- a/src/LiveComponent/assets/test/controller/model.test.ts
+++ b/src/LiveComponent/assets/test/controller/model.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { createTest, initComponent, shutdownTests } from '../tools';
 import { getByLabelText, getByTestId, getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
@@ -375,7 +373,7 @@ describe('LiveController data-model Tests', () => {
 
         // only 1 Ajax call will be made thanks to debouncing
         test.expectsAjaxCall()
-            .expectUpdatedData({ 'check': ['foo', 'bar'] });
+            .expectUpdatedData({ check: ['foo', 'bar'] });
 
         await userEvent.click(check1Element);
         await userEvent.click(check2Element);
@@ -437,7 +435,7 @@ describe('LiveController data-model Tests', () => {
 
         // only 1 Ajax call will be made thanks to debouncing
         test.expectsAjaxCall()
-            .expectUpdatedData({ 'check': ['bar'] });
+            .expectUpdatedData({ check: ['bar'] });
 
         await userEvent.click(check1Element);
         await userEvent.click(check2Element);
@@ -776,7 +774,7 @@ describe('LiveController data-model Tests', () => {
             throw new Error('wrong type');
         }
         // mimic changing the field, but without (yet) triggering the change event
-        commentField.value = commentField.value + ' ftw!';
+        commentField.value = `${commentField.value} ftw!`;
         commentField.dispatchEvent(new Event('input', { bubbles: true }));
 
         // also type into the unmapped field - but no worry about the model sync'ing this time

--- a/src/LiveComponent/assets/test/controller/poll.test.ts
+++ b/src/LiveComponent/assets/test/controller/poll.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { shutdownTests, createTest, initComponent } from '../tools';
 import { waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';

--- a/src/LiveComponent/assets/test/controller/query-binding.test.ts
+++ b/src/LiveComponent/assets/test/controller/query-binding.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {createTest, initComponent, shutdownTests, setCurrentSearch, expectCurrentSearch} from '../tools';
 import { getByText, waitFor } from '@testing-library/dom';
 
@@ -107,7 +105,7 @@ describe('LiveController query string binding', () => {
     });
 
     it('updates objects in the URL', async () => {
-        const test = await createTest({ prop: { 'foo': null, 'bar': null, 'baz': null}}, (data: any) => `
+        const test = await createTest({ prop: { foo: null, bar: null, baz: null}}, (data: any) => `
             <div ${initComponent(data, { queryMapping: {prop: {name: 'prop'}}})}></div>
         `)
 
@@ -121,25 +119,25 @@ describe('LiveController query string binding', () => {
 
         // Set multiple values
         test.expectsAjaxCall()
-            .expectUpdatedData({'prop': { 'foo': 'other', 'bar': 42 } });
+            .expectUpdatedData({prop: { foo: 'other', bar: 42 } });
 
-        await test.component.set('prop', { 'foo': 'other', 'bar': 42 }, true);
+        await test.component.set('prop', { foo: 'other', bar: 42 }, true);
 
         expectCurrentSearch().toEqual('?prop[foo]=other&prop[bar]=42');
 
         // Remove one value
         test.expectsAjaxCall()
-            .expectUpdatedData({'prop': { 'foo': 'other', 'bar': null } });
+            .expectUpdatedData({prop: { foo: 'other', bar: null } });
 
-        await test.component.set('prop', { 'foo': 'other', 'bar': null }, true);
+        await test.component.set('prop', { foo: 'other', bar: null }, true);
 
         expectCurrentSearch().toEqual('?prop[foo]=other');
 
         // Remove all values
         test.expectsAjaxCall()
-            .expectUpdatedData({'prop': { 'foo': null, 'bar': null } });
+            .expectUpdatedData({prop: { foo: null, bar: null } });
 
-        await test.component.set('prop', { 'foo': null, 'bar': null }, true);
+        await test.component.set('prop', { foo: null, bar: null }, true);
 
         expectCurrentSearch().toEqual('?prop=');
     });

--- a/src/LiveComponent/assets/test/controller/render-with-external-changes.test.ts
+++ b/src/LiveComponent/assets/test/controller/render-with-external-changes.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { shutdownTests, createTest, initComponent } from '../tools';
 import { getByTestId } from '@testing-library/dom';
 import { htmlToElement } from '../../src/dom_utils';

--- a/src/LiveComponent/assets/test/controller/render.test.ts
+++ b/src/LiveComponent/assets/test/controller/render.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { shutdownTests, createTest, initComponent } from '../tools';
 import { getByTestId, getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';

--- a/src/LiveComponent/assets/test/dom_utils.test.ts
+++ b/src/LiveComponent/assets/test/dom_utils.test.ts
@@ -11,9 +11,7 @@ import Component from '../src/Component';
 import Backend from '../src/Backend/Backend';
 import { noopElementDriver } from './tools';
 
-const createStore = function(props: any = {}): ValueStore {
-    return new ValueStore(props);
-}
+const createStore = (props: any = {}): ValueStore => new ValueStore(props)
 
 describe('getValueFromElement', () => {
     it('Correctly adds data from valued checked checkbox', () => {

--- a/src/LiveComponent/assets/test/tools.ts
+++ b/src/LiveComponent/assets/test/tools.ts
@@ -3,12 +3,12 @@ import LiveController from '../src/live_controller';
 import { waitFor } from '@testing-library/dom';
 import { htmlToElement } from '../src/dom_utils';
 import Component from '../src/Component';
-import { BackendAction, BackendInterface, ChildrenFingerprints } from '../src/Backend/Backend';
+import type { BackendAction, BackendInterface, ChildrenFingerprints } from '../src/Backend/Backend';
 import BackendRequest from '../src/Backend/BackendRequest';
 import { Response } from 'node-fetch';
 import { setDeepData } from '../src/data_manipulation_utils';
 import LiveControllerDefault from '../src/live_controller';
-import { ElementDriver } from '../src/Component/ElementDriver';
+import type { ElementDriver } from '../src/Component/ElementDriver';
 
 let activeTests: FunctionalTest[] = [];
 
@@ -31,7 +31,7 @@ export function shutdownTests() {
     });
 }
 
-const shutdownTest = function(test: FunctionalTest) {
+const shutdownTest = (test: FunctionalTest) => {
     test.pendingAjaxCallsThatAreStillExpected().forEach((mock => {
         const requestInfo = mock.getVisualSummary();
         throw new Error(`EXPECTED request was never made matching the following info: \n${requestInfo.join('\n')}`);

--- a/src/LiveComponent/assets/test/url_utils.test.ts
+++ b/src/LiveComponent/assets/test/url_utils.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { HistoryStrategy, UrlUtils } from '../src/url_utils';
 
 describe('url_utils', () => {
@@ -128,7 +126,7 @@ describe('url_utils', () => {
             history.replaceState(history.state, '', initialUrl);
         });
         it('replace URL', () => {
-           const newUrl = new URL(window.location.href + '/foo/bar');
+           const newUrl = new URL(`${window.location.href}/foo/bar`);
            HistoryStrategy.replace(newUrl);
            expect(window.location.href).toEqual(newUrl.toString());
         });

--- a/src/Notify/assets/src/controller.ts
+++ b/src/Notify/assets/src/controller.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
 
 /**

--- a/src/Notify/assets/test/controller.test.ts
+++ b/src/Notify/assets/test/controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
@@ -37,7 +35,7 @@ const startStimulus = (): Application => {
 };
 
 describe('NotifyController', () => {
-    let application;
+    let application: Application;
 
     afterEach(() => {
         clearDOM();

--- a/src/React/assets/dist/components.d.ts
+++ b/src/React/assets/dist/components.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, FunctionComponent } from 'react';
+import type { ComponentClass, FunctionComponent } from 'react';
 type Component = string | FunctionComponent<object> | ComponentClass<object, any>;
 export interface ComponentCollection {
     [key: string]: Component;

--- a/src/React/assets/dist/loader.d.ts
+++ b/src/React/assets/dist/loader.d.ts
@@ -1,5 +1,5 @@
-import { ComponentCollection } from './components.js';
-import { ComponentClass, FunctionComponent } from 'react';
+import { type ComponentCollection } from './components.js';
+import type { ComponentClass, FunctionComponent } from 'react';
 type Component = string | FunctionComponent<object> | ComponentClass<object, any>;
 declare global {
     function resolveReactComponent(name: string): Component;

--- a/src/React/assets/dist/register_controller.d.ts
+++ b/src/React/assets/dist/register_controller.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="webpack-env" />
-import { ComponentClass, FunctionComponent } from 'react';
+import type { ComponentClass, FunctionComponent } from 'react';
 type Component = string | FunctionComponent<object> | ComponentClass<object, any>;
 declare global {
     function resolveReactComponent(name: string): Component;

--- a/src/React/assets/dist/register_controller.js
+++ b/src/React/assets/dist/register_controller.js
@@ -1,7 +1,9 @@
 function registerReactControllerComponents(context) {
     const reactControllers = {};
     const importAllReactComponents = (r) => {
-        r.keys().forEach((key) => (reactControllers[key] = r(key).default));
+        r.keys().forEach((key) => {
+            reactControllers[key] = r(key).default;
+        });
     };
     importAllReactComponents(context);
     window.resolveReactComponent = (name) => {

--- a/src/React/assets/dist/render_controller.d.ts
+++ b/src/React/assets/dist/render_controller.d.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { type ReactElement } from 'react';
 import { Controller } from '@hotwired/stimulus';
 export default class extends Controller {
     readonly componentValue?: string;

--- a/src/React/assets/src/components.ts
+++ b/src/React/assets/src/components.ts
@@ -8,7 +8,7 @@
  */
 
 // This file is dynamically rewritten by ux-react + AssetMapper.
-import { ComponentClass, FunctionComponent } from 'react';
+import type { ComponentClass, FunctionComponent } from 'react';
 
 type Component = string | FunctionComponent<object> | ComponentClass<object, any>;
 

--- a/src/React/assets/src/loader.ts
+++ b/src/React/assets/src/loader.ts
@@ -7,10 +7,8 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
-import { ComponentCollection, components } from './components.js';
-import { ComponentClass, FunctionComponent } from 'react';
+import { type ComponentCollection, components } from './components.js';
+import type { ComponentClass, FunctionComponent } from 'react';
 
 type Component = string | FunctionComponent<object> | ComponentClass<object, any>;
 

--- a/src/React/assets/src/register_controller.ts
+++ b/src/React/assets/src/register_controller.ts
@@ -7,9 +7,7 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
-import { ComponentClass, FunctionComponent } from 'react';
+import type { ComponentClass, FunctionComponent } from 'react';
 
 type Component = string | FunctionComponent<object> | ComponentClass<object, any>;
 
@@ -25,7 +23,9 @@ export function registerReactControllerComponents(context: __WebpackModuleApi.Re
     const reactControllers: { [key: string]: Component } = {};
 
     const importAllReactComponents = (r: __WebpackModuleApi.RequireContext) => {
-        r.keys().forEach((key) => (reactControllers[key] = r(key).default));
+        r.keys().forEach((key) => {
+            reactControllers[key] = r(key).default;
+        });
     };
 
     importAllReactComponents(context);

--- a/src/React/assets/src/render_controller.ts
+++ b/src/React/assets/src/render_controller.ts
@@ -7,9 +7,7 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
-import React, { ReactElement } from 'react';
+import React, { type ReactElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Controller } from '@hotwired/stimulus';
 

--- a/src/React/assets/test/register_controller.test.tsx
+++ b/src/React/assets/test/register_controller.test.tsx
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {registerReactControllerComponents} from '../src/register_controller';
 import MyTsxComponent from './fixtures/MyTsxComponent';
 // @ts-ignore

--- a/src/React/assets/test/render_controller.test.tsx
+++ b/src/React/assets/test/render_controller.test.tsx
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import React from 'react';
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';

--- a/src/StimulusBundle/assets/dist/controllers.d.ts
+++ b/src/StimulusBundle/assets/dist/controllers.d.ts
@@ -1,4 +1,4 @@
-import { ControllerConstructor } from '@hotwired/stimulus';
+import type { ControllerConstructor } from '@hotwired/stimulus';
 export interface EagerControllersCollection {
     [key: string]: ControllerConstructor;
 }

--- a/src/StimulusBundle/assets/dist/loader.d.ts
+++ b/src/StimulusBundle/assets/dist/loader.d.ts
@@ -1,4 +1,4 @@
 import { Application } from '@hotwired/stimulus';
-import { EagerControllersCollection, LazyControllersCollection } from './controllers.js';
+import { type EagerControllersCollection, type LazyControllersCollection } from './controllers.js';
 export declare const loadControllers: (application: Application, eagerControllers: EagerControllersCollection, lazyControllers: LazyControllersCollection) => void;
 export declare const startStimulusApp: () => Application;

--- a/src/StimulusBundle/assets/dist/loader.js
+++ b/src/StimulusBundle/assets/dist/loader.js
@@ -59,9 +59,7 @@ class StimulusLazyControllerHandler {
         });
     }
     queryControllerNamesWithin(element) {
-        return Array.from(element.querySelectorAll(`[${controllerAttribute}]`))
-            .map(extractControllerNamesFrom)
-            .flat();
+        return Array.from(element.querySelectorAll(`[${controllerAttribute}]`)).flatMap(extractControllerNamesFrom);
     }
 }
 function registerController(name, controller, application) {

--- a/src/StimulusBundle/assets/src/controllers.ts
+++ b/src/StimulusBundle/assets/src/controllers.ts
@@ -8,7 +8,7 @@
  */
 
 // This file is dynamically rewritten by StimulusBundle + AssetMapper.
-import { ControllerConstructor } from '@hotwired/stimulus';
+import type { ControllerConstructor } from '@hotwired/stimulus';
 
 export interface EagerControllersCollection {
     [key: string]: ControllerConstructor;

--- a/src/StimulusBundle/assets/src/loader.ts
+++ b/src/StimulusBundle/assets/src/loader.ts
@@ -12,13 +12,13 @@
  *
  * Inspired by stimulus-loading.js from stimulus-rails.
  */
-import { Application, ControllerConstructor } from '@hotwired/stimulus';
+import { Application, type ControllerConstructor } from '@hotwired/stimulus';
 import {
     eagerControllers,
     lazyControllers,
     isApplicationDebug,
-    EagerControllersCollection,
-    LazyControllersCollection,
+    type EagerControllersCollection,
+    type LazyControllersCollection,
 } from './controllers.js';
 
 const controllerAttribute = 'data-controller';
@@ -109,9 +109,7 @@ class StimulusLazyControllerHandler {
     }
 
     private queryControllerNamesWithin(element: Element): string[] {
-        return Array.from(element.querySelectorAll(`[${controllerAttribute}]`))
-            .map(extractControllerNamesFrom)
-            .flat();
+        return Array.from(element.querySelectorAll(`[${controllerAttribute}]`)).flatMap(extractControllerNamesFrom);
     }
 }
 

--- a/src/StimulusBundle/assets/test/loader.test.ts
+++ b/src/StimulusBundle/assets/test/loader.test.ts
@@ -2,7 +2,7 @@
 // which does not actually exist in the source code
 import { loadControllers } from '../dist/loader';
 import { Application, Controller } from '@hotwired/stimulus';
-import {
+import type {
     EagerControllersCollection,
     LazyControllersCollection,
 } from '../src/controllers';
@@ -37,11 +37,11 @@ describe('loader', () => {
 
         const application = Application.start();
         const eagerControllers: EagerControllersCollection = {
-            'controller1': controller1,
-            'controller2': controller2,
+            controller1,
+            controller2,
         };
         const lazyControllers: LazyControllersCollection = {
-            'controller3': () => Promise.resolve({ default: controller3 }),
+            controller3: () => Promise.resolve({ default: controller3 }),
         };
 
         loadControllers(application, eagerControllers, lazyControllers);

--- a/src/Svelte/assets/dist/loader.d.ts
+++ b/src/Svelte/assets/dist/loader.d.ts
@@ -1,5 +1,5 @@
 import type { SvelteComponent } from 'svelte';
-import { ComponentCollection } from './components.js';
+import { type ComponentCollection } from './components.js';
 declare global {
     function resolveSvelteComponent(name: string): typeof SvelteComponent<any>;
     interface Window {

--- a/src/Svelte/assets/dist/register_controller.js
+++ b/src/Svelte/assets/dist/register_controller.js
@@ -1,7 +1,9 @@
 function registerSvelteControllerComponents(context) {
     const svelteControllers = {};
     const importAllSvelteComponents = (r) => {
-        r.keys().forEach((key) => (svelteControllers[key] = r(key).default));
+        r.keys().forEach((key) => {
+            svelteControllers[key] = r(key).default;
+        });
     };
     importAllSvelteComponents(context);
     window.resolveSvelteComponent = (name) => {

--- a/src/Svelte/assets/dist/render_controller.d.ts
+++ b/src/Svelte/assets/dist/render_controller.d.ts
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
-import { SvelteComponent } from 'svelte';
+import type { SvelteComponent } from 'svelte';
 export default class extends Controller<Element & {
     root?: SvelteComponent;
 }> {

--- a/src/Svelte/assets/src/loader.ts
+++ b/src/Svelte/assets/src/loader.ts
@@ -7,10 +7,8 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import type { SvelteComponent } from 'svelte';
-import { ComponentCollection, components } from './components.js';
+import { type ComponentCollection, components } from './components.js';
 
 declare global {
     function resolveSvelteComponent(name: string): typeof SvelteComponent<any>;

--- a/src/Svelte/assets/src/register_controller.ts
+++ b/src/Svelte/assets/src/register_controller.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import type { SvelteComponent } from 'svelte';
 
 declare global {
@@ -23,7 +21,9 @@ export function registerSvelteControllerComponents(context: __WebpackModuleApi.R
     const svelteControllers: { [key: string]: object } = {};
 
     const importAllSvelteComponents = (r: __WebpackModuleApi.RequireContext) => {
-        r.keys().forEach((key) => (svelteControllers[key] = r(key).default));
+        r.keys().forEach((key) => {
+            svelteControllers[key] = r(key).default;
+        });
     };
 
     importAllSvelteComponents(context);

--- a/src/Svelte/assets/src/render_controller.ts
+++ b/src/Svelte/assets/src/render_controller.ts
@@ -1,7 +1,5 @@
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
-import { SvelteComponent } from 'svelte';
+import type { SvelteComponent } from 'svelte';
 
 export default class extends Controller<Element & { root?: SvelteComponent }> {
     private app: SvelteComponent;

--- a/src/Svelte/assets/test/register_controller.test.ts
+++ b/src/Svelte/assets/test/register_controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {registerSvelteControllerComponents} from '../src/register_controller';
 import MyComponent from './fixtures/MyComponent.svelte';
 import RequireContext = __WebpackModuleApi.RequireContext;

--- a/src/Svelte/assets/test/render_controller.test.ts
+++ b/src/Svelte/assets/test/render_controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';

--- a/src/Swup/assets/src/controller.ts
+++ b/src/Swup/assets/src/controller.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
 import Swup from 'swup';
 import SwupDebugPlugin from '@swup/debug-plugin';

--- a/src/Swup/assets/test/controller.test.ts
+++ b/src/Swup/assets/test/controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';

--- a/src/TogglePassword/assets/dist/controller.js
+++ b/src/TogglePassword/assets/dist/controller.js
@@ -30,15 +30,15 @@ class default_1 extends Controller {
         button.classList.add(...this.buttonClassesValue);
         button.setAttribute('tabindex', '-1');
         button.addEventListener('click', this.toggle.bind(this));
-        button.innerHTML = this.visibleIcon + ' ' + this.visibleLabelValue;
+        button.innerHTML = `${this.visibleIcon} ${this.visibleLabelValue}`;
         return button;
     }
     toggle(event) {
         this.isDisplayed = !this.isDisplayed;
         const toggleButtonElement = event.currentTarget;
         toggleButtonElement.innerHTML = this.isDisplayed
-            ? this.hiddenIcon + ' ' + this.hiddenLabelValue
-            : this.visibleIcon + ' ' + this.visibleLabelValue;
+            ? `${this.hiddenIcon} ${this.hiddenLabelValue}`
+            : `${this.visibleIcon} ${this.visibleLabelValue}`;
         this.element.setAttribute('type', this.isDisplayed ? 'text' : 'password');
         this.dispatchEvent(this.isDisplayed ? 'show' : 'hide', { element: this.element, button: toggleButtonElement });
     }

--- a/src/TogglePassword/assets/src/controller.ts
+++ b/src/TogglePassword/assets/src/controller.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller<HTMLInputElement> {
@@ -57,7 +55,7 @@ export default class extends Controller<HTMLInputElement> {
         button.classList.add(...this.buttonClassesValue);
         button.setAttribute('tabindex', '-1');
         button.addEventListener('click', this.toggle.bind(this));
-        button.innerHTML = this.visibleIcon + ' ' + this.visibleLabelValue;
+        button.innerHTML = `${this.visibleIcon} ${this.visibleLabelValue}`;
 
         return button;
     }
@@ -69,8 +67,8 @@ export default class extends Controller<HTMLInputElement> {
         this.isDisplayed = !this.isDisplayed;
         const toggleButtonElement: HTMLButtonElement = event.currentTarget;
         toggleButtonElement.innerHTML = this.isDisplayed
-            ? this.hiddenIcon + ' ' + this.hiddenLabelValue
-            : this.visibleIcon + ' ' + this.visibleLabelValue;
+            ? `${this.hiddenIcon} ${this.hiddenLabelValue}`
+            : `${this.visibleIcon} ${this.visibleLabelValue}`;
         this.element.setAttribute('type', this.isDisplayed ? 'text' : 'password');
         this.dispatchEvent(this.isDisplayed ? 'show' : 'hide', { element: this.element, button: toggleButtonElement });
     }

--- a/src/TogglePassword/assets/test/controller.test.ts
+++ b/src/TogglePassword/assets/test/controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor, getByText } from '@testing-library/dom';
 import user from '@testing-library/user-event';
@@ -31,7 +29,7 @@ const startStimulus = () => {
 }
 
 describe('TogglePasswordController', () => {
-    let container;
+    let container: HTMLElement;
 
     beforeEach(() => {
         container = mountDOM(`

--- a/src/Translator/assets/dist/formatters/formatter.d.ts
+++ b/src/Translator/assets/dist/formatters/formatter.d.ts
@@ -1,1 +1,1 @@
-export declare function format(id: string, parameters: Record<string, string | number> | undefined, locale: string): string;
+export declare function format(id: string, parameters: Record<string, string | number>, locale: string): string;

--- a/src/Translator/assets/dist/formatters/intl-formatter.d.ts
+++ b/src/Translator/assets/dist/formatters/intl-formatter.d.ts
@@ -1,1 +1,1 @@
-export declare function formatIntl(id: string, parameters: Record<string, string | number> | undefined, locale: string): string;
+export declare function formatIntl(id: string, parameters: Record<string, string | number>, locale: string): string;

--- a/src/Translator/assets/dist/translator_controller.js
+++ b/src/Translator/assets/dist/translator_controller.js
@@ -1,6 +1,6 @@
 import { IntlMessageFormat } from 'intl-messageformat';
 
-function formatIntl(id, parameters = {}, locale) {
+function formatIntl(id, parameters, locale) {
     if (id === '') {
         return '';
     }
@@ -25,7 +25,7 @@ function strtr(string, replacePairs) {
     return string.replace(new RegExp(regex.join('|'), 'g'), (matched) => replacePairs[matched].toString());
 }
 
-function format(id, parameters = {}, locale) {
+function format(id, parameters, locale) {
     if (null === id || '' === id) {
         return '';
     }
@@ -137,7 +137,7 @@ function getPluralizationRule(number, locale) {
         case 'tk':
         case 'ur':
         case 'zu':
-            return (1 == number) ? 0 : 1;
+            return (1 === number) ? 0 : 1;
         case 'am':
         case 'bh':
         case 'fil':
@@ -159,30 +159,30 @@ function getPluralizationRule(number, locale) {
         case 'sh':
         case 'sr':
         case 'uk':
-            return ((1 == number % 10) && (11 != number % 100)) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2);
+            return ((1 === number % 10) && (11 !== number % 100)) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2);
         case 'cs':
         case 'sk':
-            return (1 == number) ? 0 : (((number >= 2) && (number <= 4)) ? 1 : 2);
+            return (1 === number) ? 0 : (((number >= 2) && (number <= 4)) ? 1 : 2);
         case 'ga':
-            return (1 == number) ? 0 : ((2 == number) ? 1 : 2);
+            return (1 === number) ? 0 : ((2 === number) ? 1 : 2);
         case 'lt':
-            return ((1 == number % 10) && (11 != number % 100)) ? 0 : (((number % 10 >= 2) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2);
+            return ((1 === number % 10) && (11 !== number % 100)) ? 0 : (((number % 10 >= 2) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2);
         case 'sl':
-            return (1 == number % 100) ? 0 : ((2 == number % 100) ? 1 : (((3 == number % 100) || (4 == number % 100)) ? 2 : 3));
+            return (1 === number % 100) ? 0 : ((2 === number % 100) ? 1 : (((3 === number % 100) || (4 === number % 100)) ? 2 : 3));
         case 'mk':
-            return (1 == number % 10) ? 0 : 1;
+            return (1 === number % 10) ? 0 : 1;
         case 'mt':
-            return (1 == number) ? 0 : (((0 == number) || ((number % 100 > 1) && (number % 100 < 11))) ? 1 : (((number % 100 > 10) && (number % 100 < 20)) ? 2 : 3));
+            return (1 === number) ? 0 : (((0 === number) || ((number % 100 > 1) && (number % 100 < 11))) ? 1 : (((number % 100 > 10) && (number % 100 < 20)) ? 2 : 3));
         case 'lv':
-            return (0 == number) ? 0 : (((1 == number % 10) && (11 != number % 100)) ? 1 : 2);
+            return (0 === number) ? 0 : (((1 === number % 10) && (11 !== number % 100)) ? 1 : 2);
         case 'pl':
-            return (1 == number) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 12) || (number % 100 > 14))) ? 1 : 2);
+            return (1 === number) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 12) || (number % 100 > 14))) ? 1 : 2);
         case 'cy':
-            return (1 == number) ? 0 : ((2 == number) ? 1 : (((8 == number) || (11 == number)) ? 2 : 3));
+            return (1 === number) ? 0 : ((2 === number) ? 1 : (((8 === number) || (11 === number)) ? 2 : 3));
         case 'ro':
-            return (1 == number) ? 0 : (((0 == number) || ((number % 100 > 0) && (number % 100 < 20))) ? 1 : 2);
+            return (1 === number) ? 0 : (((0 === number) || ((number % 100 > 0) && (number % 100 < 20))) ? 1 : 2);
         case 'ar':
-            return (0 == number) ? 0 : ((1 == number) ? 1 : ((2 == number) ? 2 : (((number % 100 >= 3) && (number % 100 <= 10)) ? 3 : (((number % 100 >= 11) && (number % 100 <= 99)) ? 4 : 5))));
+            return (0 === number) ? 0 : ((1 === number) ? 1 : ((2 === number) ? 2 : (((number % 100 >= 3) && (number % 100 <= 10)) ? 3 : (((number % 100 >= 11) && (number % 100 <= 99)) ? 4 : 5))));
         default:
             return 0;
     }

--- a/src/Translator/assets/src/formatters/formatter.ts
+++ b/src/Translator/assets/src/formatters/formatter.ts
@@ -47,7 +47,7 @@ import {strtr} from '../utils';
  * @param parameters An array of parameters for the message
  * @param locale     The locale
  */
-export function format(id: string, parameters: Record<string, string | number> = {}, locale: string): string {
+export function format(id: string, parameters: Record<string, string | number>, locale: string): string {
     if (null === id || '' === id) {
         return '';
     }
@@ -183,7 +183,7 @@ function getPluralizationRule(number: number, locale: string): number {
         case 'tk':
         case 'ur':
         case 'zu':
-            return (1 == number) ? 0 : 1;
+            return (1 === number) ? 0 : 1;
         case 'am':
         case 'bh':
         case 'fil':
@@ -205,30 +205,30 @@ function getPluralizationRule(number: number, locale: string): number {
         case 'sh':
         case 'sr':
         case 'uk':
-            return ((1 == number % 10) && (11 != number % 100)) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2);
+            return ((1 === number % 10) && (11 !== number % 100)) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2);
         case 'cs':
         case 'sk':
-            return (1 == number) ? 0 : (((number >= 2) && (number <= 4)) ? 1 : 2);
+            return (1 === number) ? 0 : (((number >= 2) && (number <= 4)) ? 1 : 2);
         case 'ga':
-            return (1 == number) ? 0 : ((2 == number) ? 1 : 2);
+            return (1 === number) ? 0 : ((2 === number) ? 1 : 2);
         case 'lt':
-            return ((1 == number % 10) && (11 != number % 100)) ? 0 : (((number % 10 >= 2) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2);
+            return ((1 === number % 10) && (11 !== number % 100)) ? 0 : (((number % 10 >= 2) && ((number % 100 < 10) || (number % 100 >= 20))) ? 1 : 2);
         case 'sl':
-            return (1 == number % 100) ? 0 : ((2 == number % 100) ? 1 : (((3 == number % 100) || (4 == number % 100)) ? 2 : 3));
+            return (1 === number % 100) ? 0 : ((2 === number % 100) ? 1 : (((3 === number % 100) || (4 === number % 100)) ? 2 : 3));
         case 'mk':
-            return (1 == number % 10) ? 0 : 1;
+            return (1 === number % 10) ? 0 : 1;
         case 'mt':
-            return (1 == number) ? 0 : (((0 == number) || ((number % 100 > 1) && (number % 100 < 11))) ? 1 : (((number % 100 > 10) && (number % 100 < 20)) ? 2 : 3));
+            return (1 === number) ? 0 : (((0 === number) || ((number % 100 > 1) && (number % 100 < 11))) ? 1 : (((number % 100 > 10) && (number % 100 < 20)) ? 2 : 3));
         case 'lv':
-            return (0 == number) ? 0 : (((1 == number % 10) && (11 != number % 100)) ? 1 : 2);
+            return (0 === number) ? 0 : (((1 === number % 10) && (11 !== number % 100)) ? 1 : 2);
         case 'pl':
-            return (1 == number) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 12) || (number % 100 > 14))) ? 1 : 2);
+            return (1 === number) ? 0 : (((number % 10 >= 2) && (number % 10 <= 4) && ((number % 100 < 12) || (number % 100 > 14))) ? 1 : 2);
         case 'cy':
-            return (1 == number) ? 0 : ((2 == number) ? 1 : (((8 == number) || (11 == number)) ? 2 : 3));
+            return (1 === number) ? 0 : ((2 === number) ? 1 : (((8 === number) || (11 === number)) ? 2 : 3));
         case 'ro':
-            return (1 == number) ? 0 : (((0 == number) || ((number % 100 > 0) && (number % 100 < 20))) ? 1 : 2);
+            return (1 === number) ? 0 : (((0 === number) || ((number % 100 > 0) && (number % 100 < 20))) ? 1 : 2);
         case 'ar':
-            return (0 == number) ? 0 : ((1 == number) ? 1 : ((2 == number) ? 2 : (((number % 100 >= 3) && (number % 100 <= 10)) ? 3 : (((number % 100 >= 11) && (number % 100 <= 99)) ? 4 : 5))));
+            return (0 === number) ? 0 : ((1 === number) ? 1 : ((2 === number) ? 2 : (((number % 100 >= 3) && (number % 100 <= 10)) ? 3 : (((number % 100 >= 11) && (number % 100 <= 99)) ? 4 : 5))));
         default:
             return 0
     }

--- a/src/Translator/assets/src/formatters/intl-formatter.ts
+++ b/src/Translator/assets/src/formatters/intl-formatter.ts
@@ -7,7 +7,7 @@ import { IntlMessageFormat } from 'intl-messageformat';
  * @param parameters An array of parameters for the message
  * @param locale     The locale
  */
-export function formatIntl(id: string, parameters: Record<string, string | number> = {}, locale: string): string {
+export function formatIntl(id: string, parameters: Record<string, string | number>, locale: string): string {
     if (id === '') {
         return '';
     }

--- a/src/Translator/assets/src/translator.ts
+++ b/src/Translator/assets/src/translator.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 export type DomainType = string;
 export type LocaleType = string;
 
@@ -106,7 +104,7 @@ export function getLocaleFallbacks(): Record<LocaleType, LocaleType> {
 export function trans<
     M extends Message<TranslationsType, LocaleType>,
     D extends DomainsOf<M>,
-    P extends ParametersOf<M, D>
+    P extends ParametersOf<M, D>,
 >(
     ...args: P extends NoParametersType
         ? [message: M, parameters?: P, domain?: RemoveIntlIcuSuffix<D>, locale?: LocaleOf<M>]
@@ -115,7 +113,7 @@ export function trans<
 export function trans<
     M extends Message<TranslationsType, LocaleType>,
     D extends DomainsOf<M>,
-    P extends ParametersOf<M, D>
+    P extends ParametersOf<M, D>,
 >(
     message: M,
     parameters: P = {} as P,

--- a/src/Translator/assets/src/translator_controller.ts
+++ b/src/Translator/assets/src/translator_controller.ts
@@ -7,6 +7,4 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 export * from './translator';

--- a/src/Translator/assets/test/formatters/formatter.test.ts
+++ b/src/Translator/assets/test/formatters/formatter.test.ts
@@ -7,15 +7,13 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {format} from '../../src/formatters/formatter';
 
-describe('Formatter', function () {
+describe('Formatter', () => {
     test.concurrent.each<[string, string, Record<string, string | number>]>([
         ['Symfony is great!', 'Symfony is great!', {}],
         ['Symfony is awesome!', 'Symfony is %what%!', {'%what%': 'awesome'}],
-    ])('#%# format should returns %p', function (expected, message, parameters) {
+    ])('#%# format should returns %p', (expected, message, parameters) => {
         expect(format(message, parameters, 'en')).toEqual(expected);
     });
 
@@ -28,7 +26,7 @@ describe('Formatter', function () {
         ['There are 10 apples', 'There is 1 apple|There are %count% apples', 10],
         // custom validation messages may be coded with a fixed value
         ['There are 2 apples', 'There are 2 apples', 2],
-    ])('#%# format with choice should returns %p', function (expected, message, number) {
+    ])('#%# format with choice should returns %p', (expected, message, number) => {
         expect(format(message, {'%count%': number}, 'en')).toEqual(expected);
     });
 
@@ -42,8 +40,8 @@ describe('Formatter', function () {
         ['bar', 2, ']1,2['],
         ['foo', Math.log(0), '[-Inf,2['],
         ['foo', -Math.log(0), '[-2,+Inf]'],
-    ])('#%# format interval should returns %p', function (expected, number, interval) {
-        expect(format(interval + ' foo|[1,Inf[ bar', {'%count%': number}, 'en')).toEqual(expected);
+    ])('#%# format interval should returns %p', (expected, number, interval) => {
+        expect(format(`${interval} foo|[1,Inf[ bar`, {'%count%': number}, 'en')).toEqual(expected);
     });
 
     test.concurrent.each<[string, number]>([
@@ -51,7 +49,7 @@ describe('Formatter', function () {
         ['{1} There is one apple|]1,Inf] There are %count% apples', 0],
         ['{1} There is one apple|]2,Inf] There are %count% apples', 2],
         ['{0} There are no apples|There is one apple', 2],
-    ])('#%# test non matching message', function (message, number) {
+    ])('#%# test non matching message', (message, number) => {
         expect(() => format(message, {'%count%': number}, 'en')).toThrow(`Unable to choose a translation for "${message}" with locale "en" for value "${number}". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %count% apples").`);
     })
 

--- a/src/Translator/assets/test/formatters/intl-formatter.test.ts
+++ b/src/Translator/assets/test/formatters/intl-formatter.test.ts
@@ -7,12 +7,10 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {formatIntl} from '../../src/formatters/intl-formatter';
 
-describe('Intl Formatter', function () {
-    test('format with named arguments', function() {
+describe('Intl Formatter', () => {
+    test('format with named arguments', () => {
         const chooseMessage = `
 {gender_of_host, select,
     female {{num_guests, plural, offset:1
@@ -41,7 +39,7 @@ describe('Intl Formatter', function () {
         expect(message).toEqual('Fabien invites Guilherme as one of the 9 people invited to his party.');
     })
 
-    test('percents and brackets are trimmed', function() {
+    test('percents and brackets are trimmed', () => {
         expect(formatIntl('Hello {name}', { name: 'Fab'}, 'en')).toEqual('Hello Fab');
         expect(formatIntl('Hello {name}', { '%name%': 'Fab'}, 'en')).toEqual('Hello Fab');
         expect(formatIntl('Hello {name}', { '{{ name }}': 'Fab'}, 'en')).toEqual('Hello Fab');
@@ -52,12 +50,12 @@ describe('Intl Formatter', function () {
         expect(parameters).toEqual({ '%name%': 'Fab' });
     });
 
-    test('format with HTML inside', function() {
+    test('format with HTML inside', () => {
         expect(formatIntl('Hello <b>{name}</b>', { name: 'Fab'}, 'en')).toEqual('Hello <b>Fab</b>');
         expect(formatIntl('Hello {name}', { name: '<b>Fab</b>'}, 'en')).toEqual('Hello <b>Fab</b>');
     })
 
-    test('format with locale containg underscore', function() {
+    test('format with locale containg underscore', () => {
         expect(formatIntl('Hello {name}', { name: 'Fab'}, 'en_US')).toEqual('Hello Fab');
         expect(formatIntl('Bonjour {name}', { name: 'Fab'}, 'fr_FR')).toEqual('Bonjour Fab');
     });

--- a/src/Translator/assets/test/translator.test.ts
+++ b/src/Translator/assets/test/translator.test.ts
@@ -1,15 +1,15 @@
-import {getLocale, Message, NoParametersType, setLocale, setLocaleFallbacks, trans} from '../src/translator';
+import {getLocale, type Message, type NoParametersType, setLocale, setLocaleFallbacks, trans} from '../src/translator';
 
-describe('Translator', function () {
-    beforeEach(function() {
+describe('Translator', () => {
+    beforeEach(() => {
         setLocale(null);
         setLocaleFallbacks({})
         document.documentElement.lang = '';
         document.documentElement.removeAttribute('data-symfony-ux-translator-locale');
     })
 
-    describe('getLocale', function () {
-        test('default locale', function () {
+    describe('getLocale', () => {
+        test('default locale', () => {
             // 'en' is the default locale
             expect(getLocale()).toEqual('en');
 
@@ -26,16 +26,16 @@ describe('Translator', function () {
         });
     });
 
-    describe('setLocale', function () {
-        test('custom locale', function () {
+    describe('setLocale', () => {
+        test('custom locale', () => {
             setLocale('fr');
 
             expect(getLocale()).toEqual('fr');
         });
     });
 
-    describe('trans', function () {
-        test('basic message', function () {
+    describe('trans', () => {
+        test('basic message', () => {
             const MESSAGE_BASIC: Message<{ messages: { parameters: NoParametersType } }, 'en'> = {
                 id: 'message.basic',
                 translations: {
@@ -60,7 +60,7 @@ describe('Translator', function () {
             expect(trans(MESSAGE_BASIC, {}, 'messages', 'fr')).toEqual('message.basic');
         });
 
-        test('basic message with parameters', function () {
+        test('basic message with parameters', () => {
             const MESSAGE_BASIC_WITH_PARAMETERS: Message<{ messages: { parameters: { '%parameter1%': string, '%parameter2%': string } } }, 'en'> = {
                 id: 'message.basic.with.parameters',
                 translations: {
@@ -104,7 +104,7 @@ describe('Translator', function () {
             }, 'messages', 'fr')).toEqual('message.basic.with.parameters');
         });
 
-        test('intl message', function () {
+        test('intl message', () => {
             const MESSAGE_INTL: Message<{ 'messages+intl-icu': { parameters: NoParametersType } }, 'en'> = {
                 id: 'message.intl',
                 translations: {
@@ -129,7 +129,7 @@ describe('Translator', function () {
             expect(trans(MESSAGE_INTL, {}, 'messages', 'fr')).toEqual('message.intl');
         });
 
-        test('intl message with parameters', function () {
+        test('intl message with parameters', () => {
             const INTL_MESSAGE_WITH_PARAMETERS: Message<{
                 'messages+intl-icu': {
                     parameters: {
@@ -186,19 +186,19 @@ describe('Translator', function () {
                 guest: 'Hugo',
             }, 'messages', 'en')).toEqual('Lola invites Hugo to her party.');
 
-            expect(function () {
+            expect(() => {
                 // @ts-expect-error Parameters "gender_of_host", "num_guests", "host", and "guest" are missing
                 trans(INTL_MESSAGE_WITH_PARAMETERS, {});
             }).toThrow(/^The intl string context variable "gender_of_host" was not provided/);
 
-            expect(function () {
+            expect(() => {
                 // @ts-expect-error Parameters "num_guests", "host", and "guest" are missing
                 trans(INTL_MESSAGE_WITH_PARAMETERS, {
                     gender_of_host: 'male',
                 });
             }).toThrow(/^The intl string context variable "num_guests" was not provided/);
 
-            expect(function () {
+            expect(() => {
                 // @ts-expect-error Parameters "host", and "guest" are missing
                 trans(INTL_MESSAGE_WITH_PARAMETERS, {
                     gender_of_host: 'male',
@@ -206,7 +206,7 @@ describe('Translator', function () {
                 })
             }).toThrow(/^The intl string context variable "host" was not provided/);
 
-            expect(function () {
+            expect(() => {
                 // @ts-expect-error Parameter "guest" is missing
                 trans(INTL_MESSAGE_WITH_PARAMETERS, {
                     gender_of_host: 'male',
@@ -239,7 +239,7 @@ describe('Translator', function () {
                 )).toEqual('message.intl.with.parameters');
         });
 
-        test('same message id for multiple domains', function () {
+        test('same message id for multiple domains', () => {
             const MESSAGE_MULTI_DOMAINS: Message<{ foobar: { parameters: NoParametersType }, messages: { parameters: NoParametersType } }, 'en'> = {
                 id: 'message.multi_domains',
                 translations: {
@@ -270,7 +270,7 @@ describe('Translator', function () {
             expect(trans(MESSAGE_MULTI_DOMAINS, {}, 'foobar', 'fr')).toEqual('message.multi_domains');
         });
 
-        test('same message id for multiple domains, and different parameters', function () {
+        test('same message id for multiple domains, and different parameters', () => {
             const MESSAGE_MULTI_DOMAINS_WITH_PARAMETERS: Message<{ foobar: { parameters: { '%parameter2%': string } }, messages: { parameters: { '%parameter1%': string } } }, 'en'> = {
                 id: 'message.multi_domains.different_parameters',
                 translations: {
@@ -299,7 +299,7 @@ describe('Translator', function () {
             expect(trans(MESSAGE_MULTI_DOMAINS_WITH_PARAMETERS, {'%parameter1%': 'foo'}, 'messages', 'fr')).toEqual('message.multi_domains.different_parameters');
         });
 
-        test('message from intl domain should be prioritized over its non-intl equivalent', function () {
+        test('message from intl domain should be prioritized over its non-intl equivalent', () => {
             const MESSAGE: Message<{ 'messages+intl-icu': { parameters: NoParametersType }, messages: { parameters: NoParametersType } }, 'en'> = {
                 id: 'message',
                 translations: {
@@ -318,8 +318,8 @@ describe('Translator', function () {
             expect(trans(MESSAGE, {}, 'messages', 'en')).toEqual('A intl message');
         });
 
-        test('fallback behavior', function() {
-            setLocaleFallbacks({'fr_FR':'fr','fr':'en','en_US':'en','en_GB':'en','de_DE':'de','de':'en'});
+        test('fallback behavior', () => {
+            setLocaleFallbacks({fr_FR:'fr',fr:'en',en_US:'en',en_GB:'en',de_DE:'de',de:'en'});
 
             const MESSAGE: Message<{ messages: { parameters: NoParametersType } }, 'en'|'en_US'|'fr'> = {
                 id: 'message',

--- a/src/Translator/assets/test/utils.test.ts
+++ b/src/Translator/assets/test/utils.test.ts
@@ -1,35 +1,35 @@
 import {strtr} from '../src/utils';
 
-describe('Utils', function () {
+describe('Utils', () => {
     test.concurrent.each<[string, string, Record<string, string>]>([
         // https://github.com/php/php-src/blob/master/ext/standard/tests/strings/strtr_basic.phpt
-        ['TEST STrTr', 'test strtr', {'t': 'T', 'e': 'E', 'st': 'ST'}],
-        ['TEST STrTr', 'test strtr', {'t': 'T', 'e': 'E', 'st': 'ST'}],
+        ['TEST STrTr', 'test strtr', {t: 'T', e: 'E', st: 'ST'}],
+        ['TEST STrTr', 'test strtr', {t: 'T', e: 'E', st: 'ST'}],
 
         // https://github.com/php/php-src/blob/master/ext/standard/tests/strings/strtr_variation1.phpt
-        ['a23', '123', {'1': 'a', 'a': '1', '2b3c': 'b2c3', 'b2c3': '3c2b'}],
-        ['1bc', 'abc', {'1': 'a', 'a': '1', '2b3c': 'b2c3', 'b2c3': '3c2b'}],
-        ['a1b2c3', '1a2b3c', {'1': 'a', 'a': '1', '2b3c': 'b2c3', 'b2c3': '3c2b'}],
+        ['a23', '123', {'1': 'a', a: '1', '2b3c': 'b2c3', b2c3: '3c2b'}],
+        ['1bc', 'abc', {'1': 'a', a: '1', '2b3c': 'b2c3', b2c3: '3c2b'}],
+        ['a1b2c3', '1a2b3c', {'1': 'a', a: '1', '2b3c': 'b2c3', b2c3: '3c2b'}],
         [`
 a23
 1bc
 a1b2c3`, `
 123
 abc
-1a2b3c`, {1: 'a', 'a': '1', '2b3c': 'b2c3', 'b2c3': '3c2b'}],
+1a2b3c`, {1: 'a', a: '1', '2b3c': 'b2c3', b2c3: '3c2b'}],
 
         // https://github.com/php/php-src/blob/master/ext/standard/tests/strings/strtr_variation2.phpt
-        ['$', '%', {'$': '%', '%': '$', '#*&@()': '()@&*#'}],
-        ['#%*', '#$*', {'$': '%', '%': '$', '#*&@()': '()@&*#'}],
-        ['text & @()', 'text & @()', {'$': '%', '%': '$', '#*&@()': '()@&*#'}],
+        ['$', '%', {$: '%', '%': '$', '#*&@()': '()@&*#'}],
+        ['#%*', '#$*', {$: '%', '%': '$', '#*&@()': '()@&*#'}],
+        ['text & @()', 'text & @()', {$: '%', '%': '$', '#*&@()': '()@&*#'}],
         [`
 $
 #%*&
 text & @()`, `
 %
 #$*&
-text & @()`, {'$': '%', '%': '$', '#*&@()': '()@&*#'}],
-    ])('strtr', function (expected, string, replacePairs) {
+text & @()`, {$: '%', '%': '$', '#*&@()': '()@&*#'}],
+    ])('strtr', (expected, string, replacePairs) => {
         expect(strtr(string, replacePairs)).toEqual(expected);
     });
 });

--- a/src/Turbo/assets/test/setup.js
+++ b/src/Turbo/assets/test/setup.js
@@ -8,4 +8,4 @@
  */
 
 // polyfill for some odd error inside of Turbo in the test environment
-window.SubmitEvent = function () {};
+window.SubmitEvent = class {};

--- a/src/Turbo/assets/test/turbo_controller.test.ts
+++ b/src/Turbo/assets/test/turbo_controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application } from '@hotwired/stimulus';
 import { getByTestId } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
@@ -21,7 +19,7 @@ const startStimulus = () => {
 
 /* eslint-disable no-undef */
 describe('TurboStreamController', () => {
-    let container;
+    let container: HTMLElement;
 
     beforeEach(() => {
         container = mountDOM('<div data-testid="turbo-core" data-controller="symfony--ux-turbo--turbo"></div>');

--- a/src/Turbo/assets/test/turbo_stream_controller.test.ts
+++ b/src/Turbo/assets/test/turbo_stream_controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application } from '@hotwired/stimulus';
 import { getByTestId } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
@@ -22,7 +20,7 @@ const startStimulus = () => {
 
 /* eslint-disable no-undef */
 describe('TurboStreamController', () => {
-    let container;
+    let container: HTMLElement;
 
     beforeEach(() => {
         global.EventSource = vi.fn(() => ({

--- a/src/Typed/assets/dist/controller.js
+++ b/src/Typed/assets/dist/controller.js
@@ -43,7 +43,7 @@ default_1.values = {
     fadeOutClass: { type: String, default: 'typed-fade-out' },
     fadeOutDelay: { type: Number, default: 500 },
     loop: Boolean,
-    loopCount: { type: Number, default: Infinity },
+    loopCount: { type: Number, default: Number.POSITIVE_INFINITY },
     showCursor: { type: Boolean, default: true },
     cursorChar: { type: String, default: '.' },
     autoInsertCss: { type: Boolean, default: true },

--- a/src/Typed/assets/src/controller.ts
+++ b/src/Typed/assets/src/controller.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
 import Typed from 'typed.js';
 
@@ -25,7 +23,7 @@ export default class extends Controller {
         fadeOutClass: { type: String, default: 'typed-fade-out' },
         fadeOutDelay: { type: Number, default: 500 },
         loop: Boolean,
-        loopCount: { type: Number, default: Infinity },
+        loopCount: { type: Number, default: Number.POSITIVE_INFINITY },
         showCursor: { type: Boolean, default: true },
         cursorChar: { type: String, default: '.' },
         autoInsertCss: { type: Boolean, default: true },

--- a/src/Typed/assets/test/controller.test.ts
+++ b/src/Typed/assets/test/controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
@@ -33,7 +31,7 @@ const startStimulus = () => {
 };
 
 describe('TypedController', () => {
-    let container;
+    let container: HTMLElement;
 
     beforeEach(() => {
         container = mountDOM(`

--- a/src/Vue/assets/dist/loader.d.ts
+++ b/src/Vue/assets/dist/loader.d.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'vue';
-import { ComponentCollection } from './components.js';
+import { type ComponentCollection } from './components.js';
 declare global {
     function resolveVueComponent(name: string): Component;
     interface Window {

--- a/src/Vue/assets/dist/render_controller.d.ts
+++ b/src/Vue/assets/dist/render_controller.d.ts
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
-import { App } from 'vue';
+import { type App } from 'vue';
 export default class extends Controller<Element & {
     __vue_app__?: App<Element>;
 }> {

--- a/src/Vue/assets/src/loader.ts
+++ b/src/Vue/assets/src/loader.ts
@@ -7,10 +7,8 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import type { Component } from 'vue';
-import { ComponentCollection, components } from './components.js';
+import { type ComponentCollection, components } from './components.js';
 
 declare global {
     function resolveVueComponent(name: string): Component;

--- a/src/Vue/assets/src/register_controller.ts
+++ b/src/Vue/assets/src/register_controller.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import type { Component } from 'vue';
 import { defineAsyncComponent } from 'vue';
 
@@ -21,10 +19,13 @@ declare global {
 }
 
 export function registerVueControllerComponents(context: __WebpackModuleApi.RequireContext) {
-    const vueControllers = context.keys().reduce((acc, key) => {
-        acc[key] = undefined;
-        return acc;
-    }, {} as Record<string, object | undefined>);
+    const vueControllers = context.keys().reduce(
+        (acc, key) => {
+            acc[key] = undefined;
+            return acc;
+        },
+        {} as Record<string, object | undefined>
+    );
 
     function loadComponent(name: string): object | never {
         const componentPath = `./${name}.vue`;

--- a/src/Vue/assets/src/render_controller.ts
+++ b/src/Vue/assets/src/render_controller.ts
@@ -7,10 +7,8 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Controller } from '@hotwired/stimulus';
-import { App, createApp } from 'vue';
+import { type App, createApp } from 'vue';
 
 export default class extends Controller<Element & { __vue_app__?: App<Element> }> {
     private props: Record<string, unknown> | null;

--- a/src/Vue/assets/test/register_controller.test.ts
+++ b/src/Vue/assets/test/register_controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import {registerVueControllerComponents} from '../src/register_controller';
 import Hello from './fixtures/Hello.vue'
 import Goodbye from './fixtures-lazy/Goodbye.vue'

--- a/src/Vue/assets/test/render_controller.test.ts
+++ b/src/Vue/assets/test/render_controller.test.ts
@@ -7,8 +7,6 @@
  * file that was distributed with this source code.
  */
 
-'use strict';
-
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { clearDOM, mountDOM } from '@symfony/stimulus-testing';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1933,6 +1933,60 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@biomejs/biome@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/biome/-/biome-1.7.3.tgz#847a317b63c811534fc8108389b7a9fae8803eed"
+  integrity sha512-ogFQI+fpXftr+tiahA6bIXwZ7CSikygASdqMtH07J2cUzrpjyTMVc9Y97v23c7/tL1xCZhM+W9k4hYIBm7Q6cQ==
+  optionalDependencies:
+    "@biomejs/cli-darwin-arm64" "1.7.3"
+    "@biomejs/cli-darwin-x64" "1.7.3"
+    "@biomejs/cli-linux-arm64" "1.7.3"
+    "@biomejs/cli-linux-arm64-musl" "1.7.3"
+    "@biomejs/cli-linux-x64" "1.7.3"
+    "@biomejs/cli-linux-x64-musl" "1.7.3"
+    "@biomejs/cli-win32-arm64" "1.7.3"
+    "@biomejs/cli-win32-x64" "1.7.3"
+
+"@biomejs/cli-darwin-arm64@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.7.3.tgz#0b0f568f6fd2153aa1a53bddd0a55355df381952"
+  integrity sha512-eDvLQWmGRqrPIRY7AIrkPHkQ3visEItJKkPYSHCscSDdGvKzYjmBJwG1Gu8+QC5ed6R7eiU63LEC0APFBobmfQ==
+
+"@biomejs/cli-darwin-x64@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.7.3.tgz#0eb0e9da1f869e65e6ce98a007a3341bb1c88446"
+  integrity sha512-JXCaIseKRER7dIURsVlAJacnm8SG5I0RpxZ4ya3dudASYUc68WGl4+FEN03ABY3KMIq7hcK1tzsJiWlmXyosZg==
+
+"@biomejs/cli-linux-arm64-musl@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.7.3.tgz#e098110cc11552857ba46cae1e00e68805c1718a"
+  integrity sha512-c8AlO45PNFZ1BYcwaKzdt46kYbuP6xPGuGQ6h4j3XiEDpyseRRUy/h+6gxj07XovmyxKnSX9GSZ6nVbZvcVUAw==
+
+"@biomejs/cli-linux-arm64@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.7.3.tgz#9e53c14acd7190ebd1e8b0a2f5a54083c118ce72"
+  integrity sha512-phNTBpo7joDFastnmZsFjYcDYobLTx4qR4oPvc9tJ486Bd1SfEVPHEvJdNJrMwUQK56T+TRClOQd/8X1nnjA9w==
+
+"@biomejs/cli-linux-x64-musl@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.7.3.tgz#f27d4a267f69e663797e3204e51a373f3e33bc30"
+  integrity sha512-UdEHKtYGWEX3eDmVWvQeT+z05T9/Sdt2+F/7zmMOFQ7boANeX8pcO6EkJPK3wxMudrApsNEKT26rzqK6sZRTRA==
+
+"@biomejs/cli-linux-x64@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64/-/cli-linux-x64-1.7.3.tgz#7112b22e32a8626d0f11d92e43d0cc034c50723d"
+  integrity sha512-vnedYcd5p4keT3iD48oSKjOIRPYcjSNNbd8MO1bKo9ajg3GwQXZLAH+0Cvlr+eMsO67/HddWmscSQwTFrC/uPA==
+
+"@biomejs/cli-win32-arm64@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.7.3.tgz#91bed8a3ae3433c3feb6a11816b0eb19b60801ef"
+  integrity sha512-unNCDqUKjujYkkSxs7gFIfdasttbDC4+z0kYmcqzRk6yWVoQBL4dNLcCbdnJS+qvVDNdI9rHp2NwpQ0WAdla4Q==
+
+"@biomejs/cli-win32-x64@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.7.3.tgz#41b65a940a360abb4a3205949370153ffe30c7de"
+  integrity sha512-ZmByhbrnmz/UUFYB622CECwhKIPjJLLPr5zr3edhu04LzbfcOrz16VYeNq5dpO1ADG70FORhAJkaIGdaVBG00w==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz"
@@ -2051,38 +2105,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@eslint-community/eslint-utils@^4.2.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz"
-  integrity sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==
-  dependencies:
-    eslint-visitor-keys "^3.3.0"
-
-"@eslint-community/regexpp@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz"
-  integrity sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==
-
-"@eslint/eslintrc@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz"
-  integrity sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==
-  dependencies:
-    ajv "^6.12.4"
-    debug "^4.3.2"
-    espree "^9.5.0"
-    globals "^13.19.0"
-    ignore "^5.2.0"
-    import-fresh "^3.2.1"
-    js-yaml "^4.1.0"
-    minimatch "^3.1.2"
-    strip-json-comments "^3.1.1"
-
-"@eslint/js@8.36.0":
-  version "8.36.0"
-  resolved "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz"
-  integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
-
 "@formatjs/ecma402-abstract@1.18.2":
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz#bf103712a406874eb1e387858d5be2371ab3aa14"
@@ -2131,25 +2153,6 @@
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.4.tgz#5c5361c06a37cdf10dcba4223f1afd0ca1c75091"
   integrity sha512-mlZEFUZrJnpfj+g/XeCWWuokvQyN68WvM78JM+0jfSFc98wegm259vCbC1zSllcspRwbgXK31ibehCy5PA78/Q==
-
-"@humanwhocodes/config-array@^0.11.8":
-  version "0.11.8"
-  resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz"
-  integrity sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==
-  dependencies:
-    "@humanwhocodes/object-schema" "^1.2.1"
-    debug "^4.1.1"
-    minimatch "^3.0.5"
-
-"@humanwhocodes/module-importer@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz"
-  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
-
-"@humanwhocodes/object-schema@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz"
-  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -2457,27 +2460,6 @@
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.2.tgz#5acd38242e8bde4f9986e7913c8fdf49d3aa199f"
   integrity sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==
-
-"@nodelib/fs.scandir@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
-  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
-  dependencies:
-    "@nodelib/fs.stat" "2.0.5"
-    run-parallel "^1.1.9"
-
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.5"
-  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
-  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
-
-"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
-  version "1.2.8"
-  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
-  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
-  dependencies:
-    "@nodelib/fs.scandir" "2.1.5"
-    fastq "^1.6.0"
 
 "@orchidjs/sifter@^1.0.3":
   version "1.0.3"
@@ -2878,11 +2860,6 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
-"@types/json-schema@^7.0.9":
-  version "7.0.11"
-  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
-
 "@types/node-fetch@^2.6.2":
   version "2.6.2"
   resolved "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz"
@@ -2949,11 +2926,6 @@
   resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/semver@^7.3.12":
-  version "7.3.13"
-  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
-
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz"
@@ -2989,90 +2961,6 @@
   integrity sha512-yuogunc04OnzGQCrfHx+Kk883Q4X0aSwmYZhKjI21m+SVYzjIbrWl8dOOwSv5hf2Um2pdCOXWo9isteZTNXUZQ==
   dependencies:
     "@types/yargs-parser" "*"
-
-"@typescript-eslint/eslint-plugin@^5.2.0":
-  version "5.56.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz"
-  integrity sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==
-  dependencies:
-    "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.56.0"
-    "@typescript-eslint/type-utils" "5.56.0"
-    "@typescript-eslint/utils" "5.56.0"
-    debug "^4.3.4"
-    grapheme-splitter "^1.0.4"
-    ignore "^5.2.0"
-    natural-compare-lite "^1.4.0"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/parser@^5.2.0":
-  version "5.56.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz"
-  integrity sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.56.0"
-    "@typescript-eslint/types" "5.56.0"
-    "@typescript-eslint/typescript-estree" "5.56.0"
-    debug "^4.3.4"
-
-"@typescript-eslint/scope-manager@5.56.0":
-  version "5.56.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz"
-  integrity sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==
-  dependencies:
-    "@typescript-eslint/types" "5.56.0"
-    "@typescript-eslint/visitor-keys" "5.56.0"
-
-"@typescript-eslint/type-utils@5.56.0":
-  version "5.56.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz"
-  integrity sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==
-  dependencies:
-    "@typescript-eslint/typescript-estree" "5.56.0"
-    "@typescript-eslint/utils" "5.56.0"
-    debug "^4.3.4"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/types@5.56.0":
-  version "5.56.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz"
-  integrity sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==
-
-"@typescript-eslint/typescript-estree@5.56.0":
-  version "5.56.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz"
-  integrity sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==
-  dependencies:
-    "@typescript-eslint/types" "5.56.0"
-    "@typescript-eslint/visitor-keys" "5.56.0"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/utils@5.56.0":
-  version "5.56.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz"
-  integrity sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.2.0"
-    "@types/json-schema" "^7.0.9"
-    "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.56.0"
-    "@typescript-eslint/types" "5.56.0"
-    "@typescript-eslint/typescript-estree" "5.56.0"
-    eslint-scope "^5.1.1"
-    semver "^7.3.7"
-
-"@typescript-eslint/visitor-keys@5.56.0":
-  version "5.56.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz"
-  integrity sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==
-  dependencies:
-    "@typescript-eslint/types" "5.56.0"
-    eslint-visitor-keys "^3.3.0"
 
 "@vitejs/plugin-react@^4.1.0":
   version "4.1.0"
@@ -3236,11 +3124,6 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.3.2:
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
-  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
-
 acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz"
@@ -3261,7 +3144,7 @@ acorn@^8.10.0, acorn@^8.8.2, acorn@^8.9.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
-acorn@^8.2.4, acorn@^8.8.0:
+acorn@^8.2.4:
   version "8.8.2"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -3272,16 +3155,6 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
-
-ajv@^6.10.0, ajv@^6.12.4:
-  version "6.12.6"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
 
 ansi-escapes@^4.2.1:
   version "4.3.2"
@@ -3347,11 +3220,6 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-argparse@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
-  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
-
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz"
@@ -3396,11 +3264,6 @@ array-buffer-byte-length@^1.0.0:
   dependencies:
     call-bind "^1.0.2"
     is-array-buffer "^3.0.1"
-
-array-union@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz"
-  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -4116,7 +3979,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -4269,7 +4132,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -4328,7 +4191,7 @@ deep-equal@^2.0.5:
     which-collection "^1.0.1"
     which-typed-array "^1.1.9"
 
-deep-is@^0.1.3, deep-is@~0.1.3:
+deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
@@ -4422,20 +4285,6 @@ diff-sequences@^29.4.3:
   version "29.4.3"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz"
   integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
-
-dir-glob@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz"
-  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
-  dependencies:
-    path-type "^4.0.0"
-
-doctrine@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz"
-  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
-  dependencies:
-    esutils "^2.0.2"
 
 dom-accessibility-api@^0.5.6:
   version "0.5.16"
@@ -4673,112 +4522,12 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^8.0.0:
-  version "8.8.0"
-  resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz"
-  integrity sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==
-
-eslint-scope@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^4.1.1"
-
-eslint-scope@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz"
-  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^5.2.0"
-
-eslint-visitor-keys@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz"
-  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
-
-eslint@^8.1.0:
-  version "8.36.0"
-  resolved "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz"
-  integrity sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.2.0"
-    "@eslint-community/regexpp" "^4.4.0"
-    "@eslint/eslintrc" "^2.0.1"
-    "@eslint/js" "8.36.0"
-    "@humanwhocodes/config-array" "^0.11.8"
-    "@humanwhocodes/module-importer" "^1.0.1"
-    "@nodelib/fs.walk" "^1.2.8"
-    ajv "^6.10.0"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.3.2"
-    doctrine "^3.0.0"
-    escape-string-regexp "^4.0.0"
-    eslint-scope "^7.1.1"
-    eslint-visitor-keys "^3.3.0"
-    espree "^9.5.0"
-    esquery "^1.4.2"
-    esutils "^2.0.2"
-    fast-deep-equal "^3.1.3"
-    file-entry-cache "^6.0.1"
-    find-up "^5.0.0"
-    glob-parent "^6.0.2"
-    globals "^13.19.0"
-    grapheme-splitter "^1.0.4"
-    ignore "^5.2.0"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    is-path-inside "^3.0.3"
-    js-sdsl "^4.1.4"
-    js-yaml "^4.1.0"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash.merge "^4.6.2"
-    minimatch "^3.1.2"
-    natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    strip-ansi "^6.0.1"
-    strip-json-comments "^3.1.0"
-    text-table "^0.2.0"
-
-espree@^9.5.0:
-  version "9.5.0"
-  resolved "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz"
-  integrity sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==
-  dependencies:
-    acorn "^8.8.0"
-    acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^3.3.0"
-
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.2:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz"
-  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
-  dependencies:
-    estraverse "^5.1.0"
-
-esrecurse@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz"
-  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
-  dependencies:
-    estraverse "^5.2.0"
-
-estraverse@^4.1.1:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
-  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
-
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -4918,38 +4667,15 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
-  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-glob@^3.2.9:
-  version "3.2.12"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz"
-  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
+fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
-
-fastq@^1.6.0:
-  version "1.15.0"
-  resolved "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz"
-  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
-  dependencies:
-    reusify "^1.0.4"
 
 fb-watchman@^2.0.0:
   version "2.0.2"
@@ -4965,13 +4691,6 @@ figures@^1.0.1:
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
-
-file-entry-cache@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
-  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
-  dependencies:
-    flat-cache "^3.0.4"
 
 filelist@^1.0.4:
   version "1.0.4"
@@ -5018,27 +4737,6 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
-
-find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
-flat-cache@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz"
-  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
-  dependencies:
-    flatted "^3.1.0"
-    rimraf "^3.0.2"
-
-flatted@^3.1.0:
-  version "3.2.7"
-  resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz"
-  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -5190,19 +4888,12 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz"
   integrity sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
-
-glob-parent@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
-  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
-  dependencies:
-    is-glob "^4.0.3"
 
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
@@ -5232,13 +4923,6 @@ globals@^11.1.0:
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^13.19.0:
-  version "13.20.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz"
-  integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
-  dependencies:
-    type-fest "^0.20.2"
-
 globalthis@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz"
@@ -5250,18 +4934,6 @@ globalyzer@0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz"
   integrity sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==
-
-globby@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz"
-  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.2.9"
-    ignore "^5.2.0"
-    merge2 "^1.4.1"
-    slash "^3.0.0"
 
 globrex@^0.1.2:
   version "0.1.2"
@@ -5279,11 +4951,6 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
-
-grapheme-splitter@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz"
-  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -5456,11 +5123,6 @@ idiomorph@^0.3.0:
   resolved "https://registry.yarnpkg.com/idiomorph/-/idiomorph-0.3.0.tgz#f6675bc5bef1a72c94021e43141a3f605d2d6288"
   integrity sha512-UhV1Ey5xCxIwR9B+OgIjQa+1Jx99XQ1vQHUsKBU1RpQzCx1u+b+N6SOXgf5mEJDqemUI/ffccu6+71l2mJUsRA==
 
-ignore@^5.2.0:
-  version "5.2.4"
-  resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz"
-  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
-
 import-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz"
@@ -5468,7 +5130,7 @@ import-cwd@^3.0.0:
   dependencies:
     import-from "^3.0.0"
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -5714,7 +5376,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -5754,11 +5416,6 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-
-is-path-inside@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
-  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -6407,11 +6064,6 @@ jest@^26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-js-sdsl@^4.1.4:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz"
-  integrity sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -6424,13 +6076,6 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
 
 jsdom@^16.4.0:
   version "16.7.0"
@@ -6479,16 +6124,6 @@ json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
-
-json-schema-traverse@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
-  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
-
-json-stable-stringify-without-jsonify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
-  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 json5@^2.2.0, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
@@ -6548,14 +6183,6 @@ leven@^3.1.0:
   resolved "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-levn@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz"
-  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
-  dependencies:
-    prelude-ls "^1.2.1"
-    type-check "~0.4.0"
-
 levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
@@ -6595,13 +6222,6 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
-
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz"
-  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
-  dependencies:
-    p-locate "^5.0.0"
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -6745,11 +6365,6 @@ merge-stream@^2.0.0:
   resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0, merge2@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
-  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
 microbundle@^0.15.1:
   version "0.15.1"
   resolved "https://registry.npmjs.org/microbundle/-/microbundle-0.15.1.tgz"
@@ -6847,7 +6462,7 @@ min-indent@^1.0.0:
   resolved "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -6937,11 +6552,6 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-natural-compare-lite@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz"
-  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -7158,18 +6768,6 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
-optionator@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz"
-  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
-  dependencies:
-    deep-is "^0.1.3"
-    fast-levenshtein "^2.0.6"
-    levn "^0.4.1"
-    prelude-ls "^1.2.1"
-    type-check "^0.4.0"
-    word-wrap "^1.2.3"
-
 p-each-series@^2.1.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz"
@@ -7187,13 +6785,6 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
-  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
-  dependencies:
-    yocto-queue "^0.1.0"
-
 p-limit@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz"
@@ -7207,13 +6798,6 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
-
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz"
-  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
-  dependencies:
-    p-limit "^3.0.2"
 
 p-queue@^6.6.2:
   version "6.6.2"
@@ -7630,20 +7214,10 @@ postcss@^8.2.1, postcss@^8.4.27:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-prelude-ls@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
-  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
-
-prettier@^2.2.1:
-  version "2.8.6"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.6.tgz"
-  integrity sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==
 
 prettier@^2.7.1:
   version "2.8.8"
@@ -7707,7 +7281,7 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
@@ -7716,11 +7290,6 @@ querystringify@^2.1.1:
   version "2.2.0"
   resolved "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
-
-queue-microtask@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
-  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -7956,12 +7525,7 @@ ret@~0.1.10:
   resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-reusify@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
-  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -8059,13 +7623,6 @@ rsvp@^4.8.4:
   resolved "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-run-parallel@^1.1.9:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
-  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
-  dependencies:
-    queue-microtask "^1.2.2"
-
 sade@^1.7.4:
   version "1.8.1"
   resolved "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz"
@@ -8158,7 +7715,7 @@ semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2, semver@^7.3.7:
+semver@^7.3.2:
   version "7.3.8"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -8539,11 +8096,6 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
-  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
 strip-literal@^1.0.1:
   version "1.3.0"
   resolved "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz"
@@ -8674,11 +8226,6 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-text-table@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
-
 throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz"
@@ -8779,11 +8326,6 @@ tr46@~0.0.3:
   resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-tslib@^1.8.1:
-  version "1.14.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@^2.0.3:
   version "2.6.2"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
@@ -8793,20 +8335,6 @@ tslib@^2.3.1, tslib@^2.4.0:
   version "2.5.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
-
-tsutils@^3.21.0:
-  version "3.21.0"
-  resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz"
-  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
-  dependencies:
-    tslib "^1.8.1"
-
-type-check@^0.4.0, type-check@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
-  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
-  dependencies:
-    prelude-ls "^1.2.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -8819,11 +8347,6 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.21.3:
   version "0.21.3"
@@ -8982,13 +8505,6 @@ update-browserslist-db@^1.0.13:
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
-
-uri-js@^4.2.2:
-  version "4.4.1"
-  resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
-  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
-  dependencies:
-    punycode "^2.1.0"
 
 urix@^0.1.0:
   version "0.1.0"
@@ -9254,7 +8770,7 @@ why-is-node-running@^2.2.2:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-word-wrap@^1.2.3, word-wrap@~1.2.3:
+word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
@@ -9374,11 +8890,6 @@ yargs@^17.5.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
-
-yocto-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
-  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 yocto-queue@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Hi everyone,

[Biome](https://biomejs.dev/) is a _new_ modern tool for code linting and formatting. 
It supports TypeScript out-of-the-box, lint and format does not conflict each-other (like ESLint and Prettier can do), and it's **super** fast!
With Biome, we can easily replace:
- ESLint
- ESLint's TypeScript plugin
- Prettier
- ESLint's Prettier plugin

There is a lot of modifications, but 99% of them are:
- use `import type ...` / `import { type ... }` when necessary
- removing `'use strict'`, since we have `type: 'module'` in `package.json` files, but I'm not 100% confidente here and I may add them back
- using template string interpolation instead of `+` operator

I've disabled the following linting rules in order to reduce the number of modifications, but later we can start to enable them: 
- `complexity/noStaticOnlyClass`
- `complexity/noForEach`
- `style/noParameterAssign`
- `performance/noDelete`

The yarn scripts `lint`, `format`, `check-lint` and `check-format` have been modified in consequences.

For performance comparisons, you can check those two CI jobs:
- https://github.com/symfony/ux/actions/runs/9063481176/job/24899508211, ESLint took ~19s and Prettier took ~2s
- https://github.com/symfony/ux/actions/runs/9091422430/job/24985996787, Biome took ~5s for linting and ~0s for formatting 

For the number of commits, I wanted to ease the review by doing many atomic commits, but feel free to squash if necessary.

WDYT?