### PR TITLE
[TwigComponent] Disable profiler integration via configuration

### DIFF
--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -125,7 +125,7 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
         $container->setAlias('console.command.stimulus_component_debug', 'ux.twig_component.command.debug')
             ->setDeprecated('symfony/ux-twig-component', '2.13', '%alias_id%');
 
-        if ($container->getParameter('kernel.debug')) {
+        if ($container->getParameter('kernel.debug') && $config['profiler']) {
             $loader->load('debug.php');
         }
     }
@@ -181,6 +181,10 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                 ->end()
                 ->scalarNode('anonymous_template_directory')
                     ->info('Defaults to `components`')
+                ->end()
+                ->booleanNode('profiler')
+                    ->info('Enables the profiler for Twig Component (in debug mode)')
+                    ->defaultValue('%kernel.debug%')
                 ->end()
             ->end();
 

--- a/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
@@ -36,6 +36,21 @@ class TwigComponentExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('ux.twig_component.data_collector'));
     }
 
+    public function testDataCollectorWithDebugModeCanBeDisabled()
+    {
+        $container = $this->createContainer();
+        $container->setParameter('kernel.debug', true);
+        $container->registerExtension(new TwigComponentExtension());
+        $container->loadFromExtension('twig_component', [
+            'defaults' => [],
+            'anonymous_template_directory' => 'components/',
+            'profiler' => false,
+        ]);
+        $this->compileContainer($container);
+
+        $this->assertFalse($container->hasDefinition('ux.twig_component.data_collector'));
+    }
+
     public function testDataCollectorWithoutDebugMode()
     {
         $container = $this->createContainer();
@@ -44,6 +59,7 @@ class TwigComponentExtensionTest extends TestCase
         $container->loadFromExtension('twig_component', [
             'defaults' => [],
             'anonymous_template_directory' => 'components/',
+            'profiler' => true,
         ]);
         $this->compileContainer($container);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #... 
| License       | MIT

Add a new configuration key allowing to disable profiler integration (enabled per default in debug mode)

(following several performance issues caused by the current DataCollector implementation)