### PR TITLE
[Autocomplete] Fix handling of associated properties in DQL joins

### DIFF
--- a/src/Autocomplete/tests/Fixtures/Entity/CategoryTag.php
+++ b/src/Autocomplete/tests/Fixtures/Entity/CategoryTag.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Autocomplete\Tests\Fixtures\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity()]
+class CategoryTag
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\Column()]
+    private ?string $name = null;
+
+    #[ORM\ManyToMany(targetEntity: Category::class, inversedBy: 'tags')]
+    #[ORM\JoinTable(name: 'category_tag')]
+    private Collection $categories;
+
+    public function __construct()
+    {
+        $this->categories = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Category>
+     */
+    public function getCategories(): Collection
+    {
+        return $this->categories;
+    }
+
+    public function addCategory(Category $category): self
+    {
+        if (!$this->categories->contains($category)) {
+            $this->categories[] = $category;
+        }
+
+        return $this;
+    }
+
+    public function removeCategory(Category $category): self
+    {
+        $this->categories->removeElement($category);
+
+        return $this;
+    }
+}

--- a/src/Autocomplete/tests/Fixtures/Entity/Product.php
+++ b/src/Autocomplete/tests/Fixtures/Entity/Product.php
@@ -40,12 +40,16 @@ class Product
     #[ORM\JoinColumn(nullable: false)]
     private ?Category $category = null;
 
-    #[Orm\OneToMany(targetEntity: Ingredient::class, mappedBy: 'product')]
+    #[ORM\OneToMany(targetEntity: Ingredient::class, mappedBy: 'product')]
     private Collection $ingredients;
+
+    #[ORM\ManyToMany(targetEntity: ProductTag::class, mappedBy: 'products')]
+    private Collection $tags;
 
     public function __construct()
     {
         $this->ingredients = new ArrayCollection();
+        $this->tags = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -138,6 +142,33 @@ class Product
             if ($ingredient->getProduct() === $this) {
                 $ingredient->setProduct(null);
             }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, ProductTag>
+     */
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function addTag(ProductTag $tag): self
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags[] = $tag;
+            $tag->addProduct($this);
+        }
+
+        return $this;
+    }
+
+    public function removeTag(ProductTag $tag): self
+    {
+        if ($this->tags->removeElement($tag)) {
+            $tag->removeProduct($this);
         }
 
         return $this;

--- a/src/Autocomplete/tests/Fixtures/Entity/ProductTag.php
+++ b/src/Autocomplete/tests/Fixtures/Entity/ProductTag.php
@@ -16,7 +16,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity()]
-class Category
+class ProductTag
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -26,19 +26,13 @@ class Category
     #[ORM\Column()]
     private ?string $name = null;
 
-    #[ORM\Column()]
-    private ?string $code = null;
-
-    #[ORM\OneToMany(mappedBy: 'category', targetEntity: Product::class)]
+    #[ORM\ManyToMany(targetEntity: Product::class, inversedBy: 'tags')]
+    #[ORM\JoinTable(name: 'product_tag')]
     private Collection $products;
-
-    #[ORM\ManyToMany(targetEntity: CategoryTag::class, mappedBy: 'categories')]
-    private Collection $tags;
 
     public function __construct()
     {
         $this->products = new ArrayCollection();
-        $this->tags = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -58,18 +52,6 @@ class Category
         return $this;
     }
 
-    public function setCode(string $code): self
-    {
-        $this->code = $code;
-
-        return $this;
-    }
-
-    public function getCode(): ?string
-    {
-        return $this->code;
-    }
-
     /**
      * @return Collection<int, Product>
      */
@@ -82,7 +64,6 @@ class Category
     {
         if (!$this->products->contains($product)) {
             $this->products[] = $product;
-            $product->setCategory($this);
         }
 
         return $this;
@@ -90,43 +71,8 @@ class Category
 
     public function removeProduct(Product $product): self
     {
-        if ($this->products->removeElement($product)) {
-            // set the owning side to null (unless already changed)
-            if ($product->getCategory() === $this) {
-                $product->setCategory(null);
-            }
-        }
+        $this->products->removeElement($product);
 
         return $this;
-    }
-
-    /**
-     * @return Collection<int, CategoryTag>
-     */
-    public function getTags(): Collection
-    {
-        return $this->tags;
-    }
-
-    public function addTag(CategoryTag $tag): self
-    {
-        if (!$this->tags->contains($tag)) {
-            $this->tags[] = $tag;
-            $tag->addCategory($this);
-        }
-
-        return $this;
-    }
-
-    public function removeTag(CategoryTag $tag): self
-    {
-        $this->tags->removeElement($tag);
-
-        return $this;
-    }
-
-    public function __toString(): string
-    {
-        return $this->getName();
     }
 }

