### PR TITLE
[StimulusBundle][Doc] Mention `removeComments` will no longer be necessary

### DIFF
--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -157,8 +157,9 @@ To make a third-party controller lazy, in ``assets/controllers.json``, set
 
 .. note::
 
-    If you write your controllers using TypeScript, make sure
-    ``removeComments`` is not set to ``true`` in your TypeScript config.
+    If you write your controllers using TypeScript and you're using
+    StimulusBundle ≤ 2.21.0, make sure ``removeComments`` is not set
+    to ``true`` in your TypeScript config.
 
 Stimulus Tools around the World
 -------------------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | N/A
| License       | MIT

Once https://github.com/symfony/ux/pull/2304 is released, it will no longer be necessary to set `removeComments` to `false` when using TypeScript, because the `stimulusFetch: 'lazy'` comment will be searched in the source rather than the compiled content.