### PR TITLE
[Autocomplete] Translate "Add ..." text

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.20.0
+
+-   Translate the `option_create` option from TomSelect #2108
+
 ## 2.17.0
 
 -   Allow `choice_value` option in entity autocomplete fields #1723

--- a/src/Autocomplete/assets/dist/controller.d.ts
+++ b/src/Autocomplete/assets/dist/controller.d.ts
@@ -15,6 +15,7 @@ export default class extends Controller {
         loadingMoreText: StringConstructor;
         noResultsFoundText: StringConstructor;
         noMoreResultsText: StringConstructor;
+        createOptionText: StringConstructor;
         minCharacters: NumberConstructor;
         tomSelectOptions: ObjectConstructor;
         preload: StringConstructor;
@@ -24,6 +25,7 @@ export default class extends Controller {
     readonly loadingMoreTextValue: string;
     readonly noMoreResultsTextValue: string;
     readonly noResultsFoundTextValue: string;
+    readonly createOptionTextValue: string;
     readonly minCharactersValue: number;
     readonly hasMinCharactersValue: boolean;
     readonly tomSelectOptionsValue: object;

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -239,6 +239,9 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
         no_results: () => {
             return `<div class="no-results">${this.noResultsFoundTextValue}</div>`;
         },
+        option_create: (data, escapeData) => {
+            return `<div class="create">${this.createOptionTextValue.replace('%placeholder%', `<strong>${escapeData(data.input)}</strong>`)}</div>`;
+        },
     };
     const config = {
         render,
@@ -314,6 +317,9 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
             no_results: () => {
                 return `<div class="no-results">${this.noResultsFoundTextValue}</div>`;
             },
+            option_create: (data, escapeData) => {
+                return `<div class="create">${this.createOptionTextValue} <strong>${escapeData(data.input)}</strong>&hellip;</div>`;
+            },
         },
         preload: this.preload,
     });
