### PR TITLE
 [TwigComponent] Fix wrong int type hint on integer concatination which results in string

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentTokenParser.php
+++ b/src/TwigComponent/src/Twig/ComponentTokenParser.php
@@ -111,7 +111,7 @@ final class ComponentTokenParser extends AbstractTokenParser
         return [$variables, $only];
     }
 
-    private function generateEmbeddedTemplateIndex(string $file, int $line): int
+    private function generateEmbeddedTemplateIndex(string $file, int $line): string
     {
         $fileAndLine = \sprintf('%s-%d', $file, $line);
         if (!isset($this->lineAndFileCounts[$fileAndLine])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | -
| License       | MIT

I just played around with the Twig Components and stumbled across an exception from the `ComponentTokenParser`. It returns a string within the method `generateEmbeddedTemplateIndex` but the type hint wants to get an integer. I tried to find out  why thid worked for someone but from my PoV there should be a string return type because the concatination of two integer values always leads to a string as far as i know.

So i have here changed the type hint without further explanaition of my use case because it is, for me, more of a general type hint error.
