### PR TITLE
Update jetbrains stimulus plugin url.

### DIFF
--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -576,4 +576,4 @@ it will normalize it:
 .. _`stimulus-components`: https://stimulus-components.netlify.app/
 .. _`TypeScript`: https://www.typescriptlang.org/
 .. _`sensiolabs/typescript-bundle`: https://github.com/sensiolabs/AssetMapperTypeScriptBundle
-.. _`Stimulus plugin`: https://plugins.jetbrains.com/plugin/18940-stimulus
+.. _`Stimulus plugin`: https://plugins.jetbrains.com/plugin/24562-stimulus


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | no
| License       | MIT

JetBrains took over the Stimulus Plugin into its official plugin catalog and the old plugin from Andrey Starovoyt is deprecated.

* Old: https://plugins.jetbrains.com/plugin/18940-stimulus
* New: https://plugins.jetbrains.com/plugin/24562-stimulus

I've updated the link in the StimulusBundle docs.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
