### PR TITLE
[StimulusBundle] Check controllers source files for laziness

### DIFF
--- a/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
+++ b/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
@@ -77,7 +77,7 @@ class ControllersMapGenerator
             $name = str_replace(['_', '/', '\\'], ['-', '--', '--'], $name);
 
             $asset = $this->assetMapper->getAssetFromSourcePath($file->getRealPath());
-            $content = $asset->content ?: file_get_contents($asset->sourcePath);
+            $content = file_get_contents($asset->sourcePath);
             $isLazy = preg_match('/\/\*\s*stimulusFetch:\s*\'lazy\'\s*\*\//i', $content);
 
             $controllersMap[$name] = new MappedControllerAsset($asset, $isLazy);

--- a/src/StimulusBundle/tests/AssetMapper/ControllersMapGeneratorTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/ControllersMapGeneratorTest.php
@@ -20,7 +20,7 @@ use Symfony\UX\StimulusBundle\AssetMapper\ControllersMapGenerator;
 use Symfony\UX\StimulusBundle\AssetMapper\MappedControllerAutoImport;
 use Symfony\UX\StimulusBundle\Ux\UxPackageReader;
 
-class ControllerMapGeneratorTest extends TestCase
+class ControllersMapGeneratorTest extends TestCase
 {
     public function testGetControllersMap()
     {
@@ -41,7 +41,12 @@ class ControllerMapGeneratorTest extends TestCase
                     $logicalPath = substr($path, $assetsPosition + 1);
                 }
 
-                return new MappedAsset($logicalPath, $path, content: file_get_contents($path));
+                $content = null;
+                if (str_ends_with($path, 'minified-controller.js')) {
+                    $content = 'import{Controller}from"@hotwired/stimulus";export default class extends Controller{}';
+                }
+
+                return new MappedAsset($logicalPath, $path, content: $content);
             });
 
         $packageReader = new UxPackageReader(__DIR__.'/../fixtures');
@@ -73,8 +78,8 @@ class ControllerMapGeneratorTest extends TestCase
         $map = $generator->getControllersMap();
         // + 3 controller.json UX controllers
         // - 1 controllers.json UX controller is disabled
-        // + 9 custom controllers (1 file is not a controller & 1 is overridden)
-        $this->assertCount(11, $map);
+        // + 10 custom controllers (1 file is not a controller & 1 is overridden)
+        $this->assertCount(12, $map);
         $packageNames = array_keys($map);
         sort($packageNames);
         $this->assertSame([
@@ -84,6 +89,7 @@ class ControllerMapGeneratorTest extends TestCase
             'hello',
             'hello-with-dashes',
             'hello-with-underscores',
+            'minified',
             'other',
             'subdir--deeper',
             'subdir--deeper-with-dashes',
@@ -115,5 +121,8 @@ class ControllerMapGeneratorTest extends TestCase
 
         $otherController = $map['other'];
         $this->assertTrue($otherController->isLazy);
+
+        $minifiedController = $map['minified'];
+        $this->assertTrue($minifiedController->isLazy);
     }
 }

--- a/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
@@ -63,8 +63,9 @@ class StimulusControllerLoaderFunctionalTest extends WebTestCase
                 // 2x from UX packages, which are enabled in controllers.json
                 '/assets/fake-vendor/ux-package1/package-controller-second.js',
                 '/assets/fake-vendor/ux-package2/package-hello-controller.js',
-                // 2x from more-controllers
+                // 3x from more-controllers
                 '/assets/more-controllers/hello-controller.js',
+                '/assets/more-controllers/minified-controller.js',
                 '/assets/more-controllers/other-controller.js',
                 // 5x from importmap.php
                 '@hotwired/stimulus',

--- a/src/StimulusBundle/tests/fixtures/assets/more-controllers/minified-controller.js
+++ b/src/StimulusBundle/tests/fixtures/assets/more-controllers/minified-controller.js
@@ -1,0 +1,6 @@
+// minified-controller.js
+import { Controller } from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix https://github.com/sensiolabs/minify-bundle/issues/10
| License       | MIT

The StimulusBundle allows to mark a controller as lazy using a `/* stimulusFetch: 'lazy' */` comment, but it will be searched in said controller’s *compiled* content. If the compilation removes that comment (it typically happens when using minifiers), then the controller is no longer considered lazy by the `ControllersMapGenerator`.

This PR makes the comment searched in source files, so that its presence doesn’t depend on the compilation’s result.