### PR TITLE
Allow to disable nested attributes with !

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.21.0
+
+-  Allow to disable nested attributes with !
+
 ## 2.20.0
 
 -  Add Anonymous Component support for 3rd-party bundles #2019

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -21,7 +21,7 @@ use Symfony\WebpackEncoreBundle\Dto\AbstractStimulusDto;
  */
 final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Countable
 {
-    private const NESTED_REGEX = '#^([\w-]+):(.+)$#';
+    private const NESTED_REGEX = '#^([\w-]+):(.+)(?<!!)$#';
 
     /** @var array<string,true> */
     private array $rendered = [];
@@ -62,6 +62,10 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
 
                 if (true === $value && str_starts_with($key, 'aria-')) {
                     $value = 'true';
+                }
+
+                if (str_ends_with($key, '!')) {
+                    $key = substr($key, 0, -1);
                 }
 
                 return match ($value) {

--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -200,7 +200,7 @@ class TwigPreLexer
     private function consumeComponentName(?string $customExceptionMessage = null): string
     {
         $start = $this->position;
-        while ($this->position < $this->length && preg_match('/[A-Za-z0-9_:@\-.]/', $this->input[$this->position])) {
+        while ($this->position < $this->length && preg_match('/[A-Za-z0-9_:@!\-.]/', $this->input[$this->position])) {
             ++$this->position;
         }
 
@@ -252,6 +252,10 @@ class TwigPreLexer
             }
 
             $key = $this->consumeAttributeName($componentName);
+
+            if (str_ends_with($key, '!')) {
+                $isAttributeDynamic = false;
+            }
 
             // <twig:component someProp> -> someProp: true
             if (!$this->check('=')) {

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -316,6 +316,44 @@ final class ComponentExtensionTest extends KernelTestCase
         );
     }
 
+    public function testRenderingComponentWithNestedAndNotNestedAttributes(): void
+    {
+        $output = $this->renderComponent('NestedAttributes');
+
+        $this->assertSame(<<<HTML
+            <main>
+                <div>
+                    <span>
+                        <div/>
+
+                    </span>
+                </div>
+            </main>
+            HTML,
+            trim($output)
+        );
+
+        $output = $this->renderComponent('NestedAttributes', [
+            'class' => 'foo',
+            'x-bind:class!' => 'alpine',
+            ':class!' => 'alpine',
+            'title:span:class' => 'baz',
+        ]);
+
+        $this->assertSame(<<<HTML
+            <main class="foo" x-bind:class="alpine" :class="alpine">
+                <div>
+                    <span class="baz">
+                        <div/>
+
+                    </span>
+                </div>
+            </main>
+            HTML,
+            trim($output)
+        );
+    }
+
     public function testRenderingHtmlSyntaxComponentWithNestedAttributes(): void
     {
         $output = self::getContainer()

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -259,6 +259,20 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame('', (string) $attributes->nested('invalid'));
     }
 
+    public function testNotNestedAttributes(): void
+    {
+        $attributes = new ComponentAttributes([
+            'class' => 'foo',
+            'x-bind:class!' => 'alpine',
+            ':class!' => 'alpine',
+            'title:span:class' => 'baz',
+        ]);
+
+        $this->assertSame(' class="foo" x-bind:class="alpine" :class="alpine"', (string) $attributes);
+        $this->assertSame(' class="baz"', (string) $attributes->nested('title')->nested('span'));
+        $this->assertSame('', (string) $attributes->nested('invalid'));
+    }
+
     public function testConvertTrueAriaAttributeValue(): void
     {
         $attributes = new ComponentAttributes([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | ~
| License       | MIT

With the nested attributes feature, components have become incompatible with the AlpineJS library, which also uses HTML attributes in a similar format, such as x-bind:class="foo" or x-transition:enter="ease-out duration-300".
This PR introduces a way to specify that an attribute containing : and ending with ! should not be treated as a nested attribute.

Propose : 

```twig
<twig:Button x-bind:class!="hey">My button</twig:Button>
```