### PR TITLE
Fix random errors are throw when empty props

### DIFF
--- a/src/TwigComponent/src/Twig/PropsNode.php
+++ b/src/TwigComponent/src/Twig/PropsNode.php
@@ -35,6 +35,10 @@ class PropsNode extends Node
             ->write('$propsNames = [];')
         ;
 
+        if (!$this->getAttribute('names')) {
+            return;
+        }
+
         foreach ($this->getAttribute('names') as $name) {
             $compiler
                 ->write('if (isset($context[\'__props\'][\''.$name.'\'])) {')

--- a/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_empty_props.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_empty_props.html.twig
@@ -1,0 +1,1 @@
+<twig:EmptyProps/>

--- a/src/TwigComponent/tests/Fixtures/templates/components/EmptyProps.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/EmptyProps.html.twig
@@ -1,0 +1,3 @@
+{% props %}
+
+<p>I have an empty props tag</p>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -366,6 +366,13 @@ final class ComponentExtensionTest extends KernelTestCase
         self::getContainer()->get(Environment::class)->render('component_with_conflict_between_props_from_template_and_class.html.twig');
     }
 
+    public function testComponentWithEmptyProps(): void
+    {
+        $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_empty_props.html.twig');
+
+        $this->assertStringContainsString('I have an empty props tag', $output);
+    }
+
     public function testAnonymousComponentWithPropsOverwriteParentsProps(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_props_overwrite_parents_props.html.twig');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1971 
| License       | MIT

We don't throw an exeption when the props tags is empty now.