### PR TITLE
[Icons] Patch to handle Iconify API change

### DIFF
--- a/src/Icons/src/Iconify.php
+++ b/src/Icons/src/Iconify.php
@@ -55,6 +55,10 @@ final class Iconify
 
         $response = $this->http->request('GET', \sprintf('/%s.json?icons=%s', $prefix, $name));
 
+        if (200 !== $response->getStatusCode()) {
+            throw new IconNotFoundException(\sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $name));
+        }
+
         try {
             $data = $response->toArray();
         } catch (JsonException) {
@@ -87,16 +91,17 @@ final class Iconify
             throw new IconNotFoundException(\sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $name));
         }
 
-        $content = $this->http
-            ->request('GET', \sprintf('/%s/%s.svg', $prefix, $name))
-            ->getContent()
-        ;
+        $response = $this->http->request('GET', \sprintf('/%s/%s.svg', $prefix, $name));
 
-        if (!str_starts_with($content, '<svg')) {
+        if (200 !== $response->getStatusCode()) {
             throw new IconNotFoundException(\sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $name));
         }
 
-        return $content;
+        if (!str_starts_with($svg = $response->getContent(), '<svg')) {
+            throw new IconNotFoundException(\sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $name));
+        }
+
+        return $svg;
     }
 
     public function getIconSets(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #...
| License       | MIT

Until now, the iconify API returned "200" even when the resource (icon data, svg) did not exist.

It will change in [the next days](https://github.com/symfony/ux/issues/2272#issuecomment-2424956881) 

This patch allow the `ux:icon:lock` and the CacheWarmer to work after this change.
