### PR TITLE
[LiveComponent] remove form property in live component docs

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1455,9 +1455,7 @@ or omit it entirely to let the ``initialFormData`` property default to ``null``:
     {# templates/post/new.html.twig #}
     {# ... #}
 
-    {{ component('PostForm', {
-        form: form
-    }) }}
+    {{ component('PostForm') }}
 
 Submitting the Form via a LiveAction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | 
| License       | MIT

Passing the form as a property isn't explained until the next section down in the docs. This clears up the example to make it less confusing.
