### PR TITLE
[Map] Re-add keyword "symfony-ux", to fix Symfony Flex `package.json` resolving

### DIFF
--- a/src/Map/src/Bridge/Google/composer.json
+++ b/src/Map/src/Bridge/Google/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/ux-google-map",
     "type": "symfony-ux-map-bridge",
     "description": "Symfony UX Map GoogleMaps Bridge",
-    "keywords": ["google-maps", "map", "symfony", "ux"],
+    "keywords": ["symfony-ux", "google-maps", "map"],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [

--- a/src/Map/src/Bridge/Leaflet/composer.json
+++ b/src/Map/src/Bridge/Leaflet/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/ux-leaflet-map",
     "type": "symfony-ux-map-bridge",
     "description": "Symfony UX Map Leaflet Bridge",
-    "keywords": ["leaflet", "map", "symfony", "ux"],
+    "keywords": ["symfony-ux", "leaflet", "map"],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

In #1937 I was asked to remove the keyword `symfony-ux` in favor `symfony` and `ux`, but it looks like it break Symfony Flex behaviour to resolve the package's `package.json`: https://github.com/symfony/flex/blob/2.x/src/PackageJsonSynchronizer.php#L372

No `importmap.php` nor `assets/controllers.json` were updated when installing UX Map bridges :( 

I'm adding back this keyword and removing the other ones. Sorry for the inconvenience :pray: