### PR TITLE
Clean and homogenize `src/*/.gitignore`

### DIFF
--- a/src/Autocomplete/.gitignore
+++ b/src/Autocomplete/.gitignore
@@ -1,5 +1,7 @@
+/assets/node_modules/
+/vendor/
 /composer.lock
 /phpunit.xml
-/vendor/
-/var/
 /.phpunit.result.cache
+
+/var

--- a/src/Chartjs/.gitignore
+++ b/src/Chartjs/.gitignore
@@ -1,4 +1,5 @@
+/assets/node_modules/
 /vendor/
-.phpunit.result.cache
-.php_cs.cache
-composer.lock
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/Cropperjs/.gitignore
+++ b/src/Cropperjs/.gitignore
@@ -1,4 +1,5 @@
-vendor
-composer.lock
-.php_cs.cache
-.phpunit.result.cache
+/assets/node_modules/
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/Dropzone/.gitignore
+++ b/src/Dropzone/.gitignore
@@ -1,3 +1,5 @@
+/assets/node_modules/
 /vendor/
-.phpunit.result.cache
-composer.lock
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/Icons/.gitignore
+++ b/src/Icons/.gitignore
@@ -1,4 +1,7 @@
-/vendor
+/assets/node_modules/
+/vendor/
 /composer.lock
-/var
+/phpunit.xml
 /.phpunit.result.cache
+
+/var

--- a/src/LazyImage/.gitignore
+++ b/src/LazyImage/.gitignore
@@ -1,4 +1,5 @@
-vendor
-composer.lock
-.php_cs.cache
-.phpunit.result.cache
+/assets/node_modules/
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/LiveComponent/.gitignore
+++ b/src/LiveComponent/.gitignore
@@ -1,5 +1,7 @@
+/assets/node_modules/
+/vendor/
 /composer.lock
 /phpunit.xml
-/vendor/
-/var/
 /.phpunit.result.cache
+
+/var

--- a/src/Notify/.gitignore
+++ b/src/Notify/.gitignore
@@ -1,4 +1,5 @@
+/assets/node_modules/
 /vendor/
-.phpunit.result.cache
-.php_cs.cache
-composer.lock
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/React/.gitignore
+++ b/src/React/.gitignore
@@ -1,4 +1,5 @@
-vendor
-composer.lock
-.php_cs.cache
-.phpunit.result.cache
+/assets/node_modules/
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/StimulusBundle/.gitignore
+++ b/src/StimulusBundle/.gitignore
@@ -1,5 +1,7 @@
-.php-cs-fixer.cache
-.phpunit.result.cache
-composer.lock
-vendor/
-tests/fixtures/var
+/assets/node_modules/
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache
+
+/tests/fixtures/var

--- a/src/Svelte/.gitignore
+++ b/src/Svelte/.gitignore
@@ -1,5 +1,5 @@
-/assets/node_modules
+/assets/node_modules/
+/vendor/
 /composer.lock
 /phpunit.xml
-/vendor/
 /.phpunit.result.cache

--- a/src/Swup/.gitignore
+++ b/src/Swup/.gitignore
@@ -1,3 +1,5 @@
-vendor
-composer.lock
-.php_cs.cache
+/assets/node_modules/
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/TogglePassword/.gitignore
+++ b/src/TogglePassword/.gitignore
@@ -1,3 +1,5 @@
-vendor/
-composer.lock
-.phpunit.result.cache
+/assets/node_modules/
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/Translator/.gitignore
+++ b/src/Translator/.gitignore
@@ -1,4 +1,5 @@
-vendor
-composer.lock
-.php_cs.cache
-.phpunit.result.cache
+/assets/node_modules/
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/Turbo/.gitignore
+++ b/src/Turbo/.gitignore
@@ -1,12 +1,5 @@
-/.php_cs.cache
-/.php_cs
-/.phpunit.result.cache
-/composer.phar
+/assets/node_modules/
+/vendor/
 /composer.lock
 /phpunit.xml
-/vendor/
-/tests/app/var
-/tests/app/public/build/
-node_modules/
-package-lock.json
-yarn.lock
+/.phpunit.result.cache

--- a/src/Turbo/tests/app/.gitignore
+++ b/src/Turbo/tests/app/.gitignore
@@ -1,0 +1,2 @@
+/var/
+/public/build/

--- a/src/TwigComponent/.gitignore
+++ b/src/TwigComponent/.gitignore
@@ -1,5 +1,7 @@
+/assets/node_modules/
+/vendor/
 /composer.lock
 /phpunit.xml
-/vendor/
-/var/
 /.phpunit.result.cache
+
+/var

--- a/src/Typed/.gitignore
+++ b/src/Typed/.gitignore
@@ -1,2 +1,5 @@
-/vendor
+/assets/node_modules/
+/vendor/
 /composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/src/Vue/.gitignore
+++ b/src/Vue/.gitignore
@@ -1,4 +1,5 @@
-vendor
-composer.lock
-.php_cs.cache
-.phpunit.result.cache
+/assets/node_modules/
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Following @smnandre 's comment (https://github.com/symfony/ux/pull/1937#discussion_r1667323358), it looks like `src/*/.gitignore` files reference files that does not exist in the context of a Package. 
For example, ignoring `.php_cs.cache` from a package does not make sense, since this file is created by PHP-CS-Fixer at the **repository root**.

Now, all the `src/*/.gitignore` contain at least this list: 
```gitignore
/assets/node_modules/
/vendor/
/composer.lock
/phpunit.xml
/.phpunit.result.cache
```