### PR TITLE
[Map] Introduce `ux_map.google_maps.default_map_id` configuration

### DIFF
--- a/src/Map/CHANGELOG.md
+++ b/src/Map/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGELOG
+ 
+## 2.22
+
+-   Add method `Symfony\UX\Map\Renderer\AbstractRenderer::tapOptions()`, to allow Renderer to modify options before rendering a Map.
+-   Add `ux_map.google_maps.default_map_id` configuration to set the Google ``Map ID``
 
 ## 2.20
 

--- a/src/Map/config/twig_component.php
+++ b/src/Map/config/twig_component.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\UX\Map\Twig\UXMapComponent;
-use Symfony\UX\Map\Twig\UXMapComponentListener;
-use Symfony\UX\TwigComponent\Event\PreCreateForRenderEvent;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()

--- a/src/Map/src/Bridge/Google/CHANGELOG.md
+++ b/src/Map/src/Bridge/Google/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.22
+
+-   Add support for configuring a default Map ID
+-   Add argument `$defaultMapId` to `Symfony\UX\Map\Bridge\Google\Renderer\GoogleRendererFactory` constructor
+-   Add argument `$defaultMapId` to `Symfony\UX\Map\Bridge\Google\Renderer\GoogleRenderer` constructor
+
 ## 2.20
 
 ### BC Breaks

--- a/src/Map/src/Bridge/Google/src/GoogleOptions.php
+++ b/src/Map/src/Bridge/Google/src/GoogleOptions.php
@@ -46,6 +46,11 @@ final class GoogleOptions implements MapOptionsInterface
         return $this;
     }
 
+    public function hasMapId(): bool
+    {
+        return null !== $this->mapId;
+    }
+
     public function gestureHandling(GestureHandling $gestureHandling): self
     {
         $this->gestureHandling = $gestureHandling;

--- a/src/Map/src/Bridge/Google/src/Renderer/GoogleRenderer.php
+++ b/src/Map/src/Bridge/Google/src/Renderer/GoogleRenderer.php
@@ -41,6 +41,7 @@ final readonly class GoogleRenderer extends AbstractRenderer
          * @var array<'core'|'maps'|'places'|'geocoding'|'routes'|'marker'|'geometry'|'elevation'|'streetView'|'journeySharing'|'drawing'|'visualization'>
          */
         private array $libraries = [],
+        private ?string $defaultMapId = null,
     ) {
         parent::__construct($stimulusHelper);
     }
@@ -66,7 +67,20 @@ final readonly class GoogleRenderer extends AbstractRenderer
 
     protected function getDefaultMapOptions(): MapOptionsInterface
     {
-        return new GoogleOptions();
+        return new GoogleOptions(mapId: $this->defaultMapId);
+    }
+
+    protected function tapOptions(MapOptionsInterface $options): MapOptionsInterface
+    {
+        if (!$options instanceof GoogleOptions) {
+            throw new \InvalidArgumentException(\sprintf('The options must be an instance of "%s", got "%s" instead.', GoogleOptions::class, get_debug_type($options)));
+        }
+
+        if (!$options->hasMapId()) {
+            $options->mapId($this->defaultMapId);
+        }
+
+        return $options;
     }
 
     public function __toString(): string

--- a/src/Map/src/Bridge/Google/src/Renderer/GoogleRendererFactory.php
+++ b/src/Map/src/Bridge/Google/src/Renderer/GoogleRendererFactory.php
@@ -17,12 +17,20 @@ use Symfony\UX\Map\Renderer\AbstractRendererFactory;
 use Symfony\UX\Map\Renderer\Dsn;
 use Symfony\UX\Map\Renderer\RendererFactoryInterface;
 use Symfony\UX\Map\Renderer\RendererInterface;
