### PR TITLE
Add ability to add inputProps in component inside eventListener

### DIFF
--- a/src/TwigComponent/src/Event/PreCreateForRenderEvent.php
+++ b/src/TwigComponent/src/Event/PreCreateForRenderEvent.php
@@ -49,6 +49,12 @@ final class PreCreateForRenderEvent extends Event
         return $this->inputProps;
     }
 
+	public function setInputProps(array $inputProps): self {
+		$this->inputProps = $inputProps;
+
+		return $this;
+	}
+
     public function setRenderedString(string $renderedString): void
     {
         $this->renderedString = $renderedString;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #2276
| License       | MIT

Add ability to modity InputProps inside EventListener

```php
#[AsEventListener(priority: 100)]
class UxIconListener
{
    public function __invoke(PreCreateForRenderEvent $event): void
    {
        if ('ux:icon' !== strtolower($event->getName())) {
            return;
        }
        $attributes = $event->getInputProps();

        if ($attributes['name']!=="my-global-icon"){
            return;
        }
        
        $attributes["class"] = "icon view";
        $attributes["title"]= "this item is public";
        
        $event->setInputProps($attributes);

    }
}
```

