### PR TITLE
[LiveComponent] Fix `ComponentWithFormTrait::extractFormValues()` with edge cases

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/FormWithManyDifferentFieldsType.php
@@ -65,6 +65,15 @@ class FormWithManyDifferentFieldsType extends AbstractType
                     'foo' => 1,
                 ],
             ])
+            ->add('choice_required_without_placeholder_and_choice_group', ChoiceType::class, [
+                'choices' => [
+                    'Bar Group' => [
+                        'Bar Label' => 'ok',
+                        'Foo Label' => 'foo_value',
+                    ],
+                    'foo' => 1,
+                ],
+            ])
             ->add('choice_expanded', ChoiceType::class, [
                 'choices' => [
                     'foo' => 1,

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -181,6 +181,7 @@ class ComponentWithFormTest extends KernelTestCase
             'choice_required_with_placeholder' => '',
             'choice_required_with_empty_placeholder' => '',
             'choice_required_without_placeholder' => '2',
+            'choice_required_without_placeholder_and_choice_group' => 'ok',
             'choice_expanded' => '',
             'choice_multiple' => ['2'],
             'select_multiple' => ['2'],

--- a/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
@@ -46,6 +46,7 @@ class ComponentWithFormTest extends KernelTestCase
                 'choice_required_with_placeholder' => '',
                 'choice_required_with_empty_placeholder' => '',
                 'choice_required_without_placeholder' => '2',
+                'choice_required_without_placeholder_and_choice_group' => 'ok',
                 'choice_expanded' => '',
                 'choice_multiple' => ['2'],
                 'select_multiple' => ['2'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #2487 
| License       | MIT

#2403 fixed an old bug to simulate browser behaviour when a select field has no option selected,  no placeholder, and is required (it then uses the first option)
#2425 and #2426 fixed the way we handled empty strings as placeholders

In #2487 @maciazek explained us how a custom type with a "choices" option became unusable since the last changes.

Also.. while I was reading all this I realized we returned wrong values here when "option groups" were used.. leading to other problems.

I updated the code of `extractFormValues()` method to:
* check if most of the caracteristic keys added in `ChoiceType::buildView` were defined in the `$view->vars`, to ensure we are dealing with a `<select>` field built by a `ChoiceType`
* fetch recursively the value of the first displayed option (even with groups)



