### PR TITLE
[Turbo] delete whitespace for `<twig:Turbo:Stream:*>` components

### DIFF
--- a/src/Turbo/templates/components/Stream/After.html.twig
+++ b/src/Turbo/templates/components/Stream/After.html.twig
@@ -1,5 +1,5 @@
 {% props target -%}
 
-<turbo-stream action="after" targets="{{ target }}" {{ attributes }}>
+<turbo-stream action="after" targets="{{ target }}" {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Append.html.twig
+++ b/src/Turbo/templates/components/Stream/Append.html.twig
@@ -1,5 +1,5 @@
 {% props target -%}
 
-<turbo-stream action="append" targets="{{ target }}" {{ attributes }}>
+<turbo-stream action="append" targets="{{ target }}" {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Before.html.twig
+++ b/src/Turbo/templates/components/Stream/Before.html.twig
@@ -1,5 +1,5 @@
 {% props target -%}
 
-<turbo-stream action="before" targets="{{ target }}" {{ attributes }}>
+<turbo-stream action="before" targets="{{ target }}" {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Prepend.html.twig
+++ b/src/Turbo/templates/components/Stream/Prepend.html.twig
@@ -1,5 +1,5 @@
 {% props target -%}
 
-<turbo-stream action="prepend" targets="{{ target }}" {{ attributes }}>
+<turbo-stream action="prepend" targets="{{ target }}" {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Refresh.html.twig
+++ b/src/Turbo/templates/components/Stream/Refresh.html.twig
@@ -1,3 +1,3 @@
 {% props requestId = null -%}
 
-<turbo-stream action="refresh"{% if requestId is not null %} request-id="{{ requestId }}"{% endif %} {{ attributes }}></turbo-stream>
+<turbo-stream action="refresh"{% if requestId is not null %} request-id="{{ requestId }}"{% endif %} {{- attributes }}></turbo-stream>

--- a/src/Turbo/templates/components/Stream/Remove.html.twig
+++ b/src/Turbo/templates/components/Stream/Remove.html.twig
@@ -1,3 +1,3 @@
 {% props target -%}
 
-<turbo-stream action="remove" targets="{{ target }}" {{ attributes }}></turbo-stream>
+<turbo-stream action="remove" targets="{{ target }}" {{- attributes }}></turbo-stream>

--- a/src/Turbo/templates/components/Stream/Replace.html.twig
+++ b/src/Turbo/templates/components/Stream/Replace.html.twig
@@ -1,5 +1,5 @@
 {% props target, morph = false -%}
 
-<turbo-stream action="replace" targets="{{ target }}"{% if morph %} method="morph"{% endif %} {{ attributes }}>
+<turbo-stream action="replace" targets="{{ target }}"{% if morph %} method="morph"{% endif %} {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Update.html.twig
+++ b/src/Turbo/templates/components/Stream/Update.html.twig
@@ -1,5 +1,5 @@
 {% props target, morph = false -%}
 
-<turbo-stream action="update" targets="{{ target }}"{% if morph %} method="morph"{% endif %} {{ attributes }}>
+<turbo-stream action="update" targets="{{ target }}"{% if morph %} method="morph"{% endif %} {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

I added whitespace trimming for delete a whitespace for `<twig:Turbo:Stream:*>` components.

Example with below code:

```twig
<twig:Turbo:Stream:Append target="#count-post">
    <div>12</div>
</twig:Turbo:Stream:Append>
```

**Before**

```twig
<turbo-stream action="append" targets="#count-post" >
<template><div>12</div>
</template>
</turbo-stream>
```

**After**

```twig
<turbo-stream action="append" targets="#count-post">
<template><div>12</div>
</template>
</turbo-stream>
```