### PR TITLE
Remove declare_strict type

### DIFF
--- a/src/Autocomplete/src/Checksum/ChecksumCalculator.php
+++ b/src/Autocomplete/src/Checksum/ChecksumCalculator.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Autocomplete/tests/Unit/Calculator/ChecksumCalculatorTest.php
+++ b/src/Autocomplete/tests/Unit/Calculator/ChecksumCalculatorTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/LiveComponent/src/Util/FingerprintCalculator.php
+++ b/src/LiveComponent/src/Util/FingerprintCalculator.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/LiveComponent/src/Util/LiveComponentStack.php
+++ b/src/LiveComponent/src/Util/LiveComponentStack.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/LiveComponent/tests/Fixtures/Component/DeferredComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/DeferredComponent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;

--- a/src/LiveComponent/tests/Fixtures/Component/DeferredComponentWithPlaceholder.php
+++ b/src/LiveComponent/tests/Fixtures/Component/DeferredComponentWithPlaceholder.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;

--- a/src/LiveComponent/tests/Fixtures/Component/TallyComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/TallyComponent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;

--- a/src/LiveComponent/tests/Fixtures/Form/BlogPostFormLiveCollectionType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/BlogPostFormLiveCollectionType.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/src/LiveComponent/tests/Fixtures/Form/BlogPostFormType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/BlogPostFormType.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/src/LiveComponent/tests/Fixtures/Form/CommentFormType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/CommentFormType.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/LiveComponent/tests/Functional/ValidatableComponentTraitTest.php
+++ b/src/LiveComponent/tests/Functional/ValidatableComponentTraitTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/config/services.php
+++ b/src/StimulusBundle/config/services.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
+++ b/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/src/Dto/StimulusAttributes.php
+++ b/src/StimulusBundle/src/Dto/StimulusAttributes.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/src/Helper/StimulusHelper.php
+++ b/src/StimulusBundle/src/Helper/StimulusHelper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/src/Twig/StimulusTwigExtension.php
+++ b/src/StimulusBundle/src/Twig/StimulusTwigExtension.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/src/Twig/UxControllersTwigExtension.php
+++ b/src/StimulusBundle/src/Twig/UxControllersTwigExtension.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/tests/Dto/StimulusAttributesTest.php
+++ b/src/StimulusBundle/tests/Dto/StimulusAttributesTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/tests/Helper/StimulusHelperTest.php
+++ b/src/StimulusBundle/tests/Helper/StimulusHelperTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/tests/StimulusIntegrationTestKernel.php
+++ b/src/StimulusBundle/tests/StimulusIntegrationTestKernel.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
+++ b/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/TogglePassword/src/DependencyInjection/TogglePasswordExtension.php
+++ b/src/TogglePassword/src/DependencyInjection/TogglePasswordExtension.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/TogglePassword/src/Form/TogglePasswordTypeExtension.php
+++ b/src/TogglePassword/src/Form/TogglePasswordTypeExtension.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/TogglePassword/src/TogglePasswordBundle.php
+++ b/src/TogglePassword/src/TogglePasswordBundle.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/TogglePassword/tests/Form/TogglePasswordTypeTest.php
+++ b/src/TogglePassword/tests/Form/TogglePasswordTypeTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/TogglePassword/tests/TogglePasswordBundleTest.php
+++ b/src/TogglePassword/tests/TogglePasswordBundleTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | 
| License       | MIT

This PR removes the declare(strict_types=1);, to follow Symfony convention.
See: https://github.com/Girgias/unify-typing-modes-rfc

I removed the declare(strict_types=1); only for the components and not for the website, in this PR for now.

cc: @nicolas-grekas 