### PR TITLE
[Icons] Expose IconRendererInterface

### DIFF
--- a/src/Icons/config/services.php
+++ b/src/Icons/config/services.php
@@ -50,6 +50,8 @@ return static function (ContainerConfigurator $container): void {
             ])
             ->tag('twig.runtime')
 
+        ->alias('Symfony\UX\Icons\IconRendererInterface', '.ux_icons.icon_renderer')
+
         ->set('.ux_icons.icon_finder', IconFinder::class)
             ->args([
                 service('twig'),

--- a/src/Icons/src/IconRenderer.php
+++ b/src/Icons/src/IconRenderer.php
@@ -16,7 +16,7 @@ namespace Symfony\UX\Icons;
  *
  * @internal
  */
-final class IconRenderer
+final class IconRenderer implements IconRendererInterface
 {
     public function __construct(
         private readonly IconRegistryInterface $registry,
@@ -32,8 +32,6 @@ final class IconRenderer
      *
      * Precedence order:
      *   Icon file < Renderer configuration < Renderer invocation
-     *
-     * @param array<string,string|bool> $attributes
      */
     public function renderIcon(string $name, array $attributes = []): string
     {

--- a/src/Icons/src/IconRendererInterface.php
+++ b/src/Icons/src/IconRendererInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons;
+
+use Symfony\UX\Icons\Exception\IconNotFoundException;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+interface IconRendererInterface
+{
+    /**
+     * Renders an icon by its name and returns the SVG string.
+     *
+     * @param string                     $name       the icon name, optionally prefixed with the icon set
+     * @param array<string, string|bool> $attributes an array of HTML attributes
+     *
+     * @throws IconNotFoundException
+     *
+     * @example
+     *  $iconRenderer->renderIcon('arrow-right');
+     *  // Renders the "arrow-right" icon from the default icons directory.
+     *
+     *  $iconRenderer->renderIcon('lucide:heart', ['class' => 'color-red']);
+     *  // Renders the "heart" icon from the "lucide" icon set, with the "color-red" class.
+     */
+    public function renderIcon(string $name, array $attributes = []): string;
+}

--- a/src/Icons/src/Twig/UXIconComponentListener.php
+++ b/src/Icons/src/Twig/UXIconComponentListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\UX\Icons\Twig;
 
-use Symfony\UX\Icons\IconRenderer;
+use Symfony\UX\Icons\IconRendererInterface;
 use Symfony\UX\TwigComponent\Event\PreCreateForRenderEvent;
 
 /**
@@ -22,7 +22,7 @@ use Symfony\UX\TwigComponent\Event\PreCreateForRenderEvent;
 final class UXIconComponentListener
 {
     public function __construct(
-        private IconRenderer $iconRenderer,
+        private IconRendererInterface $iconRenderer,
     ) {
     }
 

--- a/src/Icons/tests/Integration/IconRendererTest.php
+++ b/src/Icons/tests/Integration/IconRendererTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\Icons\IconRenderer;
+use Symfony\UX\Icons\IconRendererInterface;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class IconRendererTest extends KernelTestCase
+{
+    public function testIconRenderService(): void
+    {
+        $this->assertTrue(self::getContainer()->has(IconRendererInterface::class));
+    }
+
+    public function testIconRendererAlias(): void
+    {
+        $renderer = self::getContainer()->get(IconRendererInterface::class);
+        $this->assertInstanceOf(IconRenderer::class, $renderer);
+    }
+
+    public function testIconRendererIsPrivate(): void
+    {
+        $this->assertFalse(self::getContainer()->has(IconRenderer::class));
+    }
+}


### PR DESCRIPTION
As the renderer won't change without BC (at least via the twig function/component).. i think it's ok to expose an interface here, allowing people to use it / decorate / etc..

Only thing i think we don't want (for now): add other public methods (like exposing the Icon object)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #... 
| License       | MIT
