### PR TITLE
[TwigComponent] Fix directory separator in Debug command

### DIFF
--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -187,7 +187,7 @@ EOF
             $path = $template->getPath();
 
             if ($template->getRelativePath()) {
-                $path = \rtrim(\substr($template->getPath(), 0, -1 * \strlen($template->getRelativePath())), \DIRECTORY_SEPARATOR);
++                $path = rtrim(substr($template->getPath(), 0, -1 * \strlen($template->getRelativePath())), \DIRECTORY_SEPARATOR);
             }
 
             if (isset($dirs[$path]) && FilesystemLoader::MAIN_NAMESPACE !== $dirs[$path]) {

--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -182,12 +182,12 @@ EOF
             ->name('*.html.twig')
         ;
         foreach ($finderTemplates as $template) {
-            $component = str_replace('/', ':', $template->getRelativePathname());
+            $component = str_replace(\DIRECTORY_SEPARATOR, ':', $template->getRelativePathname());
             $component = substr($component, 0, -10); // remove file extension ".html.twig"
             $path = $template->getPath();
 
             if ($template->getRelativePath()) {
-                $path = \rtrim(\substr($template->getPath(), 0, -1 * \strlen($template->getRelativePath())), '/');
+                $path = \rtrim(\substr($template->getPath(), 0, -1 * \strlen($template->getRelativePath())), \DIRECTORY_SEPARATOR);
             }
 
             if (isset($dirs[$path]) && FilesystemLoader::MAIN_NAMESPACE !== $dirs[$path]) {

--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -187,7 +187,7 @@ EOF
             $path = $template->getPath();
 
             if ($template->getRelativePath()) {
-+                $path = rtrim(substr($template->getPath(), 0, -1 * \strlen($template->getRelativePath())), \DIRECTORY_SEPARATOR);
+                $path = rtrim(substr($template->getPath(), 0, -1 * \strlen($template->getRelativePath())), \DIRECTORY_SEPARATOR);
             }
 
             if (isset($dirs[$path]) && FilesystemLoader::MAIN_NAMESPACE !== $dirs[$path]) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        |
| License       | MIT

Component template paths are retrieved by the `SplFileInfo` class, which returns paths containing backslashes on Windows and slashes on other operating systems.

So on Windows environment, the command fails as the component `Card\Card.html.twig` is not formatted into `Card:Card`