### PR TITLE
Fix DOMException error when trying to remove non-existent classes

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1670,7 +1670,9 @@ class ElementChanges {
     }
     applyToElement(element) {
         element.classList.add(...this.addedClasses);
-        element.classList.remove(...this.removedClasses);
+        if (this.removedClasses.size > 0) {
+            element.classList.remove(...this.removedClasses);
+        }
         this.styleChanges.getChangedItems().forEach((change) => {
             element.style.setProperty(change.name, change.value);
             return;

--- a/src/LiveComponent/assets/src/Rendering/ElementChanges.ts
+++ b/src/LiveComponent/assets/src/Rendering/ElementChanges.ts
@@ -64,7 +64,9 @@ export default class ElementChanges {
 
     applyToElement(element: HTMLElement): void {
         element.classList.add(...this.addedClasses);
-        element.classList.remove(...this.removedClasses);
+        if (this.removedClasses.size > 0) {
+            element.classList.remove(...this.removedClasses);
+        }
 
         this.styleChanges.getChangedItems().forEach((change) => {
             element.style.setProperty(change.name, change.value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

### Description
In some cases the ElementChanges.applyElement tries to remove classes, but gives none as argument. This causes a DOMException which breaks the rest of the flow. 

![image](https://github.com/user-attachments/assets/f209104a-0a8a-4da5-8c82-c110f551bf58)

### Fix:
I added a check to ensure the remove method only gets called when there's something to be removed.

### Versions
ux-live-component version: 2.18.1
ux-turbo version: 2.18.0
@hotwired/turbo version: 8.0.5