### PR TITLE
[Doc] Fix some links in UX Map docs

### DIFF
--- a/src/Map/doc/index.rst
+++ b/src/Map/doc/index.rst
@@ -233,5 +233,5 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html
 .. _`Google Maps`: https://github.com/symfony/ux-google-map
 .. _`Leaflet`: https://github.com/symfony/ux-leaflet-map
-.. _`Symfony UX Map Google Maps brige docs`: https://github.com/symfony/ux/blob/{version}/src/Map/src/Bridge/Google/README.md
-.. _`Symfony UX Map Leaflet bridge docs`: https://github.com/symfony/ux/blob/{version}/src/Map/src/Bridge/Leaflet/README.md
+.. _`Symfony UX Map Google Maps brige docs`: https://github.com/symfony/ux/blob/2.x/src/Map/src/Bridge/Google/README.md
+.. _`Symfony UX Map Leaflet bridge docs`: https://github.com/symfony/ux/blob/2.x/src/Map/src/Bridge/Leaflet/README.md


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | -
| License       | MIT

Related to #2193. The `{version}` placeholder only works for Symfony Docs and I'm not sure it can be extended to also work on UX. So, let's just hardcode the `2.x` version number because this is fine.