### PR TITLE
[LiveComponent] Allow updates in arrays of DTOs

### DIFF
--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -370,6 +370,7 @@ final class LiveComponentHydrator
         foreach ($parts as $part) {
             if (\is_array($currentValue)) {
                 $finalPropertyPath .= \sprintf('[%s]', $part);
+                $currentValue = $this->propertyAccessor->getValue($rawPropertyValue, $finalPropertyPath);
 
                 continue;
             }
@@ -379,6 +380,10 @@ final class LiveComponentHydrator
             }
 
             $finalPropertyPath .= $part;
+
+            if (null !== $currentValue) {
+                $currentValue = $this->propertyAccessor->getValue($rawPropertyValue, $finalPropertyPath);
+            }
         }
 
         return $finalPropertyPath;

--- a/src/LiveComponent/tests/Fixtures/Dto/HoldsArrayOfDtos.php
+++ b/src/LiveComponent/tests/Fixtures/Dto/HoldsArrayOfDtos.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Dto;
+
+final class HoldsArrayOfDtos
+{
+    /**
+     * @var Address[] $addresses
+     */
+    public array $addresses;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #1953  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PRs allows changes in arrays of DTOs, see the linked issue for more background information.

There is one limitation though: For now it is not possible to generally set nested properties to be writable (i.e. something like `writable: 'items.*.prop'`, or `items[].prop`). You either have to set everything to writable (`writable: true`), or a very specific element (`writable: items.1.prop`). 
