### PR TITLE
React Integration Documentation Hint for AssetMapper as Standard

### DIFF
--- a/src/React/doc/index.rst
+++ b/src/React/doc/index.rst
@@ -16,7 +16,7 @@ Installation
 .. note::
 
     This package works best with WebpackEncore. To use it with AssetMapper, see
-    :ref:`Using with AssetMapper <using-with-asset-mapper>`.
+    :ref:`Using with AssetMapper <using-with-asset-mapper>`. Please note, that if your Symfony Application was created with the ``--webapp`` flag, that AssetMapper is used in your project as standard.
 
 .. caution::
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | Fix #1892
| License       | MIT

As descriped in https://github.com/symfony/ux/issues/1892#issuecomment-2153523329 I stumbled upon the fact, that Assetmapper is used as standard when creating a new project (which might not be too obvious if you are new to Symfony), which can result in conflicts when trying the prefered WebpackEncore integration.
