### PR TITLE
Add functionality to remove element from dom

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -15,19 +15,12 @@ LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 ***************************************************************************** */
-/* global Reflect, Promise, SuppressedError, Symbol */
-
 
 function __classPrivateFieldGet(receiver, state, kind, f) {
     if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
-
-typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
-    var e = new Error(message);
-    return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
-};
 
 var _default_1_instances, _default_1_getCommonConfig, _default_1_createAutocomplete, _default_1_createAutocompleteWithHtmlContents, _default_1_createAutocompleteWithRemoteData, _default_1_stripTags, _default_1_mergeObjects, _default_1_createTomSelect;
 class default_1 extends Controller {

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1667,7 +1667,7 @@ class ElementChanges {
         element.classList.remove(...this.removedClasses);
         this.styleChanges.getChangedItems().forEach((change) => {
             element.style.setProperty(change.name, change.value);
-            return;
+
         });
         this.styleChanges.getRemovedItems().forEach((styleName) => {
             element.style.removeProperty(styleName);
@@ -2040,7 +2040,8 @@ class Component {
             }
             const headers = backendResponse.response.headers;
             if (!headers.get('Content-Type')?.includes('application/vnd.live-component+html') &&
-                !headers.get('X-Live-Redirect')) {
+                !headers.get('X-Live-Redirect') &&
+                !headers.get('X-Live-Delete')) {
                 const controls = { displayError: true };
                 this.valueStore.pushPendingPropsBackToDirty();
                 this.hooks.triggerHook('response:error', backendResponse, controls);
@@ -2077,6 +2078,10 @@ class Component {
             else {
                 window.location.href = backendResponse.response.headers.get('Location') || '';
             }
+            return;
+        }
+        if (backendResponse.response.headers.get('X-Live-Delete')) {
+            this.element.remove();
             return;
         }
         this.hooks.triggerHook('loading.state:finished', this.element);
@@ -2994,7 +2999,7 @@ class LiveControllerDefault extends Controller {
             });
             validModifiers.set('self', () => {
                 if (event.target !== event.currentTarget) {
-                    return;
+
                 }
             });
             validModifiers.set('debounce', (modifier) => {

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -311,7 +311,8 @@ export default class Component {
             const headers = backendResponse.response.headers;
             if (
                 !headers.get('Content-Type')?.includes('application/vnd.live-component+html') &&
-                !headers.get('X-Live-Redirect')
+                !headers.get('X-Live-Redirect') &&
+                !headers.get('X-Live-Delete')
             ) {
                 const controls = { displayError: true };
                 this.valueStore.pushPendingPropsBackToDirty();
@@ -363,6 +364,12 @@ export default class Component {
             } else {
                 window.location.href = backendResponse.response.headers.get('Location') || '';
             }
+
+            return;
+        }
+        if (backendResponse.response.headers.get('X-Live-Delete')) {
+            // action returned a delete element from the DOM
+            this.element.remove();
 
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #2007
| License       | MIT

Add ability to remove element from dom passing the header to response

```php
#[AsLiveComponent()]
final class Component
{
	use DefaultActionTrait;

	#[LiveAction]
	public function removeFromDom() :Response{
                $response = new Response(null);
                $response->headers->set('X-Live-Delete', '1');
                return $response;
	}
}
```