### PR TITLE
[Turbo][Testing] Fix to the right test

### DIFF
--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -284,7 +284,7 @@ Symfony.
             $client->request('GET', '/');
 
             $client->clickLink('This block is scoped, the rest of the page will not change if you click here!');
-            $this->assertSelectorTextContains('body', 'This will replace the content of the Turbo Frame!');
+            $this->assertSelectorWillContain('body', 'This will replace the content of the Turbo Frame!');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | Fixing the test
| License       | MIT

In order to test the Turbo loading you don't have to use `assertSelectorTextContains` method, instead of it use `assertSelectorWillContain` cuz it's async javascript