### PR TITLE
[Map] Improve web performances by not calling "createInfoWindow" if unnecessary

### DIFF
--- a/src/Map/assets/dist/abstract_map_controller.d.ts
+++ b/src/Map/assets/dist/abstract_map_controller.d.ts
@@ -43,13 +43,15 @@ export default abstract class<MapOptions, Map, MarkerOptions, Marker, InfoWindow
     }): Map;
     createMarker(definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>): Marker;
     protected abstract doCreateMarker(definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>): Marker;
-    protected createInfoWindow({ definition, marker, }: {
+    protected createInfoWindow({ definition, marker, onMarkerClick, }: {
         definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>['infoWindow'];
         marker: Marker;
+        onMarkerClick?: boolean;
     }): InfoWindow;
-    protected abstract doCreateInfoWindow({ definition, marker, }: {
+    protected abstract doCreateInfoWindow({ definition, marker, onMarkerClick, }: {
         definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>['infoWindow'];
         marker: Marker;
+        onMarkerClick: boolean;
     }): InfoWindow;
     protected abstract doFitBoundsToMarkers(): void;
     protected abstract dispatchEvent(name: string, payload: Record<string, unknown>): void;

--- a/src/Map/assets/dist/abstract_map_controller.js
+++ b/src/Map/assets/dist/abstract_map_controller.js
@@ -27,9 +27,9 @@ class default_1 extends Controller {
         this.markers.push(marker);
         return marker;
     }
-    createInfoWindow({ definition, marker, }) {
+    createInfoWindow({ definition, marker, onMarkerClick = false, }) {
         this.dispatchEvent('info-window:before-create', { definition, marker });
-        const infoWindow = this.doCreateInfoWindow({ definition, marker });
+        const infoWindow = this.doCreateInfoWindow({ definition, marker, onMarkerClick });
         this.dispatchEvent('info-window:after-create', { infoWindow, marker });
         this.infoWindows.push(infoWindow);
         return infoWindow;

--- a/src/Map/assets/src/abstract_map_controller.ts
+++ b/src/Map/assets/src/abstract_map_controller.ts
@@ -111,12 +111,14 @@ export default abstract class<
     protected createInfoWindow({
         definition,
         marker,
+        onMarkerClick = false,
     }: {
         definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>['infoWindow'];
         marker: Marker;
+        onMarkerClick?: boolean;
     }): InfoWindow {
         this.dispatchEvent('info-window:before-create', { definition, marker });
-        const infoWindow = this.doCreateInfoWindow({ definition, marker });
+        const infoWindow = this.doCreateInfoWindow({ definition, marker, onMarkerClick });
         this.dispatchEvent('info-window:after-create', { infoWindow, marker });
 
         this.infoWindows.push(infoWindow);
@@ -127,9 +129,11 @@ export default abstract class<
     protected abstract doCreateInfoWindow({
         definition,
         marker,
+        onMarkerClick,
     }: {
         definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>['infoWindow'];
         marker: Marker;
+        onMarkerClick: boolean;
     }): InfoWindow;
 
     protected abstract doFitBoundsToMarkers(): void;

--- a/src/Map/src/Bridge/Google/assets/dist/map_controller.d.ts
+++ b/src/Map/src/Bridge/Google/assets/dist/map_controller.d.ts
@@ -16,9 +16,10 @@ export default class extends AbstractMapController<MapOptions, google.maps.Map, 
         options: MapOptions;
     }): google.maps.Map;
     protected doCreateMarker(definition: MarkerDefinition<google.maps.marker.AdvancedMarkerElementOptions, google.maps.InfoWindowOptions>): google.maps.marker.AdvancedMarkerElement;
-    protected doCreateInfoWindow({ definition, marker, }: {
+    protected doCreateInfoWindow({ definition, marker, onMarkerClick, }: {
         definition: MarkerDefinition<google.maps.marker.AdvancedMarkerElementOptions, google.maps.InfoWindowOptions>['infoWindow'];
         marker: google.maps.marker.AdvancedMarkerElement;
+        onMarkerClick: boolean;
     }): google.maps.InfoWindow;
     private createTextOrElement;
     private closeInfoWindowsExcept;

--- a/src/Map/src/Bridge/Google/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Google/assets/dist/map_controller.js
@@ -52,11 +52,18 @@ class default_1 extends AbstractMapController {
             map: this.map,
         });
         if (infoWindow) {
-            this.createInfoWindow({ definition: infoWindow, marker });
+            if (infoWindow.opened) {
+                this.createInfoWindow({ definition: infoWindow, marker });
+            }
+            else {
+                marker.addListener('click', () => {
+                    this.createInfoWindow({ definition: infoWindow, marker, onMarkerClick: true });
+                });
+            }
         }
         return marker;
     }
-    doCreateInfoWindow({ definition, marker, }) {
+    doCreateInfoWindow({ definition, marker, onMarkerClick, }) {
         const { headerContent, content, extra, rawOptions = {}, ...otherOptions } = definition;
         const infoWindow = new _google.maps.InfoWindow({
             headerContent: this.createTextOrElement(headerContent),
@@ -64,22 +71,18 @@ class default_1 extends AbstractMapController {
             ...otherOptions,
             ...rawOptions,
         });
-        if (definition.opened) {
+        if (definition.opened || onMarkerClick) {
             infoWindow.open({
                 map: this.map,
                 shouldFocus: false,
                 anchor: marker,
             });
         }
-        marker.addListener('click', () => {
+        if (onMarkerClick) {
             if (definition.autoClose) {
                 this.closeInfoWindowsExcept(infoWindow);
             }
-            infoWindow.open({
-                map: this.map,
-                anchor: marker,
-            });
-        });
+        }
         return infoWindow;
     }
     createTextOrElement(content) {

--- a/src/Map/src/Bridge/Google/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Google/assets/src/map_controller.ts
@@ -121,7 +121,13 @@ export default class extends AbstractMapController<
         });
 
         if (infoWindow) {
-            this.createInfoWindow({ definition: infoWindow, marker });
+            if (infoWindow.opened) {
+                this.createInfoWindow({ definition: infoWindow, marker });
+            } else {
+                marker.addListener('click', () => {
+                    this.createInfoWindow({ definition: infoWindow, marker, onMarkerClick: true });
+                });
+            }
         }
 
         return marker;
@@ -130,12 +136,14 @@ export default class extends AbstractMapController<
     protected doCreateInfoWindow({
         definition,
         marker,
+        onMarkerClick,
     }: {
         definition: MarkerDefinition<
             google.maps.marker.AdvancedMarkerElementOptions,
             google.maps.InfoWindowOptions
         >['infoWindow'];
         marker: google.maps.marker.AdvancedMarkerElement;
+        onMarkerClick: boolean;
     }): google.maps.InfoWindow {
         const { headerContent, content, extra, rawOptions = {}, ...otherOptions } = definition;
 
@@ -146,7 +154,7 @@ export default class extends AbstractMapController<
             ...rawOptions,
         });
 
-        if (definition.opened) {
+        if (definition.opened || onMarkerClick) {
             infoWindow.open({
                 map: this.map,
                 shouldFocus: false,
@@ -154,16 +162,11 @@ export default class extends AbstractMapController<
             });
         }
 
-        marker.addListener('click', () => {
+        if (onMarkerClick) {
             if (definition.autoClose) {
                 this.closeInfoWindowsExcept(infoWindow);
             }
-
-            infoWindow.open({
-                map: this.map,
-                anchor: marker,
-            });
-        });
+        }
 
         return infoWindow;
     }

--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.d.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.d.ts
@@ -19,9 +19,10 @@ export default class extends AbstractMapController<MapOptions, typeof L.Map, Mar
         options: MapOptions;
     }): L.Map;
     protected doCreateMarker(definition: MarkerDefinition): L.Marker;
-    protected doCreateInfoWindow({ definition, marker, }: {
+    protected doCreateInfoWindow({ definition, marker, onMarkerClick, }: {
         definition: MarkerDefinition['infoWindow'];
         marker: L.Marker;
+        onMarkerClick: boolean;
     }): L.Popup;
     protected doFitBoundsToMarkers(): void;
 }

--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
@@ -38,14 +38,21 @@ class map_controller extends AbstractMapController {
         const { position, title, infoWindow, extra, rawOptions = {}, ...otherOptions } = definition;
         const marker = L.marker(position, { title, ...otherOptions, ...rawOptions }).addTo(this.map);
         if (infoWindow) {
-            this.createInfoWindow({ definition: infoWindow, marker });
+            if (infoWindow.opened) {
+                this.createInfoWindow({ definition: infoWindow, marker });
+            }
+            else {
+                marker.on('click', () => {
+                    this.createInfoWindow({ definition: infoWindow, marker, onMarkerClick: true });
+                });
+            }
         }
         return marker;
     }
-    doCreateInfoWindow({ definition, marker, }) {
+    doCreateInfoWindow({ definition, marker, onMarkerClick, }) {
         const { headerContent, content, extra, rawOptions = {}, ...otherOptions } = definition;
         marker.bindPopup([headerContent, content].filter((x) => x).join('<br>'), { ...otherOptions, ...rawOptions });
-        if (definition.opened) {
+        if (definition.opened || onMarkerClick) {
             marker.openPopup();
         }
         const popup = marker.getPopup();

--- a/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
@@ -63,7 +63,13 @@ export default class extends AbstractMapController<
         const marker = L.marker(position, { title, ...otherOptions, ...rawOptions }).addTo(this.map);
 
         if (infoWindow) {
-            this.createInfoWindow({ definition: infoWindow, marker });
+            if (infoWindow.opened) {
+                this.createInfoWindow({ definition: infoWindow, marker });
+            } else {
+                marker.on('click', () => {
+                    this.createInfoWindow({ definition: infoWindow, marker, onMarkerClick: true });
+                });
+            }
         }
 
         return marker;
@@ -72,14 +78,16 @@ export default class extends AbstractMapController<
     protected doCreateInfoWindow({
         definition,
         marker,
+        onMarkerClick,
     }: {
         definition: MarkerDefinition['infoWindow'];
         marker: L.Marker;
+        onMarkerClick: boolean;
     }): L.Popup {
         const { headerContent, content, extra, rawOptions = {}, ...otherOptions } = definition;
 
         marker.bindPopup([headerContent, content].filter((x) => x).join('<br>'), { ...otherOptions, ...rawOptions });
-        if (definition.opened) {
+        if (definition.opened || onMarkerClick) {
             marker.openPopup();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->


This afternoon we spoke a bit with @simondaigre, and he told me about InfoWindow performance issues when you have too many of them (and depending your device).

If we have 1.000 InfoWindow, hidden by default and only visible after clicking on a marker, why should be **only** create the InfoWindow at that time?

This PR introduce lazy-creation of InfoWindow, it should improve web-performances on the user's browsers.

I've used the following PHP code:
```php

       $map = (new Map())
            ->center(new Point(0, 0))
            ->zoom(2)
            ->fitBoundsToMarkers()
            ->options(new GoogleOptions(
                mapId: 'XXX',
            ))
        ;

        for ($i = 0; $i < 1_000; $i++) {
            $map->addMarker(
                new Marker(
                    position: new Point(random_int(-90, 90), random_int(-180, 180)),
                    title: 'Marker ' . $i,
                    infoWindow: new InfoWindow(
                        content: 'Info window ' . $i,
                        opened: $i % 499 === 0
                    )
                )
            );
        }
```

## Benchmarks 

I've did some benchmarks for both Google and Leaflet:
- with 1.000 markers, 
- on a Macbook M1 Pro, CPU Throttle x6

### Google

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="1800" alt="Capture d’écran 2024-08-18 à 18 28 54" src="https://github.com/user-attachments/assets/816d8bc5-b671-4f6b-a242-28159034c8fc">
 <td><img width="1800" alt="Capture d’écran 2024-08-18 à 18 30 29" src="https://github.com/user-attachments/assets/1f77adae-e0cc-4728-a9f5-4a426d1de6a8">
</table> 

`connect()` takes 936ms instead of ~1,80s, we won ~900ms.

### Leaflet

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="1912" alt="Capture d’écran 2024-08-18 à 18 45 10" src="https://github.com/user-attachments/assets/4970c5d8-6e3b-4f3d-8713-f9434a98a661">
 <td><img width="1912" alt="Capture d’écran 2024-08-18 à 18 45 28" src="https://github.com/user-attachments/assets/8a0258cc-811e-4372-817c-43c0a9db765a">
</table> 


`connect()` takes ~1s instead of ~1,20s, we won ~200ms

---

The next steps for performance optimizations are:
- Lazyloading markers and infoWindows, in order to keep a good TTFB 
- Clusters!