### PR TITLE
[Icons] Support aliases in LockIconsCommand

### DIFF
--- a/src/Icons/src/DependencyInjection/UXIconsExtension.php
+++ b/src/Icons/src/DependencyInjection/UXIconsExtension.php
@@ -178,6 +178,11 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
             }
         }
 
+        $container->getDefinition('.ux_icons.command.lock')
+            ->setArgument(3, $mergedConfig['aliases'])
+            ->setArgument(4, $iconSetAliases)
+        ;
+
         if (!$container->getParameter('kernel.debug')) {
             $container->removeDefinition('.ux_icons.command.import');
         }

--- a/src/Icons/tests/Fixtures/TestKernel.php
+++ b/src/Icons/tests/Fixtures/TestKernel.php
@@ -60,6 +60,10 @@ final class TestKernel extends Kernel
 
         $container->extension('ux_icons', [
             'icon_dir' => '%kernel.project_dir%/tests/Fixtures/icons',
+            'aliases' => [
+                'foo' => 'lucide:circle',
+                'bar' => 'lu:circle-off',
+            ],
             'icon_sets' => [
                 'fla' => [
                     'path' => '%kernel.project_dir%/tests/Fixtures/images/flags',

--- a/src/Icons/tests/Integration/Command/LockIconsCommandTest.php
+++ b/src/Icons/tests/Integration/Command/LockIconsCommandTest.php
@@ -25,6 +25,8 @@ final class LockIconsCommandTest extends KernelTestCase
     private const ICONS = [
         __DIR__.'/../../Fixtures/icons/iconamoon/3d-duotone.svg',
         __DIR__.'/../../Fixtures/icons/flag/eu-4x3.svg',
+        __DIR__.'/../../Fixtures/icons/lucide/circle.svg',
+        __DIR__.'/../../Fixtures/icons/lucide/circle-off.svg',
     ];
 
     /**
@@ -50,9 +52,11 @@ final class LockIconsCommandTest extends KernelTestCase
         $this->executeConsoleCommand('ux:icons:lock')
             ->assertSuccessful()
             ->assertOutputContains('Scanning project for icons...')
+            ->assertOutputContains('Imported lucide:circle')
+            ->assertOutputContains('Imported lucide:circle-off')
             ->assertOutputContains('Imported flag:eu-4x3')
             ->assertOutputContains('Imported iconamoon:3d-duotone')
-            ->assertOutputContains('Imported 2 icons')
+            ->assertOutputContains('Imported 4 icons')
         ;
 
         foreach (self::ICONS as $icon) {
@@ -70,17 +74,21 @@ final class LockIconsCommandTest extends KernelTestCase
         $this->executeConsoleCommand('ux:icons:lock')
             ->assertSuccessful()
             ->assertOutputContains('Scanning project for icons...')
+            ->assertOutputContains('Imported lucide:circle')
+            ->assertOutputContains('Imported lucide:circle-off')
             ->assertOutputContains('Imported flag:eu-4x3')
             ->assertOutputContains('Imported iconamoon:3d-duotone')
-            ->assertOutputContains('Imported 2 icons')
+            ->assertOutputContains('Imported 4 icons')
         ;
 
         $this->executeConsoleCommand('ux:icons:lock --force')
             ->assertSuccessful()
             ->assertOutputContains('Scanning project for icons...')
+            ->assertOutputContains('Imported lucide:circle')
+            ->assertOutputContains('Imported lucide:circle-off')
             ->assertOutputContains('Imported flag:eu-4x3')
             ->assertOutputContains('Imported iconamoon:3d-duotone')
-            ->assertOutputContains('Imported 2 icons')
+            ->assertOutputContains('Imported 4 icons')
         ;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #2354
| License       | MIT

Alias icons are now all locked, and icon set aliases are supported too.
