### PR TITLE
[Map] Adjust changelogs and fix `render_map` deprecated version

### DIFF
--- a/src/Map/CHANGELOG.md
+++ b/src/Map/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## 2.20
 
 -   Rename `render_map` Twig function `ux_map`
 -   Deprecate `render_map` Twig function

--- a/src/Map/src/Bridge/Google/CHANGELOG.md
+++ b/src/Map/src/Bridge/Google/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG
 
-## Unreleased
+## 2.19
 
 -   Bridge added

--- a/src/Map/src/Bridge/Leaflet/CHANGELOG.md
+++ b/src/Map/src/Bridge/Leaflet/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG
 
-## Unreleased
+## 2.19
 
 -   Bridge added

--- a/src/Map/src/Twig/MapExtension.php
+++ b/src/Map/src/Twig/MapExtension.php
@@ -27,7 +27,7 @@ final class MapExtension extends AbstractExtension
         return [
             new TwigFunction('render_map', [Renderers::class, 'renderMap'], [
                 'is_safe' => ['html'],
-                'deprecated' => '2.21',
+                'deprecated' => '2.20',
                 'deprecating_package' => 'symfony/ux-map',
                 'alternative' => 'ux_map',
             ]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

While working on #2070, I noticed Map's changelogs were still containing `Unreleased` instead of the version number.
I've also changed the version where `render_map` twig function have been deprecated, to match the reality (the 2.20 will be the next release!). 