### PR TITLE
[TwigComponent] Restrict anonymous component lookup to Twig files in debug command

### DIFF
--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -151,12 +151,10 @@ EOF
         $components = [];
         $anonymousPath = $this->twigTemplatesPath.'/'.$this->anonymousDirectory;
         $finderTemplates = new Finder();
-        $finderTemplates->files()->in($anonymousPath)->notPath('/_');
+        $finderTemplates->files()->in($anonymousPath)->notPath('/_')->name('*.html.twig');
         foreach ($finderTemplates as $template) {
             $component = str_replace('/', ':', $template->getRelativePathname());
-            if (str_ends_with($component, '.html.twig')) {
-                $component = substr($component, 0, -10);
-            }
+            $component = substr($component, 0, -10);
             $components[$component] = $component;
         }
 

--- a/src/TwigComponent/tests/Fixtures/templates/components/NotAComponent.md
+++ b/src/TwigComponent/tests/Fixtures/templates/components/NotAComponent.md
@@ -1,0 +1,1 @@
+This file should not cause issues with the debug:twig:component command.

--- a/src/TwigComponent/tests/Integration/Command/TwigComponentDebugCommandTest.php
+++ b/src/TwigComponent/tests/Integration/Command/TwigComponentDebugCommandTest.php
@@ -41,6 +41,15 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Unknown component "NoMatchComponent".', $commandTester->getDisplay());
     }
 
+    public function testNotComponentsIsNotListed(): void
+    {
+        $commandTester = $this->createCommandTester();
+        $result = $commandTester->execute(['name' => 'NotAComponent']);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('Unknown component "NotAComponent".', $commandTester->getDisplay());
+    }
+
     public function testWithOnePartialMatchComponent(): void
     {
         $commandTester = $this->createCommandTester();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | 
| License       | MIT

Hi!

The `debug:twig-component` command looks for files in the anonymous template directory, but fails if some files are actually not Twig components (like .md).

For example, with a `README.md` file in `templates/components`:

```shell
$ php bin/console debug:twig-component 
[critical] Error thrown while running command "debug:twig-component". Message: "Unknown component "README.md". And no matching anonymous component template was found."

In ComponentFactory.php line 254:
                                                                                          
  Unknown component "README.md". And no matching anonymous component template was found.  
                                                                                          

debug:twig-component [<name>]


```

This PR restricts the finder to `*.html.twig` files, so others are ignored.