### PR TITLE
[LiveComponent] Check if accessed vars exist

### DIFF
--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -261,14 +261,13 @@ trait ComponentWithFormTrait
                 continue;
             }
 
-            if (\array_key_exists('choices', $child->vars)
+            if (\array_key_exists('choices', $child->vars) && $child->vars['choices']
                 && $child->vars['required']
                 && !$child->vars['disabled']
                 && !$child->vars['value']
-                && (false === $child->vars['placeholder'] || null === $child->vars['placeholder'])
-                && !$child->vars['multiple']
-                && !$child->vars['expanded']
-                && $child->vars['choices']
+                && \array_key_exists('placeholder', $child->vars) && (false === $child->vars['placeholder'] || null === $child->vars['placeholder'])
+                && \array_key_exists('multiple', $child->vars) && !$child->vars['multiple']
+                && \array_key_exists('expanded', $child->vars) && !$child->vars['expanded']
             ) {
                 if (null !== $firstKey = array_key_first($child->vars['choices'])) {
                     $values[$name] = $child->vars['choices'][$firstKey]->value ?? null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #2487 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

In my case, checking 'placeholder' for existence is sufficient. But I can imagine some very extreme custom form type which - besides 'choices' - has 'placeholder' option too. In that case, when 'placeholder' is set to false, then 'multiple' option need to be checked for existence, and so on... Considering the most pessimistic scenario, I think at least 'placeholder', 'multiple' and 'expanded' options should be checked.

I'm not sure about the rest - if there could be a situation where 'required', 'disabled' or 'value' option is nonexistent?

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
