### PR TITLE
[Map] Fix and improve TypeScript types, refactor same logic into dedicated methods (to reduce file size)

### DIFF
--- a/src/Map/assets/dist/abstract_map_controller.d.ts
+++ b/src/Map/assets/dist/abstract_map_controller.d.ts
@@ -62,11 +62,11 @@ export default abstract class<MapOptions, Map, MarkerOptions, Marker, InfoWindow
     protected polylines: globalThis.Map<string, Polyline>;
     protected infoWindows: Array<InfoWindow>;
     private isConnected;
+    private createMarker;
+    private createPolygon;
+    private createPolyline;
     protected abstract dispatchEvent(name: string, payload: Record<string, unknown>): void;
     connect(): void;
-    createMarker(definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>): Marker;
-    createPolygon(definition: PolygonDefinition<PolygonOptions, InfoWindowOptions>): Polygon;
-    createPolyline(definition: PolylineDefinition<PolylineOptions, InfoWindowOptions>): Polyline;
     createInfoWindow({ definition, element, }: {
         definition: InfoWindowWithoutPositionDefinition<InfoWindowOptions>;
         element: Marker | Polygon | Polyline;
@@ -82,14 +82,21 @@ export default abstract class<MapOptions, Map, MarkerOptions, Marker, InfoWindow
         options: MapOptions;
     }): Map;
     protected abstract doFitBoundsToMarkers(): void;
-    protected abstract doCreateMarker(definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>): Marker;
+    protected abstract doCreateMarker({ definition, }: {
+        definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>;
+    }): Marker;
     protected abstract doRemoveMarker(marker: Marker): void;
-    protected abstract doCreatePolygon(definition: PolygonDefinition<PolygonOptions, InfoWindowOptions>): Polygon;
+    protected abstract doCreatePolygon({ definition, }: {
+        definition: PolygonDefinition<PolygonOptions, InfoWindowOptions>;
+    }): Polygon;
     protected abstract doRemovePolygon(polygon: Polygon): void;
-    protected abstract doCreatePolyline(definition: PolylineDefinition<PolylineOptions, InfoWindowOptions>): Polyline;
+    protected abstract doCreatePolyline({ definition, }: {
+        definition: PolylineDefinition<PolylineOptions, InfoWindowOptions>;
+    }): Polyline;
     protected abstract doRemovePolyline(polyline: Polyline): void;
     protected abstract doCreateInfoWindow({ definition, element, }: {
         definition: InfoWindowWithoutPositionDefinition<InfoWindowOptions>;
         element: Marker | Polygon | Polyline;
     }): InfoWindow;
+    private createDrawingFactory;
 }

--- a/src/Map/assets/dist/abstract_map_controller.d.ts
+++ b/src/Map/assets/dist/abstract_map_controller.d.ts
@@ -3,30 +3,31 @@ export type Point = {
     lat: number;
     lng: number;
 };
-export type MarkerDefinition<MarkerOptions, InfoWindowOptions> = {
-    '@id': string;
+export type Identifier = string;
+export type WithIdentifier<T extends Record<string, unknown>> = T & {
+    '@id': Identifier;
+};
+export type MarkerDefinition<MarkerOptions, InfoWindowOptions> = WithIdentifier<{
     position: Point;
     title: string | null;
-    infoWindow?: Omit<InfoWindowDefinition<InfoWindowOptions>, 'position'>;
+    infoWindow?: InfoWindowWithoutPositionDefinition<InfoWindowOptions>;
     rawOptions?: MarkerOptions;
     extra: Record<string, unknown>;
-};
-export type PolygonDefinition<PolygonOptions, InfoWindowOptions> = {
-    '@id': string;
-    infoWindow?: Omit<InfoWindowDefinition<InfoWindowOptions>, 'position'>;
+}>;
+export type PolygonDefinition<PolygonOptions, InfoWindowOptions> = WithIdentifier<{
+    infoWindow?: InfoWindowWithoutPositionDefinition<InfoWindowOptions>;
     points: Array<Point>;
     title: string | null;
     rawOptions?: PolygonOptions;
     extra: Record<string, unknown>;
-};
-export type PolylineDefinition<PolylineOptions, InfoWindowOptions> = {
-    '@id': string;
-    infoWindow?: Omit<InfoWindowDefinition<InfoWindowOptions>, 'position'>;
+}>;
+export type PolylineDefinition<PolylineOptions, InfoWindowOptions> = WithIdentifier<{
+    infoWindow?: InfoWindowWithoutPositionDefinition<InfoWindowOptions>;
     points: Array<Point>;
     title: string | null;
     rawOptions?: PolylineOptions;
     extra: Record<string, unknown>;
-};
+}>;
 export type InfoWindowDefinition<InfoWindowOptions> = {
     headerContent: string | null;
     content: string | null;
@@ -36,6 +37,7 @@ export type InfoWindowDefinition<InfoWindowOptions> = {
     rawOptions?: InfoWindowOptions;
     extra: Record<string, unknown>;
 };
+export type InfoWindowWithoutPositionDefinition<InfoWindowOptions> = Omit<InfoWindowDefinition<InfoWindowOptions>, 'position'>;
 export default abstract class<MapOptions, Map, MarkerOptions, Marker, InfoWindowOptions, InfoWindow, PolygonOptions, Polygon, PolylineOptions, Polyline> extends Controller<HTMLElement> {
     static values: {
         providerOptions: ObjectConstructor;
@@ -55,50 +57,39 @@ export default abstract class<MapOptions, Map, MarkerOptions, Marker, InfoWindow
     polylinesValue: Array<PolylineDefinition<PolylineOptions, InfoWindowOptions>>;
     optionsValue: MapOptions;
     protected map: Map;
-    protected markers: globalThis.Map<any, any>;
+    protected markers: globalThis.Map<string, Marker>;
+    protected polygons: globalThis.Map<string, Polygon>;
+    protected polylines: globalThis.Map<string, Polyline>;
     protected infoWindows: Array<InfoWindow>;
-    protected polygons: globalThis.Map<any, any>;
-    protected polylines: globalThis.Map<any, any>;
-    connect(): void;
-    protected abstract doCreateMap({ center, zoom, options, }: {
-        center: Point | null;
-        zoom: number | null;
-        options: MapOptions;
-    }): Map;
-    createMarker(definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>): Marker;
-    protected abstract removeMarker(marker: Marker): void;
-    protected abstract doCreateMarker(definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>): Marker;
-    createPolygon(definition: PolygonDefinition<PolygonOptions, InfoWindowOptions>): Polygon;
-    protected abstract removePolygon(polygon: Polygon): void;
-    protected abstract doCreatePolygon(definition: PolygonDefinition<PolygonOptions, InfoWindowOptions>): Polygon;
-    createPolyline(definition: PolylineDefinition<PolylineOptions, InfoWindowOptions>): Polyline;
-    protected abstract removePolyline(polyline: Polyline): void;
-    protected abstract doCreatePolyline(definition: PolylineDefinition<PolylineOptions, InfoWindowOptions>): Polyline;
-    protected createInfoWindow({ definition, element, }: {
-        definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>['infoWindow'];
-        element: Marker;
-    } | {
-        definition: PolygonDefinition<PolygonOptions, InfoWindowOptions>['infoWindow'];
-        element: Polygon;
-    } | {
-        definition: PolylineDefinition<PolylineOptions, InfoWindowOptions>['infoWindow'];
-        element: Polyline;
-    }): InfoWindow;
-    protected abstract doCreateInfoWindow({ definition, element, }: {
-        definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>['infoWindow'];
-        element: Marker;
-    } | {
-        definition: PolygonDefinition<PolygonOptions, InfoWindowOptions>['infoWindow'];
-        element: Polygon;
-    } | {
-        definition: PolylineDefinition<PolylineOptions, InfoWindowOptions>['infoWindow'];
-        element: Polyline;
-    }): InfoWindow;
-    protected abstract doFitBoundsToMarkers(): void;
+    private isConnected;
     protected abstract dispatchEvent(name: string, payload: Record<string, unknown>): void;
+    connect(): void;
+    createMarker(definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>): Marker;
+    createPolygon(definition: PolygonDefinition<PolygonOptions, InfoWindowOptions>): Polygon;
+    createPolyline(definition: PolylineDefinition<PolylineOptions, InfoWindowOptions>): Polyline;
+    createInfoWindow({ definition, element, }: {
+        definition: InfoWindowWithoutPositionDefinition<InfoWindowOptions>;
+        element: Marker | Polygon | Polyline;
+    }): InfoWindow;
     abstract centerValueChanged(): void;
     abstract zoomValueChanged(): void;
     markersValueChanged(): void;
     polygonsValueChanged(): void;
     polylinesValueChanged(): void;
+    protected abstract doCreateMap({ center, zoom, options, }: {
+        center: Point | null;
+        zoom: number | null;
+        options: MapOptions;
+    }): Map;
+    protected abstract doFitBoundsToMarkers(): void;
+    protected abstract doCreateMarker(definition: MarkerDefinition<MarkerOptions, InfoWindowOptions>): Marker;
+    protected abstract doRemoveMarker(marker: Marker): void;
+    protected abstract doCreatePolygon(definition: PolygonDefinition<PolygonOptions, InfoWindowOptions>): Polygon;
+    protected abstract doRemovePolygon(polygon: Polygon): void;
+    protected abstract doCreatePolyline(definition: PolylineDefinition<PolylineOptions, InfoWindowOptions>): Polyline;
+    protected abstract doRemovePolyline(polyline: Polyline): void;
+    protected abstract doCreateInfoWindow({ definition, element, }: {
+        definition: InfoWindowWithoutPositionDefinition<InfoWindowOptions>;
+        element: Marker | Polygon | Polyline;
+    }): InfoWindow;
 }

--- a/src/Map/assets/dist/abstract_map_controller.d.ts
+++ b/src/Map/assets/dist/abstract_map_controller.d.ts
@@ -99,4 +99,5 @@ export default abstract class<MapOptions, Map, MarkerOptions, Marker, InfoWindow
         element: Marker | Polygon | Polyline;
     }): InfoWindow;
     private createDrawingFactory;
