### PR TITLE
[Autocomplete] Only activate clear button plugin when there is a placeholder option

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -227,8 +227,9 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
     const plugins = {};
     const isMultiple = !this.selectElement || this.selectElement.multiple;
     if (!this.formElement.disabled && !isMultiple) {
-        const firstOption = this.selectElement.options[0];
-        if (firstOption && firstOption.value === '') {
+        const placeholderOptions = Array.from(this.selectElement.options)
+            .filter((option) => option.value === '');
+        if (placeholderOptions.length) {
             plugins.clear_button = { title: '' };
         }
     }

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -15,7 +15,7 @@ LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 ***************************************************************************** */
-/* global Reflect, Promise, SuppressedError, Symbol */
+/* global Reflect, Promise, SuppressedError, Symbol, Iterator */
 
 
 function __classPrivateFieldGet(receiver, state, kind, f) {
@@ -227,7 +227,10 @@ _default_1_instances = new WeakSet(), _default_1_getCommonConfig = function _def
     const plugins = {};
     const isMultiple = !this.selectElement || this.selectElement.multiple;
     if (!this.formElement.disabled && !isMultiple) {
-        plugins.clear_button = { title: '' };
+        const firstOption = this.selectElement.options[0];
+        if (firstOption && firstOption.value === '') {
+            plugins.clear_button = { title: '' };
+        }
     }
     if (isMultiple) {
         plugins.remove_button = { title: '' };

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -131,8 +131,9 @@ export default class extends Controller {
         const isMultiple = !this.selectElement || this.selectElement.multiple;
         if (!this.formElement.disabled && !isMultiple) {
             // Only activate clear button plugin when there is a placeholder option
-            const firstOption = this.selectElement.options[0];
-            if (firstOption && firstOption.value === '') {
+            const placeholderOptions = Array.from(this.selectElement.options)
+                .filter((option) => option.value === '');
+            if (placeholderOptions.length) {
                 plugins.clear_button = { title: '' };
             }
         }

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -127,10 +127,14 @@ export default class extends Controller {
     #getCommonConfig(): Partial<TomSettings> {
         const plugins: TPluginHash = {};
 
-        // multiple values excepted if this is NOT A select (i.e. input) or a multiple select
+        // Multiple values expected if this is NOT A select (i.e. input) or a multiple select
         const isMultiple = !this.selectElement || this.selectElement.multiple;
         if (!this.formElement.disabled && !isMultiple) {
-            plugins.clear_button = { title: '' };
+            // Only activate clear button plugin when there is a placeholder option
+            const firstOption = this.selectElement.options[0];
+            if (firstOption && firstOption.value === '') {
+                plugins.clear_button = { title: '' };
+            }
         }
 
         if (isMultiple) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | maybe?
| Issues        | Fix #402 
| License       | MIT

Only add the `clear_button` plugin to TomSelect if the form element has no placeholder option.

Notes:
- I defined 'having a placeholder' as the select having an option with an empty value, as that is what TomSelect also seems to do
- I'm not 100% sure about whether this needs a test or how to even run tests locally