### PR TITLE
[Turbo] Render TurboStream (wip)

### DIFF
--- a/src/TurboStreamRender/src/Core/TurboStream.php
+++ b/src/TurboStreamRender/src/Core/TurboStream.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace src\Core;
+
+use src\Enum\TurboAction;
+
+readonly class TurboStream
+{
+    public function __construct(
+        public string $target,
+        public TurboAction $action,
+        public string $view,
+        public array $parameters,
+    ) {
+    }
+}

--- a/src/TurboStreamRender/src/Core/TurboStreamCollection.php
+++ b/src/TurboStreamRender/src/Core/TurboStreamCollection.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace src\Core;
+
+use src\Enum\TurboAction;
+
+class TurboStreamCollection
+{
+
+    /**
+     * @param TurboStream[] $streams
+     */
+    public function __construct(private array $streams = [])
+    {
+    }
+
+    public function add(string $target, TurboAction $action, $view, array $parameters = [])
+    {
+        return $this->addStream(new TurboStream($target, $action, $view, $parameters));
+    }
+
+    public function addStream(TurboStream $stream): self
+    {
+        $this->streams[] = $stream;
+
+        return $this;
+    }
+
+    /**
+     * @return TurboStream[]
+     */
+    public function all(): array
+    {
+        return $this->streams;
+    }
+}

