### PR TITLE
[Translator] Mark the translator as nullable

### DIFF
--- a/src/Translator/config/services.php
+++ b/src/Translator/config/services.php
@@ -26,6 +26,7 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('translator')->nullOnInvalid(),
                 service('ux.translator.translations_dumper'),
+                service('logger')->ignoreOnInvalid(),
             ])
             ->tag('kernel.cache_warmer')
 

--- a/src/Translator/config/services.php
+++ b/src/Translator/config/services.php
@@ -24,7 +24,7 @@ return static function (ContainerConfigurator $container): void {
     $container->services()
         ->set('ux.translator.cache_warmer.translations_cache_warmer', TranslationsCacheWarmer::class)
             ->args([
-                service('translator'),
+                service('translator')->nullOnInvalid(),
                 service('ux.translator.translations_dumper'),
             ])
             ->tag('kernel.cache_warmer')

--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -71,6 +71,10 @@ For a better developer experience, TypeScript types definitions are also generat
 Then, you will be able to import those JavaScript translations in your assets.
 Don't worry about your final bundle size, only the translations you use will be included in your final bundle, thanks to the `tree shaking <https://webpack.js.org/guides/tree-shaking/>`_.
 
+.. note::
+
+    This package requires the ``translator`` to be enabled in your Symfony application. If you don't use the `translator` package, the warmup command will not generate any translations.
+
 Configuring the dumped translations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -73,7 +73,7 @@ Don't worry about your final bundle size, only the translations you use will be 
 
 .. note::
 
-    This package requires the ``translator`` to be enabled in your Symfony application. If you don't use the `translator` package, the warmup command will not generate any translations.
+    This package requires the ``translator`` package to be enabled in your Symfony application. If you don't use the ``translator`` package, the warmup command will not generate any translations.
 
 Configuring the dumped translations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Translator/src/CacheWarmer/TranslationsCacheWarmer.php
+++ b/src/Translator/src/CacheWarmer/TranslationsCacheWarmer.php
@@ -23,7 +23,7 @@ use Symfony\UX\Translator\TranslationsDumper;
 class TranslationsCacheWarmer implements CacheWarmerInterface
 {
     public function __construct(
-        private TranslatorBagInterface $translatorBag,
+        private ?TranslatorBagInterface $translatorBag,
         private TranslationsDumper $translationsDumper,
     ) {
     }
@@ -35,6 +35,9 @@ class TranslationsCacheWarmer implements CacheWarmerInterface
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
+        if ($this->translatorBag === null) {
+            return [];
+        }
         $this->translationsDumper->dump(
             ...$this->translatorBag->getCatalogues()
         );

--- a/src/Translator/src/CacheWarmer/TranslationsCacheWarmer.php
+++ b/src/Translator/src/CacheWarmer/TranslationsCacheWarmer.php
@@ -39,6 +39,7 @@ class TranslationsCacheWarmer implements CacheWarmerInterface
     {
         if (null === $this->translatorBag) {
             $this->logger?->warning('Translator bag not available');
+
             return [];
         }
         $this->translationsDumper->dump(

--- a/src/Translator/src/CacheWarmer/TranslationsCacheWarmer.php
+++ b/src/Translator/src/CacheWarmer/TranslationsCacheWarmer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\Translator\CacheWarmer;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\UX\Translator\TranslationsDumper;
@@ -25,6 +26,7 @@ class TranslationsCacheWarmer implements CacheWarmerInterface
     public function __construct(
         private ?TranslatorBagInterface $translatorBag,
         private TranslationsDumper $translationsDumper,
+        private readonly ?LoggerInterface $logger = null,
     ) {
     }
 
@@ -35,7 +37,8 @@ class TranslationsCacheWarmer implements CacheWarmerInterface
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
-        if ($this->translatorBag === null) {
+        if (null === $this->translatorBag) {
+            $this->logger?->warning('Translator bag not available');
             return [];
         }
         $this->translationsDumper->dump(

--- a/src/Translator/src/CacheWarmer/TranslationsCacheWarmer.php
+++ b/src/Translator/src/CacheWarmer/TranslationsCacheWarmer.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\Translator\CacheWarmer;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\UX\Translator\TranslationsDumper;
 
 /**
@@ -24,7 +25,7 @@ use Symfony\UX\Translator\TranslationsDumper;
 class TranslationsCacheWarmer implements CacheWarmerInterface
 {
     public function __construct(
-        private ?TranslatorBagInterface $translatorBag,
+        private TranslatorInterface|TranslatorBagInterface|null $translatorBag,
         private TranslationsDumper $translationsDumper,
         private readonly ?LoggerInterface $logger = null,
     ) {
@@ -37,7 +38,7 @@ class TranslationsCacheWarmer implements CacheWarmerInterface
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
-        if (null === $this->translatorBag) {
+        if (!$this->translatorBag instanceof TranslatorBagInterface) {
             $this->logger?->warning('Translator bag not available');
 
             return [];

--- a/src/Translator/tests/CacheWarmer/TranslationsCacheWarmerTest.php
+++ b/src/Translator/tests/CacheWarmer/TranslationsCacheWarmerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\Translator\Tests\CacheWarmer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\TranslatorBag;
 use Symfony\UX\Translator\CacheWarmer\TranslationsCacheWarmer;
 use Symfony\UX\Translator\TranslationsDumper;

--- a/src/Translator/tests/CacheWarmer/TranslationsCacheWarmerTest.php
+++ b/src/Translator/tests/CacheWarmer/TranslationsCacheWarmerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\Translator\Tests\CacheWarmer;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\TranslatorBag;
 use Symfony\UX\Translator\CacheWarmer\TranslationsCacheWarmer;
@@ -51,6 +52,28 @@ final class TranslationsCacheWarmerTest extends TestCase
         $translationsCacheWarmer = new TranslationsCacheWarmer(
             $translatorBag,
             $translationsDumperMock
+        );
+
+        $translationsCacheWarmer->warmUp(self::$cacheDir);
+    }
+
+    public function testWithoutTranslator()
+    {
+        $translationsDumperMock = $this->createMock(TranslationsDumper::class);
+        $translationsDumperMock
+            ->expects($this->never())
+            ->method('dump');
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock
+            ->expects($this->once())
+            ->method('warning')
+            ->with('Translator bag not available');
+
+        $translationsCacheWarmer = new TranslationsCacheWarmer(
+            null,
+            $translationsDumperMock,
+            $loggerMock,
         );
 
         $translationsCacheWarmer->warmUp(self::$cacheDir);

--- a/src/Translator/tests/Kernel/FrameworkAppKernel.php
+++ b/src/Translator/tests/Kernel/FrameworkAppKernel.php
@@ -38,6 +38,10 @@ class FrameworkAppKernel extends Kernel
                 'secret' => '$ecret',
                 'test' => true,
                 'translator' => [
+                    'enabled' => match ($this->environment) {
+                        'test_without_translator' => false,
+                        default => true,
+                    },
                     'fallbacks' => ['en'],
                 ],
                 'http_method_override' => false,

--- a/src/Translator/tests/UxTranslatorBundleTest.php
+++ b/src/Translator/tests/UxTranslatorBundleTest.php
@@ -22,6 +22,7 @@ class UxTranslatorBundleTest extends TestCase
     {
         yield 'empty' => [new EmptyAppKernel('test', true)];
         yield 'framework' => [new FrameworkAppKernel('test', true)];
+        yield 'framework without translator' => [new FrameworkAppKernel('test_without_translator', true)];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #2056 
| License       | MIT

Apparently, the `translator` service is not available by default, so removing the cache warmer if the container doesn't have the definition breaks in newer versions. In order to allow this to still work when the `translator` service is not defined, but there is a `translator` defined in the container, the behaviour is updated to be `nullOnInvalid` and in the warmup it verifies whether the `TranslatorBagInterface` is null or not.

I've added the `logger` to be able to add a warning when the `translator` is not valid, which should not cause any issues.