### PR TITLE
[LiveComponent] fix required select not initialized

### DIFF
--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -258,9 +258,26 @@ trait ComponentWithFormTrait
             if (\array_key_exists('checked', $child->vars)) {
                 // special handling for check boxes
                 $values[$name] = $child->vars['checked'] ? $child->vars['value'] : null;
-            } else {
-                $values[$name] = $child->vars['value'];
+                continue;
             }
+
+            if (\array_key_exists('choices', $child->vars)
+                && $child->vars['required']
+                && !$child->vars['disabled']
+                && !$child->vars['value']
+                && !$child->vars['placeholder']
+                && !$child->vars['multiple']
+                && !$child->vars['expanded']
+                && $child->vars['choices']
+            ) {
+                if (null !== $firstKey = array_key_first($child->vars['choices'])) {
+                    $values[$name] = $child->vars['choices'][$firstKey]->value ?? null;
+                }
+
+                continue;
+            }
+
+            $values[$name] = $child->vars['value'];
         }
 
         return $values;

--- a/src/LiveComponent/tests/Fixtures/Factory/CategoryFixtureEntityFactory.php
+++ b/src/LiveComponent/tests/Fixtures/Factory/CategoryFixtureEntityFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Factory;
+
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\CategoryFixtureEntity;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+final class CategoryFixtureEntityFactory extends PersistentProxyObjectFactory
+{
+    protected function defaults(): array|callable
+    {
+        return [
+            'name' => self::faker()->name(),
+        ];
+    }
+
+    public static function class(): string
+    {
+        return CategoryFixtureEntity::class;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Form;
 
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -22,6 +23,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Length;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\CategoryFixtureEntity;
 
 /**
  * @author Jakub Caban <kuba.iluvatar@gmail.com>
@@ -40,6 +42,20 @@ class FormWithManyDifferentFieldsType extends AbstractType
                 'choices' => [
                     'foo' => 1,
                     'bar' => 2,
+                ],
+                'required' => false,
+            ])
+            ->add('choice_required_with_placeholder', ChoiceType::class, [
+                'choices' => [
+                    'bar' => 2,
+                    'foo' => 1,
+                ],
+                'placeholder' => 'foo',
+            ])
+            ->add('choice_required_without_placeholder', ChoiceType::class, [
+                'choices' => [
+                    'bar' => 2,
+                    'foo' => 1,
                 ],
             ])
             ->add('choice_expanded', ChoiceType::class, [
@@ -63,6 +79,10 @@ class FormWithManyDifferentFieldsType extends AbstractType
                     'bar' => 2,
                 ],
                 'multiple' => true,
+            ])
+            ->add('entity', EntityType::class, [
+                'class' => CategoryFixtureEntity::class,
+                'choice_label' => 'name',
             ])
             ->add('checkbox', CheckboxType::class)
             ->add('checkbox_checked', CheckboxType::class)

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Component\FormWithCollectionTypeComponent;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Factory\CategoryFixtureEntityFactory;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Form\BlogPostFormType;
 use Symfony\UX\LiveComponent\Tests\LiveComponentTestHelper;
 use Zenstruck\Browser\Test\HasBrowser;
@@ -157,6 +158,9 @@ class ComponentWithFormTest extends KernelTestCase
 
     public function testHandleCheckboxChanges(): void
     {
+        $category = CategoryFixtureEntityFactory::createMany(5);
+        $id = $category[0]->getId();
+
         $mounted = $this->mountComponent(
             'form_with_many_different_fields_type',
             [
@@ -174,9 +178,12 @@ class ComponentWithFormTest extends KernelTestCase
             'textarea' => '',
             'range' => '',
             'choice' => '',
+            'choice_required_with_placeholder' => '',
+            'choice_required_without_placeholder' => '2',
             'choice_expanded' => '',
             'choice_multiple' => ['2'],
             'select_multiple' => ['2'],
+            'entity' => (string) $id,
             'checkbox' => null,
             'checkbox_checked' => '1',
             'file' => '',
@@ -296,6 +303,7 @@ class ComponentWithFormTest extends KernelTestCase
 
     public function testResetForm(): void
     {
+        CategoryFixtureEntityFactory::createMany(5);
         $mounted = $this->mountComponent('form_with_many_different_fields_type');
 
         $dehydratedProps = $this->dehydrateComponent($mounted)->getProps();

--- a/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
+++ b/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Component\Component2;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Factory\CategoryFixtureEntityFactory;
+use Zenstruck\Foundry\Test\ResetDatabase;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -24,6 +26,7 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Component\Component2;
 final class InteractsWithLiveComponentsTest extends KernelTestCase
 {
     use InteractsWithLiveComponents;
+    use ResetDatabase;
 
     public function testCanRenderInitialData(): void
     {
@@ -172,6 +175,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
 
     public function testCanSubmitForm(): void
     {
+        CategoryFixtureEntityFactory::createMany(5);
         $testComponent = $this->createLiveComponent('form_with_many_different_fields_type');
 
         $response = $testComponent->submitForm(['form' => ['text' => 'foobar']])->response();

--- a/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
@@ -13,14 +13,21 @@ namespace Symfony\UX\LiveComponent\Tests\Unit\Form;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Component\FormComponentWithManyDifferentFieldsType;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Factory\CategoryFixtureEntityFactory;
+use Zenstruck\Foundry\Test\ResetDatabase;
 
 /**
  * @author Jakub Caban <kuba.iluvatar@gmail.com>
  */
 class ComponentWithFormTest extends KernelTestCase
 {
+    use ResetDatabase;
+
     public function testFormValues(): void
     {
+        $category = CategoryFixtureEntityFactory::createMany(5);
+        $id = $category[0]->getId();
+
         $formFactory = self::getContainer()->get('form.factory');
         $component = new FormComponentWithManyDifferentFieldsType($formFactory);
         $component->initialData = [
@@ -36,9 +43,12 @@ class ComponentWithFormTest extends KernelTestCase
                 'textarea' => '',
                 'range' => '',
                 'choice' => '',
+                'choice_required_with_placeholder' => '',
+                'choice_required_without_placeholder' => '2',
                 'choice_expanded' => '',
                 'choice_multiple' => ['2'],
                 'select_multiple' => ['2'],
+                'entity' => (string) $id,
                 'checkbox' => null,
                 'checkbox_checked' => '1',
                 'file' => '',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1332 
| License       | MIT

Initialize required select(ChoiceType or EntityType) with the first entry. Not applied to multiple or expanded.
