### PR TITLE
[Turbo] Fix broadcast with composite primary key

### DIFF
--- a/src/Turbo/CONTRIBUTING.md
+++ b/src/Turbo/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Start a Mercure Hub:
         -e MERCURE_PUBLISHER_JWT_KEY='!ChangeMe!' \
         -e MERCURE_SUBSCRIBER_JWT_KEY='!ChangeMe!' \
         -p 3000:3000 \
-        dunglas/mercure caddy run -config /etc/caddy/Caddyfile.dev
+        dunglas/mercure caddy run --config /etc/caddy/Caddyfile.dev
 
 Install the test app:
 
@@ -29,6 +29,7 @@ Start the test app:
 -   `http://localhost:8000/authors`: broadcast
 -   `http://localhost:8000/artists`: broadcast
 -   `http://localhost:8000/songs`: broadcast
+-   `http://localhost:8000/cart_products`: broadcast
 
 ## Run tests
 

--- a/src/Turbo/config/services.php
+++ b/src/Turbo/config/services.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
+use Symfony\UX\Turbo\Broadcaster\DoctrineIdAccessor;
 use Symfony\UX\Turbo\Broadcaster\IdAccessor;
 use Symfony\UX\Turbo\Broadcaster\ImuxBroadcaster;
 use Symfony\UX\Turbo\Broadcaster\TwigBroadcaster;
@@ -29,10 +30,17 @@ return static function (ContainerConfigurator $container): void {
 
         ->alias(BroadcasterInterface::class, 'turbo.broadcaster.imux')
 
+        ->set('turbo.id_formatter', IdAccessor::class)
+
+        ->set('turbo.doctrine_id_accessor', DoctrineIdAccessor::class)
+            ->args([
+                service('doctrine')->nullOnInvalid(),
+            ])
+
         ->set('turbo.id_accessor', IdAccessor::class)
             ->args([
                 service('property_accessor')->nullOnInvalid(),
-                service('doctrine')->nullOnInvalid(),
+                service('turbo.doctrine_id_accessor'),
             ])
 
         ->set('turbo.broadcaster.action_renderer', TwigBroadcaster::class)
@@ -52,6 +60,7 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('turbo.broadcaster.imux'),
                 service('annotation_reader')->nullOnInvalid(),
+                service('turbo.doctrine_id_accessor'),
             ])
             ->tag('doctrine.event_listener', ['event' => 'onFlush'])
             ->tag('doctrine.event_listener', ['event' => 'postFlush'])

--- a/src/Turbo/config/services.php
+++ b/src/Turbo/config/services.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
 use Symfony\UX\Turbo\Broadcaster\DoctrineIdAccessor;
 use Symfony\UX\Turbo\Broadcaster\IdAccessor;
+use Symfony\UX\Turbo\Broadcaster\IdFormatter;
 use Symfony\UX\Turbo\Broadcaster\ImuxBroadcaster;
 use Symfony\UX\Turbo\Broadcaster\TwigBroadcaster;
 use Symfony\UX\Turbo\Doctrine\BroadcastListener;
@@ -30,7 +31,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->alias(BroadcasterInterface::class, 'turbo.broadcaster.imux')
 
-        ->set('turbo.id_formatter', IdAccessor::class)
+        ->set('turbo.id_formatter', IdFormatter::class)
 
         ->set('turbo.doctrine_id_accessor', DoctrineIdAccessor::class)
             ->args([

--- a/src/Turbo/config/services.php
+++ b/src/Turbo/config/services.php
@@ -49,6 +49,7 @@ return static function (ContainerConfigurator $container): void {
                 service('twig'),
                 abstract_arg('entity template prefixes'),
                 service('turbo.id_accessor'),
+                service('turbo.id_formatter'),
             ])
             ->decorate('turbo.broadcaster.imux')
 

--- a/src/Turbo/config/services.php
+++ b/src/Turbo/config/services.php
@@ -12,12 +12,13 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
-use Symfony\UX\Turbo\Broadcaster\DoctrineIdAccessor;
 use Symfony\UX\Turbo\Broadcaster\IdAccessor;
 use Symfony\UX\Turbo\Broadcaster\IdFormatter;
 use Symfony\UX\Turbo\Broadcaster\ImuxBroadcaster;
 use Symfony\UX\Turbo\Broadcaster\TwigBroadcaster;
 use Symfony\UX\Turbo\Doctrine\BroadcastListener;
+use Symfony\UX\Turbo\Doctrine\DoctrineClassResolver;
+use Symfony\UX\Turbo\Doctrine\DoctrineIdAccessor;
 use Symfony\UX\Turbo\Twig\TwigExtension;
 
 /*
@@ -30,6 +31,11 @@ return static function (ContainerConfigurator $container): void {
             ->args([tagged_iterator('turbo.broadcaster')])
 
         ->alias(BroadcasterInterface::class, 'turbo.broadcaster.imux')
+
+        ->set('turbo.doctrine_class_resolver', DoctrineClassResolver::class)
+            ->args([
+                service('doctrine')->nullOnInvalid(),
+            ])
 
         ->set('turbo.id_formatter', IdFormatter::class)
 
@@ -51,6 +57,7 @@ return static function (ContainerConfigurator $container): void {
                 abstract_arg('entity template prefixes'),
                 service('turbo.id_accessor'),
                 service('turbo.id_formatter'),
+                service('turbo.doctrine_class_resolver'),
             ])
             ->decorate('turbo.broadcaster.imux')
 
@@ -63,6 +70,7 @@ return static function (ContainerConfigurator $container): void {
                 service('turbo.broadcaster.imux'),
                 service('annotation_reader')->nullOnInvalid(),
                 service('turbo.doctrine_id_accessor'),
+                service('turbo.doctrine_class_resolver'),
             ])
             ->tag('doctrine.event_listener', ['event' => 'onFlush'])
             ->tag('doctrine.event_listener', ['event' => 'postFlush'])

--- a/src/Turbo/src/Bridge/Mercure/Broadcaster.php
+++ b/src/Turbo/src/Bridge/Mercure/Broadcaster.php
@@ -99,7 +99,9 @@ final class Broadcaster implements BroadcasterInterface
                 throw new \InvalidArgumentException(sprintf('Cannot broadcast entity of class "%s": the option "topics" is empty and "id" is missing.', $entityClass));
             }
 
-            $options['topics'] = (array) sprintf(self::TOPIC_PATTERN, rawurlencode($entityClass), rawurlencode(implode('-', (array) $options['id'])));
+            $id = $options['id_formatted'] ?? implode('-', (array) $options['id']);
+
+            $options['topics'] = (array) sprintf(self::TOPIC_PATTERN, rawurlencode($entityClass), rawurlencode($id));
         }
 
         $update = new Update(

--- a/src/Turbo/src/Bridge/Mercure/Broadcaster.php
+++ b/src/Turbo/src/Bridge/Mercure/Broadcaster.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mercure\Update;
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
 use Symfony\UX\Turbo\Broadcaster\IdFormatter;
 use Symfony\UX\Turbo\Doctrine\ClassUtil;
+use Symfony\UX\Turbo\Doctrine\DoctrineClassResolver;
 
 /**
  * Broadcasts updates rendered using Twig with Mercure.
@@ -44,15 +45,17 @@ final class Broadcaster implements BroadcasterInterface
     private $name;
     private $hub;
     private $idFormatter;
+    private $doctrineClassResolver;
 
     /** @var ExpressionLanguage|null */
     private $expressionLanguage;
 
-    public function __construct(string $name, HubInterface $hub, ?IdFormatter $idFormatter = null)
+    public function __construct(string $name, HubInterface $hub, ?IdFormatter $idFormatter = null, ?DoctrineClassResolver $doctrineClassResolver = null)
     {
         $this->name = $name;
         $this->hub = $hub;
         $this->idFormatter = $idFormatter ?? new IdFormatter();
+        $this->doctrineClassResolver = $doctrineClassResolver ?? new DoctrineClassResolver();
 
         if (class_exists(ExpressionLanguage::class)) {
             $this->expressionLanguage = new ExpressionLanguage();
@@ -65,7 +68,7 @@ final class Broadcaster implements BroadcasterInterface
             return;
         }
 
-        $entityClass = ClassUtil::getEntityClass($entity);
+        $entityClass = $this->doctrineClassResolver->resolve($entity);
 
         if (!isset($options['rendered_action'])) {
             throw new \InvalidArgumentException(sprintf('Cannot broadcast entity of class "%s" as option "rendered_action" is missing.', $entityClass));

--- a/src/Turbo/src/Bridge/Mercure/Broadcaster.php
+++ b/src/Turbo/src/Bridge/Mercure/Broadcaster.php
@@ -16,7 +16,6 @@ use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
 use Symfony\UX\Turbo\Broadcaster\IdFormatter;
-use Symfony\UX\Turbo\Doctrine\ClassUtil;
 use Symfony\UX\Turbo\Doctrine\DoctrineClassResolver;
 
 /**

--- a/src/Turbo/src/Bridge/Mercure/Broadcaster.php
+++ b/src/Turbo/src/Bridge/Mercure/Broadcaster.php
@@ -15,7 +15,6 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
-use Symfony\UX\Turbo\Broadcaster\IdAccessor;
 use Symfony\UX\Turbo\Broadcaster\IdFormatter;
 use Symfony\UX\Turbo\Doctrine\ClassUtil;
 

--- a/src/Turbo/src/Bridge/Mercure/Broadcaster.php
+++ b/src/Turbo/src/Bridge/Mercure/Broadcaster.php
@@ -15,6 +15,8 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
+use Symfony\UX\Turbo\Broadcaster\IdAccessor;
+use Symfony\UX\Turbo\Broadcaster\IdFormatter;
 use Symfony\UX\Turbo\Doctrine\ClassUtil;
 
 /**
@@ -42,14 +44,16 @@ final class Broadcaster implements BroadcasterInterface
 
     private $name;
     private $hub;
+    private $idFormatter;
 
     /** @var ExpressionLanguage|null */
     private $expressionLanguage;
 
-    public function __construct(string $name, HubInterface $hub)
+    public function __construct(string $name, HubInterface $hub, ?IdFormatter $idFormatter = null)
     {
         $this->name = $name;
         $this->hub = $hub;
+        $this->idFormatter = $idFormatter ?? new IdFormatter();
 
         if (class_exists(ExpressionLanguage::class)) {
             $this->expressionLanguage = new ExpressionLanguage();
@@ -99,7 +103,7 @@ final class Broadcaster implements BroadcasterInterface
                 throw new \InvalidArgumentException(sprintf('Cannot broadcast entity of class "%s": the option "topics" is empty and "id" is missing.', $entityClass));
             }
 
-            $id = $options['id_formatted'] ?? implode('-', (array) $options['id']);
+            $id = $this->idFormatter->format($options['id']);
 
             $options['topics'] = (array) sprintf(self::TOPIC_PATTERN, rawurlencode($entityClass), rawurlencode($id));
         }

--- a/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
+++ b/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
@@ -15,6 +15,7 @@ use Symfony\Component\Mercure\HubInterface;
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
 use Symfony\UX\Turbo\Broadcaster\IdAccessor;
 use Symfony\UX\Turbo\Broadcaster\IdFormatter;
+use Symfony\UX\Turbo\Doctrine\DoctrineClassResolver;
 use Symfony\UX\Turbo\Twig\TurboStreamListenRendererInterface;
 use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
 use Twig\Environment;
@@ -30,15 +31,17 @@ final class TurboStreamListenRenderer implements TurboStreamListenRendererInterf
     private StimulusHelper $stimulusHelper;
     private IdAccessor $idAccessor;
     private IdFormatter $idFormatter;
+    private DoctrineClassResolver $doctrineClassResolver;
 
     /**
      * @param $stimulus StimulusHelper
      */
-    public function __construct(HubInterface $hub, StimulusHelper|StimulusTwigExtension $stimulus, IdAccessor $idAccessor, ?IdFormatter $idFormatter = null)
+    public function __construct(HubInterface $hub, StimulusHelper|StimulusTwigExtension $stimulus, IdAccessor $idAccessor, ?IdFormatter $idFormatter = null, ?DoctrineClassResolver $doctrineClassResolver = null)
     {
         $this->hub = $hub;
         $this->idAccessor = $idAccessor;
         $this->idFormatter = $idFormatter ?? new IdFormatter();
+        $this->doctrineClassResolver = $doctrineClassResolver ?? new DoctrineClassResolver();
 
         if ($stimulus instanceof StimulusTwigExtension) {
             trigger_deprecation('symfony/ux-turbo', '2.9', 'Passing an instance of "%s" as second argument of "%s" is deprecated, pass an instance of "%s" instead.', StimulusTwigExtension::class, __CLASS__, StimulusHelper::class);
@@ -52,7 +55,7 @@ final class TurboStreamListenRenderer implements TurboStreamListenRendererInterf
     public function renderTurboStreamListen(Environment $env, $topic): string
     {
         if (\is_object($topic)) {
-            $class = $topic::class;
+            $class = $this->doctrineClassResolver->resolve($topic);
 
             if (!$id = $this->idAccessor->getEntityId($topic)) {
                 throw new \LogicException(sprintf('Cannot listen to entity of class "%s" as the PropertyAccess component is not installed. Try running "composer require symfony/property-access".', $class));

--- a/src/Turbo/src/Broadcaster/BroadcasterInterface.php
+++ b/src/Turbo/src/Broadcaster/BroadcasterInterface.php
@@ -19,7 +19,7 @@ namespace Symfony\UX\Turbo\Broadcaster;
 interface BroadcasterInterface
 {
     /**
-     * @param array{id?: string|string[], transports?: string|string[], topics?: string|string[], template?: string, rendered_action?: string, private?: bool, sse_id?: string, sse_type?: string, sse_retry?: int} $options
+     * @param array{id?: array<string, string>|array<string, array<string, string>>, transports?: string|string[], topics?: string|string[], template?: string, rendered_action?: string, private?: bool, sse_id?: string, sse_type?: string, sse_retry?: int} $options
      */
     public function broadcast(object $entity, string $action, array $options): void;
 }

--- a/src/Turbo/src/Broadcaster/DoctrineIdAccessor.php
+++ b/src/Turbo/src/Broadcaster/DoctrineIdAccessor.php
@@ -32,7 +32,7 @@ class DoctrineIdAccessor
         $entityClass = $entity::class;
 
         if ($this->doctrine && $em = $this->doctrine->getManagerForClass($entityClass)) {
-            return $this->getIdentifierValues($em,$entity);
+            return $this->getIdentifierValues($em, $entity);
         }
 
         return null;

--- a/src/Turbo/src/Broadcaster/DoctrineIdAccessor.php
+++ b/src/Turbo/src/Broadcaster/DoctrineIdAccessor.php
@@ -32,7 +32,7 @@ class DoctrineIdAccessor
      */
     public function getEntityId(object $entity): ?array
     {
-        $entityClass = $entity::class;
+        $entityClass = ClassUtil::getEntityClass($entity);
 
         if ($this->doctrine && $em = $this->doctrine->getManagerForClass($entityClass)) {
             return $this->getIdentifierValues($em, $entity);

--- a/src/Turbo/src/Broadcaster/DoctrineIdAccessor.php
+++ b/src/Turbo/src/Broadcaster/DoctrineIdAccessor.php
@@ -27,6 +27,9 @@ class DoctrineIdAccessor
         $this->doctrine = $doctrine;
     }
 
+    /**
+     * @return array<string, array<string, string>>|array<string, string>|null
+     */
     public function getEntityId(object $entity): ?array
     {
         $entityClass = $entity::class;
@@ -38,6 +41,9 @@ class DoctrineIdAccessor
         return null;
     }
 
+    /**
+     * @return array<string, string>|array<string, array<string, string>>
+     */
     private function getIdentifierValues(ObjectManager $em, object $entity): array
     {
         $class = ClassUtil::getEntityClass($entity);

--- a/src/Turbo/src/Broadcaster/DoctrineIdAccessor.php
+++ b/src/Turbo/src/Broadcaster/DoctrineIdAccessor.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Broadcaster;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\UX\Turbo\Doctrine\ClassUtil;
+
+/**
+ * @author Jason Schilling <jason@sourecode.dev>
+ */
+class DoctrineIdAccessor
+{
+    private $doctrine;
+
+    public function __construct(?ManagerRegistry $doctrine = null)
+    {
+        $this->doctrine = $doctrine;
+    }
+
+    public function getEntityId(object $entity): ?array
+    {
+        $entityClass = $entity::class;
+
+        if ($this->doctrine && $em = $this->doctrine->getManagerForClass($entityClass)) {
+            return $this->getIdentifierValues($em,$entity);
+        }
+
+        return null;
+    }
+
+    private function getIdentifierValues(ObjectManager $em, object $entity): array
+    {
+        $class = ClassUtil::getEntityClass($entity);
+
+        $values = $em->getClassMetadata($class)->getIdentifierValues($entity);
+
+        foreach ($values as $key => $value) {
+            if (\is_object($value)) {
+                $values[$key] = $this->getIdentifierValues($em, $value);
+            }
+        }
+
+        return $values;
+    }
+}

--- a/src/Turbo/src/Broadcaster/IdAccessor.php
+++ b/src/Turbo/src/Broadcaster/IdAccessor.php
@@ -11,19 +11,18 @@
 
 namespace Symfony\UX\Turbo\Broadcaster;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 class IdAccessor
 {
     private $propertyAccessor;
-    private $doctrine;
+    private $doctrineIdAccessor;
 
-    public function __construct(?PropertyAccessorInterface $propertyAccessor = null, ?ManagerRegistry $doctrine = null)
+    public function __construct(?PropertyAccessorInterface $propertyAccessor = null, ?DoctrineIdAccessor $doctrineIdAccessor = null)
     {
         $this->propertyAccessor = $propertyAccessor ?? (class_exists(PropertyAccess::class) ? PropertyAccess::createPropertyAccessor() : null);
-        $this->doctrine = $doctrine;
+        $this->doctrineIdAccessor = $doctrineIdAccessor ?? new DoctrineIdAccessor();
     }
 
     /**
@@ -33,9 +32,8 @@ class IdAccessor
     {
         $entityClass = $entity::class;
 
-        if ($this->doctrine && $em = $this->doctrine->getManagerForClass($entityClass)) {
-            // @todo: Not sure how to use the same method like in the BroadcastListener without duplicating the code.
-            return $em->getClassMetadata($entityClass)->getIdentifierValues($entity);
+        if (null !== ($id = $this->doctrineIdAccessor->getEntityId($entity))) {
+            return $id;
         }
 
         if ($this->propertyAccessor) {

--- a/src/Turbo/src/Broadcaster/IdAccessor.php
+++ b/src/Turbo/src/Broadcaster/IdAccessor.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\Turbo\Broadcaster;
 
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\UX\Turbo\Doctrine\DoctrineIdAccessor;
 
 class IdAccessor
 {

--- a/src/Turbo/src/Broadcaster/IdAccessor.php
+++ b/src/Turbo/src/Broadcaster/IdAccessor.php
@@ -34,6 +34,7 @@ class IdAccessor
         $entityClass = $entity::class;
 
         if ($this->doctrine && $em = $this->doctrine->getManagerForClass($entityClass)) {
+            // @todo: Not sure how to use the same method like in the BroadcastListener without duplicating the code.
             return $em->getClassMetadata($entityClass)->getIdentifierValues($entity);
         }
 

--- a/src/Turbo/src/Broadcaster/IdAccessor.php
+++ b/src/Turbo/src/Broadcaster/IdAccessor.php
@@ -26,7 +26,7 @@ class IdAccessor
     }
 
     /**
-     * @return string[]
+     * @return array<string, array<string, string>>|array<string, string>|null
      */
     public function getEntityId(object $entity): ?array
     {

--- a/src/Turbo/src/Broadcaster/IdAccessor.php
+++ b/src/Turbo/src/Broadcaster/IdAccessor.php
@@ -30,8 +30,6 @@ class IdAccessor
      */
     public function getEntityId(object $entity): ?array
     {
-        $entityClass = $entity::class;
-
         if (null !== ($id = $this->doctrineIdAccessor->getEntityId($entity))) {
             return $id;
         }

--- a/src/Turbo/src/Broadcaster/IdFormatter.php
+++ b/src/Turbo/src/Broadcaster/IdFormatter.php
@@ -28,7 +28,7 @@ class IdFormatter
      */
     public function format(array|string $id): string
     {
-        if (is_string($id)) {
+        if (\is_string($id)) {
             return $id;
         }
 

--- a/src/Turbo/src/Broadcaster/IdFormatter.php
+++ b/src/Turbo/src/Broadcaster/IdFormatter.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Broadcaster;
+
+/**
+ * Formats an id array to a string.
+ *
+ * In defaults the id array is something like `['id' => 1]` or `['uuid' => '00000000-0000-0000-0000-000000000000']`.
+ * For a composite key it could be something like `['cart' => ['id' => 1], 'product' => ['id' => 1]]`.
+ *
+ * To create a string representation of the id, the values of the array are flattened and concatenated with a dash.
+ *
+ * @author Jason Schilling <jason@sourecode.dev>
+ */
+class IdFormatter
+{
+    public function format(array $id): string
+    {
+        $flatten = [];
+
+        array_walk_recursive($id, static function ($item) use (&$flatten) { $flatten[] = $item; });
+
+        return implode('-', $flatten);
+    }
+}

--- a/src/Turbo/src/Broadcaster/IdFormatter.php
+++ b/src/Turbo/src/Broadcaster/IdFormatter.php
@@ -23,8 +23,15 @@ namespace Symfony\UX\Turbo\Broadcaster;
  */
 class IdFormatter
 {
-    public function format(array $id): string
+    /**
+     * @param array<string, array<string, string>>|array<string, string>|string $id
+     */
+    public function format(array|string $id): string
     {
+        if (is_string($id)) {
+            return $id;
+        }
+
         $flatten = [];
 
         array_walk_recursive($id, static function ($item) use (&$flatten) { $flatten[] = $item; });

--- a/src/Turbo/src/Broadcaster/TwigBroadcaster.php
+++ b/src/Turbo/src/Broadcaster/TwigBroadcaster.php
@@ -25,23 +25,24 @@ final class TwigBroadcaster implements BroadcasterInterface
     private $twig;
     private $templatePrefixes;
     private $idAccessor;
+    private $idFormatter;
 
     /**
      * @param array<string, string> $templatePrefixes
      */
-    public function __construct(BroadcasterInterface $broadcaster, Environment $twig, array $templatePrefixes = [], ?IdAccessor $idAccessor = null)
+    public function __construct(BroadcasterInterface $broadcaster, Environment $twig, array $templatePrefixes = [], ?IdAccessor $idAccessor = null, ?IdFormatter $idFormatter = null)
     {
         $this->broadcaster = $broadcaster;
         $this->twig = $twig;
         $this->templatePrefixes = $templatePrefixes;
         $this->idAccessor = $idAccessor ?? new IdAccessor();
+        $this->idFormatter = $idFormatter ?? new IdFormatter();
     }
 
     public function broadcast(object $entity, string $action, array $options): void
     {
         if (!isset($options['id']) && null !== $id = $this->idAccessor->getEntityId($entity)) {
             $options['id'] = $id;
-            $options['id_formatted'] = $id;
         }
 
         $class = ClassUtil::getEntityClass($entity);
@@ -64,7 +65,7 @@ final class TwigBroadcaster implements BroadcasterInterface
             ->renderBlock($action, [
                 'entity' => $entity,
                 'action' => $action,
-                'id' => $options['id_formatted'],
+                'id' => $this->idFormatter->format($options['id'] ?? []),
             ] + $options);
 
         $this->broadcaster->broadcast($entity, $action, $options);

--- a/src/Turbo/src/Broadcaster/TwigBroadcaster.php
+++ b/src/Turbo/src/Broadcaster/TwigBroadcaster.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\UX\Turbo\Broadcaster;
 
-use Symfony\UX\Turbo\Doctrine\ClassUtil;
 use Symfony\UX\Turbo\Doctrine\DoctrineClassResolver;
 use Twig\Environment;
 

--- a/src/Turbo/src/Broadcaster/TwigBroadcaster.php
+++ b/src/Turbo/src/Broadcaster/TwigBroadcaster.php
@@ -41,6 +41,7 @@ final class TwigBroadcaster implements BroadcasterInterface
     {
         if (!isset($options['id']) && null !== $id = $this->idAccessor->getEntityId($entity)) {
             $options['id'] = $id;
+            $options['id_formatted'] = $id;
         }
 
         $class = ClassUtil::getEntityClass($entity);
@@ -63,7 +64,7 @@ final class TwigBroadcaster implements BroadcasterInterface
             ->renderBlock($action, [
                 'entity' => $entity,
                 'action' => $action,
-                'id' => implode('-', (array) ($options['id'] ?? [])),
+                'id' => $options['id_formatted'],
             ] + $options);
 
         $this->broadcaster->broadcast($entity, $action, $options);

--- a/src/Turbo/src/Doctrine/BroadcastListener.php
+++ b/src/Turbo/src/Doctrine/BroadcastListener.php
@@ -20,7 +20,6 @@ use Symfony\Contracts\Service\ResetInterface;
 use Symfony\UX\Turbo\Attribute\Broadcast;
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
 use Symfony\UX\Turbo\Broadcaster\DoctrineIdAccessor;
-use Symfony\UX\Turbo\Broadcaster\IdAccessor;
 
 /**
  * Detects changes made from Doctrine entities and broadcasts updates to the broadcasters.

--- a/src/Turbo/src/Doctrine/DoctrineClassResolver.php
+++ b/src/Turbo/src/Doctrine/DoctrineClassResolver.php
@@ -1,11 +1,23 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\UX\Turbo\Doctrine;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 
+/**
+ * @author Jason Schilling <jason@sourecode.dev>
+ */
 class DoctrineClassResolver
 {
     private $doctrine;
@@ -16,7 +28,6 @@ class DoctrineClassResolver
     }
 
     /**
-     * @param object $entity
      * @return class-string
      */
     public function resolve(object $entity, ?ObjectManager $em = null): string

--- a/src/Turbo/src/Doctrine/DoctrineClassResolver.php
+++ b/src/Turbo/src/Doctrine/DoctrineClassResolver.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Symfony\UX\Turbo\Doctrine;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+
+class DoctrineClassResolver
+{
+    private $doctrine;
+
+    public function __construct(?ManagerRegistry $doctrine = null)
+    {
+        $this->doctrine = $doctrine;
+    }
+
+    /**
+     * @param object $entity
+     * @return class-string
+     */
+    public function resolve(object $entity, ?ObjectManager $em = null): string
+    {
+        $class = ClassUtil::getEntityClass($entity);
+
+        if (!$this->doctrine) {
+            return $class;
+        }
+
+        $em = $em ?? $this->doctrine->getManagerForClass($class);
+
+        if (!$em) {
+            return $class;
+        }
+
+        $classMetadata = $em->getClassMetadata($class);
+
+        if ($classMetadata instanceof ClassMetadata) {
+            return $classMetadata->rootEntityName;
+        }
+
+        return $class;
+    }
+}

--- a/src/Turbo/src/Doctrine/DoctrineIdAccessor.php
+++ b/src/Turbo/src/Doctrine/DoctrineIdAccessor.php
@@ -9,11 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\UX\Turbo\Broadcaster;
+namespace Symfony\UX\Turbo\Doctrine;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
-use Symfony\UX\Turbo\Doctrine\ClassUtil;
 
 /**
  * @author Jason Schilling <jason@sourecode.dev>
@@ -30,11 +29,11 @@ class DoctrineIdAccessor
     /**
      * @return array<string, array<string, string>>|array<string, string>|null
      */
-    public function getEntityId(object $entity): ?array
+    public function getEntityId(object $entity, ?ObjectManager $em = null): ?array
     {
-        $entityClass = ClassUtil::getEntityClass($entity);
+        $em = $em ?? $this->doctrine?->getManagerForClass($entity::class);
 
-        if ($this->doctrine && $em = $this->doctrine->getManagerForClass($entityClass)) {
+        if ($em) {
             return $this->getIdentifierValues($em, $entity);
         }
 
@@ -46,9 +45,7 @@ class DoctrineIdAccessor
      */
     private function getIdentifierValues(ObjectManager $em, object $entity): array
     {
-        $class = ClassUtil::getEntityClass($entity);
-
-        $values = $em->getClassMetadata($class)->getIdentifierValues($entity);
+        $values = $em->getClassMetadata($entity::class)->getIdentifierValues($entity);
 
         foreach ($values as $key => $value) {
             if (\is_object($value)) {

--- a/src/Turbo/src/TurboBundle.php
+++ b/src/Turbo/src/TurboBundle.php
@@ -35,7 +35,7 @@ final class TurboBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new class () implements CompilerPassInterface {
+        $container->addCompilerPass(new class() implements CompilerPassInterface {
             public function process(ContainerBuilder $container): void
             {
                 if (!$container->hasDefinition('turbo.broadcaster.imux')) {
@@ -47,7 +47,7 @@ final class TurboBundle extends Bundle
             }
         }, PassConfig::TYPE_BEFORE_REMOVING);
 
-        $container->addCompilerPass(new class () implements CompilerPassInterface {
+        $container->addCompilerPass(new class() implements CompilerPassInterface {
             public function process(ContainerBuilder $container): void
             {
                 $serviceIds = [

--- a/src/Turbo/tests/BroadcastTest.php
+++ b/src/Turbo/tests/BroadcastTest.php
@@ -27,7 +27,7 @@ class BroadcastTest extends PantherTestCase
     protected function setUp(): void
     {
         if (!file_exists(__DIR__.'/app/public/build')) {
-            throw new \Exception(sprintf('Move into %s and execute Encore before running this test.', realpath(__DIR__.'/app')));
+            throw new \Exception(sprintf('Move into "%s" and execute Encore before running this test.', realpath(__DIR__.'/app')));
         }
 
         parent::setUp();

--- a/src/Turbo/tests/BroadcastTest.php
+++ b/src/Turbo/tests/BroadcastTest.php
@@ -111,12 +111,12 @@ class BroadcastTest extends PantherTestCase
 
         // submit first to create the entities
         $client->submitForm('Submit', ['title' => 'product 1']);
-        $this->assertSelectorWillContain('#cartProducts', 'product 1');
+        $this->assertSelectorWillContain('#cart_products', 'product 1');
 
         // submit again to update the quantity
         $client->submitForm('Submit');
-        $this->assertSelectorWillContain('#cartProducts', '2x product 1');
+        $this->assertSelectorWillContain('#cart_products', '2x product 1');
         // this part is from the stream template
-        $this->assertSelectorWillContain('#cartProducts', ', updated)');
+        $this->assertSelectorWillContain('#cart_products', ', updated)');
     }
 }

--- a/src/Turbo/tests/BroadcastTest.php
+++ b/src/Turbo/tests/BroadcastTest.php
@@ -104,4 +104,19 @@ class BroadcastTest extends PantherTestCase
         // this part is from the stream template
         $this->assertSelectorWillContain('#artists', ', updated)');
     }
+
+    public function testBroadcastWithCompositePrimaryKey(): void
+    {
+        ($client = self::createPantherClient())->request('GET', '/cartProducts');
+
+        // submit first to create the entities
+        $client->submitForm('Submit', ['title' => 'product 1']);
+        $this->assertSelectorWillContain('#cartProducts', 'product 1');
+
+        // submit again to update the quantity
+        $client->submitForm('Submit');
+        $this->assertSelectorWillContain('#cartProducts', '2x product 1');
+        // this part is from the stream template
+        $this->assertSelectorWillContain('#cartProducts', ', updated)');
+    }
 }

--- a/src/Turbo/tests/app/Entity/Cart.php
+++ b/src/Turbo/tests/app/Entity/Cart.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Jason Schilling <jason@sourecode.dev>
+ */
+#[ORM\Entity]
+class Cart
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(type: Types::INTEGER)]
+    public ?int $id = null;
+}

--- a/src/Turbo/tests/app/Entity/CartProduct.php
+++ b/src/Turbo/tests/app/Entity/CartProduct.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\UX\Turbo\Attribute\Broadcast;
+
+/**
+ * @author Jason Schilling <jason@sourecode.dev>
+ */
+#[Broadcast]
+#[ORM\Entity]
+class CartProduct
+{
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Cart::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    public ?Cart $cart = null;
+
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: Product::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    public ?Product $product = null;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $quantity = 1;
+}

--- a/src/Turbo/tests/app/Entity/Product.php
+++ b/src/Turbo/tests/app/Entity/Product.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Jason Schilling <jason@sourecode.dev>
+ */
+#[ORM\Entity]
+class Product
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(type: Types::INTEGER)]
+    public ?int $id = null;
+
+    #[ORM\Column]
+    public string $title = '';
+}

--- a/src/Turbo/tests/app/Entity/Song.php
+++ b/src/Turbo/tests/app/Entity/Song.php
@@ -24,7 +24,7 @@ class Song
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     #[ORM\Column(type: 'integer')]
-    public ?string $id = null;
+    public ?int $id = null;
 
     #[ORM\Column]
     public string $title = '';

--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -345,8 +345,12 @@ class Kernel extends BaseKernel
 
                 if ($remove = $request->get('remove')) {
                     $doctrine->remove($cartProduct);
-                    $doctrine->remove($cartProduct->product); // for cleanup
-                    $doctrine->remove($cartProduct->cart); // for cleanup
+                    if ($cartProduct->product) {
+                        $doctrine->remove($cartProduct->product); // for cleanup
+                    }
+                    if ($cartProduct->cart) {
+                        $doctrine->remove($cartProduct->cart); // for cleanup
+                    }
                 } else {
                     $doctrine->persist($cartProduct);
                 }

--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -319,7 +319,6 @@ class Kernel extends BaseKernel
 
             if (!$cartId || !$productId) {
                 $cart = new Cart();
-
                 $product = new Product();
 
                 if ($title = $request->get('title')) {

--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -13,6 +13,9 @@ namespace App;
 
 use App\Entity\Artist;
 use App\Entity\Book;
+use App\Entity\Cart;
+use App\Entity\CartProduct;
+use App\Entity\Product;
 use App\Entity\Song;
 use Composer\InstalledVersions;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
@@ -137,6 +140,7 @@ class Kernel extends BaseKernel
         $routes->add('artists', '/artists')->controller('kernel::artists');
         $routes->add('artist', '/artists/{id}')->controller('kernel::artist');
         $routes->add('artist_from_song', '/artistFromSong')->controller('kernel::artistFromSong');
+        $routes->add('cart_products', '/cartProducts')->controller('kernel::cartProducts');
     }
 
     public function getProjectDir(): string
@@ -303,6 +307,57 @@ class Kernel extends BaseKernel
 
         return new Response($twig->render('artist_from_song.html.twig', [
             'song' => $song,
+        ]));
+    }
+
+    public function cartProducts(Request $request, EntityManagerInterface $doctrine, Environment $twig): Response
+    {
+        $cartProduct = null;
+        if ($request->isMethod('POST')) {
+            $cartId = $request->get('cartId');
+            $productId = $request->get('productId');
+
+            if (!$cartId || !$productId) {
+                $cart = new Cart();
+
+                $product = new Product();
+
+                if ($title = $request->get('title')) {
+                    $product->title = $title;
+                }
+
+                $cartProduct = new CartProduct();
+                $cartProduct->cart = $cart;
+                $cartProduct->product = $product;
+                $cartProduct->quantity = 1;
+
+                $doctrine->persist($cart);
+                $doctrine->persist($product);
+                $doctrine->persist($cartProduct);
+                $doctrine->flush();
+            } else {
+                $cartProduct = $doctrine->find(CartProduct::class, [$cartId, $productId]);
+
+                if (!$cartProduct) {
+                    throw new NotFoundHttpException();
+                }
+
+                ++$cartProduct->quantity;
+
+                if ($remove = $request->get('remove')) {
+                    $doctrine->remove($cartProduct);
+                    $doctrine->remove($cartProduct->product); // for cleanup
+                    $doctrine->remove($cartProduct->cart); // for cleanup
+                } else {
+                    $doctrine->persist($cartProduct);
+                }
+
+                $doctrine->flush();
+            }
+        }
+
+        return new Response($twig->render('cart_products.html.twig', [
+            'cartProduct' => $cartProduct,
         ]));
     }
 }

--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -336,7 +336,7 @@ class Kernel extends BaseKernel
                 $doctrine->persist($cartProduct);
                 $doctrine->flush();
             } else {
-                $cartProduct = $doctrine->find(CartProduct::class, [$cartId, $productId]);
+                $cartProduct = $doctrine->find(CartProduct::class, ['cart' => $cartId, 'product' => $productId]);
 
                 if (!$cartProduct) {
                     throw new NotFoundHttpException();

--- a/src/Turbo/tests/app/templates/base.html.twig
+++ b/src/Turbo/tests/app/templates/base.html.twig
@@ -14,6 +14,7 @@
                 <li><a href="{{ path('books') }}">Books (broadcast)</a></li>
                 <li><a href="{{ path('songs') }}">Songs (broadcast)</a></li>
                 <li><a href="{{ path('artists') }}">Artists (broadcast)</a></li>
+                <li><a href="{{ path('cart_products') }}">CartProducts (broadcast)</a></li>
             </ul>
         </nav>
 

--- a/src/Turbo/tests/app/templates/broadcast/CartProduct.stream.html.twig
+++ b/src/Turbo/tests/app/templates/broadcast/CartProduct.stream.html.twig
@@ -1,0 +1,20 @@
+
+{% block create %}
+    <turbo-stream action="append" target="cart_products">
+        <template>
+            <div id="{{ 'cart_product_' ~ id }}">{{ entity.quantity }}x {{ entity.product.title }} (cart: {{ entity.cart.id }}, product: {{ entity.product.id }})</div>
+        </template>
+    </turbo-stream>
+{% endblock %}
+
+{% block update %}
+    <turbo-stream action="update" target="{{ 'cart_product_' ~ id }}">
+        <template>
+            {{ entity.quantity }}x {{ entity.product.title }} (cart: {{ entity.cart.id }}, product: {{ entity.product.id }}, updated)
+        </template>
+    </turbo-stream>
+{% endblock %}
+
+{% block remove %}
+    <turbo-stream action="remove" target="{{ 'cart_product_' ~ id }}"></turbo-stream>
+{% endblock %}

--- a/src/Turbo/tests/app/templates/cart_products.html.twig
+++ b/src/Turbo/tests/app/templates/cart_products.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
     <h1>Create Cart, Product and CartProduct, increase quantity on update</h1>
 
-    <div id="cart_products" {{ turbo_stream_listen('App\\Entity\\CartProducts') }}></div>
+    <div id="cart_products" {{ turbo_stream_listen('App\\Entity\\CartProduct') }}></div>
 
     <turbo-frame id="api">
         <form method="post" enctype="application/x-www-form-urlencoded">

--- a/src/Turbo/tests/app/templates/cart_products.html.twig
+++ b/src/Turbo/tests/app/templates/cart_products.html.twig
@@ -1,0 +1,17 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <h1>Create Cart, Product and CartProduct, increase quantity on update</h1>
+
+    <div id="cart_products" {{ turbo_stream_listen('App\\Entity\\CartProducts') }}></div>
+
+    <turbo-frame id="api">
+        <form method="post" enctype="application/x-www-form-urlencoded">
+            <input placeholder="Title" name="title">
+            <input placeholder="Cart ID" name="cartId" value="{{ cartProduct ? cartProduct.cart.id }}">
+            <input placeholder="Product ID" name="productId" value="{{ cartProduct ? cartProduct.product.id }}">
+            <label><input type="checkbox" name="remove" value="remove"> Remove</label>
+            <button>Submit</button>
+        </form>
+    </turbo-frame>
+{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1856
| License       | MIT

Kind of a feature as it adds support for using broadcast with entities using a composite primary key.

- Add tests to reproduce the issue
- Fix composite primary keys
- Split `IdAccessor` into another `DoctrineIdAccessor` to prevent duplicated code
- Introduce `IdFormatter` to format the values returned from the doctrine function `getIdentifierValues`
- Introduce `DoctrineClassResolver` to resolve real entity class names. (Doctrine;Proxy)

### Others 

- Add missing dash in the `CONTRIBUTING.md`
- Fix primary key type in test data (`Song.php`)

Last workflow issue with phpstan is fixed in #1854

Fixed more than I wanted, a bit unsure about the injection of services into `Broadcaster` in the Mercure integration, was even confused that the turbo services for the Mercure integration are registered in the MercureBundle.