+use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
 
 /**
  * @author Hugo Alliaume <hugo@alliau.me>
  */
 final class GoogleRendererFactory extends AbstractRendererFactory implements RendererFactoryInterface
 {
+    public function __construct(
+        StimulusHelper $stimulus,
+        private ?string $defaultMapId = null,
+    ) {
+        parent::__construct($stimulus);
+    }
+
     public function create(Dsn $dsn): RendererInterface
     {
         if (!$this->supports($dsn)) {
@@ -42,6 +50,7 @@ final class GoogleRendererFactory extends AbstractRendererFactory implements Ren
             url: $dsn->getOption('url'),
             version: $dsn->getOption('version', 'weekly'),
             libraries: ['maps', 'marker', ...$dsn->getOption('libraries', [])],
+            defaultMapId: $this->defaultMapId,
         );
     }
 

--- a/src/Map/src/Bridge/Google/tests/GoogleRendererTest.php
+++ b/src/Map/src/Bridge/Google/tests/GoogleRendererTest.php
@@ -78,5 +78,23 @@ class GoogleRendererTest extends RendererTestCase
                     fullscreenControl: false,
                 )),
         ];
+
+        yield 'with default map id' => [
+            'expected_renderer' => '<div data-controller="symfony--ux-google-map--map" data-symfony--ux-google-map--map-provider-options-value="{&quot;apiKey&quot;:&quot;my_api_key&quot;}" data-symfony--ux-google-map--map-view-value="{&quot;center&quot;:{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522},&quot;zoom&quot;:12,&quot;fitBoundsToMarkers&quot;:false,&quot;options&quot;:{&quot;mapId&quot;:&quot;DefaultMapId&quot;,&quot;gestureHandling&quot;:&quot;auto&quot;,&quot;backgroundColor&quot;:null,&quot;disableDoubleClickZoom&quot;:false,&quot;zoomControlOptions&quot;:{&quot;position&quot;:22},&quot;mapTypeControlOptions&quot;:{&quot;mapTypeIds&quot;:[],&quot;position&quot;:14,&quot;style&quot;:0},&quot;streetViewControlOptions&quot;:{&quot;position&quot;:22},&quot;fullscreenControlOptions&quot;:{&quot;position&quot;:20}},&quot;markers&quot;:[],&quot;polygons&quot;:[]}"></div>',
+            'renderer' => new GoogleRenderer(new StimulusHelper(null), 'my_api_key', defaultMapId: 'DefaultMapId'),
+            'map' => (clone $map),
+        ];
+        yield 'with default map id, when passing options (except the "mapId")' => [
+            'expected_renderer' => '<div data-controller="symfony--ux-google-map--map" data-symfony--ux-google-map--map-provider-options-value="{&quot;apiKey&quot;:&quot;my_api_key&quot;}" data-symfony--ux-google-map--map-view-value="{&quot;center&quot;:{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522},&quot;zoom&quot;:12,&quot;fitBoundsToMarkers&quot;:false,&quot;options&quot;:{&quot;mapId&quot;:&quot;DefaultMapId&quot;,&quot;gestureHandling&quot;:&quot;auto&quot;,&quot;backgroundColor&quot;:null,&quot;disableDoubleClickZoom&quot;:false,&quot;zoomControlOptions&quot;:{&quot;position&quot;:22},&quot;mapTypeControlOptions&quot;:{&quot;mapTypeIds&quot;:[],&quot;position&quot;:14,&quot;style&quot;:0},&quot;streetViewControlOptions&quot;:{&quot;position&quot;:22},&quot;fullscreenControlOptions&quot;:{&quot;position&quot;:20}},&quot;markers&quot;:[],&quot;polygons&quot;:[]}"></div>',
+            'renderer' => new GoogleRenderer(new StimulusHelper(null), 'my_api_key', defaultMapId: 'DefaultMapId'),
+            'map' => (clone $map)
+                ->options(new GoogleOptions()),
+        ];
+        yield 'with default map id overridden by option "mapId"' => [
+            'expected_renderer' => '<div data-controller="symfony--ux-google-map--map" data-symfony--ux-google-map--map-provider-options-value="{&quot;apiKey&quot;:&quot;my_api_key&quot;}" data-symfony--ux-google-map--map-view-value="{&quot;center&quot;:{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522},&quot;zoom&quot;:12,&quot;fitBoundsToMarkers&quot;:false,&quot;options&quot;:{&quot;mapId&quot;:&quot;CustomMapId&quot;,&quot;gestureHandling&quot;:&quot;auto&quot;,&quot;backgroundColor&quot;:null,&quot;disableDoubleClickZoom&quot;:false,&quot;zoomControlOptions&quot;:{&quot;position&quot;:22},&quot;mapTypeControlOptions&quot;:{&quot;mapTypeIds&quot;:[],&quot;position&quot;:14,&quot;style&quot;:0},&quot;streetViewControlOptions&quot;:{&quot;position&quot;:22},&quot;fullscreenControlOptions&quot;:{&quot;position&quot;:20}},&quot;markers&quot;:[],&quot;polygons&quot;:[]}"></div>',
+            'renderer' => new GoogleRenderer(new StimulusHelper(null), 'my_api_key', defaultMapId: 'DefaultMapId'),
+            'map' => (clone $map)
+                ->options(new GoogleOptions(mapId: 'CustomMapId')),
+        ];
     }
 }

