### PR TITLE
[Map] Fix typos 'an' should be 'a' in READMEs

### DIFF
--- a/src/Map/src/Bridge/Google/README.md
+++ b/src/Map/src/Bridge/Google/README.md
@@ -119,7 +119,7 @@ export default class extends Controller
 
         // 1. To use a custom image for the marker 
         const beachFlagImg = document.createElement("img");
-        // Note: instead of using an hardcoded URL, you can use the `extra` parameter from `new Marker()` (PHP) and access it here with `definition.extra`.
+        // Note: instead of using a hardcoded URL, you can use the `extra` parameter from `new Marker()` (PHP) and access it here with `definition.extra`.
         beachFlagImg.src = "https://developers.google.com/maps/documentation/javascript/examples/full/images/beachflag.png";
         definition.rawOptions =  { 
             content: beachFlagImg
@@ -127,7 +127,7 @@ export default class extends Controller
       
         // 2. To use a custom glyph for the marker
         const pinElement = new google.maps.marker.PinElement({
-            // Note: instead of using an hardcoded URL, you can use the `extra` parameter from `new Marker()` (PHP) and access it here with `definition.extra`. 
+            // Note: instead of using a hardcoded URL, you can use the `extra` parameter from `new Marker()` (PHP) and access it here with `definition.extra`. 
             glyph: new URL('https://maps.gstatic.com/mapfiles/place_api/icons/v2/museum_pinlet.svg'), 
             glyphColor: "white",
         });

--- a/src/Map/src/Bridge/Leaflet/README.md
+++ b/src/Map/src/Bridge/Leaflet/README.md
@@ -73,7 +73,7 @@ export default class extends Controller
 
         // Use a custom icon for the marker
         const redIcon = L.icon({
-          // Note: instead of using an hardcoded URL, you can use the `extra` parameter from `new Marker()` (PHP) and access it here with `definition.extra`.
+          // Note: instead of using a hardcoded URL, you can use the `extra` parameter from `new Marker()` (PHP) and access it here with `definition.extra`.
           iconUrl: 'https://leafletjs.com/examples/custom-icons/leaf-red.png',
           shadowUrl: 'https://leafletjs.com/examples/custom-icons/leaf-shadow.png',
           iconSize: [38, 95], // size of the icon


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

| License       | MIT

simple typos fixes.