### PR TITLE
Disable cache warmup when translator is identity translator

### DIFF
--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -71,6 +71,10 @@ For a better developer experience, TypeScript types definitions are also generat
 Then, you will be able to import those JavaScript translations in your assets.
 Don't worry about your final bundle size, only the translations you use will be included in your final bundle, thanks to the `tree shaking <https://webpack.js.org/guides/tree-shaking/>`_.
 
+.. note::
+
+    This package requires the `translator` to be enabled in your Symfony application. If you don't use the `translator` service, the warmup command will not generate any translations.
+
 Configuring the default locale
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Translator/src/DependencyInjection/TranslatorCompilerPass.php
+++ b/src/Translator/src/DependencyInjection/TranslatorCompilerPass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\UX\Translator\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Translation\TranslatorBagInterface;
+
+class TranslatorCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$this->hasValidTranslator($container)) {
+            $container->removeDefinition('ux.translator.cache_warmer.translations_cache_warmer');
+        }
+    }
+
+    private function hasValidTranslator(ContainerBuilder $containerBuilder): bool
+    {
+        if (!$containerBuilder->hasDefinition('translator')) {
+            return false;
+        }
+
+        $translator = $containerBuilder->getDefinition('translator');
+        if (!is_subclass_of($translator->getClass(), TranslatorBagInterface::class)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/Translator/src/UxTranslatorBundle.php
+++ b/src/Translator/src/UxTranslatorBundle.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\UX\Translator;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\UX\Translator\DependencyInjection\TranslatorCompilerPass;
 
 /**
  * @author Hugo Alliaume <hugo@alliau.me>
@@ -25,5 +27,10 @@ class UxTranslatorBundle extends Bundle
     public function getPath(): string
     {
         return \dirname(__DIR__);
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new TranslatorCompilerPass());
     }
 }

--- a/src/Translator/tests/Kernel/FrameworkAppKernel.php
+++ b/src/Translator/tests/Kernel/FrameworkAppKernel.php
@@ -38,6 +38,10 @@ class FrameworkAppKernel extends Kernel
                 'secret' => '$ecret',
                 'test' => true,
                 'translator' => [
+                    'enabled' => match ($this->environment) {
+                        'test_without_translator' => false,
+                        default => true,
+                    },
                     'fallbacks' => ['en'],
                 ],
                 'http_method_override' => false,

--- a/src/Translator/tests/UxTranslatorBundleTest.php
+++ b/src/Translator/tests/UxTranslatorBundleTest.php
@@ -22,6 +22,7 @@ class UxTranslatorBundleTest extends TestCase
     {
         yield 'empty' => [new EmptyAppKernel('test', true)];
         yield 'framework' => [new FrameworkAppKernel('test', true)];
+        yield 'framework without translator' => [new FrameworkAppKernel('test_without_translator', true)];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1962
| License       | MIT

If the present `translator` does not implement the `TranslatorBag` interface, which is the case if the framework bundle is enabled and either the form, or the validator are enabled, removes the warmup phase.
