### PR TITLE
[Map][Leaflet] Fix Popup's automatic-content

### DIFF
--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
@@ -35,7 +35,7 @@ class map_controller extends AbstractMapController {
     }
     doCreateInfoWindow({ definition, marker, }) {
         const { headerContent, content, rawOptions = {}, ...otherOptions } = definition;
-        marker.bindPopup(`${headerContent}<br>${content}`, { ...otherOptions, ...rawOptions });
+        marker.bindPopup([headerContent, content].filter((x) => x).join('<br>'), { ...otherOptions, ...rawOptions });
         if (definition.opened) {
             marker.openPopup();
         }

--- a/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
@@ -71,7 +71,7 @@ export default class extends AbstractMapController<
     }): Popup {
         const { headerContent, content, rawOptions = {}, ...otherOptions } = definition;
 
-        marker.bindPopup(`${headerContent}<br>${content}`, { ...otherOptions, ...rawOptions });
+        marker.bindPopup([headerContent, content].filter((x) => x).join('<br>'), { ...otherOptions, ...rawOptions });
         if (definition.opened) {
             marker.openPopup();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Leaflet's Popup does not have `headerContent`, but GoogleMaps does. 

To prevent too many issues when developpers change for another Map Bridge, with Simon we took the decision to render `headerContent` and `content` data in Leaflet Popup's content.

But it looks like I've did things wrong, if I don't specify `headerContent`, then a `null` text is displayed in the popup:
<img width="460" alt="Capture d’écran 2024-08-08 à 14 01 11" src="https://github.com/user-attachments/assets/c88e6c91-7ff6-4c40-8642-abbc9f1883fe">

Because in JavaScript, `null + 'foo'` gives `nullfoo` :(
<img width="1692" alt="Capture d’écran 2024-08-08 à 14 04 29" src="https://github.com/user-attachments/assets/2caf390c-d05c-4e16-93e1-3d865201e7a7">

With this PR, the popup is now nicely displayed:
<img width="409" alt="Capture d’écran 2024-08-08 à 14 08 14" src="https://github.com/user-attachments/assets/0da41c34-9afd-4441-8350-892461f59796">
