### PR TITLE
[Map] Enhance `ux_map()`, allow to create a Map directly in Twig!

### DIFF
--- a/src/Map/src/InfoWindow.php
+++ b/src/Map/src/InfoWindow.php
@@ -18,6 +18,24 @@ namespace Symfony\UX\Map;
  */
 final readonly class InfoWindow
 {
+    public static function fromArray(
+        ?string $headerContent = null,
+        ?string $content = null,
+        ?array $position = null,
+        bool $opened = false,
+        bool $autoClose = true,
+        array $extra = [],
+    ): self {
+        return new self(
+            $headerContent,
+            $content,
+            $position ? Point::fromArray($position) : null,
+            $opened,
+            $autoClose,
+            $extra,
+        );
+    }
+
     /**
      * @param array<string, mixed> $extra Extra data, can be used by the developer to store additional information and use them later JavaScript side
      */

--- a/src/Map/src/Map.php
+++ b/src/Map/src/Map.php
@@ -20,6 +20,28 @@ use Symfony\UX\Map\Exception\InvalidArgumentException;
  */
 final class Map
 {
+    /**
+     * @param array{0: float, 1: float}                       $center
+     * @param array<array{ point: array, title: string|null}> $markers
+     *
+     * @return self
+     */
+    public static function fromArray(
+        array $center,
+        float $zoom,
+        bool $fitBoundsToMarkers,
+        array $markers,
+    ) {
+        return new self(
+            null,
+            null,
+            Point::fromArray($center),
+            $zoom,
+            $fitBoundsToMarkers,
+            array_map(static fn (array $marker) => Marker::fromArray(...$marker), $markers),
+        );
+    }
+
     public function __construct(
         private readonly ?string $rendererName = null,
         private ?MapOptionsInterface $options = null,

--- a/src/Map/src/Marker.php
+++ b/src/Map/src/Marker.php
@@ -18,6 +18,20 @@ namespace Symfony\UX\Map;
  */
 final readonly class Marker
 {
+    public static function fromArray(
+        array $position,
+        ?string $title = null,
+        ?array $infoWindow = null,
+        array $extra = [],
+    ): self {
+        return new self(
+            Point::fromArray($position),
+            $title,
+            $infoWindow ? InfoWindow::fromArray(...$infoWindow) : null,
+            $extra,
+        );
+    }
+
     /**
      * @param array<string, mixed> $extra Extra data, can be used by the developer to store additional information and use them later JavaScript side
      */

--- a/src/Map/src/Point.php
+++ b/src/Map/src/Point.php
@@ -34,6 +34,16 @@ final readonly class Point
     }
 
     /**
+     * @param array{0: float, 1: float} $center
+     *
+     * @return self
+     */
+    public static function fromArray(array $center)
+    {
+        return new self($center[0], $center[1]);
+    }
+
+    /**
      * @return array{lat: float, lng: float}
      */
     public function toArray(): array

--- a/src/Map/src/Renderer/Renderers.php
+++ b/src/Map/src/Renderer/Renderers.php
@@ -42,8 +42,16 @@ final class Renderers implements RendererInterface
         }
     }
 
-    public function renderMap(Map $map, array $attributes = []): string
-    {
+    public function renderMap(
+        ?Map $map = null,
+        array $attributes = [],
+        ?array $center = null,
+        ?float $zoom = null,
+        bool $fitBoundsToMarkers = false,
+        array $markers = [],
+    ): string {
+        $map ??= Map::fromArray($center, $zoom, $fitBoundsToMarkers, $markers);
+
         $renderer = $this->default;
 
         if ($rendererName = $map->getRendererName()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

A lighter alternative to #2117.

 Note that this PR is not 100% complete, it's a POC, it's missing some runtime-checks and options to build a map. 

With the following code:
```twig
{{ ux_map(
    center=[51.5074, 0.1278],
    fit_bounds_to_markers=true,
    zoom=10,
    markers= [
        { position: [51.5074, 0.1278], title: 'London' },
        { position: [48.8566, 2.3522], title: 'Paris' },
        {
            position: [40.7128, -74.0060], 
            title: 'New York',
            infoWindow: { content: 'Welcom to <b>New York</b>', opened: true }
        },
    ],
    attributes={
        class: 'foo',
        style: 'height: 400px; width: 100%;',
    }
) }}
```

I'm able to render this map:
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/6e35810d-74fd-4b80-80ae-cf38c0a3afae">

WDYT @smnandre?