### PR TITLE
[TwigComponent] Allow `:` as value separator in `{% props %}` tag

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.23.0
+
+-  Allow to use `:` as value separator in `props` tag
+
 ## 2.20.0
 
 -  Add Anonymous Component support for 3rd-party bundles #2019

--- a/src/TwigComponent/src/Twig/PropsTokenParser.php
+++ b/src/TwigComponent/src/Twig/PropsTokenParser.php
@@ -30,14 +30,14 @@ class PropsTokenParser extends AbstractTokenParser
         $values = [];
         while (!$stream->nextIf(Token::BLOCK_END_TYPE)) {
             $name = $stream->expect(Token::NAME_TYPE)->getValue();
-            
+
             if ($stream->nextIf(Token::OPERATOR_TYPE, '=') || $stream->nextIf(Token::PUNCTUATION_TYPE, ':')) {
                 $values[$name] = $this->parser->getExpressionParser()->parseExpression();
             }
-            
+
             $names[] = $name;
 
-            if (!$stream->nextIf(Token::PUNCTUATION_TYPE) && !$stream->nextIf(Token::PUNCTUATION_TYPE, ':')) {
+            if (!$stream->nextIf(Token::PUNCTUATION_TYPE, ',')) {
                 $stream->expect(Token::BLOCK_END_TYPE);
                 break;
             }

--- a/src/TwigComponent/src/Twig/PropsTokenParser.php
+++ b/src/TwigComponent/src/Twig/PropsTokenParser.php
@@ -24,21 +24,20 @@ class PropsTokenParser extends AbstractTokenParser
 {
     public function parse(Token $token): Node
     {
-        $parser = $this->parser;
-        $stream = $parser->getStream();
+        $stream = $this->parser->getStream();
 
         $names = [];
         $values = [];
         while (!$stream->nextIf(Token::BLOCK_END_TYPE)) {
             $name = $stream->expect(Token::NAME_TYPE)->getValue();
-
-            if ($stream->nextIf(Token::OPERATOR_TYPE, '=')) {
-                $values[$name] = $parser->getExpressionParser()->parseExpression();
+            
+            if ($stream->nextIf(Token::OPERATOR_TYPE, '=') || $stream->nextIf(Token::PUNCTUATION_TYPE, ':')) {
+                $values[$name] = $this->parser->getExpressionParser()->parseExpression();
             }
-
+            
             $names[] = $name;
 
-            if (!$stream->nextIf(Token::PUNCTUATION_TYPE)) {
+            if (!$stream->nextIf(Token::PUNCTUATION_TYPE) && !$stream->nextIf(Token::PUNCTUATION_TYPE, ':')) {
                 $stream->expect(Token::BLOCK_END_TYPE);
                 break;
             }

--- a/src/TwigComponent/tests/Integration/Twig/ComponentPropsParserTest.php
+++ b/src/TwigComponent/tests/Integration/Twig/ComponentPropsParserTest.php
@@ -75,6 +75,13 @@ class ComponentPropsParserTest extends KernelTestCase
             ],
             ' foo ',
         ];
+        yield 'One Prop with value comma using : as value separator' => [
+            '{% props propA:123 %} foo ',
+            [
+                'propA' => 123,
+            ],
+            ' foo ',
+        ];
         yield 'One Prop without value' => [
             '{% props propA %} foo ',
             [
@@ -98,6 +105,14 @@ class ComponentPropsParserTest extends KernelTestCase
             ],
             ' foo ',
         ];
+        yield 'All Props with values comma using : as value separator' => [
+            '{% props propA:1, propB:2 %} foo ',
+            [
+                'propA' => 1,
+                'propB' => 2,
+            ],
+            ' foo ',
+        ];
         yield 'Some Props with values' => [
             '{% props propA, propB=2 %} foo ',
             [
@@ -106,8 +121,23 @@ class ComponentPropsParserTest extends KernelTestCase
             ],
             ' foo ',
         ];
+        yield 'Some Props with values comma using : as value separator' => [
+            '{% props propA, propB:2 %} foo ',
+            [
+                'propA' => null,
+                'propB' => 2,
+            ],
+            ' foo ',
+        ];
         yield 'One Prop with value and trailing comma' => [
             '{% props propA=123, %} foo ',
+            [
+                'propA' => 123,
+            ],
+            ' foo ',
+        ];
+        yield 'One Prop with value and trailing comma using : as value separator' => [
+            '{% props propA:123, %} foo ',
             [
                 'propA' => 123,
             ],
@@ -136,8 +166,24 @@ class ComponentPropsParserTest extends KernelTestCase
             ],
             ' foo ',
         ];
+        yield 'All Props with values and trailing comma using : as value separator' => [
+            '{% props propA:1, propB:2, %} foo ',
+            [
+                'propA' => 1,
+                'propB' => 2,
+            ],
+            ' foo ',
+        ];
         yield 'Some Props with values and trailing comma' => [
             '{% props propA, propB=2, %} foo ',
+            [
+                'propA' => null,
+                'propB' => 2,
+            ],
+            ' foo ',
+        ];
+        yield 'Some Props with values and trailing comma using : as value separator' => [
+            '{% props propA, propB:2, %} foo ',
             [
                 'propA' => null,
                 'propB' => 2,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Previous syntax

```twig
{% props foo = true,  baz = 'foobar' %}
```

New syntax

```twig
{% props foo: true,  baz: 'foobar' %}
```

Both are now valid!

~but if we follow Twig conventions, we should switch to the new one in the documentation, etc..~
 removed :) 