### PR TITLE
[Doc] Mention that boolean properties require the dynamic syntax

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -295,6 +295,18 @@ prefix the attribute with ``:`` or use the normal ``{{ }}`` syntax:
     // pass object, array, or anything you imagine
     <twig:Alert :foo="['col' => ['foo', 'oof']]" />
 
+Boolean props require using the dynamic syntax:
+
+.. code-block:: html+twig
+
+    {# in this example, the 'false' value is passed as a string
+       (so it's converted automatically to the true boolean value) #}
+    <twig:Alert message="..." withCloseButton="false" />
+
+    {# in the following examples, the 'false' value is passed as a boolean property #}
+    <twig:Alert message="..." :withCloseButton="false" />
+    <twig:Alert message="..." withCloseButton="{{ false }}" />
+
 Don't forget that you can mix and match props with attributes that you
 want to render on the root element:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | -
| License       | MIT

This confused me. On Symfony Slack folks mentioned that changing this behavior would be bad for DX (e.g. we can do it in components backend by a PHP class with typed properties but we cannot for anonymous components). So, I think it might be enough to mention this in the docs. Thanks.