### PR TITLE
[TwigComponent][Fix] Revert throwing exception when public property is unitialized

### DIFF
--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -142,11 +142,7 @@ final class ComponentRenderer implements ComponentRendererInterface
     private function exposedVariables(object $component, bool $exposePublicProps): \Iterator
     {
         if ($exposePublicProps) {
-            $publicProps = get_object_vars($component);
-            if ($uninitializedProps = array_diff_key(get_class_vars($component::class), $publicProps)) {
-                throw new \LogicException(sprintf('Cannot expose uninitialized property "$%s" from "%s".', array_keys($uninitializedProps)[0], $component::class));
-            }
-            yield from $publicProps;
+            yield from get_object_vars($component);
         }
 
         $class = new \ReflectionClass($component);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | Fix #1909
| License       | MIT

Revert #1780

If someone want to give another go at the original problem i'd appreciate.