### PR TITLE
[LiveComponent] Add `setRouteLocale` in `TestLiveComponent`

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3711,6 +3711,9 @@ uses Symfony's test client to render and make requests to your components::
             // authenticate a user ($user is instance of UserInterface)
             $testComponent->actingAs($user);
 
+            // set the '_locale' route parameter (if the component route is localized)  
+            $testComponent->setRouteLocale('fr');
+
             // customize the test client
             $client = self::getContainer()->get('test.client');
 

--- a/src/LiveComponent/tests/Fixtures/Component/LocalizedRoute.php
+++ b/src/LiveComponent/tests/Fixtures/Component/LocalizedRoute.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * @author Simon André
+ */
+#[AsLiveComponent('localized_route', route: 'localized_route')]
+final class LocalizedRoute
+{
+    use DefaultActionTrait;
+}

--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -214,5 +214,6 @@ final class Kernel extends BaseKernel
         $routes->add('render_namespaced_template', '/render-namespaced-template/{template}')->controller('kernel::renderNamespacedTemplate');
         $routes->add('homepage', '/')->controller('kernel::index');
         $routes->add('alternate_live_route', '/alt/{_live_component}/{_live_action}')->defaults(['_live_action' => 'get']);
+        $routes->add('localized_route', '/locale/{_locale}/{_live_component}/{_live_action}')->defaults(['_live_action' => 'get']);
     }
 }

--- a/src/LiveComponent/tests/Fixtures/templates/components/localized_route.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/localized_route.html.twig
@@ -1,0 +1,3 @@
+<div{{ attributes }}>
+    Localized route <em>Locale: {{ app.request.locale }}</em>
+</div>

--- a/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
+++ b/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
@@ -194,4 +194,21 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
 
         $this->assertStringContainsString('Total: 9', $testComponent->render());
     }
+
+    public function testSetLocaleRenderLocalizedComponent(): void
+    {
+        $testComponent = $this->createLiveComponent('localized_route');
+        $testComponent->setRouteLocale('fr');
+        $this->assertStringContainsString('Locale: fr', $testComponent->render());
+
+        $testComponent->refresh();
+        $this->assertStringContainsString('Locale: fr', $testComponent->render());
+
+        $testComponent->setRouteLocale('es');
+        $this->assertStringContainsString('Locale: es', $testComponent->render());
+
+        $testComponent = $this->createLiveComponent('localized_route');
+        $testComponent->setRouteLocale('de');
+        $this->assertStringContainsString('Locale: de', $testComponent->render());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #1565 
| License       | MIT

The `live_component` route can be localized. It then requires the `{_locale}` the parameter to be defined.

```diff
# config/routes/ux_live_component.yaml
  live_component:
      resource: '@LiveComponentBundle/config/routes.php'
-     prefix: /_components
+     prefix: /{_locale}/_components
```

This PR adds a `setRouteLocale` method in `TestLiveComponent` to help in this situation.

```php
$testComponent = $this->createLiveComponent('Acme:Foo');
$testComponent->setRouteLocale('de');

// $testComponent is rendered with the 'de' locale
```

Thank you @javiereguiluz for the idea and your help :)
