### PR TITLE
[Autocomplete][Doc] Mention `preload` can be set to `false`

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -272,6 +272,7 @@ to the options above, you can also pass:
 ``preload`` (default: ``focus``)
     Set to ``focus`` to call the ``load`` function when control receives focus.
     Set to ``true`` to call the ``load`` upon control initialization (with an empty search).
+    Set to ``false`` not to call the ``load`` function when control receives focus.
 
 ``extra_options`` (default ``[]``)
     Allow you to pass extra options for Ajax-based autocomplete fields.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | N/A
| License       | MIT

Setting `preload` to `false` is useful when you only want to display search results; that way nothing is loaded on focus.