### PR TITLE
[TwigComponent] Minor doc syntax fix

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -122,7 +122,7 @@ and any other components by running:
 
 Take a moment to fist pump - then come back!
 
-.. tip
+.. tip::
 
     If you use the `Symfony MakerBundle`_, you can easily create a new component
     with the ``make:twig-component`` command:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | -
| License       | MIT

Fixes this:

![imagen](https://github.com/user-attachments/assets/a8805a4d-699c-4e0c-bddd-d12b7235c6f1)