--- a/src/TurboStreamRender/src/Core/TurboStreamRenderer.php
+++ b/src/TurboStreamRender/src/Core/TurboStreamRenderer.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace src\Core;
+
+use src\Enum\TurboAction;
+use TurboStreamRendererInterface;
+
+class TurboStreamRenderer implements TurboStreamRendererInterface
+{
+    /**
+     * This is a hacky way to reuse the code of renderView form AbstractController - just pass the method as a callable to the renderer constructor.
+     * @var callable $renderer
+     */
+    protected $renderer = null;
+
+    public function __construct(callable $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * @throws \InvalidRendererException
+     */
+    public function renderView(string $view, array $parameters = []): string
+    {
+        try {
+            $renderer = $this->renderer;
+            return $renderer($view, $parameters);
+        }catch (\Throwable $e) {
+            throw new \InvalidRendererException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    public function renderAsStreamView(string $target, TurboAction $action, string $view, array $parameters = []): string
+    {
+        $streams = (new TurboStreamCollection())->add($target, $action, $view, $parameters);
+
+        return $this->renderTurboStreamsView($streams->all());
+    }
+
+    /**
+     * @throws \InvalidRendererException
+     */
+    public function renderTurboStreamsView(array $streams): string
+    {
+        $response = "";
+        foreach ($streams as $stream) {
+            $content = $this->renderView($stream['view'], $stream['parameters']);
+            $response .= $this->wrapWithTurboStream($stream['target'], $stream['action'], $content);
+            $response .= "\n";
+        }
+
+        return $response;
+    }
+
+    private function wrapWithTurboStream(string $target, TurboAction $action, string $content): string
+    {
+        return <<<HTML
+        <turbo-stream action="$action->value" target="$target">
+            <template>
+                $content
+            </template>
+        </turbo-stream>
+        HTML;
+    }
+}

--- a/src/TurboStreamRender/src/Enum/TurboAction.php
+++ b/src/TurboStreamRender/src/Enum/TurboAction.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace src\Enum;
+
+enum TurboAction: string
+{
+    case APPEND = 'append';
+    case PREPEND = 'prepend';
+    case REPLACE = 'replace';
+    case UPDATE = 'update';
+    case REMOVE = 'remove';
+    case BEFORE = 'before';
+    case AFTER = 'after';
+    case REFRESH = 'refresh';
+}

--- a/src/TurboStreamRender/src/Exception/InvalidRendererException.php
+++ b/src/TurboStreamRender/src/Exception/InvalidRendererException.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+
+class InvalidRendererException extends \Exception
+{
+}

--- a/src/TurboStreamRender/src/Interface/TurboStreamRendererInterface.php
+++ b/src/TurboStreamRender/src/Interface/TurboStreamRendererInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use src\Core\TurboStream;
+use src\Enum\TurboAction;
+
+interface TurboStreamRendererInterface
+{
+    function renderAsStreamView(string $target, TurboAction $action, string$view, array $parameters = []): string;
+
+    /**
+     * @param TurboStream[] $streams
+     */
+    function renderTurboStreamsView(array $streams): string;
+}

--- a/src/TurboStreamRender/src/Trait/TurboRenderTrait.php
+++ b/src/TurboStreamRender/src/Trait/TurboRenderTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace src\Trait;
+
+use src\Core\TurboStream;
+use src\Core\TurboStreamCollection;
+use src\Enum\TurboAction;
+use TurboStreamRendererInterface;
+
+// This needs Symfony\Component\HttpFoundation\Response so it won't work as part of the turbo bundle, unless there is another way to keep it decoupled.
+// An alternative would be to have this as a separate bundle.
+
+
+trait TurboRenderTrait
+{
+    abstract protected function getTurboStreamRenderer(): TurboStreamRendererInterface;
+
+    protected function renderAsStreamView(string $target, TurboAction $action, $view, array $parameters = []): string
+    {
+        $streams = (new TurboStreamCollection())->add($target, $action, $view, $parameters);
+
+        return $this->renderTurboStreamsView($streams->all());
+    }
+
+    /**
+     * @param TurboStream[] $streams
+     */
+    protected function renderTurboStreamsView(array $streams): string
+    {
+        return $this->getTurboStreamRenderer()->renderTurboStreamsView($streams);
+    }
+
+    private function wrapWithTurboStream(string $target, TurboAction $action, string $content): string
+    {
+        return <<<HTML
+        <turbo-stream action="$action->value" target="$target">
+            <template>
+                $content
+            </template>
+        </turbo-stream>
+        HTML;
+    }
+}

--- a/src/TurboStreamResponse/src/Trait/TurboResponseTrait.php
+++ b/src/TurboStreamResponse/src/Trait/TurboResponseTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace src\Trait;
+
+use src\Core\TurboStream;
+use src\Enum\TurboAction;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\UX\Turbo\TurboBundle;
+
+// This needs Symfony\Component\HttpFoundation\Response so it won't work as part of the turbo bundle, unless there is another way to keep it decoupled.
+// An alternative would be to have this as a separate bundle.
+
+
+trait TurboResponseTrait
+{
+
+    use TurboRenderTrait;
+
+    protected function renderAsStream(string $target, TurboAction $action, $view, array $parameters = []): Response
+    {
+       return $this->renderTurboStreams([new TurboStream($target, $action, $view, $parameters)]);
+    }
+
+    /**
+     * @param TurboStream[] $streams
+     */
+    protected function renderTurboStreams(array $streams): Response
+    {
+        $content = $this->renderTurboStreamsView($streams);
+        $response ??= new Response();
+
+        // I would like to keep this part of the standard AbstractController, but I don't really like the idea of duplication the code.
+        // Any suggestions for a way to reuse it?
+
+        foreach ($streams as $stream) {
+            if (200 === $response->getStatusCode()) {
+                $parameters = $stream->getParameters();
+                foreach ($parameters as $v) {
+                    if ($v instanceof FormInterface && $v->isSubmitted() && !$v->isValid()) {
+                        $response->setStatusCode(422);
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        $response->setContent($content);
+        $response->headers->set('Content-Type', TurboBundle::STREAM_MEDIA_TYPE);
+
+        return $response;
+    }
+
+    private function wrapWithTurboStream(string $target, TurboAction $action, string $content): string
+    {
+        return <<<HTML
+        <turbo-stream action="$action->value" target="$target">
+            <template>
+                $content
+            </template>
+        </turbo-stream>
+        HTML;
+    }
+}

--- a/ux.symfony.com/templates/components/TurboStream.html.twig
+++ b/ux.symfony.com/templates/components/TurboStream.html.twig
@@ -1,0 +1,5 @@
+<turbo-stream action="{{ action }}" target="{{ target }}">
+    <template>
+        {% block content %}{% endblock %}
+    </template>
+</turbo-stream>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #2068 
| License       | MIT

This is a WIP to aid in further discussions of the RFC implementation

@smnandre As discussed in #2068 I have opened a PR with some rough outline of the implementation

It is far from ready, but I think it is a good start. I can continue to work on this, but I will need some direction.
I understand now what you meant earlier - the bundle is an independent component not tied to the symfony framework's AbstractController, nor HttpFoundation nor even Twig

So I think my initial concept should be split into 2 parts - one is the abstract implementation of rendering streams, or rather wrapping a view in a turbo stream, and the other part should be specific to the full-fat symfony framework and it will  build on top of the first to provide an easy way to go from a bunch of turbo streams to a HttpFoundation\Response with the correct content type, etc.