### PR TITLE
[Site] Skip yarn & npm install during deploy

### DIFF
--- a/ux.symfony.com/.platform.app.yaml
+++ b/ux.symfony.com/.platform.app.yaml
@@ -47,6 +47,11 @@ hooks:
 
         curl -s https://get.symfony.com/cloud/configurator | (>&2 bash)
 
+        # We don't need to run yarn or npm... 
+        # ...let's skip both build steps  
+        NO_YARN=1
+        NO_NPM=1
+
         (>&2 symfony-build)
 
     deploy: |
@@ -55,6 +60,7 @@ hooks:
         (>&2 symfony-deploy)
 
         php bin/console app:load-data
+        
         # needed because StimulusBundle / asset mapper will currently
         # expect this asset mapper directory to exist at runtime
         mkdir -p var/translations


### PR DESCRIPTION
> To disable the JavaScript dependencies and asset building, set NO_NPM or NO_YARN to 1 depending on your package manager.

cf https://docs.platform.sh/guides/symfony/integration.html#symfony-build

