### PR TITLE
[Icons] Fix commands receive polluted SVG

### DIFF
--- a/src/Icons/src/Command/ImportIconCommand.php
+++ b/src/Icons/src/Command/ImportIconCommand.php
@@ -68,7 +68,7 @@ final class ImportIconCommand extends Command
             $io->comment(\sprintf('Importing %s...', $fullName));
 
             try {
-                $svg = $this->iconify->fetchSvg($prefix, $name);
+                $iconSvg = $this->iconify->fetchIcon($prefix, $name)->toHtml();
             } catch (IconNotFoundException $e) {
                 $io->error($e->getMessage());
                 $result = Command::FAILURE;
@@ -79,7 +79,7 @@ final class ImportIconCommand extends Command
             $cursor = new Cursor($output);
             $cursor->moveUp(2);
 
-            $this->registry->add(\sprintf('%s/%s', $prefix, $name), $svg);
+            $this->registry->add(\sprintf('%s/%s', $prefix, $name), $iconSvg);
 
             $license = $this->iconify->metadataFor($prefix)['license'];
 

--- a/src/Icons/src/Command/LockIconsCommand.php
+++ b/src/Icons/src/Command/LockIconsCommand.php
@@ -81,7 +81,7 @@ final class LockIconsCommand extends Command
             }
 
             try {
-                $svg = $this->iconify->fetchSvg($prefix, $name);
+                $iconSvg = $this->iconify->fetchIcon($prefix, $name)->toHtml();
             } catch (IconNotFoundException) {
                 // icon not found on iconify
                 if ($io->isVerbose()) {
@@ -90,7 +90,7 @@ final class LockIconsCommand extends Command
                 continue;
             }
 
-            $this->registry->add(\sprintf('%s/%s', $prefix, $name), $svg);
+            $this->registry->add(\sprintf('%s/%s', $prefix, $name), $iconSvg);
 
             $license = $this->iconify->metadataFor($prefix)['license'];
             ++$count;

--- a/src/Icons/src/Iconify.php
+++ b/src/Icons/src/Iconify.php
@@ -85,25 +85,6 @@ final class Iconify
         ]);
     }
 
-    public function fetchSvg(string $prefix, string $name): string
-    {
-        if (!isset($this->sets()[$prefix])) {
-            throw new IconNotFoundException(\sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $name));
-        }
-
-        $response = $this->http->request('GET', \sprintf('/%s/%s.svg', $prefix, $name));
-
-        if (200 !== $response->getStatusCode()) {
-            throw new IconNotFoundException(\sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $name));
-        }
-
-        if (!str_starts_with($svg = $response->getContent(), '<svg')) {
-            throw new IconNotFoundException(\sprintf('The icon "%s:%s" does not exist on iconify.design.', $prefix, $name));
-        }
-
-        return $svg;
-    }
-
     public function hasIconSet(string $prefix): bool
     {
         return isset($this->sets()[$prefix]);

--- a/src/Icons/tests/Unit/IconifyTest.php
+++ b/src/Icons/tests/Unit/IconifyTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
-use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
 use Symfony\UX\Icons\Iconify;
 
@@ -171,37 +170,6 @@ class IconifyTest extends TestCase
 
         $metadata = $iconify->metadataFor('fa6-solid');
         $this->assertSame('Font Awesome Solid', $metadata['name']);
-    }
-
-    public function testFetchSvg(): void
-    {
-        $client = new MockHttpClient([
-            new MockResponse(file_get_contents(__DIR__.'/../Fixtures/Iconify/collections.json'), [
-                'response_headers' => ['content-type' => 'application/json'],
-            ]),
-            new MockResponse(file_get_contents(__DIR__.'/../Fixtures/Iconify/icon.svg')),
-        ]);
-        $iconify = new Iconify(new NullAdapter(), 'https://localhost', $client);
-
-        $svg = $iconify->fetchSvg('fa6-regular', 'bar');
-
-        $this->assertIsString($svg);
-        $this->stringContains('-.224l.235-.468ZM6.013 2.06c-.649-.1', $svg);
-    }
-
-    public function testFetchSvgThrowIconNotFoundExceptionWhenStatusCodeNot200(): void
-    {
-        $client = new MockHttpClient([
-            new MockResponse(file_get_contents(__DIR__.'/../Fixtures/Iconify/collections.json'), [
-                'response_headers' => ['content-type' => 'application/json'],
-            ]),
-            new MockResponse('', ['http_code' => 404]),
-        ]);
-        $iconify = new Iconify(new NullAdapter(), 'https://localhost', $client);
-
-        $this->expectException(IconNotFoundException::class);
-
-        $iconify->fetchSvg('fa6-regular', 'bar');
     }
 
     private function createHttpClient(mixed $data, int $code = 200): MockHttpClient


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #2223
| License       | MIT

These commands were getting SVG with CSS size attributes

Fix #2223
