### PR TITLE
[Turbo] Add generic `<Turbo:Stream>` component

### DIFF
--- a/src/Turbo/CHANGELOG.md
+++ b/src/Turbo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.22.0
+
+-   Add `<twig:Turbo:Stream>` component
+
 ## 2.21.0
 
 -   Add `Helper/TurboStream::append()` et al. methods

--- a/src/Turbo/templates/components/Stream.html.twig
+++ b/src/Turbo/templates/components/Stream.html.twig
@@ -1,0 +1,3 @@
+{% props action -%}
+
+<turbo-stream action="{{ action }}" {{- attributes }}></turbo-stream>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | https://github.com/symfony/ux/pull/2298#issuecomment-2434799250
| License       | MIT

I added a generic Turbo Stream component. To use it, you can do this:

```twig
<twig:Turbo:Stream action="turbo_frame_reload" targets="#count-post" />
```

The rendering is:

```twig
<turbo-stream action="turbo_frame_reload" targets="#count-post"></turbo-stream>
```