### PR TITLE
[Map] Rename `render_map` Twig function `ux_map`

### DIFF
--- a/src/Map/CHANGELOG.md
+++ b/src/Map/CHANGELOG.md
@@ -2,4 +2,9 @@
 
 ## Unreleased
 
+-   Rename `render_map` Twig function `ux_map`
+-   Deprecate `render_map` Twig function
+
+## 2.19
+
 -   Component added

--- a/src/Map/doc/index.rst
+++ b/src/Map/doc/index.rst
@@ -120,14 +120,14 @@ A map is created by calling ``new Map()``. You can configure the center, zoom, a
         }
     }
 
-To render a map in your Twig template, use the ``render_map`` Twig function, e.g.:
+To render a map in your Twig template, use the ``ux_map`` Twig function, e.g.:
 
 .. code-block:: twig
 
-    {{ render_map(my_map) }}
+    {{ ux_map(my_map) }}
     
     {# or with custom attributes #}
-    {{ render_map(my_map, { style: 'height: 300px' }) }}
+    {{ ux_map(my_map, { style: 'height: 300px' }) }}
 
 Extend the default behavior
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -207,7 +207,7 @@ Then, you can use this controller in your template:
 
 .. code-block:: twig
     
-    {{ render_map(my_map, { 'data-controller': 'mymap', style: 'height: 300px' }) }}
+    {{ ux_map(my_map, { 'data-controller': 'mymap', style: 'height: 300px' }) }}
 
 Backward Compatibility promise
 ------------------------------

--- a/src/Map/src/Bridge/Google/README.md
+++ b/src/Map/src/Bridge/Google/README.md
@@ -90,7 +90,7 @@ A common use case is to customize the marker. You can listen to the `ux:map:mark
 
 Assuming you have a map with a custom controller:
 ```twig
-{{ render_map(map, {'data-controller': 'my-map' }) }}
+{{ ux_map(map, {'data-controller': 'my-map' }) }}
 ```
 
 You can create a Stimulus controller to customize the markers before they are created:

--- a/src/Map/src/Bridge/Leaflet/README.md
+++ b/src/Map/src/Bridge/Leaflet/README.md
@@ -47,7 +47,7 @@ A common use case is to customize the marker. You can listen to the `ux:map:mark
 
 Assuming you have a map with a custom controller:
 ```twig
-{{ render_map(map, {'data-controller': 'my-map' }) }}
+{{ ux_map(map, {'data-controller': 'my-map' }) }}
 ```
 
 You can create a Stimulus controller to customize the markers before they are created:

--- a/src/Map/src/Twig/MapExtension.php
+++ b/src/Map/src/Twig/MapExtension.php
@@ -24,6 +24,12 @@ final class MapExtension extends AbstractExtension
 {
     public function getFunctions(): iterable
     {
-        yield new TwigFunction('render_map', [Renderers::class, 'renderMap'], ['is_safe' => ['html']]);
+        yield new TwigFunction('render_map', [Renderers::class, 'renderMap'], [
+            'is_safe' => ['html'],
+            'deprecated' => '2.20',
+            'deprecating_package' => 'symfony/ux-map',
+            'alternative' => 'ux_map',
+        ]);
+        yield new TwigFunction('ux_map', [Renderers::class, 'renderMap'], ['is_safe' => ['html']]);
     }
 }

--- a/src/Map/tests/TwigTest.php
+++ b/src/Map/tests/TwigTest.php
@@ -44,7 +44,7 @@ final class TwigTest extends KernelTestCase
         $twig = self::getContainer()->get('twig');
         $twig->setLoader(new ChainLoader([
             new ArrayLoader([
-                'test' => '{{ render_map(map, attributes) }}',
+                'test' => '{{ ux_map(map, attributes) }}',
             ]),
             $twig->getLoader(),
         ]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | Fix #... 
| License       | MIT

### Context

As we recently saw with the `cva` function and forgot to do here: we should prefix every new component / package / Twig function or filter with `ux` to avoid conflict with existing codebases... and with future symfony or twig new methods.

### This PR

This PR renames `render_map` (inspired by charts hjs "render_chart") into `ux_map` (in line with what we did for UX Icons)

```diff
<div>
-    {{ render_map(map) }}
+    {{ ux_map(map) }}
</div>
```

### Next

We can keep the render_map for _some_ time, but it's marked as deprecated right now, and i think this is the good moment to update documentation, to limit future BC break / changes for users (even if we are in experimental)

### Website

Once this once is merged, the website page will need to be updated