### PR TITLE
[TwigComponent] Ignore "nested" for Alpine & Vue attributes

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -37,48 +37,43 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
 
     public function __toString(): string
     {
-        return array_reduce(
-            array_filter(
-                array_keys($this->attributes),
-                fn (string $key) => !isset($this->rendered[$key])
-            ),
-            function (string $carry, string $key) {
-                if (
-                    str_contains($key, ':')
-                    && preg_match(self::NESTED_REGEX, $key)
-                    && !preg_match(self::ALPINE_REGEX, $key)
-                    && !preg_match(self::VUE_REGEX, $key)
-                ) {
-                    return $carry;
-                }
+        $attributes = '';
 
-                $value = $this->attributes[$key];
+        foreach ($this->attributes as $key => $value) {
+            if (isset($this->rendered[$key])) {
+                continue;
+            }
 
-                if ($value instanceof \Stringable) {
-                    $value = (string) $value;
-                }
+            if (
+                str_contains($key, ':')
+                && preg_match(self::NESTED_REGEX, $key)
+                && !preg_match(self::ALPINE_REGEX, $key)
+                && !preg_match(self::VUE_REGEX, $key)
+            ) {
+                continue;
+            }
 
-                if (!\is_scalar($value) && null !== $value) {
-                    throw new \LogicException(\sprintf('A "%s" prop was passed when creating the component. No matching "%s" property or mount() argument was found, so we attempted to use this as an HTML attribute. But, the value is not a scalar (it\'s a "%s"). Did you mean to pass this to your component or is there a typo on its name?', $key, $key, get_debug_type($value)));
-                }
+            if (null === $value) {
+                trigger_deprecation('symfony/ux-twig-component', '2.8.0', 'Passing "null" as an attribute value is deprecated and will throw an exception in 3.0.');
+                $value = true;
+            }
 
-                if (null === $value) {
-                    trigger_deprecation('symfony/ux-twig-component', '2.8.0', 'Passing "null" as an attribute value is deprecated and will throw an exception in 3.0.');
-                    $value = true;
-                }
+            if (!\is_scalar($value) && !($value instanceof \Stringable)) {
+                throw new \LogicException(\sprintf('A "%s" prop was passed when creating the component. No matching "%s" property or mount() argument was found, so we attempted to use this as an HTML attribute. But, the value is not a scalar (it\'s a "%s"). Did you mean to pass this to your component or is there a typo on its name?', $key, $key, get_debug_type($value)));
+            }
 
-                if (true === $value && str_starts_with($key, 'aria-')) {
-                    $value = 'true';
-                }
+            if (true === $value && str_starts_with($key, 'aria-')) {
+                $value = 'true';
+            }
 
-                return match ($value) {
-                    true => "{$carry} {$key}",
-                    false => $carry,
-                    default => \sprintf('%s %s="%s"', $carry, $key, $value),
-                };
-            },
-            ''
-        );
+            $attributes .= match ($value) {
+                true => ' '.$key,
+                false => '',
+                default => \sprintf(' %s="%s"', $key, $value),
+            };
+        }
+
+        return $attributes;
     }
 
     public function __clone(): void

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -222,7 +222,10 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
         $attributes = [];
 
         foreach ($this->attributes as $key => $value) {
-            if (preg_match(self::NESTED_REGEX, $key, $matches) && $namespace === $matches[1]) {
+            if (
+                str_contains($key, ':')
+                && preg_match(self::NESTED_REGEX, $key, $matches) && $namespace === $matches[1]
+            ) {
                 $attributes[$matches[2]] = $value;
             }
         }

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -44,7 +44,8 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
             ),
             function (string $carry, string $key) {
                 if (
-                    preg_match(self::NESTED_REGEX, $key)
+                    str_contains($key, ':')
+                    && preg_match(self::NESTED_REGEX, $key)
                     && !preg_match(self::ALPINE_REGEX, $key)
                     && !preg_match(self::VUE_REGEX, $key)
                 ) {

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -22,6 +22,8 @@ use Symfony\WebpackEncoreBundle\Dto\AbstractStimulusDto;
 final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Countable
 {
     private const NESTED_REGEX = '#^([\w-]+):(.+)$#';
+    private const ALPINE_REGEX = '#^x-([a-z]+):[^:]+$#';
+    private const VUE_REGEX = '#^v-([a-z]+):[^:]+$#';
 
     /** @var array<string,true> */
     private array $rendered = [];
@@ -41,7 +43,11 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
                 fn (string $key) => !isset($this->rendered[$key])
             ),
             function (string $carry, string $key) {
-                if (preg_match(self::NESTED_REGEX, $key)) {
+                if (
+                    preg_match(self::NESTED_REGEX, $key)
+                    && !preg_match(self::ALPINE_REGEX, $key)
+                    && !preg_match(self::VUE_REGEX, $key)
+                ) {
                     return $carry;
                 }
 

--- a/src/TwigComponent/tests/Fixtures/templates/components/PrefixedAttributes.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/PrefixedAttributes.html.twig
@@ -1,0 +1,1 @@
+<div{{ attributes }}></div>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -352,11 +352,11 @@ final class ComponentExtensionTest extends KernelTestCase
         // Not AlpineJS
         yield ['z-click="count++"', true];
         yield ['z-on:click="count++"', false]; // Nested
-        
+
         // Stencil
         yield ['onClick="count++"', true];
         yield ['@onClick="count++"', true];
-        
+
         // VueJs
         yield ['v-model="message"', true];
         yield ['v-bind:id="dynamicId"', true];

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -258,7 +258,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(' class="baz"', (string) $attributes->nested('title')->nested('span'));
         $this->assertSame('', (string) $attributes->nested('invalid'));
     }
-    
+
     public function testPrefixedAttributes(): void
     {
         $attributes = new ComponentAttributes([

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -258,6 +258,19 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(' class="baz"', (string) $attributes->nested('title')->nested('span'));
         $this->assertSame('', (string) $attributes->nested('invalid'));
     }
+    
+    public function testPrefixedAttributes(): void
+    {
+        $attributes = new ComponentAttributes([
+            'x-click' => 'x+',
+            'title:x-click' => 'title:x+',
+        ]);
+
+        $this->assertSame(' x-click="x+"', (string) $attributes);
+        $this->assertSame(' x-click="title:x+"', (string) $attributes->nested('title'));
+        $this->assertSame('', (string) $attributes->nested('title')->nested('span'));
+        $this->assertSame('', (string) $attributes->nested('invalid'));
+    }
 
     public function testConvertTrueAriaAttributeValue(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #1839
| License       | MIT

Have lost time on Twig & the website :sweat:

Alternative implementation of #2325 

Update: Improved `__toString` performance following @Kocal comments

--- 
Now all these attributes are directly rendered 

| Framework       | Prefix | Code Example                                                                                       | Documentation                                                 |
|-----------------|---------|-------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
| **Alpine.js**   | `x-`    | `<div x-data="{ open: false }" x-show="open"></div>`                                                 | [Documentation Alpine.js](https://alpinejs.dev/)               |
| **Vue.js**      | `v-`    | `<input v-model="message" v-if="show">`                                                              | [Documentation Vue.js](https://vuejs.org/guide/)               |
| **Stencil**     | `@`     | `<my-component @onClick="handleClick"></my-component>`                                               | [Documentation Stencil](https://stenciljs.com/docs/)           |
| **Lit**         | `@`     | `<button @click="${this.handleClick}">Click me</button>`                                             | [Documentation Lit](https://lit.dev/docs/)                    |
