### PR TITLE
[TwigComponent] Minimal support of comment lines

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -233,6 +233,7 @@ class TwigPreLexer
             $isAttributeDynamic = false;
 
             // :someProp="dynamicVar"
+            $this->consumeWhitespace();
             if ($this->check(':')) {
                 $this->consume(':');
                 $isAttributeDynamic = true;
@@ -244,6 +245,7 @@ class TwigPreLexer
 
             // <twig:component someProp> -> someProp: true
             if (!$this->check('=')) {
+                $this->consumeWhitespace();
                 // don't allow "<twig:component :someProp>"
                 if ($isAttributeDynamic) {
                     throw new SyntaxError(\sprintf('Expected "=" after ":%s" when parsing the "<twig:%s" syntax.', $key, $componentName), $this->line);
@@ -332,6 +334,12 @@ class TwigPreLexer
         $whitespace = substr($this->input, $this->position, strspn($this->input, " \t\n\r\0\x0B", $this->position));
         $this->line += substr_count($whitespace, "\n");
         $this->position += \strlen($whitespace);
+
+        if ($this->check('#')) {
+            $this->consume('#');
+            $this->consumeUntil("\n");
+            $this->consumeWhitespace();
+        }
     }
 
     /**

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -376,5 +376,65 @@ final class TwigPreLexerTest extends TestCase
             '<twig:foobar bar="baz" {{ ...attr }}>content</twig:foobar>',
             '{% component \'foobar\' with { bar: \'baz\', ...attr } %}{% block content %}content{% endblock %}{% endcomponent %}',
         ];
+        yield 'component_with_comment_line' => [
+            "<twig:foo \n   # bar  \n />",
+            '{{ component(\'foo\') }}',
+        ];
+        yield 'component_with_comment_line_between_args' => [
+            <<<TWIG
+            <twig:foo
+                # bar
+                bar="baz"
+            />
+            TWIG,
+            '{{ component(\'foo\', { bar: \'baz\' }) }}',
+        ];
+        yield 'component_with_comment_lines_between_args' => [
+            <<<TWIG
+            <twig:foo
+                # comment
+                foo="foo"
+                # comment
+                bar="bar"
+            />
+            TWIG,
+            '{{ component(\'foo\', { foo: \'foo\', bar: \'bar\' }) }}',
+        ];
+        yield 'component_with_comment_line_containing_ending_tag' => [
+            <<<TWIG
+            <twig:foo
+                # comment /></twig:foo>
+                bar="bar"
+            />
+            TWIG,
+            '{{ component(\'foo\', { bar: \'bar\' }) }}',
+        ];
+        yield 'component_with_comment_line_in_argument_value' => [
+            <<<TWIG
+            <twig:foo
+                bar="# bar"
+            />
+            TWIG,
+            '{{ component(\'foo\', { bar: \'# bar\' }) }}',
+        ];
+        yield 'component_with_comment_line_in_argument_array_value_is_kept' => [
+            <<<TWIG
+            <twig:foo
+                bar="{{ {
+                    a: 'b',
+                    # comment
+                    c: 'd'
+                } }}"
+            />
+            TWIG,
+            // Twig will remove the comment, we don't need to remove it
+            <<<TWIG
+            {{ component('foo', { bar: ({
+                    a: 'b',
+                    # comment
+                    c: 'd'
+                }) }) }}
+            TWIG,
+        ];
     }
 }


### PR DESCRIPTION
Twig introduced the inline comments in https://github.com/twigphp/Twig/pull/4349

This PR add minimal support for it the PreLexer / HTML syntax

```twig
<twig:Button
    # comment
    bar="bar"
/>
```

I'd like some IRL feedbacks on this one :)
