### PR TITLE
[LiveComponent] Handle loose comparison with empty placeholder 

### DIFF
--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -265,7 +265,7 @@ trait ComponentWithFormTrait
                 && $child->vars['required']
                 && !$child->vars['disabled']
                 && !$child->vars['value']
-                && !$child->vars['placeholder']
+                && (false === $child->vars['placeholder'] || null === $child->vars['placeholder'])
                 && !$child->vars['multiple']
                 && !$child->vars['expanded']
                 && $child->vars['choices']

--- a/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
@@ -52,6 +52,13 @@ class FormWithManyDifferentFieldsType extends AbstractType
                 ],
                 'placeholder' => 'foo',
             ])
+            ->add('choice_required_with_empty_placeholder', ChoiceType::class, [
+                'choices' => [
+                    'bar' => 2,
+                    'foo' => 1,
+                ],
+                'placeholder' => '',
+            ])
             ->add('choice_required_without_placeholder', ChoiceType::class, [
                 'choices' => [
                     'bar' => 2,

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -179,6 +179,7 @@ class ComponentWithFormTest extends KernelTestCase
             'range' => '',
             'choice' => '',
             'choice_required_with_placeholder' => '',
+            'choice_required_with_empty_placeholder' => '',
             'choice_required_without_placeholder' => '2',
             'choice_expanded' => '',
             'choice_multiple' => ['2'],

--- a/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
@@ -44,6 +44,7 @@ class ComponentWithFormTest extends KernelTestCase
                 'range' => '',
                 'choice' => '',
                 'choice_required_with_placeholder' => '',
+                'choice_required_with_empty_placeholder' => '',
                 'choice_required_without_placeholder' => '2',
                 'choice_expanded' => '',
                 'choice_multiple' => ['2'],


### PR DESCRIPTION
Fix for a bug that arises when using an empty placeholder in a required select field, that is wrongly treated as an absence of placeholder by LiveComponents.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #2425  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

LiveComponents test placeholders of required selects to detect when to set a default value from the choices (i.e. if the select is required and does not have a placeholder, among other conditions) by just casting the placeholder to a boolean. This leads to empty placeholders (placeholders that are the empty string) to be treated as an absence of placeholders when they should not. This MR fixes this by replacing the condition on placeholders with a more appropriate one.
According to the docs https://symfony.com/doc/current/reference/forms/types/choice.html#placeholder and https://symfony.com/doc/current/reference/forms/types/choice.html#field-variables, the placeholder can be a boolean (`false` indicates that there should not be a placeholder), a string (the text to display for the empty value) or a TranslatableMessage (same as string, but goes through a translator before being displayed). The vars property is either the value of the field, or `null` if there is no placeholder specified. From this, I considered that there is no placeholder either if the placeholder holds `false` or `null`.

I added a simple test that checks the behaviour when there is a required select with an empty placeholder ; we expect the value of the field to be empty in such cases when we do not modify it.

#SymfonyHackday :)