### PR TITLE
[Autocomplete] Reset form state on each request for applications that reuse the Symfony application between requests

### DIFF
--- a/src/Autocomplete/src/DependencyInjection/AutocompleteFormTypePass.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteFormTypePass.php
@@ -47,7 +47,8 @@ class AutocompleteFormTypePass implements CompilerPassInterface
             $wrappedDefinition = (new ChildDefinition('ux.autocomplete.wrapped_entity_type_autocompleter'))
                 // the "formType" string
                 ->replaceArgument(0, $serviceDefinition->getClass())
-                ->addTag(self::ENTITY_AUTOCOMPLETER_TAG, ['alias' => $alias]);
+                ->addTag(self::ENTITY_AUTOCOMPLETER_TAG, ['alias' => $alias])
+                ->addTag('kernel.reset', ['method' => 'reset']);
             $container->setDefinition('ux.autocomplete.wrapped_entity_type_autocompleter.'.$alias, $wrappedDefinition);
         }
     }

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
+use Symfony\Contracts\Service\ResetInterface;
 use Symfony\UX\Autocomplete\Doctrine\EntityMetadata;
 use Symfony\UX\Autocomplete\Doctrine\EntityMetadataFactory;
 use Symfony\UX\Autocomplete\Doctrine\EntitySearchUtil;
@@ -29,7 +30,7 @@ use Symfony\UX\Autocomplete\OptionsAwareEntityAutocompleterInterface;
  *
  * @internal
  */
-final class WrappedEntityTypeAutocompleter implements OptionsAwareEntityAutocompleterInterface
+final class WrappedEntityTypeAutocompleter implements OptionsAwareEntityAutocompleterInterface, ResetInterface
 {
     private ?FormInterface $form = null;
     private ?EntityMetadata $entityMetadata = null;
@@ -187,5 +188,11 @@ final class WrappedEntityTypeAutocompleter implements OptionsAwareEntityAutocomp
         }
 
         $this->options = $options;
+    }
+
+    public function reset(): void
+    {
+        unset($this->form);
+        $this->form = null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | 
| License       | MIT

Hi there, in ux-autocomplete there is an WrappedEntityTypeAutocompleter::getForm which on first call saves form instance in WrappedEntityTypeAutocompleter $form property, it has method setOptions which is called on each request in EntityAutocompleteController, in PHP-FPM everything will work as expected where container is created on each request, but with Swoole or similar where container is not created on each request rather only first request on first EntityAutocompleteController request everything is also fine, but on second request WrappedEntityTypeAutocompleter  will have an instance of form from previous request which is fine but the call of setOptions in controller will throw exception.

So in Swoole on second and next requests $this->form already contains an instance of form from previous request because DI Container is not created on each request as in PHP-FPM (Container is created only once) and exception is thrown. So, Symfony have an kernel.reset / kernel.terminate event which probably can be used here to reset $this->form in WrappedEntityTypeAutocompleter because they are fired after request is completed.