### PR TITLE
[Meta] Drop format, lint, check-format and check-lint commands, replace them with check and ci commands

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,8 +28,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-yarn-
             - run: yarn --immutable
-            - run: yarn check-lint
-            - run: yarn check-format
+            - run: yarn ci
 
     js-dist-current:
         name: Check for UnBuilt JS Dist Files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,14 +81,14 @@ To help you with assets, you can run the following commands in a specific packag
   - `yarn run build`: build (compile) assets from the package,
   - `yarn run watch`: watch for modifications and rebuild assets from the package,
   - `yarn run test`: run the tests from the package,
-  - `yarn run lint`: lint assets from the package,
-  - `yarn run format`: format assets from the package.
+  - `yarn run check`: run the formatter, linter, and sort imports, and fails if any modifications 
+  - `yarn run check --write`: run the formatter, linter, imports sorting, and write modifications 
 
 Thanks to [Yarn Workspaces](https://yarnpkg.com/features/workspaces), you can also run these commands from the root directory of the project:
   - `yarn run build`: build (compile) assets from **all** packages,
   - `yarn run test`: run the tests from **all** packages,
-  - `yarn run lint`: lint assets from **all** packages,
-  - `yarn run format`: format assets from **all** packages,
+  - `yarn run check`: run the formatter, linter, and sort imports for **all** packages, and fails if any modifications
+  - `yarn run check --write`: run the formatter, linter, imports sorting for **all** packages, and write modifications
 
 ## Useful Git commands
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
     "scripts": {
         "build": "yarn workspaces foreach -Apt run build",
         "test": "yarn workspaces foreach -Apt run test",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/src/Autocomplete/assets/package.json
+++ b/src/Autocomplete/assets/package.json
@@ -9,10 +9,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -10,10 +10,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Cropperjs/assets/package.json
+++ b/src/Cropperjs/assets/package.json
@@ -12,10 +12,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Dropzone/assets/package.json
+++ b/src/Dropzone/assets/package.json
@@ -12,10 +12,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/LazyImage/assets/package.json
+++ b/src/LazyImage/assets/package.json
@@ -9,10 +9,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/LiveComponent/assets/package.json
+++ b/src/LiveComponent/assets/package.json
@@ -12,10 +12,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Map/assets/package.json
+++ b/src/Map/assets/package.json
@@ -10,10 +10,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "importmap": {

--- a/src/Map/src/Bridge/Google/assets/package.json
+++ b/src/Map/src/Bridge/Google/assets/package.json
@@ -10,10 +10,8 @@
         "build": "node ../../../../../../bin/build_package.js .",
         "watch": "node ../../../../../../bin/build_package.js . --watch",
         "test": "../../../../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Map/src/Bridge/Leaflet/assets/package.json
+++ b/src/Map/src/Bridge/Leaflet/assets/package.json
@@ -10,10 +10,8 @@
         "build": "node ../../../../../../bin/build_package.js .",
         "watch": "node ../../../../../../bin/build_package.js . --watch",
         "test": "../../../../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Notify/assets/package.json
+++ b/src/Notify/assets/package.json
@@ -9,10 +9,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/React/assets/package.json
+++ b/src/React/assets/package.json
@@ -9,10 +9,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/StimulusBundle/assets/package.json
+++ b/src/StimulusBundle/assets/package.json
@@ -8,10 +8,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "needsPackageAsADependency": false,

--- a/src/Svelte/assets/package.json
+++ b/src/Svelte/assets/package.json
@@ -8,10 +8,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Swup/assets/package.json
+++ b/src/Swup/assets/package.json
@@ -9,10 +9,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/TogglePassword/assets/package.json
+++ b/src/TogglePassword/assets/package.json
@@ -12,10 +12,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Translator/assets/package.json
+++ b/src/Translator/assets/package.json
@@ -9,10 +9,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "importmap": {

--- a/src/Turbo/assets/package.json
+++ b/src/Turbo/assets/package.json
@@ -10,10 +10,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Typed/assets/package.json
+++ b/src/Typed/assets/package.json
@@ -9,10 +9,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {

--- a/src/Vue/assets/package.json
+++ b/src/Vue/assets/package.json
@@ -9,10 +9,8 @@
         "build": "node ../../../bin/build_package.js .",
         "watch": "node ../../../bin/build_package.js . --watch",
         "test": "../../../bin/test_package.sh .",
-        "lint": "biome lint --write",
-        "format": "biome format --write",
-        "check-lint": "biome lint",
-        "check-format": "biome format"
+        "check": "biome check",
+        "ci": "biome ci"
     },
     "symfony": {
         "controllers": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT


Following https://github.com/symfony/ux/pull/2423#issuecomment-2520352394.

When I've migrated from ESLint and Prettier to Biome.js, I kept commands `yarn lint`, `yarn format` (and `yarn check-`) for historical and simplicity reasons, because it was two separate tools.

_Now_ that we use a single tool, we can use its two dedicated commands:
- [`biome check`](https://biomejs.dev/reference/cli/#biome-check), like `biome format + biome lint + imports sorting`
- [`biome ci`](https://biomejs.dev/reference/cli/#biome-ci), for the CI (it does not write files)

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/ea3481f8-308a-4a8a-a47f-53692c0a3488">


cc @chadyred 