### PR TITLE
[LiveComponent] Add a new helper to interact with forms in functional tests

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+-   Add `submitForm()` to `TestLiveComponent`.
+
 ## 2.18.0
 
 -   Add parameter to `TestLiveComponent::call()` to add files to the request

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3659,7 +3659,7 @@ uses Symfony's test client to render and make requests to your components::
 
             // call live action with file uploads
             $testComponent
-                ->save('processUpload', files: ['file' => new UploadedFile(...)]);
+                ->call('processUpload', files: ['file' => new UploadedFile(...)]);
 
             // emit live events
             $testComponent
@@ -3671,6 +3671,10 @@ uses Symfony's test client to render and make requests to your components::
             $testComponent
                 ->set('count', 99)
             ;
+
+            // Submit form data
+            $testComponent
+                ->submitForm(['form' => ['input' => 'value']], 'save');
 
             $this->assertStringContainsString('Count: 99', $testComponent->render());
 

--- a/src/LiveComponent/src/Test/TestLiveComponent.php
+++ b/src/LiveComponent/src/Test/TestLiveComponent.php
@@ -125,6 +125,13 @@ final class TestLiveComponent
         return $this->client()->getResponse();
     }
 
+    public function submitForm(array $formValues, ?string $action = null): self
+    {
+        $flattenValues = $this->flattenFormValues($formValues);
+
+        return $this->request(['updated' => $flattenValues, 'validatedFields' => array_keys($flattenValues)], $action);
+    }
+
     private function request(array $content = [], ?string $action = null, array $files = []): self
     {
         $csrfToken = $this->csrfToken();
@@ -204,5 +211,20 @@ final class TestLiveComponent
         $this->performedInitialRequest = true;
 
         return $this->client;
+    }
+
+    private function flattenFormValues(array $values, string $prefix = ''): array
+    {
+        $result = [];
+
+        foreach ($values as $key => $value) {
+            if (\is_array($value)) {
+                $result += $this->flattenFormValues($value, $prefix.$key.'.');
+            } else {
+                $result[$prefix.$key] = $value;
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
+++ b/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
@@ -169,4 +169,14 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
 
         $this->assertStringContainsString('Username: kevin', $testComponent->render());
     }
+
+    public function testCanSubmitForm(): void
+    {
+        $testComponent = $this->createLiveComponent('form_with_many_different_fields_type');
+
+        $response = $testComponent->submitForm(['form' => ['text' => 'foobar']])->response();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('foobar', $testComponent->render());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| License       | MIT

Add a new method in `TestLiveComponent` to interact with live components that contains forms. Submitted data must be passed as an array like you'll do with `KernelBrowser`.

```php
$component = $this->createLiveComponent(name: Component::class);
$component->submitForm(['foo' => ['bar' => 'baz']]); // The method will change this values in ['foo.bar' => 'baz'] as expected by the component.
```