### PR TITLE
[Autocomplete] Remove unused "symfony/security-csrf" dev dependency

### DIFF
--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -45,7 +45,6 @@
         "symfony/phpunit-bridge": "^6.3|^7.0",
         "symfony/process": "^6.3|^7.0",
         "symfony/security-bundle": "^6.3|^7.0",
-        "symfony/security-csrf": "^6.3|^7.0",
         "symfony/twig-bundle": "^6.3|^7.0",
         "symfony/uid": "^6.3|^7.0",
         "twig/twig": "^2.14.7|^3.0.4",


### PR DESCRIPTION
Spotted by @nicolas-grekas in #2251

