### PR TITLE
[LiveComponent] Fix checkbox/radio value matching

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -250,26 +250,18 @@ function setValueOnElement(element, value) {
             return;
         }
         if (element.type === 'radio') {
-            element.checked = element.value === value;
+            element.checked = element.value == value;
             return;
         }
         if (element.type === 'checkbox') {
             if (Array.isArray(value)) {
-                let valueFound = false;
-                value.forEach((val) => {
-                    if (val === element.value) {
-                        valueFound = true;
-                    }
-                });
-                element.checked = valueFound;
+                element.checked = value.some((val) => val == element.value);
+            }
+            else if (element.hasAttribute('value')) {
+                element.checked = element.value == value;
             }
             else {
-                if (element.hasAttribute('value')) {
-                    element.checked = element.value === value;
-                }
-                else {
-                    element.checked = value;
-                }
+                element.checked = value;
             }
             return;
         }

--- a/src/LiveComponent/assets/src/dom_utils.ts
+++ b/src/LiveComponent/assets/src/dom_utils.ts
@@ -79,34 +79,26 @@ export function setValueOnElement(element: HTMLElement, value: any): void {
         }
 
         if (element.type === 'radio') {
-            element.checked = element.value === value;
+            // biome-ignore lint/suspicious/noDoubleEquals: need fuzzy matching
+            element.checked = element.value == value;
 
             return;
         }
 
         if (element.type === 'checkbox') {
             if (Array.isArray(value)) {
-                // I'm purposely not using Array.includes here because it's
-                // strict, and because of Numeric/String mis-casting, I
-                // want the "includes" to be "fuzzy".
-                let valueFound = false;
-                value.forEach((val) => {
-                    if (val === element.value) {
-                        valueFound = true;
-                    }
-                });
-
-                element.checked = valueFound;
+                // Because of Numeric/String mis-casting,
+                // we want the "includes" to be "fuzzy".
+                // biome-ignore lint/suspicious/noDoubleEquals: need fuzzy matching
+                element.checked = value.some((val) => val == element.value);
+            } else if (element.hasAttribute('value')) {
+                // if the checkbox has a value="", then check if it matches
+                // biome-ignore lint/suspicious/noDoubleEquals: need fuzzy matching
+                element.checked = element.value == value;
             } else {
-                if (element.hasAttribute('value')) {
-                    // if the checkbox has a value="", then check if it matches
-                    element.checked = element.value === value;
-                } else {
-                    // no value, treat it like a boolean
-                    element.checked = value;
-                }
+                // no value, treat it like a boolean
+                element.checked = value;
             }
-
             return;
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Issues        | Fix #...
| License       | MIT

It seems we let [some changes](https://github.com/symfony/ux/commit/b40699762be5cc096f27099a22bd627edbec1b69#diff-9e1dc5b957786f187f0ba493e27e3324bf16cac1129765adacfc2b26b41b6adbR82) appear using linter/formater.. and this time the fuzzy comparaison was intended.

This PR revert those changes to bring back some flexibility and better value matching.
