### PR TITLE
[Autocomplete] reorder autocomplete data-controller

### DIFF
--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -55,7 +55,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
         $attr = $view->vars['attr'] ?? [];
 
         $controllerName = 'symfony--ux-autocomplete--autocomplete';
-        $attr['data-controller'] = $controllerName.' '.trim(($attr['data-controller'] ?? ''));
+        $attr['data-controller'] = $controllerName.' '.trim($attr['data-controller'] ?? '');
 
         $values = [];
         if ($options['autocomplete_url']) {

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -55,7 +55,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
         $attr = $view->vars['attr'] ?? [];
 
         $controllerName = 'symfony--ux-autocomplete--autocomplete';
-        $attr['data-controller'] = trim(($attr['data-controller'] ?? '').' '.$controllerName);
+        $attr['data-controller'] = $controllerName.' '.trim(($attr['data-controller'] ?? ''));
 
         $values = [];
         if ($options['autocomplete_url']) {

--- a/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
+++ b/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
@@ -30,7 +30,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
         $this->browser()
             ->throwExceptions()
             ->get('/test-form')
-            ->assertElementAttributeContains('#product_category', 'data-controller', 'custom-autocomplete symfony--ux-autocomplete--autocomplete')
+            ->assertElementAttributeContains('#product_category', 'data-controller', 'symfony--ux-autocomplete--autocomplete custom-autocomplete')
             ->assertElementAttributeContains('#product_category', 'data-symfony--ux-autocomplete--autocomplete-url-value', '/test/autocomplete/category_autocomplete_type?extra_options=')
             ->assertElementAttributeContains('#product_category', 'data-symfony--ux-autocomplete--autocomplete-min-characters-value', '2')
             ->assertElementAttributeContains('#product_category', 'data-symfony--ux-autocomplete--autocomplete-max-results-value', '25')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        |
| License       | MIT

load `symfony--ux-autocomplete--autocomplete` controller first before other controller make other controllers able access the tomselect instance, this will make autocomplete more extensible

having an custom-tomselect controller

```
import { Controller } from '@hotwired/stimulus';

export default class extends Controller {
    connect() {
        console.log(this.element.tomselect)
    }
}
```

and a form field

```
$builder->add('field', ChoiceType::class, [
            'autocomplete' => true,
            'attr' => [
                'data-controller' => 'custom-tomselect',
            ],
        ]);
```

in current behavior it will print out `undefined`, with this change it print tomselect instance