### PR TITLE
[TwigComponent] allow attributes to be prefixed with `@`

### DIFF
--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -331,15 +331,15 @@ final class ComponentExtensionTest extends KernelTestCase
 
         $output = self::getContainer()
             ->get(Environment::class)
-            ->createTemplate('<twig:NestedAttributes class="foo" title:class="bar" title:span:class="baz" inner:class="foo" />')
+            ->createTemplate('<twig:NestedAttributes class="foo" title:class="bar" title:span:class="baz" inner:class="foo" inner:@class="qux" @class="vex" />')
             ->render()
         ;
 
         $this->assertSame(<<<HTML
-            <main class="foo">
+            <main class="foo" @class="vex">
                 <div class="bar">
                     <span class="baz">
-                        <div class="foo"/>
+                        <div class="foo" @class="qux"/>
 
                     </span>
                 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix (partial) #1839
| License       | MIT

Allow attributes to be prefixed with `@` (like `@click="!open"`).
