### PR TITLE
Fix the example with Expression Language

### DIFF
--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -729,8 +729,8 @@ Example::
 
     use Symfony\UX\Turbo\Attribute\Broadcast;
 
-    #[Broadcast(topics: ['@="book_detail" ~ entity.id', 'books'], template: 'book_detail.stream.html.twig', private: true)]
-    #[Broadcast(topics: ['@="book_list" ~ entity.id', 'books'], template: 'book_list.stream.html.twig', private: true)]
+    #[Broadcast(topics: ['@="book_detail" ~ entity.getId()', 'books'], template: 'book_detail.stream.html.twig', private: true)]
+    #[Broadcast(topics: ['@="book_list" ~ entity.getId()', 'books'], template: 'book_list.stream.html.twig', private: true)]
     class Book
     {
         // ...


### PR DESCRIPTION
@stof said in https://github.com/symfony/symfony-docs/pull/17905: 
> When evaluating the expression, the ExpressionLanguage does not have access to private properties of the object, as it runs from its outside. And contrary to Twig, ExpressionLanguage does not have the magic . operator that tries to find a getter when it cannot use the property.

I then improved the documentation :).