### PR TITLE
[TwigComponent] escape nesting separator with `::`

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.19.0
+
+-   Allow escape nesting separator with `::` #1959
+
 ## 2.17.0
 
 -   Add nested attribute support #1405

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -486,12 +486,12 @@ component use a ``PreMount`` hook::
    In its default configuration, the OptionsResolver treats all props.
    However, if more props are passed than the options defined in the OptionsResolver, an error will be prompted, indicating that one or more options do not exist.
    To avoid this, use the `ignoreUndefined()` method with `true`. See `ignore not defined options`_ for more info.
-   
+
       $resolver->setIgnoreUndefined(true);
-   
-   The major drawback of this configuration is that the OptionsResolver will remove every non-defined option when resolving data. 
+
+   The major drawback of this configuration is that the OptionsResolver will remove every non-defined option when resolving data.
    To maintain props that have not been defined within the OptionsResolver, combine the data from the hook with the resolved data.
-   
+
       return $resolver->resolve($data) + $data;
 
 
@@ -1126,6 +1126,15 @@ The nesting is recursive so you could potentially do something like this:
         row:label:class="ui-form-label"
         row:widget:class="ui-form-widget"
     />
+
+.. note::
+
+    If you require an attribute that actually includes a ``:`` (like ``x-on:click``),
+    you can escape the nested attribute separator by using a double colon (``x-on::click``).
+
+.. versionadded:: 2.19
+
+    The ability to escape the nested attribute separator was added in TwigComponents 2.19.
 
 Component with Complex Variants (CVA)
 -------------------------------------

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -21,7 +21,7 @@ use Symfony\WebpackEncoreBundle\Dto\AbstractStimulusDto;
  */
 final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Countable
 {
-    private const NESTED_REGEX = '#^([\w-]+):(.+)$#';
+    private const NESTED_REGEX = '#^([\w-]+):(?!:)(.+)$#';
 
     /** @var array<string,true> */
     private array $rendered = [];
@@ -63,6 +63,8 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
                 if (true === $value && str_starts_with($key, 'aria-')) {
                     $value = 'true';
                 }
+
+                $key = str_replace('::', ':', $key);
 
                 return match ($value) {
                     true => "{$carry} {$key}",

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -331,12 +331,12 @@ final class ComponentExtensionTest extends KernelTestCase
 
         $output = self::getContainer()
             ->get(Environment::class)
-            ->createTemplate('<twig:NestedAttributes class="foo" title:class="bar" title:span:class="baz" inner:class="foo" />')
+            ->createTemplate('<twig:NestedAttributes class="foo" title:class="bar" title:span:class="baz" inner:class="foo" x-on::click="!open" />')
             ->render()
         ;
 
         $this->assertSame(<<<HTML
-            <main class="foo">
+            <main class="foo" x-on:click="!open">
                 <div class="bar">
                     <span class="baz">
                         <div class="foo"/>

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -249,14 +249,18 @@ final class ComponentAttributesTest extends TestCase
     {
         $attributes = new ComponentAttributes([
             'class' => 'foo',
+            'data-class' => 'qux',
             'title:class' => 'bar',
             'title:span:class' => 'baz',
+            'data-title:class' => 'flo',
+            'data-title:data-class' => 'shi',
         ]);
 
-        $this->assertSame(' class="foo"', (string) $attributes);
+        $this->assertSame(' class="foo" data-class="qux"', (string) $attributes);
         $this->assertSame(' class="bar"', (string) $attributes->nested('title'));
         $this->assertSame(' class="baz"', (string) $attributes->nested('title')->nested('span'));
         $this->assertSame('', (string) $attributes->nested('invalid'));
+        $this->assertSame(' class="flo" data-class="shi"', (string) $attributes->nested('data-title'));
     }
 
     public function testConvertTrueAriaAttributeValue(): void

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -251,15 +251,18 @@ final class ComponentAttributesTest extends TestCase
             'class' => 'foo',
             'data-class' => 'qux',
             'title:class' => 'bar',
+            'title:x-on::click' => '!close',
             'title:span:class' => 'baz',
             'data-title:class' => 'flo',
             'data-title:data-class' => 'shi',
+            'x-on::click' => '!open',
         ]);
 
-        $this->assertSame(' class="foo" data-class="qux"', (string) $attributes);
-        $this->assertSame(' class="bar"', (string) $attributes->nested('title'));
+        $this->assertSame(' class="foo" data-class="qux" x-on:click="!open"', (string) $attributes);
+        $this->assertSame(' class="bar" x-on:click="!close"', (string) $attributes->nested('title'));
         $this->assertSame(' class="baz"', (string) $attributes->nested('title')->nested('span'));
         $this->assertSame('', (string) $attributes->nested('invalid'));
+        $this->assertSame('', (string) $attributes->nested('x-on'));
         $this->assertSame(' class="flo" data-class="shi"', (string) $attributes->nested('data-title'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix (partial) #1839
| License       | MIT

If you require a Twig component attribute that includes a `:` (like `x-on:click`) you'll trigger the [nested attribute system](https://symfony.com/bundles/ux-twig-component/current/index.html#nested-attributes). This PR allows escaping `:` with `::`. So to render `x-on:click="!open"`, you can to write `x-on::click="!open"`.
