### PR TITLE
[TwigComponent] Remove `$tag` parameter from `*Node`, as it is now deprecated by twig/twig 3.12

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -29,14 +29,14 @@ use Twig\Node\NodeOutputInterface;
 #[YieldReady]
 final class ComponentNode extends Node implements NodeOutputInterface
 {
-    public function __construct(string $component, string $embeddedTemplateName, int $embeddedTemplateIndex, ?AbstractExpression $props, bool $only, int $lineno, string $tag)
+    public function __construct(string $component, string $embeddedTemplateName, int $embeddedTemplateIndex, ?AbstractExpression $props, bool $only, int $lineno)
     {
         $nodes = [];
         if (null !== $props) {
             $nodes['props'] = $props;
         }
 
-        parent::__construct($nodes, [], $lineno, $tag);
+        parent::__construct($nodes, [], $lineno);
 
         $this->setAttribute('only', $only);
         $this->setAttribute('embedded_template', $embeddedTemplateName);

--- a/src/TwigComponent/src/Twig/ComponentTokenParser.php
+++ b/src/TwigComponent/src/Twig/ComponentTokenParser.php
@@ -67,7 +67,7 @@ final class ComponentTokenParser extends AbstractTokenParser
 
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        return new ComponentNode($componentName, $module->getTemplateName(), $module->getAttribute('index'), $propsExpression, $only, $token->getLine(), $this->getTag());
+        return new ComponentNode($componentName, $module->getTemplateName(), $module->getAttribute('index'), $propsExpression, $only, $token->getLine());
     }
 
     public function getTag(): string

--- a/src/TwigComponent/src/Twig/PropsNode.php
+++ b/src/TwigComponent/src/Twig/PropsNode.php
@@ -23,9 +23,9 @@ use Twig\Node\Node;
 #[YieldReady]
 class PropsNode extends Node
 {
-    public function __construct(array $propsNames, array $values, $lineno = 0, ?string $tag = null)
+    public function __construct(array $propsNames, array $values, $lineno = 0)
     {
-        parent::__construct($values, ['names' => $propsNames], $lineno, $tag);
+        parent::__construct($values, ['names' => $propsNames], $lineno);
     }
 
     public function compile(Compiler $compiler): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR fix the deprecations added in twig/twig 3.12, about the `$tag` parameter from `Node` class:
```
➜  TwigComponent git:(2.x) sf php vendor/bin/simple-phpunit
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.

Testing 
...............................................................  63 / 249 ( 25%)
............................................................... 126 / 249 ( 50%)
............................................................... 189 / 249 ( 75%)
............................................................    249 / 249 (100%)

Time: 00:00.514, Memory: 38.00 MB

OK (249 tests, 632 assertions)

Remaining direct deprecation notices (39)

  28x: Since twig/twig 3.12: The "tag" constructor argument of the "Symfony\UX\TwigComponent\Twig\ComponentNode" class is deprecated and ignored (check which TokenParser class set it to "component"), the tag is now automatically set by the Parser when needed.
    5x in EmbeddedComponentTest::testPassingDownBlocksMultipleLevelsNeedsToBeDoneManually from Symfony\UX\TwigComponent\Tests\Integration
    3x in EmbeddedComponentTest::testDeepNesting from Symfony\UX\TwigComponent\Tests\Integration
    3x in EmbeddedComponentTest::testItCanHandleMissingOuterBlocks from Symfony\UX\TwigComponent\Tests\Integration
    3x in EmbeddedComponentTest::testBlockDefinitionCanAccessTheContextOfTheDestinationBlocks from Symfony\UX\TwigComponent\Tests\Integration
    2x in EmbeddedComponentTest::testABlockIsNotPassedIntoAnEmbeddedComponent from Symfony\UX\TwigComponent\Tests\Integration
    ...

  11x: Since twig/twig 3.12: The "tag" constructor argument of the "Symfony\UX\TwigComponent\Twig\PropsNode" class is deprecated and ignored (check which TokenParser class set it to "props"), the tag is now automatically set by the Parser when needed.
    10x in ComponentPropsParserTest::testPropsData from Symfony\UX\TwigComponent\Tests\Integration\Twig
    1x in TwigComponentDebugCommandTest::testWithAnonymousComponent from Symfony\UX\TwigComponent\Tests\Integration\Command

Legacy deprecation notices (4)
➜  TwigComponent git:(2.x) 

```