### PR TITLE
[Fix] Handle `loading="lazy"` for LiveComponent only

### DIFF
--- a/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
@@ -29,6 +29,10 @@ final class DeferLiveComponentSubscriber implements EventSubscriberInterface
     public function onPostMount(PostMountEvent $event): void
     {
         $data = $event->getData();
+        if (!$event->getMetadata()->get('live', false)) {
+            // Not a live component
+            return;
+        }
 
         if (\array_key_exists('defer', $data)) {
             trigger_deprecation('symfony/ux-live-component', '2.17', 'The "defer" attribute is deprecated and will be removed in 3.0. Use the "loading" attribute instead set to the value "defer".');

--- a/src/LiveComponent/tests/Fixtures/Component/SimpleTwigComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/SimpleTwigComponent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+#[AsTwigComponent('simple_twig')]
+final class SimpleTwigComponent
+{
+    public string $foo = 'foo';
+
+    public string $bar = 'bar';
+
+    public function getFooBar(): string
+    {
+        return $this->foo.$this->bar;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/simple_twig.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/simple_twig.html.twig
@@ -1,0 +1,1 @@
+<div{{ attributes }}>{{ this.getFooBar() }}</div>

--- a/src/LiveComponent/tests/Fixtures/templates/render_lazy_twig_component.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/render_lazy_twig_component.html.twig
@@ -1,0 +1,1 @@
+<twig:simple_twig foo="Foo" bar="Bar" loading="lazy" />

--- a/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
@@ -170,4 +170,17 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         $browser->assertElementCount('#count', 1);
         $browser->assertElementAttributeContains('#count', 'value', '7');
     }
+
+    public function testSubscriberDoesNotHandleTwigComponent(): void
+    {
+        $browser = $this->browser()
+            ->visit('/render-template/render_lazy_twig_component')
+            ->assertSuccessful();
+
+        $browser->assertElementCount('[loading="lazy"]', 1);
+        $browser->assertElementCount('[data-controller]', 0);
+
+        $componentDiv = $browser->crawler()->filter('div');
+        $this->assertSame('<div loading="lazy">FooBar</div>', trim($componentDiv->outerHtml()));
+    }
 }

--- a/src/LiveComponent/tests/Unit/EventListener/DeferLiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Unit/EventListener/DeferLiveComponentSubscriberTest.php
@@ -36,6 +36,19 @@ class DeferLiveComponentSubscriberTest extends TestCase
         $this->assertArrayNotHasKey('loading', $event->getData());
     }
 
+    public function testLoadingAttributeIsNotExtractedWhenComponentIsNotLive()
+    {
+        $data = ['loading' => 'lazy'];
+        $event = new PostMountEvent(new \stdClass(), $data, new ComponentMetadata([]));
+        $event->setData($data);
+
+        $subscriber = new DeferLiveComponentSubscriber();
+        $subscriber->onPostMount($event);
+
+        $this->assertArrayNotHasKey('loading', $event->getExtraMetadata());
+        $this->assertArrayHasKey('loading', $event->getData());
+    }
+
     /**
      * @group legacy
      */
@@ -110,7 +123,7 @@ class DeferLiveComponentSubscriberTest extends TestCase
 
     private function createPostMountEvent(array $data): PostMountEvent
     {
-        $componentMetadata = new ComponentMetadata([]);
+        $componentMetadata = new ComponentMetadata(['live' => true]);
         $event = new PostMountEvent(new \stdClass(), $data, $componentMetadata);
         $event->setData($data);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1975
| License       | MIT

A TwigComponent with loading=lazy was interpreted as a live and its attributes were changed.
