### PR TITLE
[TwigComponent] Ignore array|sequence in exception message

### DIFF
--- a/src/TwigComponent/tests/Integration/EmbeddedComponentTest.php
+++ b/src/TwigComponent/tests/Integration/EmbeddedComponentTest.php
@@ -160,7 +160,9 @@ final class EmbeddedComponentTest extends KernelTestCase
 
     public function testAccessingTheHierarchyTooHighThrowsAnException(): void
     {
-        $this->expectExceptionMessage('Key "this" for array with keys "app, __embedded" does not exist.');
+        // Twig renamed "array" into "sequence" in 3.11
+        $this->expectExceptionMessage('Key "$this" for ');
+        $this->expectExceptionMessage('with keys "app, __embedded" does not exist.');
         self::render('embedded_component_hierarchy_exception.html.twig');
     }
 


### PR DESCRIPTION
Twig switched from using "array" to "sequence" in 3.11 (#4106)

So let's go simple and test start/end of the exception message there