### PR TITLE
[LiveComponent] Allow form elements to live outside the form tag by using "form" attribute

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -305,7 +305,8 @@ function getModelDirectiveFromElement(element, throwOnMissing = true) {
         return dataModelDirectives[0];
     }
     if (element.getAttribute('name')) {
-        const formElement = element.closest('form');
+        const formId = element.getAttribute('form');
+        const formElement = formId ? document.getElementById(formId) : element.closest('form');
         if (formElement && 'model' in formElement.dataset) {
             const directives = parseDirectives(formElement.dataset.model || '*');
             const directive = directives[0];

--- a/src/LiveComponent/assets/src/dom_utils.ts
+++ b/src/LiveComponent/assets/src/dom_utils.ts
@@ -161,7 +161,8 @@ export function getModelDirectiveFromElement(element: HTMLElement, throwOnMissin
     }
 
     if (element.getAttribute('name')) {
-        const formElement = element.closest('form');
+        const formId = element.getAttribute('form');
+        const formElement = formId ? document.getElementById(formId) : element.closest('form');
         // require a <form data-model="*"> around elements in order to
         // activate automatic "data binding" via the "name" attribute
         if (formElement && 'model' in formElement.dataset) {

--- a/src/LiveComponent/assets/test/dom_utils.test.ts
+++ b/src/LiveComponent/assets/test/dom_utils.test.ts
@@ -230,6 +230,19 @@ describe('getModelDirectiveFromInput', () => {
         expect(directive?.action).toBe('user.firstName');
     });
 
+    it('reads name attribute if element lives out of form and use "form" attribute', () => {
+        const container = document.createElement('div');
+        const formElement = htmlToElement('<form data-model="*" id="my-form"></form>');
+        const element = htmlToElement('<input name="user[firstName]" form="my-form">');
+        container.appendChild(element);
+        container.appendChild(formElement);
+        document.body.appendChild(container);
+
+        const directive = getModelDirectiveFromElement(element);
+        expect(directive).not.toBeNull();
+        expect(directive?.action).toBe('user.firstName');
+    });
+
     it('does NOT reads name attribute if form[data-model] is NOT present', () => {
         const formElement = htmlToElement('<form></form>');
         const element = htmlToElement('<input name="user[firstName]">');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Issues        | 
| License       | MIT

Actually there is an issue if we want to use form elements that live outside the form tag and refer it by using the "form" attribute, i.e:

```html
<input type="text" name="myinput" form="custom-form">
<form data-model="*" id="custom-form"></form>
```

this should work, especially to be able to handle nested forms (managed by others live components).

This PR fix this issue.
