### PR TITLE
[ux.symfony.com] Update docker compose configuration

### DIFF
--- a/ux.symfony.com/compose.override.yml
+++ b/ux.symfony.com/compose.override.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 ###> symfony/mercure-bundle ###
   mercure:

--- a/ux.symfony.com/compose.yml
+++ b/ux.symfony.com/compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 ###> symfony/mercure-bundle ###
   mercure:
@@ -12,8 +10,6 @@ services:
       # Set the URL of your Symfony project (without trailing slash!) as value of the cors_origins directive
       MERCURE_EXTRA_DIRECTIVES: |
         cors_origins https://127.0.0.1:9044
-    # Comment the following line to disable the development mode
-    command: /usr/bin/caddy run --config /etc/caddy/Caddyfile.dev
     volumes:
       - mercure_data:/data
       - mercure_config:/config


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | None
| License       | MIT

- Mercure docker runs without the command line (actual issue there!)
- Docker compose file format is now "compose.yml"
- "version" field is also deprecated