### PR TITLE
[LiveComponent] Allow configuring secret for fingerprints and checksums

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.23.0
+
+-   Allow configuring the secret used to compute fingerprints and checksums.
+
 ## 2.22.0
 
 -   Remove CSRF tokens - rely on same-origin/CORS instead

--- a/src/LiveComponent/tests/Unit/DependencyInjection/LiveComponentConfigurationTest.php
+++ b/src/LiveComponent/tests/Unit/DependencyInjection/LiveComponentConfigurationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Unit\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\UX\LiveComponent\DependencyInjection\LiveComponentExtension;
+
+class LiveComponentConfigurationTest extends TestCase
+{
+    public function testDefaultSecret()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new LiveComponentExtension(), []);
+
+        $this->assertEquals('%kernel.secret%', $config['secret']);
+    }
+
+    public function testEmptySecretThrows()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The path "live_component.secret" cannot contain an empty value, but got null.');
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new LiveComponentExtension(), [
+            'live_component' => [
+                'secret' => null,
+            ],
+        ]);
+    }
+
+    public function testCustomSecret()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new LiveComponentExtension(), [
+            'live_component' => [
+                'secret' => 'my_secret',
+            ],
+        ]);
+
+        $this->assertEquals('my_secret', $config['secret']);
+    }
+}

--- a/src/LiveComponent/tests/Unit/DependencyInjection/LiveComponentExtensionTest.php
+++ b/src/LiveComponent/tests/Unit/DependencyInjection/LiveComponentExtensionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Unit\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\UX\LiveComponent\DependencyInjection\LiveComponentExtension;
+
+class LiveComponentExtensionTest extends TestCase
+{
+    public function testKernelSecretIsUsedByDefault(): void
+    {
+        $container = $this->createContainer();
+        $container->registerExtension(new LiveComponentExtension());
+        $container->loadFromExtension('live_component', []);
+        $this->compileContainer($container);
+
+        $this->assertSame('%kernel.secret%', $container->getDefinition('ux.live_component.component_hydrator')->getArgument(4));
+        $this->assertSame('%kernel.secret%', $container->getDefinition('ux.live_component.fingerprint_calculator')->getArgument(0));
+    }
+
+    public function testCustomSecretIsUsedInDefinition(): void
+    {
+        $container = $this->createContainer();
+        $container->registerExtension(new LiveComponentExtension());
+        $container->loadFromExtension('live_component', [
+            'secret' => 'custom_secret',
+        ]);
+        $this->compileContainer($container);
+
+        $this->assertSame('custom_secret', $container->getDefinition('ux.live_component.component_hydrator')->getArgument(4));
+        $this->assertSame('custom_secret', $container->getDefinition('ux.live_component.fingerprint_calculator')->getArgument(0));
+    }
+
+    private function createContainer(): ContainerBuilder
+    {
+        $container = new ContainerBuilder(new ParameterBag([
+            'kernel.cache_dir' => __DIR__,
+            'kernel.project_dir' => __DIR__,
+            'kernel.charset' => 'UTF-8',
+            'kernel.debug' => false,
+            'kernel.bundles' => [],
+            'kernel.bundles_metadata' => [],
+        ]));
+
+        return $container;
+    }
+
+    private function compileContainer(ContainerBuilder $container): void
+    {
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+        $container->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #2453
| License       | MIT

Allow to configure a dedicated secret (used in FingerprintCalculator and LiveComonentHydrator)

Suggested by @dkarlovi in #2453 
Implementation inspired by [symfony #56840](https://github.com/symfony/symfony/pull/56840)

Should be merged _after_  #2461