### PR TITLE
[TwigComponent][Docs] Fix outerblock markup example

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -872,7 +872,6 @@ that's passed to it via the ``outerBlocks`` variable and forward it into ``Alert
 
     {# templates/components/SuccessAlert.html.twig #}
     <twig:Alert type="success">
-    {% component Alert with {type: 'success'} %}
         {{ block(outerBlocks.content) }}
     </twig:Alert>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | See below...
| License       | MIT

I was following the guide for nested UX components and inheritance. Really cool stuff. 👍 

[Inheritance & Forwarding "Outer Blocks"](https://symfony.com/bundles/ux-twig-component/current/index.html#inheritance-forwarding-outer-blocks)

I was confused about this code example that re-uses the alert component and "passes through" the content text from the `SuccessAlert` component usage:
```twig
{# templates/components/SuccessAlert.html.twig #}
<twig:Alert type="success">
{% component Alert with {type: 'success'} %}
    {{ block(outerBlocks.content) }}
</twig:Alert>
```

Is it really supposed to be two nested alert components? Because this throws an error because of the missing `{% endcomponent %}` tag.

Should it be either this...

```twig
{# templates/components/SuccessAlert.html.twig #}
<twig:Alert type="success">
    {{ block(outerBlocks.content) }}
</twig:Alert>
```

or this syntax?

```twig
{# templates/components/SuccessAlert.html.twig #}
{% component Alert with {type: 'success'} %}
    {{ block(outerBlocks.content) }}
{% endcomponent %}
```