### PR TITLE
[Icons] use dedicated cache pool 

### DIFF
--- a/src/Icons/config/iconify.php
+++ b/src/Icons/config/iconify.php
@@ -27,7 +27,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->set('.ux_icons.iconify', Iconify::class)
             ->args([
-                service('cache.system'),
+                service('.ux_icons.cache'),
                 abstract_arg('endpoint'),
                 service('http_client')->nullOnInvalid(),
             ])

--- a/src/Icons/config/services.php
+++ b/src/Icons/config/services.php
@@ -24,10 +24,15 @@ use Symfony\UX\Icons\Twig\UXIconRuntime;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()
+        ->set('.ux_icons.cache')
+            ->parent('cache.system')
+            ->private()
+            ->tag('cache.pool')
+
         ->set('.ux_icons.cache_icon_registry', CacheIconRegistry::class)
             ->args([
                 service('.ux_icons.chain_registry'),
-                service('cache.system'),
+                service('.ux_icons.cache'),
             ])
 
         ->set('.ux_icons.local_svg_icon_registry', LocalSvgIconRegistry::class)

--- a/src/Icons/src/Iconify.php
+++ b/src/Icons/src/Iconify.php
@@ -196,7 +196,7 @@ final class Iconify
 
     private function sets(): \ArrayObject
     {
-        return $this->sets ??= $this->cache->get('ux-iconify-sets', function () {
+        return $this->sets ??= $this->cache->get('iconify-sets', function () {
             $response = $this->http->request('GET', '/collections');
 
             return new \ArrayObject($response->toArray());

--- a/src/Icons/src/Registry/CacheIconRegistry.php
+++ b/src/Icons/src/Registry/CacheIconRegistry.php
@@ -34,7 +34,7 @@ final class CacheIconRegistry implements IconRegistryInterface
         }
 
         return $this->cache->get(
-            \sprintf('ux-icon-%s', Icon::nameToId($name)),
+            Icon::nameToId($name),
             fn () => $this->inner->get($name),
             beta: $refresh ? \INF : null,
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

based on @stof comment on EasyAdminBundle repository https://github.com/EasyCorp/EasyAdminBundle/pull/6507#discussion_r1831159693

> you should probably create a dedicated cache pool inheriting its configuration from cache.system instead of using cache.system directly. this is how core Symfony components work (allowing them to avoid having to care about conflicting keys between the caches of different component, as the key only needs to be unique inside the cache pool)
