### PR TITLE
[Icon] Emphasis HTML syntax requires TwigComponent

### DIFF
--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -180,7 +180,7 @@ tag:
     <!-- you can also add any HTML attributes -->
     <twig:ux:icon name="user-profile" height="16" width="16" aria-hidden="true" />
 
-.. note::
+.. tip::
 
     To use the HTML syntax, the ``symfony/ux-twig-component`` package must be
     installed in your project.


### PR DESCRIPTION
First time HTML syntax is shown, use "tip" (green borders) instead of "note" 

Fix: #1993

| Before | After |
| - | - |
| ![Capture d’écran 2024-07-17 à 21 17 54 - Grande](https://github.com/user-attachments/assets/e344aa2c-d0d7-4dfb-bf09-bc4a2efcae14) | <img width="969" alt="Capture d’écran 2024-07-17 à 21 29 14" src="https://github.com/user-attachments/assets/bc5cfa67-801c-4018-8173-8ee9f647e8eb"> |

