### PR TITLE
[Site] Skip yarn & npm install during deploy

### DIFF
--- a/ux.symfony.com/.platform.app.yaml
+++ b/ux.symfony.com/.platform.app.yaml
@@ -49,8 +49,8 @@ hooks:
 
         # We don't need to run yarn or npm... 
         # ...let's skip both build steps  
-        NO_YARN=1
-        NO_NPM=1
+        export NO_YARN=1
+        export NO_NPM=1
 
         (>&2 symfony-build)
 


### PR DESCRIPTION
> To disable the JavaScript dependencies and asset building, set NO_NPM or NO_YARN to 1 depending on your package manager.

cf https://docs.platform.sh/guides/symfony/integration.html#symfony-build

With the correct export syntax :facepalm-sorry:
