### PR TITLE
Remove yarn commands in documentations

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -30,10 +30,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage in a Form (without Ajax)
 ------------------------------
 

--- a/src/Chartjs/doc/index.rst
+++ b/src/Chartjs/doc/index.rst
@@ -26,10 +26,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage
 -----
 
@@ -98,9 +94,6 @@ First, install the plugin:
 .. code-block:: terminal
 
     $ npm install chartjs-plugin-zoom -D
-
-    # or use yarn
-    $ yarn add chartjs-plugin-zoom --dev
 
 Then register the plugin globally. This can be done in your ``app.js`` file:
 

--- a/src/Cropperjs/doc/index.rst
+++ b/src/Cropperjs/doc/index.rst
@@ -26,10 +26,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage
 -----
 

--- a/src/Dropzone/doc/index.rst
+++ b/src/Dropzone/doc/index.rst
@@ -28,10 +28,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage
 -----
 

--- a/src/LazyImage/doc/index.rst
+++ b/src/LazyImage/doc/index.rst
@@ -30,10 +30,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage
 -----
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -87,10 +87,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 If your project is localized in different languages (either via the `locale route parameter`_
 or by `setting the locale in the request`_) add the ``{_locale}`` attribute to
 the UX Live Components route definition to keep the locale between re-renders:

--- a/src/Notify/doc/index.rst
+++ b/src/Notify/doc/index.rst
@@ -25,10 +25,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage
 -----
 

--- a/src/React/doc/index.rst
+++ b/src/React/doc/index.rst
@@ -39,10 +39,6 @@ Next, install a package to help React:
     $ npm install -D @babel/preset-react --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn add @babel/preset-react --dev --force
-    $ yarn watch
-
 That's it! Any files inside ``assets/react/controllers/`` can now be rendered as
 React components.
 

--- a/src/Svelte/doc/index.rst
+++ b/src/Svelte/doc/index.rst
@@ -31,10 +31,6 @@ Install the bundle using Composer and Symfony Flex:
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 The Flex recipe will automatically set things up for you, like adding
 ``.enableSvelte()`` to your ``webpack.config.js`` file and adding code
 to load your Svelte components inside ``assets/app.js``.
@@ -44,9 +40,6 @@ Next, install a package to help Svelte:
 .. code-block:: terminal
 
     $ npm install svelte-loader --save-dev
-
-    # or use yarn
-    $ yarn add svelte-loader --dev
 
 That's it! Any files inside ``assets/svelte/controllers/`` can now be rendered as
 Svelte components.

--- a/src/Swup/doc/index.rst
+++ b/src/Swup/doc/index.rst
@@ -30,10 +30,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage
 -----
 

--- a/src/TogglePassword/doc/index.rst
+++ b/src/TogglePassword/doc/index.rst
@@ -32,10 +32,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage with Symfony Forms
 ------------------------
 

--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -35,10 +35,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 After installing the bundle, the following file should be created, thanks to the Symfony Flex recipe:
 
 .. code-block:: javascript

--- a/src/Turbo/CONTRIBUTING.md
+++ b/src/Turbo/CONTRIBUTING.md
@@ -13,8 +13,6 @@ Install the test app:
 
     $ composer install
     $ cd tests/app
-    $ yarn install
-    $ yarn build
     $ php public/index.php doctrine:schema:create
 
 Start the test app:

--- a/src/Turbo/README.md
+++ b/src/Turbo/README.md
@@ -37,8 +37,6 @@ Configure test environment (working directory: `src/Turbo`):
 composer update
 docker compose up -d
 cd tests/app
-yarn install
-yarn build
 php public/index.php doctrine:schema:create
 ```
 

--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -37,10 +37,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage
 -----
 

--- a/src/Typed/doc/index.rst
+++ b/src/Typed/doc/index.rst
@@ -31,10 +31,6 @@ needed if you're using AssetMapper):
     $ npm install --force
     $ npm run watch
 
-    # or use yarn
-    $ yarn install --force
-    $ yarn watch
-
 Usage
 -----
 

--- a/src/Vue/doc/index.rst
+++ b/src/Vue/doc/index.rst
@@ -39,10 +39,6 @@ Next, install a package to help Vue:
     $ npm install -D vue-loader --force
     $ npm run watch
 
-    # or with yarn
-    $ yarn add vue-loader --dev --force
-    $ yarn watch
-
 That's it! Any files inside ``assets/vue/controllers/`` can now be rendered as
 Vue components.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Alternative to https://github.com/symfony/ux/pull/1200, for the same reasons explained in https://github.com/symfony/symfony-docs/pull/19348, we don't want to keep `yarn` commands.