### PR TITLE
[Site] Visual improvments on IconModal 

### DIFF
--- a/ux.symfony.com/assets/styles/components/_IconModal.scss
+++ b/ux.symfony.com/assets/styles/components/_IconModal.scss
@@ -176,7 +176,7 @@
   padding: 0.35rem 0.5rem;
   border-radius: .5rem;
   border: 1px solid var(--bs-dark-border-subtle);
-  background: var(--bs-secondary-bg-subtle);
+  background: var(--bs-secondary-bg);
   overflow: hidden;
   position: relative;
   opacity: .8;
@@ -212,7 +212,7 @@
 }
 
 .IconModal__code span {
-  color: lightskyblue;
+  color: var(--bs-code-color);
 }
 
 .IconModal__copy {
@@ -238,4 +238,3 @@
 .IconModal__main h3:first-child {
   padding-top: 0;
 }
-

--- a/ux.symfony.com/assets/styles/components/_IconModal.scss
+++ b/ux.symfony.com/assets/styles/components/_IconModal.scss
@@ -15,7 +15,7 @@
   min-height: 1rem;
   max-width: 100vw;
   max-height: 100vh;
-  overflow: clip;
+  overflow: auto;
   padding: 1rem 1.5rem;
   background: var(--bs-body-bg);
   color: var(--bs-body-color);
@@ -59,7 +59,6 @@
 
 .IconModal__body {
   display: grid;
-  grid-template-columns: 300px 1fr;
   gap: 1.5rem;
 }
 
@@ -237,4 +236,22 @@
 
 .IconModal__main h3:first-child {
   padding-top: 0;
+}
+
+.IconModal__main .TabBody {
+    padding-block-end: 0;
+}
+
+@media screen and (max-width: 768px) {
+  .IconModal {
+    padding: .5rem;
+    margin: .5rem;
+    width: auto;
+    height: auto;
+  }
+}
+@media screen and (min-width: 768px) {
+  .IconModal__body {
+    grid-template-columns: 300px 1fr;
+  }
 }

--- a/ux.symfony.com/assets/styles/components/_Tabs.scss
+++ b/ux.symfony.com/assets/styles/components/_Tabs.scss
@@ -30,7 +30,7 @@
   transition: background-color 150ms ease-in-out;
 }
 .TabControl.active {
-  background: var(--bs-secondary-bg);
+  background: var(--bs-tertiary-bg);
 }
 
 .TabPanel {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

The `lightsky` color was hard to read on a grey background, I changed it to the Bootstrap code color and it is better (it still does not pass accessibility tests, but that's better). I also changed the active `Tab` background-color: 
<img width="1800" alt="Capture d’écran 2024-12-23 à 09 18 52" src="https://github.com/user-attachments/assets/abffd1b2-17be-419b-a6ae-7281d82b65fe" />

On mobile, or resized window, opening and use the `IconModal` was not convenient, so I adapted it:
<img width="1800" alt="Capture d’écran 2024-12-23 à 09 17 41" src="https://github.com/user-attachments/assets/d84d4af2-66e4-404d-b032-46a41bca2a76" />