### PR TITLE
[Translator] Fix changing dump directory using AssetMapper

### DIFF
--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -138,6 +138,12 @@ file. 2 of the new items are::
         'path' => 'var/translations/configuration.js',
     ],
 
+.. caution::
+
+    If you change the ``dump_directory`` in your configuration file, you will need to
+    replace the default ``var/translations/***`` with your new path in the
+    ``importmap.php`` file.
+
 These are then imported in your ``assets/translator.js`` file. This setup is
 very similar to working with WebpackEncore. However, the ``var/translations/index.js``
 file contains *every* translation in your app, which is not ideal for production

--- a/src/Translator/src/DependencyInjection/UxTranslatorExtension.php
+++ b/src/Translator/src/DependencyInjection/UxTranslatorExtension.php
@@ -43,12 +43,12 @@ class UxTranslatorExtension extends Extension implements PrependExtensionInterfa
         if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
-
+        $config = $container->getExtensionConfig('ux_translator')[0];
         $container->prependExtensionConfig('framework', [
             'asset_mapper' => [
                 'paths' => [
                     __DIR__.'/../../assets/dist' => '@symfony/ux-translator',
-                    '%kernel.project_dir%/var/translations' => 'var/translations',
+                    $config['dump_directory'] => '@app/translations',
                 ],
             ],
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1642
| License       | MIT

The configuration node `ux_translator.dump_directory` wasn't correctly taken into account when using UxTranslator with AssetMapper.  
This PR fixes the configuration prepend of AssetMapper to use the custom path + adds a "caution" section in the docs to remind developers to also update their `importmap.php`.