### PR TITLE
[TwigComponent] Documents the spread syntax under the "Component Attribute" section

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -929,6 +929,10 @@ component's template:
       My Component!
     </div>
 
+.. note::
+
+    Quick reminder that passing an array of attributes to the *Component* requires the spread operator syntax (``<twig:MyComponent {{ ...attributes }} />``). See `Component HTML Syntax`_.
+
 When rendering the component, you can pass an array of html attributes to add:
 
 .. code-block:: html+twig
@@ -1796,6 +1800,7 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Live Components`: https://symfony.com/bundles/ux-live-component/current/index.html
 .. _`live component`: https://symfony.com/bundles/ux-live-component/current/index.html
 .. _`Vue`: https://v3.vuejs.org/guide/computed.html
+.. _`Component HTML Syntax`: https://symfony.com/bundles/ux-live-component/current/index.html#component-html-syntax
 .. _`Live Nested Components`: https://symfony.com/bundles/ux-live-component/current/index.html#nested-components
 .. _`Passing Blocks to Live Components`: https://symfony.com/bundles/ux-live-component/current/index.html#passing-blocks
 .. _`Stimulus controller`: https://symfony.com/bundles/StimulusBundle/current/index.html


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | — <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT


Motivated by https://github.com/symfony/ux/issues/2455, adds a syntax reminder in a place where many readers might be looking for it.

Used an inline code sample to keep the note minimal and unobtrusive, but I can update it with a proper code block if needed.