### PR TITLE
[Docs][Stimulus] use camelCase for target naming

### DIFF
--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -337,24 +337,24 @@ For example:
 
 .. code-block:: html+twig
 
-    <div {{ stimulus_target('controller', 'a-target') }}>Hello</div>
-    <div {{ stimulus_target('controller', 'a-target second-target') }}>Hello</div>
+    <div {{ stimulus_target('controller', 'myTarget') }}>Hello</div>
+    <div {{ stimulus_target('controller', 'myTarget secondTarget') }}>Hello</div>
 
     <!-- would render -->
-    <div data-controller-target="a-target">Hello</div>
-    <div data-controller-target="a-target second-target">Hello</div>
+    <div data-controller-target="myTarget">Hello</div>
+    <div data-controller-target="myTarget secondTarget">Hello</div>
 
 If you have multiple targets on the same element, you can chain them as there's
 also a ``stimulus_target`` filter:
 
 .. code-block:: html+twig
 
-    <div {{ stimulus_target('controller', 'a-target')|stimulus_target('other-controller', 'another-target') }}>
+    <div {{ stimulus_target('controller', 'myTarget')|stimulus_target('other-controller', 'anotherTarget') }}>
         Hello
     </div>
 
     <!-- would render -->
-    <div data-controller-target="a-target" data-other-controller-target="another-target">
+    <div data-controller-target="myTarget" data-other-controller-target="anotherTarget">
         Hello
     </div>
 
@@ -362,7 +362,7 @@ You can also retrieve the generated attributes as an array, which can be helpful
 
 .. code-block:: twig
 
-    {{ form_row(form.password, { attr: stimulus_target('hello-controller', 'a-target').toArray() }) }}
+    {{ form_row(form.password, { attr: stimulus_target('hello-controller', 'myTarget').toArray() }) }}
 
 .. _configuration:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Hello! 

I had some trouble following the doc for use `stimulus_target` and how to use them inside my stimulus controller. 

As we can see [on the stimulus target doc](https://stimulus.hotwired.dev/reference/targets#naming-conventions), the value of target should be in camelCase as it's mapped in property in the controller. 

IE 
```
<div data-my-controller-target="myElement">
```

```
import { Controller } from "@hotwired/stimulus"

export default class extends Controller {
  static targets = [ "myElement"]
  // …
  foo() {
	this.myElementTarget.innerHTML = "...";
  }
}
```

So in this PR, I changed examples for `stimulus_target` usage.