### PR TITLE
[Autocomplete] Translate "Add ..." text with remote data setup

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.21.0
+
+-   Translate the `option_create` option from TomSelect with remote data setup #2279
+-   Add one missing Dutch translation #2279
+
 ## 2.20.0
 
 -   Translate the `option_create` option from TomSelect #2108

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -318,7 +318,7 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
                 return `<div class="no-results">${this.noResultsFoundTextValue}</div>`;
             },
             option_create: (data, escapeData) => {
-                return `<div class="create">${this.createOptionTextValue} <strong>${escapeData(data.input)}</strong>&hellip;</div>`;
+                return `<div class="create">${this.createOptionTextValue.replace('%placeholder%', `<strong>${escapeData(data.input)}</strong>`)}</div>`;
             },
         },
         preload: this.preload,

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -253,7 +253,7 @@ export default class extends Controller {
                     return `<div class="no-results">${this.noResultsFoundTextValue}</div>`;
                 },
                 option_create: (data: TomOption, escapeData: typeof escape_html): string => {
-                    return `<div class="create">${this.createOptionTextValue} <strong>${escapeData(data.input)}</strong>&hellip;</div>`;
+                    return `<div class="create">${this.createOptionTextValue.replace('%placeholder%', `<strong>${escapeData(data.input)}</strong>`)}</div>`;
                 },
             },
             preload: this.preload,

--- a/src/Autocomplete/translations/AutocompleteBundle.nl.php
+++ b/src/Autocomplete/translations/AutocompleteBundle.nl.php
@@ -13,5 +13,5 @@ return [
     'Loading more results...' => 'Meer resultaten aan het laden...',
     'No results found' => 'Geen resultaten gevonden…',
     'No more results' => 'Niet meer resultaten gevonden…',
-    // 'Add %placeholder%...' => 'Add %placeholder%...',
+    'Add %placeholder%...' => 'Voeg %placeholder% toe...',
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

In https://github.com/symfony/ux/pull/2108 the "Add..." translation has been added. But this only worked for non remote data setups. This PR makes it work for remote data setup too.

Also add translation for Dutch. 
