### PR TITLE
[Fix] Revert removing `twig_component.controllers_json`

### DIFF
--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -186,6 +186,10 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                     ->info('Enables the profiler for Twig Component (in debug mode)')
                     ->defaultValue('%kernel.debug%')
                 ->end()
+                ->scalarNode('controllers_json')
+                    ->setDeprecated('symfony/ux-twig-component', '2.18', 'The "twig_component.controllers_json" config option is deprecated, and will be removed in 3.0.')
+                    ->defaultNull()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\TwigComponent\Test\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\UX\TwigComponent\DependencyInjection\TwigComponentExtension;
@@ -22,6 +23,8 @@ use Symfony\UX\TwigComponent\TwigComponentBundle;
  */
 class TwigComponentExtensionTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testDataCollectorWithDebugMode()
     {
         $container = $this->createContainer();
@@ -64,6 +67,26 @@ class TwigComponentExtensionTest extends TestCase
         $this->compileContainer($container);
 
         $this->assertFalse($container->hasDefinition('ux.twig_component.data_collector'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testSettingControllerJsonKeyTriggerDeprecation()
+    {
+        $container = $this->createContainer();
+        $container->setParameter('kernel.debug', true);
+        $container->registerExtension(new TwigComponentExtension());
+        $container->loadFromExtension('twig_component', [
+            'defaults' => [],
+            'anonymous_template_directory' => 'components/',
+            'profiler' => false,
+            'controllers_json' => null,
+        ]);
+
+        $this->expectDeprecation('Since symfony/ux-twig-component 2.18: The "twig_component.controllers_json" config option is deprecated, and will be removed in 3.0.');
+
+        $this->compileContainer($container);
     }
 
     private function createContainer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #
| License       | MIT

I [removed](https://github.com/symfony/ux/pull/1823/files) this key because it was an [mistake](https://github.com/symfony/ux/commit/0284c0a51dd3b5be1a1b7bfe34b53aae61cf33c2) (never used, documented, or written in recipes)

I wrongly did not consider this a BC break, and it was.

This PR re-adds the configuration key and deprecates it instead.

--

Should this be acceptable in a hotfix version like 2.18.1 ?