### PR TITLE
[LiveComponent] Fix morphing for Alpine.js v3

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1375,14 +1375,14 @@ function executeMorphdom(rootFromElement, rootToElement, modifiedFieldElements, 
                     return false;
                 }
                 if (fromEl instanceof HTMLElement && toEl instanceof HTMLElement) {
-                    if (typeof fromEl.__x !== 'undefined') {
+                    if (typeof fromEl.__x !== 'undefined' || typeof fromEl._x_dataStack !== 'undefined') {
                         if (!window.Alpine) {
                             throw new Error('Unable to access Alpine.js though the global window.Alpine variable. Please make sure Alpine.js is loaded before Symfony UX LiveComponent.');
                         }
                         if (typeof window.Alpine.morph !== 'function') {
                             throw new Error('Unable to access Alpine.js morph function. Please make sure the Alpine.js Morph plugin is installed and loaded, see https://alpinejs.dev/plugins/morph for more information.');
                         }
-                        window.Alpine.morph(fromEl.__x, toEl);
+                        window.Alpine.morph(fromEl.__x || fromEl, toEl);
                     }
                     if (externalMutationTracker.wasElementAdded(fromEl)) {
                         fromEl.insertAdjacentElement('afterend', toEl);

--- a/src/LiveComponent/assets/src/morphdom.ts
+++ b/src/LiveComponent/assets/src/morphdom.ts
@@ -118,11 +118,11 @@ export function executeMorphdom(
 
                 // skip special checking if this is, for example, an SVG
                 if (fromEl instanceof HTMLElement && toEl instanceof HTMLElement) {
-                    // We assume fromEl is an Alpine component if it has `__x` property.
+                    // We assume fromEl is an Alpine component if it has `__x` (Alpine v2) or `_x_dataStack` (Alpine v3) property.
                     // If it's the case, then we should morph `fromEl` to `ToEl` (thanks to https://alpinejs.dev/plugins/morph)
                     // in order to keep the component state and UI in sync.
                     // @ts-ignore
-                    if (typeof fromEl.__x !== 'undefined') {
+                    if (typeof fromEl.__x !== 'undefined' || typeof fromEl._x_dataStack !== 'undefined') {
                         // @ts-ignore
                         if (!window.Alpine) {
                             throw new Error(
@@ -138,7 +138,7 @@ export function executeMorphdom(
                         }
 
                         // @ts-ignore
-                        window.Alpine.morph(fromEl.__x, toEl);
+                        window.Alpine.morph(fromEl.__x || fromEl, toEl);
                     }
 
                     if (externalMutationTracker.wasElementAdded(fromEl)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        |  /
| License       | MIT

This PR fixes live component compatibility for Alpine v3.

Currently, the live component controller already implements the Alpine morph plugin. This works fine for Alpine v2, but since v3, the `__x` property is no longer used by Alpine. Instead, we can check for `_x_dataStack`.

Also, the morph plugin no longer requires the `__x` property; the DOM element should be used instead.

I made sure the changes support both Alpine v2 and v3.

Original implementation and issue:
- https://github.com/symfony/ux/issues/984
- https://github.com/symfony/ux/pull/1126