### PR TITLE
Fixed typo in links to Symfony UX repo

### DIFF
--- a/src/Map/doc/index.rst
+++ b/src/Map/doc/index.rst
@@ -233,5 +233,5 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`Google Maps`: https://github.com/symfony/ux-google-map
 .. _`Leaflet`: https://github.com/symfony/ux-leaflet-map
-.. _`Symfony UX Map Google Maps brige docs`: https://github.com/symfony/symfony-ux/blob/{version}/src/Map/src/Bridge/Google/README.md
-.. _`Symfony UX Map Leaflet bridge docs`: https://github.com/symfony/symfony-ux/blob/{version}/src/Map/src/Bridge/Leaflet/README.md
+.. _`Symfony UX Map Google Maps brige docs`: https://github.com/symfony/ux/blob/{version}/src/Map/src/Bridge/Google/README.md
+.. _`Symfony UX Map Leaflet bridge docs`: https://github.com/symfony/ux/blob/{version}/src/Map/src/Bridge/Leaflet/README.md


### PR DESCRIPTION
I fixed typo in the links to Symfony UX repo (before: symfony/symfony-ux).
Note: I wasn't able to deal with the "version" variable.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature? |  no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Before :  https://github.com/symfony/symfony-ux/blob/4.4/src/Map/src/Bridge/Leaflet/README.md  (404)
Now : https://github.com/symfony/ux/blob/2.x/src/Map/src/Bridge/Leaflet/README.md
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