+    private onDrawChanged;
 }

--- a/src/Map/assets/dist/abstract_map_controller.js
+++ b/src/Map/assets/dist/abstract_map_controller.js
@@ -42,20 +42,7 @@ class default_1 extends Controller {
         if (!this.isConnected) {
             return;
         }
-        const idsToRemove = new Set(this.markers.keys());
-        this.markersValue.forEach((definition) => {
-            idsToRemove.delete(definition['@id']);
-        });
-        idsToRemove.forEach((id) => {
-            const marker = this.markers.get(id);
-            this.doRemoveMarker(marker);
-            this.markers.delete(id);
-        });
-        this.markersValue.forEach((definition) => {
-            if (!this.markers.has(definition['@id'])) {
-                this.createMarker({ definition });
-            }
-        });
+        this.onDrawChanged(this.markers, this.markersValue, this.createMarker, this.doRemoveMarker);
         if (this.fitBoundsToMarkersValue) {
             this.doFitBoundsToMarkers();
         }
@@ -64,50 +51,40 @@ class default_1 extends Controller {
         if (!this.isConnected) {
             return;
         }
-        const idsToRemove = new Set(this.polygons.keys());
-        this.polygonsValue.forEach((definition) => {
-            idsToRemove.delete(definition['@id']);
-        });
-        idsToRemove.forEach((id) => {
-            const polygon = this.polygons.get(id);
-            this.doRemovePolygon(polygon);
-            this.polygons.delete(id);
-        });
-        this.polygonsValue.forEach((definition) => {
-            if (!this.polygons.has(definition['@id'])) {
-                this.createPolygon({ definition });
-            }
-        });
+        this.onDrawChanged(this.polygons, this.polygonsValue, this.createPolygon, this.doRemovePolygon);
     }
     polylinesValueChanged() {
         if (!this.isConnected) {
             return;
         }
-        const idsToRemove = new Set(this.polylines.keys());
-        this.polylinesValue.forEach((definition) => {
-            idsToRemove.delete(definition['@id']);
-        });
-        idsToRemove.forEach((id) => {
-            const polyline = this.polylines.get(id);
-            this.doRemovePolyline(polyline);
-            this.polylines.delete(id);
-        });
-        this.polylinesValue.forEach((definition) => {
-            if (!this.polylines.has(definition['@id'])) {
-                this.createPolyline({ definition });
-            }
-        });
+        this.onDrawChanged(this.polylines, this.polylinesValue, this.createPolyline, this.doRemovePolyline);
     }
     createDrawingFactory(type, draws, factory) {
         const eventBefore = `${type}:before-create`;
         const eventAfter = `${type}:after-create`;
         return ({ definition }) => {
             this.dispatchEvent(eventBefore, { definition });
-            const drawing = factory(definition);
+            const drawing = factory({ definition });
             this.dispatchEvent(eventAfter, { [type]: drawing });
             draws.set(definition['@id'], drawing);
             return drawing;
         };
+    }
+    onDrawChanged(draws, newDrawDefinitions, factory, remover) {
+        const idsToRemove = new Set(draws.keys());
+        newDrawDefinitions.forEach((definition) => {
+            idsToRemove.delete(definition['@id']);
+        });
+        idsToRemove.forEach((id) => {
+            const draw = draws.get(id);
+            remover(draw);
+            draws.delete(id);
+        });
+        newDrawDefinitions.forEach((definition) => {
+            if (!draws.has(definition['@id'])) {
+                factory({ definition });
+            }
+        });
     }
 }
 default_1.values = {

--- a/src/Map/assets/dist/abstract_map_controller.js
+++ b/src/Map/assets/dist/abstract_map_controller.js
@@ -4,9 +4,10 @@ class default_1 extends Controller {
     constructor() {
         super(...arguments);
         this.markers = new Map();
-        this.infoWindows = [];
         this.polygons = new Map();
         this.polylines = new Map();
+        this.infoWindows = [];
+        this.isConnected = false;
     }
     connect() {
         const options = this.optionsValue;
@@ -25,12 +26,12 @@ class default_1 extends Controller {
             polylines: [...this.polylines.values()],
             infoWindows: this.infoWindows,
         });
+        this.isConnected = true;
     }
     createMarker(definition) {
         this.dispatchEvent('marker:before-create', { definition });
         const marker = this.doCreateMarker(definition);
         this.dispatchEvent('marker:after-create', { marker });
-        marker['@id'] = definition['@id'];
         this.markers.set(definition['@id'], marker);
         return marker;
     }
@@ -38,7 +39,6 @@ class default_1 extends Controller {
         this.dispatchEvent('polygon:before-create', { definition });
         const polygon = this.doCreatePolygon(definition);
         this.dispatchEvent('polygon:after-create', { polygon });
-        polygon['@id'] = definition['@id'];
         this.polygons.set(definition['@id'], polygon);
         return polygon;
     }
@@ -46,7 +46,6 @@ class default_1 extends Controller {
         this.dispatchEvent('polyline:before-create', { definition });
         const polyline = this.doCreatePolyline(definition);
         this.dispatchEvent('polyline:after-create', { polyline });
-        polyline['@id'] = definition['@id'];
         this.polylines.set(definition['@id'], polyline);
         return polyline;
     }
@@ -58,18 +57,21 @@ class default_1 extends Controller {
         return infoWindow;
     }
     markersValueChanged() {
-        if (!this.map) {
+        if (!this.isConnected) {
             return;
         }
-        this.markers.forEach((marker) => {
-            if (!this.markersValue.find((m) => m['@id'] === marker['@id'])) {
-                this.removeMarker(marker);
-                this.markers.delete(marker['@id']);
-            }
+        const idsToRemove = new Set(this.markers.keys());
+        this.markersValue.forEach((definition) => {
+            idsToRemove.delete(definition['@id']);
         });
-        this.markersValue.forEach((marker) => {
-            if (!this.markers.has(marker['@id'])) {
-                this.createMarker(marker);
+        idsToRemove.forEach((id) => {
+            const marker = this.markers.get(id);
+            this.doRemoveMarker(marker);
+            this.markers.delete(id);
+        });
+        this.markersValue.forEach((definition) => {
+            if (!this.markers.has(definition['@id'])) {
+                this.createMarker(definition);
             }
         });
         if (this.fitBoundsToMarkersValue) {
@@ -77,34 +79,40 @@ class default_1 extends Controller {
         }
     }
     polygonsValueChanged() {
-        if (!this.map) {
+        if (!this.isConnected) {
             return;
         }
-        this.polygons.forEach((polygon) => {
-            if (!this.polygonsValue.find((p) => p['@id'] === polygon['@id'])) {
-                this.removePolygon(polygon);
-                this.polygons.delete(polygon['@id']);
-            }
+        const idsToRemove = new Set(this.polygons.keys());
+        this.polygonsValue.forEach((definition) => {
+            idsToRemove.delete(definition['@id']);
         });
-        this.polygonsValue.forEach((polygon) => {
-            if (!this.polygons.has(polygon['@id'])) {
-                this.createPolygon(polygon);
+        idsToRemove.forEach((id) => {
+            const polygon = this.polygons.get(id);
+            this.doRemovePolygon(polygon);
+            this.polygons.delete(id);
+        });
+        this.polygonsValue.forEach((definition) => {
+            if (!this.polygons.has(definition['@id'])) {
+                this.createPolygon(definition);
             }
         });
     }
     polylinesValueChanged() {
-        if (!this.map) {
+        if (!this.isConnected) {
             return;
         }
-        this.polylines.forEach((polyline) => {
-            if (!this.polylinesValue.find((p) => p['@id'] === polyline['@id'])) {
-                this.removePolyline(polyline);
-                this.polylines.delete(polyline['@id']);
-            }
+        const idsToRemove = new Set(this.polylines.keys());
+        this.polylinesValue.forEach((definition) => {
+            idsToRemove.delete(definition['@id']);
         });
-        this.polylinesValue.forEach((polyline) => {
-            if (!this.polylines.has(polyline['@id'])) {
-                this.createPolyline(polyline);
+        idsToRemove.forEach((id) => {
+            const polyline = this.polylines.get(id);
+            this.doRemovePolyline(polyline);
+            this.polylines.delete(id);
+        });
+        this.polylinesValue.forEach((definition) => {
+            if (!this.polylines.has(definition['@id'])) {
+                this.createPolyline(definition);
             }
         });
     }

--- a/src/Map/assets/dist/abstract_map_controller.js
+++ b/src/Map/assets/dist/abstract_map_controller.js
@@ -12,10 +12,13 @@ class default_1 extends Controller {
     connect() {
         const options = this.optionsValue;
         this.dispatchEvent('pre-connect', { options });
+        this.createMarker = this.createDrawingFactory('marker', this.markers, this.doCreateMarker.bind(this));
+        this.createPolygon = this.createDrawingFactory('polygon', this.polygons, this.doCreatePolygon.bind(this));
+        this.createPolyline = this.createDrawingFactory('polyline', this.polylines, this.doCreatePolyline.bind(this));
         this.map = this.doCreateMap({ center: this.centerValue, zoom: this.zoomValue, options });
-        this.markersValue.forEach((marker) => this.createMarker(marker));
-        this.polygonsValue.forEach((polygon) => this.createPolygon(polygon));
-        this.polylinesValue.forEach((polyline) => this.createPolyline(polyline));
+        this.markersValue.forEach((definition) => this.createMarker({ definition }));
+        this.polygonsValue.forEach((definition) => this.createPolygon({ definition }));
+        this.polylinesValue.forEach((definition) => this.createPolyline({ definition }));
         if (this.fitBoundsToMarkersValue) {
             this.doFitBoundsToMarkers();
         }
@@ -27,27 +30,6 @@ class default_1 extends Controller {
             infoWindows: this.infoWindows,
         });
         this.isConnected = true;
-    }
-    createMarker(definition) {
-        this.dispatchEvent('marker:before-create', { definition });
-        const marker = this.doCreateMarker(definition);
-        this.dispatchEvent('marker:after-create', { marker });
-        this.markers.set(definition['@id'], marker);
-        return marker;
-    }
-    createPolygon(definition) {
-        this.dispatchEvent('polygon:before-create', { definition });
-        const polygon = this.doCreatePolygon(definition);
-        this.dispatchEvent('polygon:after-create', { polygon });
-        this.polygons.set(definition['@id'], polygon);
-        return polygon;
-    }
-    createPolyline(definition) {
-        this.dispatchEvent('polyline:before-create', { definition });
-        const polyline = this.doCreatePolyline(definition);
-        this.dispatchEvent('polyline:after-create', { polyline });
-        this.polylines.set(definition['@id'], polyline);
-        return polyline;
     }
     createInfoWindow({ definition, element, }) {
         this.dispatchEvent('info-window:before-create', { definition, element });
@@ -71,7 +53,7 @@ class default_1 extends Controller {
         });
         this.markersValue.forEach((definition) => {
             if (!this.markers.has(definition['@id'])) {
-                this.createMarker(definition);
+                this.createMarker({ definition });
             }
         });
         if (this.fitBoundsToMarkersValue) {
@@ -93,7 +75,7 @@ class default_1 extends Controller {
         });
         this.polygonsValue.forEach((definition) => {
             if (!this.polygons.has(definition['@id'])) {
-                this.createPolygon(definition);
+                this.createPolygon({ definition });
             }
         });
     }
@@ -112,9 +94,20 @@ class default_1 extends Controller {
         });
         this.polylinesValue.forEach((definition) => {
             if (!this.polylines.has(definition['@id'])) {
-                this.createPolyline(definition);
+                this.createPolyline({ definition });
             }
         });
+    }
+    createDrawingFactory(type, draws, factory) {
+        const eventBefore = `${type}:before-create`;
+        const eventAfter = `${type}:after-create`;
+        return ({ definition }) => {
+            this.dispatchEvent(eventBefore, { definition });
+            const drawing = factory(definition);
+            this.dispatchEvent(eventAfter, { [type]: drawing });
+            draws.set(definition['@id'], drawing);
+            return drawing;
+        };
     }
 }
 default_1.values = {

--- a/src/Map/assets/test/abstract_map_controller.test.ts
+++ b/src/Map/assets/test/abstract_map_controller.test.ts
@@ -16,7 +16,7 @@ class MyMapController extends AbstractMapController {
         return { map: 'map', center, zoom, options };
     }
 
-    doCreateMarker(definition) {
+    doCreateMarker({ definition }) {
         const marker = { marker: 'marker', title: definition.title };
 
         if (definition.infoWindow) {
@@ -26,7 +26,7 @@ class MyMapController extends AbstractMapController {
         return marker;
     }
 
-    doCreatePolygon(definition) {
+    doCreatePolygon({ definition }) {
         const polygon = { polygon: 'polygon', title: definition.title };
 
         if (definition.infoWindow) {
@@ -35,7 +35,7 @@ class MyMapController extends AbstractMapController {
         return polygon;
     }
 
-    doCreatePolyline(definition) {
+    doCreatePolyline({ definition }) {
         const polyline = { polyline: 'polyline', title: definition.title };
 
         if (definition.infoWindow) {
@@ -103,20 +103,18 @@ describe('AbstractMapController', () => {
         expect(controller.map).toEqual({ map: 'map', center: { lat: 48.8566, lng: 2.3522 }, zoom: 4, options: {} });
         expect(controller.markers).toEqual(
             new Map([
-                ['a69f13edd2e571f3', { '@id': 'a69f13edd2e571f3', marker: 'marker', title: 'Paris' }],
-                ['cb9c1a30d562694b', { '@id': 'cb9c1a30d562694b', marker: 'marker', title: 'Lyon' }],
-                ['e6b3acef1325fb52', { '@id': 'e6b3acef1325fb52', marker: 'marker', title: 'Toulouse' }],
+                ['a69f13edd2e571f3', { marker: 'marker', title: 'Paris' }],
+                ['cb9c1a30d562694b', { marker: 'marker', title: 'Lyon' }],
+                ['e6b3acef1325fb52', { marker: 'marker', title: 'Toulouse' }],
             ])
         );
         expect(controller.polygons).toEqual(
             new Map([
-                ['228ae6f5c1b17cfd', { '@id': '228ae6f5c1b17cfd', polygon: 'polygon', title: null }],
-                ['9874334e4e8caa16', { '@id': '9874334e4e8caa16', polygon: 'polygon', title: null }],
+                ['228ae6f5c1b17cfd', { polygon: 'polygon', title: null }],
+                ['9874334e4e8caa16', { polygon: 'polygon', title: null }],
             ])
         );
-        expect(controller.polylines).toEqual(
-            new Map([['0fa955da866c7720', { '@id': '0fa955da866c7720', polyline: 'polyline', title: null }]])
-        );
+        expect(controller.polylines).toEqual(new Map([['0fa955da866c7720', { polyline: 'polyline', title: null }]]));
         expect(controller.infoWindows).toEqual([
             {
                 headerContent: 'Paris',

--- a/src/Map/src/Bridge/Google/assets/dist/map_controller.d.ts
+++ b/src/Map/src/Bridge/Google/assets/dist/map_controller.d.ts
@@ -1,10 +1,13 @@
 import AbstractMapController from '@symfony/ux-map';
-import type { Point, MarkerDefinition, PolygonDefinition, PolylineDefinition } from '@symfony/ux-map';
+import type { Point, MarkerDefinition, PolygonDefinition, PolylineDefinition, InfoWindowWithoutPositionDefinition } from '@symfony/ux-map';
 import type { LoaderOptions } from '@googlemaps/js-api-loader';
 type MapOptions = Pick<google.maps.MapOptions, 'mapId' | 'gestureHandling' | 'backgroundColor' | 'disableDoubleClickZoom' | 'zoomControl' | 'zoomControlOptions' | 'mapTypeControl' | 'mapTypeControlOptions' | 'streetViewControl' | 'streetViewControlOptions' | 'fullscreenControl' | 'fullscreenControlOptions'>;
 export default class extends AbstractMapController<MapOptions, google.maps.Map, google.maps.marker.AdvancedMarkerElementOptions, google.maps.marker.AdvancedMarkerElement, google.maps.InfoWindowOptions, google.maps.InfoWindow, google.maps.PolygonOptions, google.maps.Polygon, google.maps.PolylineOptions, google.maps.Polyline> {
     providerOptionsValue: Pick<LoaderOptions, 'apiKey' | 'id' | 'language' | 'region' | 'nonce' | 'retries' | 'url' | 'version' | 'libraries'>;
+    map: google.maps.Map;
     connect(): Promise<void>;
+    centerValueChanged(): void;
+    zoomValueChanged(): void;
     protected dispatchEvent(name: string, payload?: Record<string, unknown>): void;
     protected doCreateMap({ center, zoom, options, }: {
         center: Point | null;
@@ -12,25 +15,17 @@ export default class extends AbstractMapController<MapOptions, google.maps.Map, 
         options: MapOptions;
     }): google.maps.Map;
     protected doCreateMarker(definition: MarkerDefinition<google.maps.marker.AdvancedMarkerElementOptions, google.maps.InfoWindowOptions>): google.maps.marker.AdvancedMarkerElement;
-    protected removeMarker(marker: google.maps.marker.AdvancedMarkerElement): void;
-    protected doCreatePolygon(definition: PolygonDefinition<google.maps.Polygon, google.maps.InfoWindowOptions>): google.maps.Polygon;
-    protected removePolygon(polygon: google.maps.Polygon): void;
-    protected doCreatePolyline(definition: PolylineDefinition<google.maps.Polyline, google.maps.InfoWindowOptions>): google.maps.Polyline;
-    protected removePolyline(polyline: google.maps.Polyline): void;
+    protected doRemoveMarker(marker: google.maps.marker.AdvancedMarkerElement): void;
+    protected doCreatePolygon(definition: PolygonDefinition<google.maps.PolygonOptions, google.maps.InfoWindowOptions>): google.maps.Polygon;
+    protected doRemovePolygon(polygon: google.maps.Polygon): void;
+    protected doCreatePolyline(definition: PolylineDefinition<google.maps.PolylineOptions, google.maps.InfoWindowOptions>): google.maps.Polyline;
+    protected doRemovePolyline(polyline: google.maps.Polyline): void;
     protected doCreateInfoWindow({ definition, element, }: {
-        definition: MarkerDefinition<google.maps.marker.AdvancedMarkerElementOptions, google.maps.InfoWindowOptions>['infoWindow'];
-        element: google.maps.marker.AdvancedMarkerElement;
-    } | {
-        definition: PolygonDefinition<google.maps.Polygon, google.maps.InfoWindowOptions>['infoWindow'];
-        element: google.maps.Polygon;
-    } | {
-        definition: PolylineDefinition<google.maps.Polyline, google.maps.InfoWindowOptions>['infoWindow'];
-        element: google.maps.Polyline;
+        definition: InfoWindowWithoutPositionDefinition<google.maps.InfoWindowOptions>;
+        element: google.maps.marker.AdvancedMarkerElement | google.maps.Polygon | google.maps.Polyline;
     }): google.maps.InfoWindow;
+    protected doFitBoundsToMarkers(): void;
     private createTextOrElement;
     private closeInfoWindowsExcept;
-    protected doFitBoundsToMarkers(): void;
-    centerValueChanged(): void;
-    zoomValueChanged(): void;
 }
 export {};

--- a/src/Map/src/Bridge/Google/assets/dist/map_controller.d.ts
+++ b/src/Map/src/Bridge/Google/assets/dist/map_controller.d.ts
@@ -14,11 +14,17 @@ export default class extends AbstractMapController<MapOptions, google.maps.Map, 
         zoom: number | null;
         options: MapOptions;
     }): google.maps.Map;
-    protected doCreateMarker(definition: MarkerDefinition<google.maps.marker.AdvancedMarkerElementOptions, google.maps.InfoWindowOptions>): google.maps.marker.AdvancedMarkerElement;
+    protected doCreateMarker({ definition, }: {
+        definition: MarkerDefinition<google.maps.marker.AdvancedMarkerElementOptions, google.maps.InfoWindowOptions>;
+    }): google.maps.marker.AdvancedMarkerElement;
     protected doRemoveMarker(marker: google.maps.marker.AdvancedMarkerElement): void;
-    protected doCreatePolygon(definition: PolygonDefinition<google.maps.PolygonOptions, google.maps.InfoWindowOptions>): google.maps.Polygon;
+    protected doCreatePolygon({ definition, }: {
+        definition: PolygonDefinition<google.maps.PolygonOptions, google.maps.InfoWindowOptions>;
+    }): google.maps.Polygon;
     protected doRemovePolygon(polygon: google.maps.Polygon): void;
-    protected doCreatePolyline(definition: PolylineDefinition<google.maps.PolylineOptions, google.maps.InfoWindowOptions>): google.maps.Polyline;
+    protected doCreatePolyline({ definition, }: {
+        definition: PolylineDefinition<google.maps.PolylineOptions, google.maps.InfoWindowOptions>;
+    }): google.maps.Polyline;
     protected doRemovePolyline(polyline: google.maps.Polyline): void;
     protected doCreateInfoWindow({ definition, element, }: {
         definition: InfoWindowWithoutPositionDefinition<google.maps.InfoWindowOptions>;

--- a/src/Map/src/Bridge/Google/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Google/assets/dist/map_controller.js
@@ -43,20 +43,7 @@ class default_1 extends Controller {
         if (!this.isConnected) {
             return;
         }
-        const idsToRemove = new Set(this.markers.keys());
-        this.markersValue.forEach((definition) => {
-            idsToRemove.delete(definition['@id']);
-        });
-        idsToRemove.forEach((id) => {
-            const marker = this.markers.get(id);
-            this.doRemoveMarker(marker);
-            this.markers.delete(id);
-        });
-        this.markersValue.forEach((definition) => {
-            if (!this.markers.has(definition['@id'])) {
-                this.createMarker({ definition });
-            }
-        });
+        this.onDrawChanged(this.markers, this.markersValue, this.createMarker, this.doRemoveMarker);
         if (this.fitBoundsToMarkersValue) {
             this.doFitBoundsToMarkers();
         }
@@ -65,50 +52,40 @@ class default_1 extends Controller {
         if (!this.isConnected) {
             return;
         }
-        const idsToRemove = new Set(this.polygons.keys());
-        this.polygonsValue.forEach((definition) => {
-            idsToRemove.delete(definition['@id']);
-        });
-        idsToRemove.forEach((id) => {
-            const polygon = this.polygons.get(id);
-            this.doRemovePolygon(polygon);
-            this.polygons.delete(id);
-        });
-        this.polygonsValue.forEach((definition) => {
-            if (!this.polygons.has(definition['@id'])) {
-                this.createPolygon({ definition });
-            }
-        });
+        this.onDrawChanged(this.polygons, this.polygonsValue, this.createPolygon, this.doRemovePolygon);
     }
     polylinesValueChanged() {
         if (!this.isConnected) {
             return;
         }
-        const idsToRemove = new Set(this.polylines.keys());
-        this.polylinesValue.forEach((definition) => {
-            idsToRemove.delete(definition['@id']);
-        });
-        idsToRemove.forEach((id) => {
-            const polyline = this.polylines.get(id);
-            this.doRemovePolyline(polyline);
-            this.polylines.delete(id);
-        });
-        this.polylinesValue.forEach((definition) => {
-            if (!this.polylines.has(definition['@id'])) {
-                this.createPolyline({ definition });
-            }
-        });
+        this.onDrawChanged(this.polylines, this.polylinesValue, this.createPolyline, this.doRemovePolyline);
     }
     createDrawingFactory(type, draws, factory) {
         const eventBefore = `${type}:before-create`;
         const eventAfter = `${type}:after-create`;
         return ({ definition }) => {
             this.dispatchEvent(eventBefore, { definition });
-            const drawing = factory(definition);
+            const drawing = factory({ definition });
             this.dispatchEvent(eventAfter, { [type]: drawing });
             draws.set(definition['@id'], drawing);
             return drawing;
         };
+    }
+    onDrawChanged(draws, newDrawDefinitions, factory, remover) {
+        const idsToRemove = new Set(draws.keys());
+        newDrawDefinitions.forEach((definition) => {
+            idsToRemove.delete(definition['@id']);
+        });
+        idsToRemove.forEach((id) => {
+            const draw = draws.get(id);
+            remover(draw);
+            draws.delete(id);
+        });
+        newDrawDefinitions.forEach((definition) => {
+            if (!draws.has(definition['@id'])) {
+                factory({ definition });
+            }
+        });
     }
 }
 default_1.values = {

--- a/src/Map/src/Bridge/Google/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Google/assets/src/map_controller.ts
@@ -129,9 +129,11 @@ export default class extends AbstractMapController<
         });
     }
 
-    protected doCreateMarker(
-        definition: MarkerDefinition<google.maps.marker.AdvancedMarkerElementOptions, google.maps.InfoWindowOptions>
-    ): google.maps.marker.AdvancedMarkerElement {
+    protected doCreateMarker({
+        definition,
+    }: {
+        definition: MarkerDefinition<google.maps.marker.AdvancedMarkerElementOptions, google.maps.InfoWindowOptions>;
+    }): google.maps.marker.AdvancedMarkerElement {
         const { '@id': _id, position, title, infoWindow, extra, rawOptions = {}, ...otherOptions } = definition;
 
         const marker = new _google.maps.marker.AdvancedMarkerElement({
@@ -153,9 +155,11 @@ export default class extends AbstractMapController<
         marker.map = null;
     }
 
-    protected doCreatePolygon(
-        definition: PolygonDefinition<google.maps.PolygonOptions, google.maps.InfoWindowOptions>
-    ): google.maps.Polygon {
+    protected doCreatePolygon({
+        definition,
+    }: {
+        definition: PolygonDefinition<google.maps.PolygonOptions, google.maps.InfoWindowOptions>;
+    }): google.maps.Polygon {
         const { '@id': _id, points, title, infoWindow, rawOptions = {} } = definition;
 
         const polygon = new _google.maps.Polygon({
@@ -179,9 +183,11 @@ export default class extends AbstractMapController<
         polygon.setMap(null);
     }
 
-    protected doCreatePolyline(
-        definition: PolylineDefinition<google.maps.PolylineOptions, google.maps.InfoWindowOptions>
-    ): google.maps.Polyline {
+    protected doCreatePolyline({
+        definition,
+    }: {
+        definition: PolylineDefinition<google.maps.PolylineOptions, google.maps.InfoWindowOptions>;
+    }): google.maps.Polyline {
         const { '@id': _id, points, title, infoWindow, rawOptions = {} } = definition;
 
         const polyline = new _google.maps.Polyline({

--- a/src/Map/src/Bridge/Google/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Google/assets/src/map_controller.ts
@@ -8,7 +8,13 @@
  */
 
 import AbstractMapController from '@symfony/ux-map';
-import type { Point, MarkerDefinition, PolygonDefinition, PolylineDefinition } from '@symfony/ux-map';
+import type {
+    Point,
+    MarkerDefinition,
+    PolygonDefinition,
+    PolylineDefinition,
+    InfoWindowWithoutPositionDefinition,
+} from '@symfony/ux-map';
 import type { LoaderOptions } from '@googlemaps/js-api-loader';
 import { Loader } from '@googlemaps/js-api-loader';
 
@@ -47,9 +53,11 @@ export default class extends AbstractMapController<
         'apiKey' | 'id' | 'language' | 'region' | 'nonce' | 'retries' | 'url' | 'version' | 'libraries'
     >;
 
+    declare map: google.maps.Map;
+
     async connect() {
         if (!_google) {
-            _google = { maps: {} };
+            _google = { maps: {} as typeof google.maps };
 
             let { libraries = [], ...loaderOptions } = this.providerOptionsValue;
 
@@ -75,6 +83,18 @@ export default class extends AbstractMapController<
         }
 
         super.connect();
+    }
+
+    public centerValueChanged(): void {
+        if (this.map && this.centerValue) {
+            this.map.setCenter(this.centerValue);
+        }
+    }
+
+    public zoomValueChanged(): void {
+        if (this.map && this.zoomValue) {
+            this.map.setZoom(this.zoomValue);
+        }
     }
 
     protected dispatchEvent(name: string, payload: Record<string, unknown> = {}): void {
@@ -129,12 +149,12 @@ export default class extends AbstractMapController<
         return marker;
     }
 
-    protected removeMarker(marker: google.maps.marker.AdvancedMarkerElement): void {
+    protected doRemoveMarker(marker: google.maps.marker.AdvancedMarkerElement): void {
         marker.map = null;
     }
 
     protected doCreatePolygon(
-        definition: PolygonDefinition<google.maps.Polygon, google.maps.InfoWindowOptions>
+        definition: PolygonDefinition<google.maps.PolygonOptions, google.maps.InfoWindowOptions>
     ): google.maps.Polygon {
         const { '@id': _id, points, title, infoWindow, rawOptions = {} } = definition;
 
@@ -155,12 +175,12 @@ export default class extends AbstractMapController<
         return polygon;
     }
 
-    protected removePolygon(polygon: google.maps.Polygon) {
+    protected doRemovePolygon(polygon: google.maps.Polygon) {
         polygon.setMap(null);
     }
 
     protected doCreatePolyline(
-        definition: PolylineDefinition<google.maps.Polyline, google.maps.InfoWindowOptions>
+        definition: PolylineDefinition<google.maps.PolylineOptions, google.maps.InfoWindowOptions>
     ): google.maps.Polyline {
         const { '@id': _id, points, title, infoWindow, rawOptions = {} } = definition;
 
@@ -181,29 +201,17 @@ export default class extends AbstractMapController<
         return polyline;
     }
 
-    protected removePolyline(polyline: google.maps.Polyline): void {
+    protected doRemovePolyline(polyline: google.maps.Polyline): void {
         polyline.setMap(null);
     }
 
     protected doCreateInfoWindow({
         definition,
         element,
-    }:
-        | {
-              definition: MarkerDefinition<
-                  google.maps.marker.AdvancedMarkerElementOptions,
-                  google.maps.InfoWindowOptions
-              >['infoWindow'];
-              element: google.maps.marker.AdvancedMarkerElement;
-          }
-        | {
-              definition: PolygonDefinition<google.maps.Polygon, google.maps.InfoWindowOptions>['infoWindow'];
-              element: google.maps.Polygon;
-          }
-        | {
-              definition: PolylineDefinition<google.maps.Polyline, google.maps.InfoWindowOptions>['infoWindow'];
-              element: google.maps.Polyline;
-          }): google.maps.InfoWindow {
+    }: {
+        definition: InfoWindowWithoutPositionDefinition<google.maps.InfoWindowOptions>;
+        element: google.maps.marker.AdvancedMarkerElement | google.maps.Polygon | google.maps.Polyline;
+    }): google.maps.InfoWindow {
         const { headerContent, content, extra, rawOptions = {}, ...otherOptions } = definition;
 
         const infoWindow = new _google.maps.InfoWindow({
@@ -246,6 +254,23 @@ export default class extends AbstractMapController<
         return infoWindow;
     }
 
+    protected doFitBoundsToMarkers(): void {
+        if (this.markers.size === 0) {
+            return;
+        }
+
+        const bounds = new google.maps.LatLngBounds();
+        this.markers.forEach((marker) => {
+            if (!marker.position) {
+                return;
+            }
+
+            bounds.extend(marker.position);
+        });
+
+        this.map.fitBounds(bounds);
+    }
+
     private createTextOrElement(content: string | null): string | HTMLElement | null {
         if (!content) {
             return null;
@@ -267,34 +292,5 @@ export default class extends AbstractMapController<
                 otherInfoWindow.close();
             }
         });
-    }
-
-    protected doFitBoundsToMarkers(): void {
-        if (this.markers.length === 0) {
-            return;
-        }
-
-        const bounds = new google.maps.LatLngBounds();
-        this.markers.forEach((marker) => {
-            if (!marker.position) {
-                return;
-            }
-
-            bounds.extend(marker.position);
-        });
-
-        this.map.fitBounds(bounds);
-    }
-
-    public centerValueChanged(): void {
-        if (this.map && this.centerValue) {
-            this.map.setCenter(this.centerValue);
-        }
-    }
-
-    public zoomValueChanged(): void {
-        if (this.map && this.zoomValue) {
-            this.map.setZoom(this.zoomValue);
-        }
     }
 }

--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.d.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.d.ts
@@ -21,11 +21,17 @@ export default class extends AbstractMapController<MapOptions, L.Map, MarkerOpti
         zoom: number | null;
         options: MapOptions;
     }): L.Map;
-    protected doCreateMarker(definition: MarkerDefinition<MarkerOptions, PopupOptions>): L.Marker;
+    protected doCreateMarker({ definition }: {
+        definition: MarkerDefinition<MarkerOptions, PopupOptions>;
+    }): L.Marker;
     protected doRemoveMarker(marker: L.Marker): void;
-    protected doCreatePolygon(definition: PolygonDefinition<PolygonOptions, PopupOptions>): L.Polygon;
+    protected doCreatePolygon({ definition, }: {
+        definition: PolygonDefinition<PolygonOptions, PopupOptions>;
+    }): L.Polygon;
     protected doRemovePolygon(polygon: L.Polygon): void;
-    protected doCreatePolyline(definition: PolylineDefinition<PolylineOptions, PopupOptions>): L.Polyline;
+    protected doCreatePolyline({ definition, }: {
+        definition: PolylineDefinition<PolylineOptions, PopupOptions>;
+    }): L.Polyline;
     protected doRemovePolyline(polyline: L.Polyline): void;
     protected doCreateInfoWindow({ definition, element, }: {
         definition: InfoWindowWithoutPositionDefinition<PopupOptions>;

--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.d.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.d.ts
@@ -1,5 +1,5 @@
 import AbstractMapController from '@symfony/ux-map';
-import type { Point, MarkerDefinition, PolygonDefinition, PolylineDefinition } from '@symfony/ux-map';
+import type { Point, MarkerDefinition, PolygonDefinition, PolylineDefinition, InfoWindowWithoutPositionDefinition } from '@symfony/ux-map';
 import 'leaflet/dist/leaflet.min.css';
 import * as L from 'leaflet';
 import type { MapOptions as LeafletMapOptions, MarkerOptions, PopupOptions, PolylineOptions as PolygonOptions, PolylineOptions } from 'leaflet';
@@ -10,32 +10,27 @@ type MapOptions = Pick<LeafletMapOptions, 'center' | 'zoom'> & {
         options: Record<string, unknown>;
     };
 };
-export default class extends AbstractMapController<MapOptions, typeof L.Map, MarkerOptions, typeof L.Marker, PopupOptions, typeof L.Popup, PolygonOptions, typeof L.Polygon, PolylineOptions, typeof L.Polyline> {
+export default class extends AbstractMapController<MapOptions, L.Map, MarkerOptions, L.Marker, PopupOptions, L.Popup, PolygonOptions, L.Polygon, PolylineOptions, L.Polyline> {
+    map: L.Map;
     connect(): void;
+    centerValueChanged(): void;
+    zoomValueChanged(): void;
     protected dispatchEvent(name: string, payload?: Record<string, unknown>): void;
     protected doCreateMap({ center, zoom, options, }: {
         center: Point | null;
         zoom: number | null;
         options: MapOptions;
     }): L.Map;
-    protected doCreateMarker(definition: MarkerDefinition<typeof L.Marker, typeof L.Popup>): L.Marker;
-    protected removeMarker(marker: L.Marker): void;
-    protected doCreatePolygon(definition: PolygonDefinition<typeof L.Polygon, typeof L.Popup>): L.Polygon;
-    protected removePolygon(polygon: L.Polygon): void;
-    protected doCreatePolyline(definition: PolylineDefinition): L.Polyline;
-    protected removePolyline(polyline: L.Polyline): void;
+    protected doCreateMarker(definition: MarkerDefinition<MarkerOptions, PopupOptions>): L.Marker;
+    protected doRemoveMarker(marker: L.Marker): void;
+    protected doCreatePolygon(definition: PolygonDefinition<PolygonOptions, PopupOptions>): L.Polygon;
+    protected doRemovePolygon(polygon: L.Polygon): void;
+    protected doCreatePolyline(definition: PolylineDefinition<PolylineOptions, PopupOptions>): L.Polyline;
+    protected doRemovePolyline(polyline: L.Polyline): void;
     protected doCreateInfoWindow({ definition, element, }: {
-        definition: MarkerDefinition<typeof L.Marker, typeof L.Popup>['infoWindow'];
-        element: L.Marker;
-    } | {
-        definition: PolygonDefinition<typeof L.Polygon, typeof L.Popup>['infoWindow'];
-        element: L.Polygon;
-    } | {
-        definition: PolylineDefinition<typeof L.Polyline, typeof L.Popup>['infoWindow'];
-        element: L.Polyline;
+        definition: InfoWindowWithoutPositionDefinition<PopupOptions>;
+        element: L.Marker | L.Polygon | L.Polyline;
     }): L.Popup;
     protected doFitBoundsToMarkers(): void;
-    centerValueChanged(): void;
-    zoomValueChanged(): void;
 }
 export {};

--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
@@ -44,20 +44,7 @@ class default_1 extends Controller {
         if (!this.isConnected) {
             return;
         }
-        const idsToRemove = new Set(this.markers.keys());
-        this.markersValue.forEach((definition) => {
-            idsToRemove.delete(definition['@id']);
-        });
-        idsToRemove.forEach((id) => {
-            const marker = this.markers.get(id);
-            this.doRemoveMarker(marker);
-            this.markers.delete(id);
-        });
-        this.markersValue.forEach((definition) => {
-            if (!this.markers.has(definition['@id'])) {
-                this.createMarker({ definition });
-            }
-        });
+        this.onDrawChanged(this.markers, this.markersValue, this.createMarker, this.doRemoveMarker);
         if (this.fitBoundsToMarkersValue) {
             this.doFitBoundsToMarkers();
         }
@@ -66,50 +53,40 @@ class default_1 extends Controller {
         if (!this.isConnected) {
             return;
         }
-        const idsToRemove = new Set(this.polygons.keys());
-        this.polygonsValue.forEach((definition) => {
-            idsToRemove.delete(definition['@id']);
-        });
-        idsToRemove.forEach((id) => {
-            const polygon = this.polygons.get(id);
-            this.doRemovePolygon(polygon);
-            this.polygons.delete(id);
-        });
-        this.polygonsValue.forEach((definition) => {
-            if (!this.polygons.has(definition['@id'])) {
-                this.createPolygon({ definition });
-            }
-        });
+        this.onDrawChanged(this.polygons, this.polygonsValue, this.createPolygon, this.doRemovePolygon);
     }
     polylinesValueChanged() {
         if (!this.isConnected) {
             return;
         }
-        const idsToRemove = new Set(this.polylines.keys());
-        this.polylinesValue.forEach((definition) => {
-            idsToRemove.delete(definition['@id']);
-        });
-        idsToRemove.forEach((id) => {
-            const polyline = this.polylines.get(id);
-            this.doRemovePolyline(polyline);
-            this.polylines.delete(id);
-        });
-        this.polylinesValue.forEach((definition) => {
-            if (!this.polylines.has(definition['@id'])) {
-                this.createPolyline({ definition });
-            }
-        });
+        this.onDrawChanged(this.polylines, this.polylinesValue, this.createPolyline, this.doRemovePolyline);
     }
     createDrawingFactory(type, draws, factory) {
         const eventBefore = `${type}:before-create`;
         const eventAfter = `${type}:after-create`;
         return ({ definition }) => {
             this.dispatchEvent(eventBefore, { definition });
-            const drawing = factory(definition);
+            const drawing = factory({ definition });
             this.dispatchEvent(eventAfter, { [type]: drawing });
             draws.set(definition['@id'], drawing);
             return drawing;
         };
+    }
+    onDrawChanged(draws, newDrawDefinitions, factory, remover) {
+        const idsToRemove = new Set(draws.keys());
+        newDrawDefinitions.forEach((definition) => {
+            idsToRemove.delete(definition['@id']);
+        });
+        idsToRemove.forEach((id) => {
+            const draw = draws.get(id);
+            remover(draw);
+            draws.delete(id);
+        });
+        newDrawDefinitions.forEach((definition) => {
+            if (!draws.has(definition['@id'])) {
+                factory({ definition });
+            }
+        });
     }
 }
 default_1.values = {

--- a/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
@@ -14,6 +14,7 @@ import type {
     PopupOptions,
     PolylineOptions as PolygonOptions,
     PolylineOptions,
+    LatLngBoundsExpression,
 } from 'leaflet';
 
 type MapOptions = Pick<LeafletMapOptions, 'center' | 'zoom'> & {
@@ -87,7 +88,7 @@ export default class extends AbstractMapController<
         return map;
     }
 
-    protected doCreateMarker(definition: MarkerDefinition<MarkerOptions, PopupOptions>): L.Marker {
+    protected doCreateMarker({ definition }: { definition: MarkerDefinition<MarkerOptions, PopupOptions> }): L.Marker {
         const { '@id': _id, position, title, infoWindow, extra, rawOptions = {}, ...otherOptions } = definition;
 
         const marker = L.marker(position, { title: title || undefined, ...otherOptions, ...rawOptions }).addTo(
@@ -105,7 +106,9 @@ export default class extends AbstractMapController<
         marker.remove();
     }
 
-    protected doCreatePolygon(definition: PolygonDefinition<PolygonOptions, PopupOptions>): L.Polygon {
+    protected doCreatePolygon({
+        definition,
+    }: { definition: PolygonDefinition<PolygonOptions, PopupOptions> }): L.Polygon {
         const { '@id': _id, points, title, infoWindow, rawOptions = {} } = definition;
 
         const polygon = L.polygon(points, { ...rawOptions }).addTo(this.map);
@@ -125,7 +128,9 @@ export default class extends AbstractMapController<
         polygon.remove();
     }
 
-    protected doCreatePolyline(definition: PolylineDefinition<PolylineOptions, PopupOptions>): L.Polyline {
+    protected doCreatePolyline({
+        definition,
+    }: { definition: PolylineDefinition<PolylineOptions, PopupOptions> }): L.Polyline {
         const { '@id': _id, points, title, infoWindow, rawOptions = {} } = definition;
 
         const polyline = L.polyline(points, { ...rawOptions }).addTo(this.map);
@@ -173,12 +178,11 @@ export default class extends AbstractMapController<
             return;
         }
 
-        this.map.fitBounds(
-            this.markers.map((marker: L.Marker) => {
-                const position = marker.getLatLng();
-
-                return [position.lat, position.lng];
-            })
-        );
+        const bounds: LatLngBoundsExpression = [];
+        this.markers.forEach((marker) => {
+            const position = marker.getLatLng();
+            bounds.push([position.lat, position.lng]);
+        });
+        this.map.fitBounds(bounds);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This PRs is purely internal, and aims to:
- Making TypeScript happy by fixing types definitions and usages, but also simplify them
- Refactoring methods containing the same logic (ex: `this.create*` or `this....ValueChanged`) methods) to dedicated methods:
```js
    createMarker(definition) {
        this.dispatchEvent('marker:before-create', { definition });
        const marker = this.doCreateMarker(definition);
        this.dispatchEvent('marker:after-create', { marker });
        marker['@id'] = definition['@id'];
        this.markers.set(definition['@id'], marker);
        return marker;
    }
    createPolygon(definition) {
        this.dispatchEvent('polygon:before-create', { definition });
        const polygon = this.doCreatePolygon(definition);
        this.dispatchEvent('polygon:after-create', { polygon });
        polygon['@id'] = definition['@id'];
        this.polygons.set(definition['@id'], polygon);
        return polygon;
    }
    createPolyline(definition) {
        this.dispatchEvent('polyline:before-create', { definition });
        const polyline = this.doCreatePolyline(definition);
        this.dispatchEvent('polyline:after-create', { polyline });
        polyline['@id'] = definition['@id'];
        this.polylines.set(definition['@id'], polyline);
        return polyline;
    }
```
becomes
```js
        this.createMarker = this.createDrawingFactory('marker', this.markers, this.doCreateMarker.bind(this));
        this.createPolygon = this.createDrawingFactory('polygon', this.polygons, this.doCreatePolygon.bind(this));
        this.createPolyline = this.createDrawingFactory('polyline', this.polylines, this.doCreatePolyline.bind(this));
```

and
```js
    markersValueChanged() {
        if (!this.map) {
            return;
        }
        this.markers.forEach((marker) => {
            if (!this.markersValue.find((m) => m['@id'] === marker['@id'])) {
                this.removeMarker(marker);
                this.markers.delete(marker['@id']);
            }
        });
        this.markersValue.forEach((marker) => {
            if (!this.markers.has(marker['@id'])) {
                this.createMarker(marker);
            }
        });
        if (this.fitBoundsToMarkersValue) {
            this.doFitBoundsToMarkers();
        }
    }
    polygonsValueChanged() {
        if (!this.map) {
            return;
        }
        this.polygons.forEach((polygon) => {
            if (!this.polygonsValue.find((p) => p['@id'] === polygon['@id'])) {
                this.removePolygon(polygon);
                this.polygons.delete(polygon['@id']);
            }
        });
        this.polygonsValue.forEach((polygon) => {
            if (!this.polygons.has(polygon['@id'])) {
                this.createPolygon(polygon);
            }
        });
    }
    polylinesValueChanged() {
        if (!this.map) {
            return;
        }
        this.polylines.forEach((polyline) => {
            if (!this.polylinesValue.find((p) => p['@id'] === polyline['@id'])) {
                this.removePolyline(polyline);
                this.polylines.delete(polyline['@id']);
            }
        });
        this.polylinesValue.forEach((polyline) => {
            if (!this.polylines.has(polyline['@id'])) {
                this.createPolyline(polyline);
            }
        });
    }
```
becomes
```js
markersValueChanged() {
        if (!this.isConnected) {
            return;
        }
        this.onDrawChanged(this.markers, this.markersValue, this.createMarker, this.doRemoveMarker);
        if (this.fitBoundsToMarkersValue) {
            this.doFitBoundsToMarkers();
        }
    }
    polygonsValueChanged() {
        if (!this.isConnected) {
            return;
        }
        this.onDrawChanged(this.polygons, this.polygonsValue, this.createPolygon, this.doRemovePolygon);
    }
    polylinesValueChanged() {
        if (!this.isConnected) {
            return;
        }
        this.onDrawChanged(this.polylines, this.polylinesValue, this.createPolyline, this.doRemovePolyline);
    }
```