### PR TITLE
[Icons] Configure icon sets: path, alias & icon attributes

### DIFF
--- a/src/Icons/config/services.php
+++ b/src/Icons/config/services.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\UX\Icons\Command\WarmCacheCommand;
 use Symfony\UX\Icons\IconCacheWarmer;
 use Symfony\UX\Icons\IconRenderer;
+use Symfony\UX\Icons\IconRendererInterface;
 use Symfony\UX\Icons\Registry\CacheIconRegistry;
 use Symfony\UX\Icons\Registry\ChainIconRegistry;
 use Symfony\UX\Icons\Registry\LocalSvgIconRegistry;
@@ -60,7 +61,7 @@ return static function (ContainerConfigurator $container): void {
                 abstract_arg('icon_aliases'),
             ])
 
-        ->alias('Symfony\UX\Icons\IconRendererInterface', '.ux_icons.icon_renderer')
+        ->alias(IconRendererInterface::class, '.ux_icons.icon_renderer')
 
         ->set('.ux_icons.icon_finder', IconFinder::class)
             ->args([

--- a/src/Icons/src/Registry/IconifyOnDemandRegistry.php
+++ b/src/Icons/src/Registry/IconifyOnDemandRegistry.php
@@ -23,8 +23,10 @@ use Symfony\UX\Icons\IconRegistryInterface;
  */
 final class IconifyOnDemandRegistry implements IconRegistryInterface
 {
-    public function __construct(private Iconify $iconify)
-    {
+    public function __construct(
+        private Iconify $iconify,
+        private ?array $prefixAliases = [],
+    ) {
     }
 
     public function get(string $name): Icon
@@ -32,7 +34,8 @@ final class IconifyOnDemandRegistry implements IconRegistryInterface
         if (2 !== \count($parts = explode(':', $name))) {
             throw new IconNotFoundException(\sprintf('The icon name "%s" is not valid.', $name));
         }
+        [$prefix, $icon] = $parts;
 
-        return $this->iconify->fetchIcon(...$parts);
+        return $this->iconify->fetchIcon($this->prefixAliases[$prefix] ?? $prefix, $icon);
     }
 }

--- a/src/Icons/tests/Fixtures/TestKernel.php
+++ b/src/Icons/tests/Fixtures/TestKernel.php
@@ -50,7 +50,7 @@ final class TestKernel extends Kernel
         ]);
 
         $container->extension('twig', [
-            'default_path' => __DIR__ . '/templates',
+            'default_path' => __DIR__.'/templates',
         ]);
 
         $container->extension('twig_component', [
@@ -60,6 +60,14 @@ final class TestKernel extends Kernel
 
         $container->extension('ux_icons', [
             'icon_dir' => '%kernel.project_dir%/tests/Fixtures/icons',
+            'icon_sets' => [
+                'fla' => [
+                    'path' => '%kernel.project_dir%/tests/Fixtures/images/flags',
+                ],
+                'lu' => [
+                    'alias' => 'lucide',
+                ],
+            ],
         ]);
 
         $container->services()->set('logger', NullLogger::class);

--- a/src/Icons/tests/Fixtures/icons/a/icon.svg
+++ b/src/Icons/tests/Fixtures/icons/a/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+<circle aria-label="icons/a/" r="1" />
+</svg>

--- a/src/Icons/tests/Fixtures/images/a/b/icon.svg
+++ b/src/Icons/tests/Fixtures/images/a/b/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+<circle aria-label="images/a/b/" r="1" />
+</svg>

--- a/src/Icons/tests/Fixtures/images/a/icon.svg
+++ b/src/Icons/tests/Fixtures/images/a/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+<circle aria-label="images/a/" r="1" />
+</svg>

--- a/src/Icons/tests/Fixtures/images/ab/icon.svg
+++ b/src/Icons/tests/Fixtures/images/ab/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+<circle aria-label="images/ab/" r="1" />
+</svg>

--- a/src/Icons/tests/Fixtures/images/icon.svg
+++ b/src/Icons/tests/Fixtures/images/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 2 2">
+<circle aria-label="images/" r="1" />
+</svg>

--- a/src/Icons/tests/Unit/Registry/IconifyOnDemandRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/IconifyOnDemandRegistryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons\Tests\Unit\Registry;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\UX\Icons\Icon;
+use Symfony\UX\Icons\Iconify;
+use Symfony\UX\Icons\Registry\IconifyOnDemandRegistry;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class IconifyOnDemandRegistryTest extends TestCase
+{
+    public function testWithIconSetAlias(): void
+    {
+        $client = new MockHttpClient([
+            new JsonMockResponse(['lucide' => []]),
+            new JsonMockResponse([
+                'icons' => [
+                    'circle' => [
+                        'body' => '<path aria-label="lucide:circle"/>',
+                        'height' => 24,
+                    ],
+                ],
+            ]),
+        ]);
+
+        $registry = new IconifyOnDemandRegistry(
+            new Iconify(new NullAdapter(), 'https://example.com', $client),
+            ['bi' => 'lucide'],
+        );
+
+        $icon = $registry->get('bi:circle');
+        $this->assertInstanceOf(Icon::class, $icon);
+        $this->assertSame('<path aria-label="lucide:circle"/>', $icon->getInnerSvg());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #
| License       | MIT

I'm opening now if you guys have feedback, and i will add more tests the next couple days


> [!NOTE]  
> This PR brings 3 new features: iconset aliases, custom path and attributes.  So let's focus on that 😄 



```yaml
ux_icons:
    icon_dir: '%kernel.project_dir%/assets/icons'

    # Default icon set
    default_icon_attributes:
        class: 'icon'
        fill: 'currentColor'
        width: '24'
        height: '24'

    icon_sets:
        # Local icon set    (prefix mapped to a local directory)
        flags:
            path: '%kernel.project_dir%/assets/images/flags'

        # Remote icon set   (prefix mapped to an icon set identifier)
        lu:
            alias: 'lucide'

        # Icon set configuration (work for local/remote)
        oc:
            icon_attributes:
                class: 'oc-icon'       # Replace the default class
                stroke: 'none'      # Add a new attribute
                fill: false         # Use "false" to remove a default attribute
```


### Default attributes

```twig

<twig:ux:icon name="anything" />

{# Renders #}
<svg class="icon" fill="currentColor" width="24" height="24"> ... </svg>
```

## Icon set configuration

### Local icons: path

```twig

<twig:ux:icon name="flags:fr" />

{# Renders:  #}
<svg class="icon" fill="currentColor" width="24" height="24">
    <!-- file assets/images/flags/fr.svg -->
</svg>
```

### Remote icons: alias 

```twig

<twig:ux:icon name="lu:circle-check" />

{# Renders:  #}
<svg class="icon" fill="currentColor" width="24" height="24">
    <!-- file lucide:circle-check.svg from iconify -->
</svg>
```

### Icon set attributes

```twig

<twig:ux:icon name="oc:check" />

{# Renders:  #}
{# Attributes are merged into the default attributes #}
<svg class="oc-icon" stroke="none" width="24" height="24">
    <!-- file oc:check.svg from local or remote -->
</svg>
```



