### PR TITLE
[Turbo] Add explanations regarding form submissions and the `data-turbo` attribute for Flash Messages

### DIFF
--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -179,6 +179,26 @@ situation.
                 ]
             ]);
 
+
+4. Flash Messages and forward-fetching side effects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Of course, if you have side effects, like added `Flash Messages <https://symfony.com/doc/current/session.html#flash-messages>`_ 
+to your form submissions, they will be flushed during the asynchronous call.
+To prevent such actions on form submissions to be executed ahead of time 
+(like emptying a FlashBag of session messages), the best way is 
+to simply disable Turbo Drive on submission inputs/buttons 
+(which are tried on hover by default).
+
+Simply add a ``data-turbo="false"`` attribute and value to your widgets:
+
+.. code-block:: html
+
+        <button data-turbo="false">Submit form</button>
+
+This way, only your real user manual action will trigger the form submission.  
+More information can be found in the Turbo documentation: https://turbo.hotwired.dev/reference/attributes.
+
 More Turbo Drive Info
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -181,7 +181,7 @@ situation.
 
 
 4. Flash Messages and forward-fetching side effects
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Of course, if you have side effects, like added `Flash Messages <https://symfony.com/doc/current/session.html#flash-messages>`_ 
 to your form submissions, they will be flushed during the asynchronous call.


### PR DESCRIPTION
Added info for form submission inputs

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Issues        | 
| License       | MIT

Just added some info regarding how not to lose Flash Messages with Turbo Drive prefetching resources on hover/load.