### PR TITLE
autocomplete: add czech and slovak translation for "Add ..." message

### DIFF
--- a/src/Autocomplete/translations/AutocompleteBundle.cs.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.cs.php
@@ -13,5 +13,5 @@ return [
     'Loading more results...' => 'Načítání dalších výsledků...',
     'No results found' => 'Nenalezeny žádné položky',
     'No more results' => 'Žádné další výsledky',
-    // 'Add %placeholder%...' => 'Add %placeholder%...',
+    'Add %placeholder%...' => 'Přidat %placeholder%...',
 ];

--- a/src/Autocomplete/translations/AutocompleteBundle.sk.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.sk.php
@@ -13,5 +13,5 @@ return [
     'Loading more results...' => 'Načítavajú sa ďalšie výsledky...',
     'No results found' => 'Neboli nájdené žiadne výsledky',
     'No more results' => 'Žiadne ďalšie výsledky',
-    // 'Add %placeholder%...' => 'Add %placeholder%...',
+    'Add %placeholder%...' => 'Pridať %placeholder%...',
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Issues        | 
| License       | MIT

Add czech and slovak translation for `"Add %placeholder%..."` message