### PR TITLE
[CI] Test ux.symfony.com with local UX packages

### DIFF
--- a/.github/workflows/ux.symfony.com.yaml
+++ b/.github/workflows/ux.symfony.com.yaml
@@ -4,9 +4,15 @@ on:
     push:
         paths:
             - 'ux.symfony.com/**'
+            - 'src/*/**'
+            - '!src/*/doc/**'
+            - '.github/**'
     pull_request:
         paths:
             - 'ux.symfony.com/**'
+            - 'src/*/**'
+            - '!src/*/doc/**'
+            - '.github/**'
 
 jobs:
 
@@ -58,10 +64,18 @@ jobs:
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: '8.3'
+            -   name: Install root dependencies
+                uses: ramsey/composer-install@v3
+                with:
+                    working-directory: ${{ github.workspace }}
+            -   name: Build root packages
+                run: php .github/build-packages.php
+                working-directory: ${{ github.workspace }}
             -   name: Install dependencies
                 uses: ramsey/composer-install@v3
                 with:
                     working-directory: ux.symfony.com
+                    dependency-versions: 'highest'
             -   name: Importmap dependencies
                 run: php bin/console importmap:install
             -   name: Build Sass assets


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Following #1965 and #2060, I was a bit surprised to see ux.symfony.com tests were executed with UX packages coming from `2.x` branch, instead of UX packages from the same PR.

I believe doing this could help us for the future and prevent some regressions.

I've updated the script `.github/build-packages.php` to automatically replaces **all UX packages requires(-dev)** from all significant `composer.json` files from the repo:
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/e04ff73f-7558-46cc-91e2-bf49c26a7f04">
