### PR TITLE
[Live] Fix nullable DateTime hydration with empty value

### DIFF
--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -531,6 +531,10 @@ final class LiveComponentHydrator
                 throw new BadRequestHttpException(sprintf('The model path "%s" was sent an invalid data type "%s" for a date.', $propertyPathForError, get_debug_type($value)));
             }
 
+            if ('' === $value) {
+                return $allowsNull ? null : throw new BadRequestHttpException(sprintf('The model path "%s" was sent invalid date data "%s". Setting empty date value is not allowed, send a non-empty value or make the property nullable.', $propertyPathForError, $value, $dateFormat)) ;
+            }
+
             if (null !== $dateFormat) {
                 return $className::createFromFormat($dateFormat, $value) ?: throw new BadRequestHttpException(sprintf('The model path "%s" was sent invalid date data "%s" or in an invalid format. Make sure it\'s a valid date and it matches the expected format "%s".', $propertyPathForError, $value, $dateFormat));
             }

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -307,6 +307,21 @@ final class LiveComponentHydratorTest extends KernelTestCase
             ;
         }];
 
+        yield 'empty DateTime hydrates correctly' => [function () {
+            $date = new \DateTime('2023-03-05 9:23', new \DateTimeZone('America/New_York'));
+
+            return HydrationTest::create(new class() {
+                #[LiveProp(writable: true)]
+                public ?\DateTime $createdAt = null;
+            })
+                ->mountWith(['createdAt' => $date])
+                ->userUpdatesProps(['createdAt' => ''])
+                ->assertObjectAfterHydration(function (object $object) use ($date) {
+                    self::assertNull($object->createdAt);
+                })
+            ;
+        }];
+
         yield 'Persisted entity: (de)hydration works correctly to/from id' => [function () {
             $entity1 = create(Entity1::class)->object();
             \assert($entity1 instanceof Entity1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | -
| License       | MIT

Currently when we send an empty string as value, the `new DateTime('')` call
creates an object with the current time, which I think is not correct and the
object should be set to null instead.
