### PR TITLE
[Icons] Allow to add custom pre-renderers

### DIFF
--- a/src/Icons/CHANGELOG.md
+++ b/src/Icons/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Add `aliases` configuration option to define icon alternative names.
 -   Add support for `int` and `float` attribute values in `<twig:ux:icon />`.
+-   Allow to add custom pre-renderers
 
 ## 2.19.0
 

--- a/src/Icons/config/services.php
+++ b/src/Icons/config/services.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\UX\Icons\AriaHiddenPreRenderer;
 use Symfony\UX\Icons\Command\WarmCacheCommand;
 use Symfony\UX\Icons\IconCacheWarmer;
 use Symfony\UX\Icons\IconRenderer;
@@ -58,6 +59,7 @@ return static function (ContainerConfigurator $container): void {
                 service('.ux_icons.icon_registry'),
                 abstract_arg('default_icon_attributes'),
                 abstract_arg('icon_aliases'),
+                tagged_iterator('ux_icons.icon_pre_renderer'),
             ])
 
         ->alias('Symfony\UX\Icons\IconRendererInterface', '.ux_icons.icon_renderer')
@@ -79,5 +81,8 @@ return static function (ContainerConfigurator $container): void {
                 service('.ux_icons.cache_warmer'),
             ])
             ->tag('console.command')
+
+        ->set('.ux_icons.aria_hidden_pre_renderer', AriaHiddenPreRenderer::class)
+            ->tag('ux_icons.icon_pre_renderer')
     ;
 };

--- a/src/Icons/src/AriaHiddenPreRenderer.php
+++ b/src/Icons/src/AriaHiddenPreRenderer.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons;
+
+final class AriaHiddenPreRenderer implements IconPreRendererInterface
+{
+    public function __invoke(string $name, Icon $icon): Icon
+    {
+        if ([] === array_intersect(['aria-hidden', 'aria-label', 'aria-labelledby', 'title'], array_keys($icon->getAttributes()))) {
+            return $icon->withAttributes(['aria-hidden' => 'true']);
+        }
+
+        return $icon;
+    }
+}

--- a/src/Icons/src/DependencyInjection/UXIconsExtension.php
+++ b/src/Icons/src/DependencyInjection/UXIconsExtension.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\UX\Icons\Iconify;
+use Symfony\UX\Icons\IconPreRendererInterface;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -128,5 +129,9 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
         if (!$container->getParameter('kernel.debug')) {
             $container->removeDefinition('.ux_icons.command.import');
         }
+
+        $container
+            ->registerForAutoconfiguration(IconPreRendererInterface::class)
+            ->addTag('ux_icons.icon_pre_renderer');
     }
 }

--- a/src/Icons/src/IconPreRendererInterface.php
+++ b/src/Icons/src/IconPreRendererInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons;
+
+interface IconPreRendererInterface
+{
+    public function __invoke(string $name, Icon $icon): Icon;
+}

--- a/src/Icons/src/IconRenderer.php
+++ b/src/Icons/src/IconRenderer.php
@@ -18,10 +18,14 @@ namespace Symfony\UX\Icons;
  */
 final class IconRenderer implements IconRendererInterface
 {
+    /**
+     * @param iterable<IconPreRendererInterface> $preRenderers
+     */
     public function __construct(
         private readonly IconRegistryInterface $registry,
         private readonly array $defaultIconAttributes = [],
         private readonly ?array $iconAliases = [],
+        private readonly iterable $preRenderers = [],
     ) {
     }
 
@@ -42,30 +46,10 @@ final class IconRenderer implements IconRendererInterface
             ->withAttributes($this->defaultIconAttributes)
             ->withAttributes($attributes);
 
-        foreach ($this->getPreRenderers() as $preRenderer) {
-            $icon = $preRenderer($icon);
+        foreach ($this->preRenderers as $preRenderer) {
+            $icon = $preRenderer($name, $icon);
         }
 
         return $icon->toHtml();
-    }
-
-    /**
-     * @return iterable<callable(Icon): Icon>
-     */
-    private function getPreRenderers(): iterable
-    {
-        yield self::setAriaHidden(...);
-    }
-
-    /**
-     * Set `aria-hidden=true` if not defined & no textual alternative provided.
-     */
-    private static function setAriaHidden(Icon $icon): Icon
-    {
-        if ([] === array_intersect(['aria-hidden', 'aria-label', 'aria-labelledby', 'title'], array_keys($icon->getAttributes()))) {
-            return $icon->withAttributes(['aria-hidden' => 'true']);
-        }
-
-        return $icon;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | N/A
| License       | MIT

I want to add `data-test-id="icon_name"` attribute to all used icons, but there is no easy way without overriding whole `IconRenderer` and then duplicating the logic.

But `IconRendererInterface` and `Icon` is marked as internal and IDE complains..

I think adding `ux_icons.pre_renderer` tag is a nice extension point where you can control them.