--- a/src/Autocomplete/tests/Fixtures/Factory/CategoryTagFactory.php
+++ b/src/Autocomplete/tests/Fixtures/Factory/CategoryTagFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Autocomplete\Tests\Fixtures\Factory;
+
+use Doctrine\ORM\EntityRepository;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\CategoryTag;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
+
+/**
+ * @extends ModelFactory<CategoryTag>
+ *
+ * @method static CategoryTag|Proxy                createOne(array $attributes = [])
+ * @method static CategoryTag[]|Proxy[]            createMany(int $number, array|callable $attributes = [])
+ * @method static CategoryTag|Proxy                find(object|array|mixed $criteria)
+ * @method static CategoryTag|Proxy                findOrCreate(array $attributes)
+ * @method static CategoryTag|Proxy                first(string $sortedField = 'id')
+ * @method static CategoryTag|Proxy                last(string $sortedField = 'id')
+ * @method static CategoryTag|Proxy                random(array $attributes = [])
+ * @method static CategoryTag|Proxy                randomOrCreate(array $attributes = [])
+ * @method static CategoryTag[]|Proxy[]            all()
+ * @method static CategoryTag[]|Proxy[]            findBy(array $attributes)
+ * @method static CategoryTag[]|Proxy[]            randomSet(int $number, array $attributes = [])
+ * @method static CategoryTag[]|Proxy[]            randomRange(int $min, int $max, array $attributes = [])
+ * @method static EntityRepository|RepositoryProxy repository()
+ * @method        CategoryTag|Proxy                create(array|callable $attributes = [])
+ */
+final class CategoryTagFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'name' => self::faker()->word(),
+        ];
+    }
+
+    protected function initialize(): self
+    {
+        return $this;
+    }
+
+    protected static function getClass(): string
+    {
+        return CategoryTag::class;
+    }
+}

--- a/src/Autocomplete/tests/Fixtures/Factory/ProductTagFactory.php
+++ b/src/Autocomplete/tests/Fixtures/Factory/ProductTagFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Autocomplete\Tests\Fixtures\Factory;
+
+use Doctrine\ORM\EntityRepository;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\ProductTag;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
+
+/**
+ * @extends ModelFactory<ProductTag>
+ *
+ * @method static ProductTag|Proxy                createOne(array $attributes = [])
+ * @method static ProductTag[]|Proxy[]            createMany(int $number, array|callable $attributes = [])
+ * @method static ProductTag|Proxy                find(object|array|mixed $criteria)
+ * @method static ProductTag|Proxy                findOrCreate(array $attributes)
+ * @method static ProductTag|Proxy                first(string $sortedField = 'id')
+ * @method static ProductTag|Proxy                last(string $sortedField = 'id')
+ * @method static ProductTag|Proxy                random(array $attributes = [])
+ * @method static ProductTag|Proxy                randomOrCreate(array $attributes = [])
+ * @method static ProductTag[]|Proxy[]            all()
+ * @method static ProductTag[]|Proxy[]            findBy(array $attributes)
+ * @method static ProductTag[]|Proxy[]            randomSet(int $number, array $attributes = [])
+ * @method static ProductTag[]|Proxy[]            randomRange(int $min, int $max, array $attributes = [])
+ * @method static EntityRepository|RepositoryProxy repository()
+ * @method        ProductTag|Proxy                create(array|callable $attributes = [])
+ */
+final class ProductTagFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'name' => self::faker()->word(),
+        ];
+    }
+
+    protected function initialize(): self
+    {
+        return $this;
+    }
+
+    protected static function getClass(): string
+    {
+        return ProductTag::class;
+    }
+}

--- a/src/Autocomplete/tests/Fixtures/Form/ProductWithTagsAutocompleteType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/ProductWithTagsAutocompleteType.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Autocomplete\Tests\Fixtures\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Product;
+
+#[AsEntityAutocompleteField]
+class ProductWithTagsAutocompleteType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'class' => Product::class,
+            'choice_label' => function (Product $product) {
+                return '<strong>'.$product->getName().'</strong>';
+            },
+            'multiple' => true,
+            'searchable_fields' => [
+                'tags.name',
+                'category.tags.name',
+            ],
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return BaseEntityAutocompleteType::class;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #2370
| License       | MIT

Changes:

- The alias generation logic has been improved to correctly handle nested associations and avoid alias collisions.
- The code was modified to ensure that the parent entity is correctly accounted for when generating aliases, which helps prevent issues in complex joins with multiple associated entities.
- A check was added to verify the existence of a parent property before using it as part of the alias. This prevents logical errors in cases where the parent entity is not directly involved in the join.