### PR TITLE
[Icons] Improve `icons:lock` command verbosity

### DIFF
--- a/src/Icons/src/Command/LockIconsCommand.php
+++ b/src/Icons/src/Command/LockIconsCommand.php
@@ -72,10 +72,21 @@ final class LockIconsCommand extends Command
 
             [$prefix, $name] = $parts;
 
+            if (!$this->iconify->hasIconSet($prefix)) {
+                // not an icon set? example: "og:twitter"
+                if ($io->isVeryVerbose()) {
+                    $io->writeln(\sprintf(' <fg=bright-yellow;options=bold>✗</> IconSet Not Found: <fg=bright-white;bg=black>%s:%s</>.', $prefix, $name));
+                }
+                continue;
+            }
+
             try {
                 $svg = $this->iconify->fetchSvg($prefix, $name);
             } catch (IconNotFoundException) {
                 // icon not found on iconify
+                if ($io->isVerbose()) {
+                    $io->writeln(\sprintf(' <fg=bright-red;options=bold>✗</> Icon Not Found: <fg=bright-white;bg=black>%s:%s</>.', $prefix, $name));
+                }
                 continue;
             }
 
@@ -84,7 +95,7 @@ final class LockIconsCommand extends Command
             $license = $this->iconify->metadataFor($prefix)['license'];
             ++$count;
 
-            $io->text(\sprintf(
+            $io->writeln(\sprintf(
                 " <fg=bright-green;options=bold>✓</> Imported <fg=bright-white;bg=black>%s:</><fg=bright-magenta;bg=black;options>%s</> (License: <href=%s>%s</>). Render with: <comment>{{ ux_icon('%s') }}</comment>",
                 $prefix,
                 $name,

--- a/src/Icons/src/Iconify.php
+++ b/src/Icons/src/Iconify.php
@@ -99,6 +99,11 @@ final class Iconify
         return $content;
     }
 
+    public function hasIconSet(string $prefix): bool
+    {
+        return isset($this->sets()[$prefix]);
+    }
+
     public function getIconSets(): array
     {
         return $this->sets()->getArrayCopy();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | #2272
| License       | MIT

* display "Icon Not Found" (verbose)
* display "IconSet Not Found" (very verbose)


---

| verbose | very verbose |
| - | - | 
|  <img width="891" alt="icon-lock-v" src="https://github.com/user-attachments/assets/42dded28-839b-4fcf-8c17-9147addb7652"> | <img width="889" alt="icon-lock" src="https://github.com/user-attachments/assets/115d2eb7-4c8d-4299-8aac-b72c8a7b6289">