### PR TITLE
[Site] Update file tree icons

### DIFF
--- a/ux.symfony.com/assets/icons/file.svg
+++ b/ux.symfony.com/assets/icons/file.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/>
+</svg>

--- a/ux.symfony.com/assets/styles/components/_FileTree.scss
+++ b/ux.symfony.com/assets/styles/components/_FileTree.scss
@@ -8,7 +8,8 @@
 .FileTree li > span {
   display: flex;
   flex-direction: row;
-  gap: 1rem;
+  align-items: center;
+  gap: .75rem;
 }
 
 .FileTree-main::before {
@@ -44,4 +45,3 @@
   left: 0;
   z-index: -1;
 }
-

--- a/ux.symfony.com/templates/main/_file_tree.html.twig
+++ b/ux.symfony.com/templates/main/_file_tree.html.twig
@@ -21,7 +21,7 @@
     {% else %}
         <li class="FileTree-main FileTree-file">
             <span {{- _self.summaryAttributes(file_info.description) -}}>
-                <twig:Icon name="folder" class="d-inline-block m-0 mr-2" />
+                <twig:Icon name="file" class="d-inline-block m-0 mr-2" />
                 {{ file_info.filename }}
             </span>
         </li>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | None
| License       | MIT

This is a quick proposal at updating the file tree present on the home page, replacing folder icons for file icons when appropriate.

**Before:**

![image](https://github.com/user-attachments/assets/8824d125-bb22-4d38-94bd-df9fef913c7e)

**After:**

![image](https://github.com/user-attachments/assets/376f9239-9a6e-4a69-9b58-5787061e11ec)

