### PR TITLE
[Live] Fix 'onUpdated' hook call

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Component/WithOnUpdated.php
+++ b/src/LiveComponent/tests/Fixtures/Component/WithOnUpdated.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+use Symfony\UX\TwigComponent\Attribute\PostMount;
+
+#[AsLiveComponent('with_on_updated')]
+final class WithOnUpdated
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true, onUpdated: 'onNumber1Updated')]
+    public int $number1;
+
+    #[LiveProp]
+    public int $number2;
+
+    #[LiveProp]
+    public int $number3;
+
+    #[LiveProp]
+    public int $total;
+
+    #[PostMount]
+    public function postMount(): void
+    {
+        $this->calculateTotal();
+    }
+
+    public function onNumber1Updated(): void
+    {
+        $this->calculateTotal();
+    }
+
+    private function calculateTotal(): void
+    {
+        // All live props must be available to read
+        $this->total = $this->number1 + $this->number2 + $this->number3;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/with_on_updated.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/with_on_updated.html.twig
@@ -1,0 +1,13 @@
+<div{{ attributes }}>
+    <label>
+        <input type="number" data-model="number1" step="1">
+    </label>
+
+    <ul>
+        <li>Number1: {{ number1 }}</li>
+        <li>Number2: {{ number2 }}</li>
+        <li>Number3: {{ number3 }}</li>
+    </ul>
+
+    <div>Total: {{ total }}</div>
+</div>

--- a/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
+++ b/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
@@ -179,4 +179,19 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertStringContainsString('foobar', $testComponent->render());
     }
+
+    public function testAccessAllLivePropsInsideOnUpdatedHook(): void
+    {
+        $testComponent = $this->createLiveComponent('with_on_updated', [
+            'number1' => 1,
+            'number2' => 2,
+            'number3' => 3,
+        ]);
+
+        $this->assertStringContainsString('Total: 6', $testComponent->render());
+
+        $testComponent->set('number1', 4);
+
+        $this->assertStringContainsString('Total: 9', $testComponent->render());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1952 
| License       | MIT

All 'onUpdated' handlers should be called after all live props have been initialized.