### PR TITLE
[Translator] Revert Fix changing dump directory using AssetMapper

### DIFF
--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -138,12 +138,6 @@ file. 2 of the new items are::
         'path' => 'var/translations/configuration.js',
     ],
 
-.. caution::
-
-    If you change the ``dump_directory`` in your configuration file, you will need to
-    replace the default ``var/translations/***`` with your new path in the
-    ``importmap.php`` file.
-
 These are then imported in your ``assets/translator.js`` file. This setup is
 very similar to working with WebpackEncore. However, the ``var/translations/index.js``
 file contains *every* translation in your app, which is not ideal for production

--- a/src/Translator/src/DependencyInjection/UxTranslatorExtension.php
+++ b/src/Translator/src/DependencyInjection/UxTranslatorExtension.php
@@ -43,12 +43,12 @@ class UxTranslatorExtension extends Extension implements PrependExtensionInterfa
         if (!$this->isAssetMapperAvailable($container)) {
             return;
         }
-        $config = $container->getExtensionConfig('ux_translator')[0];
+
         $container->prependExtensionConfig('framework', [
             'asset_mapper' => [
                 'paths' => [
                     __DIR__.'/../../assets/dist' => '@symfony/ux-translator',
-                    $config['dump_directory'] => '@app/translations',
+                    '%kernel.project_dir%/var/translations' => 'var/translations',
                 ],
             ],
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Issues        | https://github.com/symfony/ux/pull/1904#issuecomment-2162066941
| License       | MIT

[This PR ](https://github.com/symfony/ux/pull/1904) introduced a bug : when using 'var/translations' in the `importmap.php` file instead of a relative path, it would break the twig `importmap()` function.

~~This PR aims to rectify this regression by keeping a 'var/translations' namespace pointing to the dump_directory. If this is not accepted, the previous PR should be reverted to prevent users using 'var/translations' in there `importmap.php` to face this issue, but the documentation should still be updated to display an example using the relative path instead of a misleading namespace.~~

This PR reverts the change. A word in the doc to say that the `dump_directory` conf is not compatible with asset_mapper would be nice.