### PR TITLE
Fix: Original Throwable get lost during component render

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -120,10 +120,6 @@ final class ComponentExtension extends AbstractExtension implements ServiceSubsc
             throw $e;
         }
 
-        if (!($e instanceof \Exception)) {
-            $e = new \Exception($e->getMessage(), $e->getCode(), $e->getPrevious());
-        }
-
-        throw new RuntimeError(\sprintf('Error rendering "%s" component: %s', $name, $e->getMessage()), previous: $e);
+        throw new RuntimeError(\sprintf('Error rendering "%s" component: "%s"', $name, $e->getMessage()), previous: $e);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | 
| License       | MIT

When non-Exception Throwable is thrown during component rendering, original Throwable is lost together with it's stacktrace. Without stacktrace it is hard to debug the problem. This simple change fixes the problem in the same way as in https://github.com/cuchac/ux/blob/f69b9656f318464253590a6575da65f34262d931/src/TwigComponent/src/Twig/ComponentExtension.php#L127  where `previous: $e` is used instead of  `previous: $e->getPrevious()`
