### PR TITLE
Update naming of stimulus controller on default attributes - index.rst

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -880,7 +880,7 @@ To add a custom Stimulus controller to your root component element:
 
 .. code-block:: html+twig
 
-    <div {{ attributes.defaults(stimulus_controller('my-controller', { someValue: 'foo' })) }}>
+    <div {{ attributes.defaults(stimulus_controller('some-custom', { someValue: 'foo' })) }}>
 
 JavaScript Component Hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
To add a custom stimulus controller to the root component element the name can not contain `-controller`.

If using `some_custom_controller.js`, the name should be `some-custom`

I had some issues with that and figured it out on this github issue : https://github.com/symfony/ux/issues/687#issuecomment-1619792223

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| License       | MIT

