### PR TITLE
Generic `<Turbo:Stream>` component

### DIFF
--- a/src/Turbo/templates/components/Stream.html.twig
+++ b/src/Turbo/templates/components/Stream.html.twig
@@ -1,0 +1,3 @@
+{% props action -%}
+
+<turbo-stream action="{{ action }}" {{- attributes }}></turbo-stream>

--- a/src/Turbo/templates/components/Stream/After.html.twig
+++ b/src/Turbo/templates/components/Stream/After.html.twig
@@ -1,5 +1,0 @@
-{% props target -%}
-
-<turbo-stream action="after" targets="{{ target }}" {{- attributes }}>
-    <template>{% block content %}{% endblock %}</template>
-</turbo-stream>

--- a/src/Turbo/templates/components/Stream/After.html.twig
+++ b/src/Turbo/templates/components/Stream/After.html.twig
@@ -1,5 +1,5 @@
 {% props target -%}
 
-<turbo-stream action="after" targets="{{ target }}" {{ attributes }}>
+<turbo-stream action="after" targets="{{ target }}" {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Append.html.twig
+++ b/src/Turbo/templates/components/Stream/Append.html.twig
@@ -1,5 +1,0 @@
-{% props target -%}
-
-<turbo-stream action="append" targets="{{ target }}" {{- attributes }}>
-    <template>{% block content %}{% endblock %}</template>
-</turbo-stream>

--- a/src/Turbo/templates/components/Stream/Append.html.twig
+++ b/src/Turbo/templates/components/Stream/Append.html.twig
@@ -1,5 +1,5 @@
 {% props target -%}
 
-<turbo-stream action="append" targets="{{ target }}" {{ attributes }}>
+<turbo-stream action="append" targets="{{ target }}" {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Before.html.twig
+++ b/src/Turbo/templates/components/Stream/Before.html.twig
@@ -1,5 +1,5 @@
 {% props target -%}
 
-<turbo-stream action="before" targets="{{ target }}" {{ attributes }}>
+<turbo-stream action="before" targets="{{ target }}" {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Prepend.html.twig
+++ b/src/Turbo/templates/components/Stream/Prepend.html.twig
@@ -1,5 +1,5 @@
 {% props target -%}
 
-<turbo-stream action="prepend" targets="{{ target }}" {{ attributes }}>
+<turbo-stream action="prepend" targets="{{ target }}" {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Refresh.html.twig
+++ b/src/Turbo/templates/components/Stream/Refresh.html.twig
@@ -1,3 +1,3 @@
 {% props requestId = null -%}
 
-<turbo-stream action="refresh"{% if requestId is not null %} request-id="{{ requestId }}"{% endif %} {{ attributes }}></turbo-stream>
+<turbo-stream action="refresh"{% if requestId is not null %} request-id="{{ requestId }}"{% endif %} {{- attributes }}></turbo-stream>

--- a/src/Turbo/templates/components/Stream/Remove.html.twig
+++ b/src/Turbo/templates/components/Stream/Remove.html.twig
@@ -1,3 +1,3 @@
 {% props target -%}
 
-<turbo-stream action="remove" targets="{{ target }}" {{ attributes }}></turbo-stream>
+<turbo-stream action="remove" targets="{{ target }}" {{- attributes }}></turbo-stream>

--- a/src/Turbo/templates/components/Stream/Replace.html.twig
+++ b/src/Turbo/templates/components/Stream/Replace.html.twig
@@ -1,5 +1,5 @@
 {% props target, morph = false -%}
 
-<turbo-stream action="replace" targets="{{ target }}"{% if morph %} method="morph"{% endif %} {{ attributes }}>
+<turbo-stream action="replace" targets="{{ target }}"{% if morph %} method="morph"{% endif %} {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>

--- a/src/Turbo/templates/components/Stream/Update.html.twig
+++ b/src/Turbo/templates/components/Stream/Update.html.twig
@@ -1,5 +1,5 @@
 {% props target, morph = false -%}
 
-<turbo-stream action="update" targets="{{ target }}"{% if morph %} method="morph"{% endif %} {{ attributes }}>
+<turbo-stream action="update" targets="{{ target }}"{% if morph %} method="morph"{% endif %} {{- attributes }}>
     <template>{% block content %}{% endblock %}</template>
 </turbo-stream>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | https://github.com/symfony/ux/pull/2298#issuecomment-2434799250
| License       | MIT

I have a genetic Turbo Stream component. To use it, you can do this:

```twig
<twig:Turbo:Stream action="turbo_frame_reload" target="count-post" />
```

The rendering is:

```twig
<turbo-stream action="turbo_frame_reload" target="count-post"></turbo-stream>
```