@@ -336,6 +342,7 @@ default_1.values = {
     loadingMoreText: String,
     noResultsFoundText: String,
     noMoreResultsText: String,
+    createOptionText: String,
     minCharacters: Number,
     tomSelectOptions: Object,
     preload: String,

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -1,7 +1,14 @@
 import { Controller } from '@hotwired/stimulus';
 import TomSelect from 'tom-select';
 import type { TPluginHash } from 'tom-select/dist/types/contrib/microplugin';
-import type { RecursivePartial, TomSettings, TomTemplates, TomLoadCallback } from 'tom-select/dist/types/types';
+import type {
+    RecursivePartial,
+    TomSettings,
+    TomTemplates,
+    TomLoadCallback,
+    TomOption,
+} from 'tom-select/dist/types/types';
+import type { escape_html } from 'tom-select/dist/types/utils';
 
 export interface AutocompletePreConnectOptions {
     options: any;
@@ -18,6 +25,7 @@ export default class extends Controller {
         loadingMoreText: String,
         noResultsFoundText: String,
         noMoreResultsText: String,
+        createOptionText: String,
         minCharacters: Number,
         tomSelectOptions: Object,
         preload: String,
@@ -28,6 +36,7 @@ export default class extends Controller {
     declare readonly loadingMoreTextValue: string;
     declare readonly noMoreResultsTextValue: string;
     declare readonly noResultsFoundTextValue: string;
+    declare readonly createOptionTextValue: string;
     declare readonly minCharactersValue: number;
     declare readonly hasMinCharactersValue: boolean;
     declare readonly tomSelectOptionsValue: object;
@@ -136,6 +145,9 @@ export default class extends Controller {
             no_results: () => {
                 return `<div class="no-results">${this.noResultsFoundTextValue}</div>`;
             },
+            option_create: (data: TomOption, escapeData: typeof escape_html): string => {
+                return `<div class="create">${this.createOptionTextValue.replace('%placeholder%', `<strong>${escapeData(data.input)}</strong>`)}</div>`;
+            },
         };
 
         const config: RecursivePartial<TomSettings> = {
@@ -239,6 +251,9 @@ export default class extends Controller {
                 },
                 no_results: (): string => {
                     return `<div class="no-results">${this.noResultsFoundTextValue}</div>`;
+                },
+                option_create: (data: TomOption, escapeData: typeof escape_html): string => {
+                    return `<div class="create">${this.createOptionTextValue} <strong>${escapeData(data.input)}</strong>&hellip;</div>`;
                 },
             },
             preload: this.preload,

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -91,6 +91,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
         $values['loading-more-text'] = $this->trans($options['loading_more_text']);
         $values['no-results-found-text'] = $this->trans($options['no_results_found_text']);
         $values['no-more-results-text'] = $this->trans($options['no_more_results_text']);
+        $values['create-option-text'] = $this->trans($options['create_option_text']);
         $values['preload'] = $options['preload'];
 
         foreach ($values as $name => $value) {
@@ -147,6 +148,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'loading_more_text' => 'Loading more results...',
             'no_results_found_text' => 'No results found',
             'no_more_results_text' => 'No more results',
+            'create_option_text' => 'Add %placeholder%...',
             'min_characters' => null,
             'max_results' => 10,
             'preload' => 'focus',

--- a/src/Autocomplete/translations/AutocompleteBundle.ar.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.ar.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'تحميل المزيد من النتائج...',
     'No results found' => 'لم يتم العثور على أي نتائج',
     'No more results' => 'لا توجد نتائج أٌخرى',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.bg.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.bg.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Зареждане на още резултати...',
     'No results found' => 'Няма намерени съвпадения',
     'No more results' => 'Няма повече резултати',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.ca.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.ca.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'S\'estan carregant més resultats...',
     'No results found' => 'No s\'han trobat resultats',
     'No more results' => 'No hi ha més resultats',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.cs.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.cs.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Načítání dalších výsledků...',
     'No results found' => 'Nenalezeny žádné položky',
     'No more results' => 'Žádné další výsledky',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.da.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.da.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Indlæser flere resultater...',
     'No results found' => 'Ingen resultater fundet',
     'No more results' => 'Ingen flere resultater',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.de.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.de.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Lade weitere Ergebnisse...',
     'No results found' => 'Keine Übereinstimmungen gefunden',
     'No more results' => 'Keine weiteren Ergebnisse',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.el.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.el.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Φόρτωση περισσότερων αποτελεσμάτων...',
     'No results found' => 'Δεν βρέθηκαν αποτελέσματα',
     'No more results' => 'Δεν υπάρχουν άλλα αποτελέσματα',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.en.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.en.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Loading more results...',
     'No results found' => 'No results found',
     'No more results' => 'No more results',
+    'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.es.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.es.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Cargando más resultados...',
     'No results found' => 'No se han encontrado resultados',
     'No more results' => 'No hay más resultados',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.eu.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.eu.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Emaitza gehiago kargatzen...',
     'No results found' => 'Ez da bat datorrenik aurkitu',
     'No more results' => 'Ez dago emaitza gehiagorik',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.fa.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.fa.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'در حال بارگذاری نتایج بیشتر...',
     'No results found' => 'هیچ نتیجه‌ای یافت نشد',
     'No more results' => 'نتیجه دیگری وجود ندارد',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.fi.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.fi.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Ladataan lisää tuloksia...',
     'No results found' => 'Ei tuloksia',
     'No more results' => 'Ei enempää tuloksia',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.fr.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.fr.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Chargement d\'autres résultats...',
     'No results found' => 'Aucun résultat trouvé',
     'No more results' => 'Aucun autre résultat trouvé',
+    'Add %placeholder%...' => 'Ajouter %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.gl.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.gl.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Cargando máis resultados...',
     'No results found' => 'Non se atoparon resultados',
     'No more results' => 'Non hai máis resultados',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.hr.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.hr.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Učitavanje više rezultata...',
     'No results found' => 'Nema rezultata',
     'No more results' => 'Nema više rezultata',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.hu.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.hu.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'További találatok betöltése...',
     'No results found' => 'Nincs találat',
     'No more results' => 'Nincs több találat',
+    'Add %placeholder%...' => '"%placeholder%" hozzáadása',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.id.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.id.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Memuat hasil lebih banyak...',
     'No results found' => 'Tidak ada hasil yang ditemukan',
     'No more results' => 'Tidak ada hasil lagi',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.it.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.it.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Caricamento di altri risultati...',
     'No results found' => 'Nessun risultato trovato',
     'No more results' => 'Non ci sono altri risultati',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.lb.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.lb.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Lueden méi Resultater...',
     'No results found' => 'Keng Resultater fonnt',
     'No more results' => 'Keng weider Resultater',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.lt.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.lt.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Kraunama daugiau rezultatų...',
     'No results found' => 'Atitikmenų nerasta',
     'No more results' => 'Daugiau rezultatų nėra',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.nl.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.nl.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Meer resultaten aan het laden...',
     'No results found' => 'Geen resultaten gevonden…',
     'No more results' => 'Niet meer resultaten gevonden…',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.pl.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.pl.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Wczytywanie więcej wyników...',
     'No results found' => 'Brak wyników',
     'No more results' => 'Brak więcej wyników',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.pt.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.pt.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Carregando mais resultados...',
     'No results found' => 'Sem resultados',
     'No more results' => 'Não há mais resultados',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.pt_BR.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.pt_BR.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Carregando mais resultados...',
     'No results found' => 'Nenhum resultado encontrado',
     'No more results' => 'Não há mais resultados',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.ro.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.ro.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Se încarcă mai multe rezultate...',
     'No results found' => 'Nu au fost găsite rezultate',
     'No more results' => 'Nu mai sunt alte rezultate',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.ru.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.ru.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Загрузка дополнительных результатов...',
     'No results found' => 'Совпадений не найдено',
     'No more results' => 'Больше результатов нет',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.sk.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.sk.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Načítavajú sa ďalšie výsledky...',
     'No results found' => 'Neboli nájdené žiadne výsledky',
     'No more results' => 'Žiadne ďalšie výsledky',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.sl.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.sl.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Nalaganje več rezultatov...',
     'No results found' => 'Ni zadetkov',
     'No more results' => 'Ni več rezultatov',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.sr_RS.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.sr_RS.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Учитавање још резултата...',
     'No results found' => 'Nema rezultata',
     'No more results' => 'Nema više rezultata',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.sv.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.sv.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Laddar fler resultat...',
     'No results found' => 'Inga träffar',
     'No more results' => 'Inga fler resultat',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.tr.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.tr.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Daha fazla sonuç yükleniyor...',
     'No results found' => 'Sonuç bulunamadı',
     'No more results' => 'Başka sonuç yok',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.uk.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.uk.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => 'Завантаження додаткових результатів...',
     'No results found' => 'Нічого не знайдено',
     'No more results' => 'Більше результатів немає',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.zh_CN.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.zh_CN.php
@@ -13,4 +13,5 @@ return [
     'Loading more results...' => '加载更多结果...',
     'No results found' => '未找到结果',
     'No more results' => '没有更多结果',
+    // 'Add %placeholder%...' => 'Add %placeholder%...',
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #745 
| License       | MIT

Hi, this PR fixes #745, allowing to translate the "Add Abc..." text when the create option is set to true :) 

Added the translated text as comment in most translation files.

![image](https://github.com/user-attachments/assets/594c4b50-46cb-4bdb-b0b5-81168f83d53e)
