### PR TITLE
[TwigComponent] Add notice about needing `phpdocumentor/reflection-docblock`

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -474,6 +474,13 @@ can read::
     /** @var Product[] */
     public $products = [];
 
+Collection type extraction from the docblock requires the ``phpdocumentor/reflection-docblock``
+library. Make sure it is installed in you application:
+
+.. code-block:: terminal
+
+    $ composer require phpdocumentor/reflection-docblock
+
 Writable Object Properties or Array Keys
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | NA
| License       | MIT

This notice is present in this in section [Using DTO's on a LiveProp](https://symfony.com/bundles/ux-live-component/current/index.html#using-dto-s-on-a-liveprop) but not here: [LiveProp for Entities & More Complex Data](https://symfony.com/bundles/ux-live-component/current/index.html#liveprop-for-entities-more-complex-data)

<img width="485" alt="image" src="https://github.com/user-attachments/assets/e6eb388a-d740-42fc-9d15-d2d2f8ac005e">

This is where I personally ran into trouble. https://symfony-devs.slack.com/archives/C01FN4EQNLX/p1724839078396519