--- a/src/Map/src/Renderer/AbstractRenderer.php
+++ b/src/Map/src/Renderer/AbstractRenderer.php
@@ -31,6 +31,18 @@ abstract readonly class AbstractRenderer implements RendererInterface
 
     abstract protected function getDefaultMapOptions(): MapOptionsInterface;
 
+    /**
+     * @template T of MapOptionsInterface
+     *
+     * @param T $options
+     *
+     * @return T
+     */
+    protected function tapOptions(MapOptionsInterface $options): MapOptionsInterface
+    {
+        return $options;
+    }
+
     final public function renderMap(Map $map, array $attributes = []): string
     {
         if (!$map->hasOptions()) {
@@ -38,6 +50,8 @@ abstract readonly class AbstractRenderer implements RendererInterface
         } elseif (!$map->getOptions() instanceof ($defaultMapOptions = $this->getDefaultMapOptions())) {
             $map->options($defaultMapOptions);
         }
+
+        $map->options($this->tapOptions($map->getOptions()));
 
         $controllers = [];
         if ($attributes['data-controller'] ?? null) {

--- a/src/Map/src/UXMapBundle.php
+++ b/src/Map/src/UXMapBundle.php
@@ -44,6 +44,12 @@ final class UXMapBundle extends AbstractBundle
         $rootNode
             ->children()
                 ->scalarNode('renderer')->defaultNull()->end()
+                ->arrayNode('google_maps')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('default_map_id')->defaultNull()->end()
+                    ->end()
+                ->end()
             ->end()
         ;
     }
@@ -75,9 +81,17 @@ final class UXMapBundle extends AbstractBundle
         foreach (self::$bridges as $name => $bridge) {
             if (ContainerBuilder::willBeAvailable('symfony/ux-'.$name.'-map', $bridge['renderer_factory'], ['symfony/ux-map'])) {
                 $container->services()
-                    ->set('ux_map.renderer_factory.'.$name, $bridge['renderer_factory'])
+                    ->set($rendererFactoryName = 'ux_map.renderer_factory.'.$name, $bridge['renderer_factory'])
                     ->parent('ux_map.renderer_factory.abstract')
                     ->tag('ux_map.renderer_factory');
+
+                if ('google' === $name) {
+                    $container->services()
+                        ->get($rendererFactoryName)
+                        ->args([
+                            '$defaultMapId' => $config['google_maps']['default_map_id'],
+                        ]);
+                }
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #2306 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

With this modification, I can configure a default Google Maps `mapId`:
```yaml
# config/packages/ux_map.yaml
ux_map:
    # https://symfony.com/bundles/ux-map/current/index.html#available-renderers
    renderer: '%env(resolve:default::UX_MAP_DSN)%'
    google_maps:
        default_map_id: abcdefgh123456789
```
without having to manually pass the `mapId` when creating a `Map`:
```php
// use default mapId
$map = (new Map());
    ->center(new Point(48.8566, 2.3522))
    ->zoom(6);

// use default mapId
$map2 = (clone $map)
    ->options(new GoogleOptions());

// use custom mapId
$map3 = (clone $map)
    ->options(new GoogleOptions(mapId: 'foobar));
```