### PR TITLE
[GH] Link to UX support page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: 🛟 Support / help
-    url: https://symfony.com/support
+    url: https://ux.symfony.com/support
     about: Ask your questions about Symfony UX


### PR DESCRIPTION
Now we have this page we can use it in the ISSUE_TEMPLATE selector :)

https://github.com/symfony/ux/issues/new/choose

