### PR TITLE
Fix a typo in UX Icons docs

### DIFF
--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -80,7 +80,7 @@ define the HTML attributes added to the ``<svg>`` element:
     {{ ux_icon('user-profile', {class: 'w-4 h-4'}) }}
     {# renders <svg class="w-4 h-4"> ... </svg> #}
 
-    {{ ux_icon('user-profile', {height: '16px', width: '16px', aria-hidden: true}) }}
+    {{ ux_icon('user-profile', {height: '16px', width: '16px', 'aria-hidden': true}) }}
     {# renders <svg height="16" width="16" aria-hidden="true"> ... </svg> #}
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | 
| License       | MIT

There is an error (below is an exception) if copying snippet from [UX Icons docs](https://symfony.com/bundles/ux-icons/current/index.html#loading-icons). This can confuse some less experienced programmers.

```
A mapping key must be followed by a colon (:). Unexpected token "operator" of value "-" ("punctuation" expected with value ":").