### PR TITLE
[Map] Fix default values of Stimulus Map Controller

### DIFF
--- a/src/Map/assets/dist/abstract_map_controller.d.ts
+++ b/src/Map/assets/dist/abstract_map_controller.d.ts
@@ -56,6 +56,13 @@ export default abstract class<MapOptions, Map, MarkerOptions, Marker, InfoWindow
     polygonsValue: Array<PolygonDefinition<PolygonOptions, InfoWindowOptions>>;
     polylinesValue: Array<PolylineDefinition<PolylineOptions, InfoWindowOptions>>;
     optionsValue: MapOptions;
+    hasCenterValue: boolean;
+    hasZoomValue: boolean;
+    hasFitBoundsToMarkersValue: boolean;
+    hasMarkersValue: boolean;
+    hasPolygonsValue: boolean;
+    hasPolylinesValue: boolean;
+    hasOptionsValue: boolean;
     protected map: Map;
     protected markers: globalThis.Map<string, Marker>;
     protected polygons: globalThis.Map<string, Polygon>;

--- a/src/Map/assets/dist/abstract_map_controller.js
+++ b/src/Map/assets/dist/abstract_map_controller.js
@@ -15,7 +15,11 @@ class default_1 extends Controller {
         this.createMarker = this.createDrawingFactory('marker', this.markers, this.doCreateMarker.bind(this));
         this.createPolygon = this.createDrawingFactory('polygon', this.polygons, this.doCreatePolygon.bind(this));
         this.createPolyline = this.createDrawingFactory('polyline', this.polylines, this.doCreatePolyline.bind(this));
-        this.map = this.doCreateMap({ center: this.centerValue, zoom: this.zoomValue, options });
+        this.map = this.doCreateMap({
+            center: this.hasCenterValue ? this.centerValue : null,
+            zoom: this.hasZoomValue ? this.zoomValue : null,
+            options,
+        });
         this.markersValue.forEach((definition) => this.createMarker({ definition }));
         this.polygonsValue.forEach((definition) => this.createPolygon({ definition }));
         this.polylinesValue.forEach((definition) => this.createPolyline({ definition }));

--- a/src/Map/assets/src/abstract_map_controller.ts
+++ b/src/Map/assets/src/abstract_map_controller.ts
@@ -112,6 +112,14 @@ export default abstract class<
     declare polylinesValue: Array<PolylineDefinition<PolylineOptions, InfoWindowOptions>>;
     declare optionsValue: MapOptions;
 
+    declare hasCenterValue: boolean;
+    declare hasZoomValue: boolean;
+    declare hasFitBoundsToMarkersValue: boolean;
+    declare hasMarkersValue: boolean;
+    declare hasPolygonsValue: boolean;
+    declare hasPolylinesValue: boolean;
+    declare hasOptionsValue: boolean;
+
     protected map: Map;
     protected markers = new Map<Identifier, Marker>();
     protected polygons = new Map<Identifier, Polygon>();
@@ -140,7 +148,11 @@ export default abstract class<
         this.createPolygon = this.createDrawingFactory('polygon', this.polygons, this.doCreatePolygon.bind(this));
         this.createPolyline = this.createDrawingFactory('polyline', this.polylines, this.doCreatePolyline.bind(this));
 
-        this.map = this.doCreateMap({ center: this.centerValue, zoom: this.zoomValue, options });
+        this.map = this.doCreateMap({
+            center: this.hasCenterValue ? this.centerValue : null,
+            zoom: this.hasZoomValue ? this.zoomValue : null,
+            options,
+        });
         this.markersValue.forEach((definition) => this.createMarker({ definition }));
         this.polygonsValue.forEach((definition) => this.createPolygon({ definition }));
         this.polylinesValue.forEach((definition) => this.createPolyline({ definition }));

--- a/src/Map/src/Bridge/Google/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Google/assets/dist/map_controller.js
@@ -16,7 +16,11 @@ class default_1 extends Controller {
         this.createMarker = this.createDrawingFactory('marker', this.markers, this.doCreateMarker.bind(this));
         this.createPolygon = this.createDrawingFactory('polygon', this.polygons, this.doCreatePolygon.bind(this));
         this.createPolyline = this.createDrawingFactory('polyline', this.polylines, this.doCreatePolyline.bind(this));
-        this.map = this.doCreateMap({ center: this.centerValue, zoom: this.zoomValue, options });
+        this.map = this.doCreateMap({
+            center: this.hasCenterValue ? this.centerValue : null,
+            zoom: this.hasZoomValue ? this.zoomValue : null,
+            options,
+        });
         this.markersValue.forEach((definition) => this.createMarker({ definition }));
         this.polygonsValue.forEach((definition) => this.createPolygon({ definition }));
         this.polylinesValue.forEach((definition) => this.createPolyline({ definition }));
@@ -121,12 +125,12 @@ class map_controller extends default_1 {
         super.connect();
     }
     centerValueChanged() {
-        if (this.map && this.centerValue) {
+        if (this.map && this.hasCenterValue && this.centerValue) {
             this.map.setCenter(this.centerValue);
         }
     }
     zoomValueChanged() {
-        if (this.map && this.zoomValue) {
+        if (this.map && this.hasZoomValue && this.zoomValue) {
             this.map.setZoom(this.zoomValue);
         }
     }

--- a/src/Map/src/Bridge/Google/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Google/assets/src/map_controller.ts
@@ -86,13 +86,13 @@ export default class extends AbstractMapController<
     }
 
     public centerValueChanged(): void {
-        if (this.map && this.centerValue) {
+        if (this.map && this.hasCenterValue && this.centerValue) {
             this.map.setCenter(this.centerValue);
         }
     }
 
     public zoomValueChanged(): void {
-        if (this.map && this.zoomValue) {
+        if (this.map && this.hasZoomValue && this.zoomValue) {
             this.map.setZoom(this.zoomValue);
         }
     }

--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
@@ -17,7 +17,11 @@ class default_1 extends Controller {
         this.createMarker = this.createDrawingFactory('marker', this.markers, this.doCreateMarker.bind(this));
         this.createPolygon = this.createDrawingFactory('polygon', this.polygons, this.doCreatePolygon.bind(this));
         this.createPolyline = this.createDrawingFactory('polyline', this.polylines, this.doCreatePolyline.bind(this));
-        this.map = this.doCreateMap({ center: this.centerValue, zoom: this.zoomValue, options });
+        this.map = this.doCreateMap({
+            center: this.hasCenterValue ? this.centerValue : null,
+            zoom: this.hasZoomValue ? this.zoomValue : null,
+            options,
+        });
         this.markersValue.forEach((definition) => this.createMarker({ definition }));
         this.polygonsValue.forEach((definition) => this.createPolygon({ definition }));
         this.polylinesValue.forEach((definition) => this.createPolyline({ definition }));
@@ -112,12 +116,12 @@ class map_controller extends default_1 {
         super.connect();
     }
     centerValueChanged() {
-        if (this.map && this.centerValue && this.zoomValue) {
+        if (this.map && this.hasCenterValue && this.centerValue && this.hasZoomValue && this.zoomValue) {
             this.map.setView(this.centerValue, this.zoomValue);
         }
     }
     zoomValueChanged() {
-        if (this.map && this.zoomValue) {
+        if (this.map && this.hasZoomValue && this.zoomValue) {
             this.map.setZoom(this.zoomValue);
         }
     }

--- a/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
@@ -48,13 +48,13 @@ export default class extends AbstractMapController<
     }
 
     public centerValueChanged(): void {
-        if (this.map && this.centerValue && this.zoomValue) {
+        if (this.map && this.hasCenterValue && this.centerValue && this.hasZoomValue && this.zoomValue) {
             this.map.setView(this.centerValue, this.zoomValue);
         }
     }
 
     public zoomValueChanged(): void {
-        if (this.map && this.zoomValue) {
+        if (this.map && this.hasZoomValue && this.zoomValue) {
             this.map.setZoom(this.zoomValue);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #2417 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This issue happens at `doCreateMap` when we called `->fitBoundsToMarkers()` instead of `->center(...)`. 

The value `center` was supposed to be `null`, but since I forgot to configure the default value of `this.centerValue` to `null`, it automatically used `{}` as default value (https://stimulus.hotwired.dev/reference/values#getters) and it breaks the code.

This bug has been introduced in #2385.