### PR TITLE
[TwigComponent] Add new ComponentReflection to extract properties from TwigComponent

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.23.0
+
+- Add `ComponentPropertiesExtractor` to extract component properties from a Twig component
+
 ## 2.20.0
 
 -  Add Anonymous Component support for 3rd-party bundles #2019

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.23.0
 
-- Add `ComponentPropertiesExtractor` to extract component properties from a Twig component
+- Add `ComponentPropertiesExtractor` to extract component properties from a Twig component (experimental)
 
 ## 2.20.0
 

--- a/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
+++ b/src/TwigComponent/src/Command/TwigComponentDebugCommand.php
@@ -21,10 +21,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
-use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentMetadata;
-use Symfony\UX\TwigComponent\Twig\PropsNode;
+use Symfony\UX\TwigComponent\ComponentPropertiesExtractor;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -32,6 +31,7 @@ use Twig\Loader\FilesystemLoader;
 class TwigComponentDebugCommand extends Command
 {
     private readonly string $anonymousDirectory;
+    private readonly ComponentPropertiesExtractor $componentPropertiesExtractor;
 
     public function __construct(
         private string $twigTemplatesPath,
@@ -39,9 +39,11 @@ class TwigComponentDebugCommand extends Command
         private Environment $twig,
         private readonly array $componentClassMap,
         ?string $anonymousDirectory = null,
+        ?ComponentPropertiesExtractor $componentPropertiesExtractor = null,
     ) {
         parent::__construct();
         $this->anonymousDirectory = $anonymousDirectory ?? 'components';
+        $this->componentPropertiesExtractor = $componentPropertiesExtractor ?? new ComponentPropertiesExtractor($this->twig);
     }
 
     protected function configure(): void
@@ -212,12 +214,18 @@ EOF
             ['Template', $metadata->getTemplate()],
         ]);
 
+        $properties = $this->componentPropertiesExtractor->getComponentProperties($metadata);
+        $propertiesAsArrayOfStrings = array_filter(array_map(
+            fn (array $property) => $property['display'],
+            $properties,
+        ));
+
         // Anonymous Component
         if ($metadata->isAnonymous()) {
             $table->addRows([
                 ['Type', '<comment>Anonymous</comment>'],
                 new TableSeparator(),
-                ['Properties', implode("\n", $this->getAnonymousComponentProperties($metadata))],
+                ['Properties', implode("\n", $propertiesAsArrayOfStrings)],
             ]);
             $table->render();
 
@@ -229,7 +237,7 @@ EOF
             new TableSeparator(),
             // ['Attributes Var', $metadata->get('attributes_var')],
             ['Public Props', $metadata->isPublicPropsExposed() ? 'Yes' : 'No'],
-            ['Properties', implode("\n", $this->getComponentProperties($metadata))],
+            ['Properties', implode("\n", $propertiesAsArrayOfStrings)],
         ]);
 
         $logMethod = function (\ReflectionMethod $m) {
@@ -279,81 +287,5 @@ EOF
             ]);
         }
         $table->render();
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function getComponentProperties(ComponentMetadata $metadata): array
-    {
-        $properties = [];
-        $reflectionClass = new \ReflectionClass($metadata->getClass());
-        foreach ($reflectionClass->getProperties() as $property) {
-            $propertyName = $property->getName();
-
-            if ($metadata->isPublicPropsExposed() && $property->isPublic()) {
-                $type = $property->getType();
-                if ($type instanceof \ReflectionNamedType) {
-                    $typeName = $type->getName();
-                } else {
-                    $typeName = (string) $type;
-                }
-                $value = $property->getDefaultValue();
-                $propertyDisplay = $typeName.' $'.$propertyName.(null !== $value ? ' = '.json_encode($value) : '');
-                $properties[$property->name] = $propertyDisplay;
-            }
-
-            foreach ($property->getAttributes(ExposeInTemplate::class) as $exposeAttribute) {
-                /** @var ExposeInTemplate $attribute */
-                $attribute = $exposeAttribute->newInstance();
-                $properties[$property->name] = $attribute->name ?? $property->name;
-            }
-        }
-
-        return $properties;
-    }
-
-    /**
-     * Extract properties from {% props %} tag in anonymous template.
-     *
-     * @return array<string, string>
-     */
-    private function getAnonymousComponentProperties(ComponentMetadata $metadata): array
-    {
-        $source = $this->twig->load($metadata->getTemplate())->getSourceContext();
-        $tokenStream = $this->twig->tokenize($source);
-        $moduleNode = $this->twig->parse($tokenStream);
-
-        $propsNode = null;
-        foreach ($moduleNode->getNode('body') as $bodyNode) {
-            foreach ($bodyNode as $node) {
-                if (PropsNode::class === $node::class) {
-                    $propsNode = $node;
-                    break 2;
-                }
-            }
-        }
-        if (!$propsNode instanceof PropsNode) {
-            return [];
-        }
-
-        $propertyNames = $propsNode->getAttribute('names');
-        $properties = array_combine($propertyNames, $propertyNames);
-        foreach ($propertyNames as $propName) {
-            if ($propsNode->hasNode($propName)
-                && ($valueNode = $propsNode->getNode($propName))
-                && $valueNode->hasAttribute('value')
-            ) {
-                $value = $valueNode->getAttribute('value');
-                if (\is_bool($value)) {
-                    $value = $value ? 'true' : 'false';
-                } else {
-                    $value = json_encode($value);
-                }
-                $properties[$propName] = $propName.' = '.$value;
-            }
-        }
-
-        return $properties;
     }
 }

--- a/src/TwigComponent/src/ComponentPropertiesExtractor.php
+++ b/src/TwigComponent/src/ComponentPropertiesExtractor.php
@@ -17,7 +17,7 @@ use Twig\Environment;
 
 /**
  * @author Jean-François Lépine <lepinejeanfrancois@gmail.com>
- * 
+ *
  * @experimental This class is not covered by the BC promise yet
  */
 final class ComponentPropertiesExtractor
@@ -28,17 +28,19 @@ final class ComponentPropertiesExtractor
     }
 
     /**
-     * Returns a list of properties from a Component. 
+     * Returns a list of properties from a Component.
      *
      * Warning: We do not recommend using this method at runtime, as it is rather slow.
+     *
+     * @return array<string, array{display: string, name: string, type: string, default: mixed}>
      */
     public function getComponentProperties(ComponentMetadata $metadata): array
     {
-        if ($medata->isAnonymous()) {
-            return $this->getAnonymousComponentProperties($medata);
+        if ($metadata->isAnonymous()) {
+            return $this->getAnonymousComponentProperties($metadata);
         }
 
-        return $this->getNonAnonymousComponentProperties($medata);
+        return $this->getNonAnonymousComponentProperties($metadata);
     }
 
     /**

--- a/src/TwigComponent/src/ComponentPropertiesExtractor.php
+++ b/src/TwigComponent/src/ComponentPropertiesExtractor.php
@@ -17,6 +17,8 @@ use Twig\Environment;
 
 /**
  * @author Jean-François Lépine <lepinejeanfrancois@gmail.com>
+ * 
+ * @experimental This class is not covered by the BC promise yet
  */
 final class ComponentPropertiesExtractor
 {

--- a/src/TwigComponent/src/ComponentPropertiesExtractor.php
+++ b/src/TwigComponent/src/ComponentPropertiesExtractor.php
@@ -15,6 +15,9 @@ use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 use Symfony\UX\TwigComponent\Twig\PropsNode;
 use Twig\Environment;
 
+/**
+ * @author Jean-François Lépine <lepinejeanfrancois@gmail.com>
+ */
 final class ComponentPropertiesExtractor
 {
     public function __construct(

--- a/src/TwigComponent/src/ComponentPropertiesExtractor.php
+++ b/src/TwigComponent/src/ComponentPropertiesExtractor.php
@@ -23,7 +23,7 @@ final class ComponentPropertiesExtractor
     }
 
     /**
-     * @return array<string, string>
+     * @return array<array{display: string, name: string, type: string, default: mixed}>
      */
     public function getComponentProperties(ComponentMetadata $medata)
     {
@@ -35,7 +35,7 @@ final class ComponentPropertiesExtractor
     }
 
     /**
-     * @return array<string, string>
+     * @return array<array{display: string, name: string, type: string, default: mixed}>
      */
     private function getNonAnonymousComponentProperties(ComponentMetadata $metadata): array
     {
@@ -81,7 +81,7 @@ final class ComponentPropertiesExtractor
     /**
      * Extract properties from {% props %} tag in anonymous template.
      *
-     * @return array<string, string>
+     * @return array<array{display: string, name: string, type: string, default: mixed}>
      */
     private function getAnonymousComponentProperties(ComponentMetadata $metadata): array
     {

--- a/src/TwigComponent/src/ComponentPropertiesExtractor.php
+++ b/src/TwigComponent/src/ComponentPropertiesExtractor.php
@@ -28,7 +28,7 @@ final class ComponentPropertiesExtractor
     /**
      * @return array<array{display: string, name: string, type: string, default: mixed}>
      */
-    public function getComponentProperties(ComponentMetadata $medata)
+    public function getComponentProperties(ComponentMetadata $metadata): array
     {
         if ($medata->isAnonymous()) {
             return $this->getAnonymousComponentProperties($medata);

--- a/src/TwigComponent/src/ComponentPropertiesExtractor.php
+++ b/src/TwigComponent/src/ComponentPropertiesExtractor.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent;
+
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+use Symfony\UX\TwigComponent\Twig\PropsNode;
+use Twig\Environment;
+
+final class ComponentPropertiesExtractor
+{
+    public function __construct(
+        private readonly Environment $twig,
+    ) {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getComponentProperties(ComponentMetadata $medata)
+    {
+        if ($medata->isAnonymous()) {
+            return $this->getAnonymousComponentProperties($medata);
+        }
+
+        return $this->getNonAnonymousComponentProperties($medata);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getNonAnonymousComponentProperties(ComponentMetadata $metadata): array
+    {
+        $properties = [];
+        $reflectionClass = new \ReflectionClass($metadata->getClass());
+        foreach ($reflectionClass->getProperties() as $property) {
+            $propertyName = $property->getName();
+
+            if ($metadata->isPublicPropsExposed() && $property->isPublic()) {
+                $type = $property->getType();
+                if ($type instanceof \ReflectionNamedType) {
+                    $typeName = $type->getName();
+                } else {
+                    $typeName = (string) $type;
+                }
+                $value = $property->getDefaultValue();
+                $propertyDisplay = $typeName.' $'.$propertyName.(null !== $value ? ' = '.json_encode(
+                    $value
+                ) : '');
+                $properties[$property->name] = [
+                    'name' => $propertyName,
+                    'display' => $propertyDisplay,
+                    'type' => $typeName,
+                    'default' => $value,
+                ];
+            }
+
+            foreach ($property->getAttributes(ExposeInTemplate::class) as $exposeAttribute) {
+                /** @var ExposeInTemplate $attribute */
+                $attribute = $exposeAttribute->newInstance();
+                $properties[$property->name] = [
+                    'name' => $attribute->name ?? $property->name,
+                    'display' => $attribute->name ?? $property->name,
+                    'type' => 'mixed',
+                    'default' => null,
+                ];
+            }
+        }
+
+        return $properties;
+    }
+
+    /**
+     * Extract properties from {% props %} tag in anonymous template.
+     *
+     * @return array<string, string>
+     */
+    private function getAnonymousComponentProperties(ComponentMetadata $metadata): array
+    {
+        $source = $this->twig->load($metadata->getTemplate())->getSourceContext();
+        $tokenStream = $this->twig->tokenize($source);
+        $moduleNode = $this->twig->parse($tokenStream);
+
+        $propsNode = null;
+        foreach ($moduleNode->getNode('body') as $bodyNode) {
+            foreach ($bodyNode as $node) {
+                if (PropsNode::class === $node::class) {
+                    $propsNode = $node;
+                    break 2;
+                }
+            }
+        }
+        if (!$propsNode instanceof PropsNode) {
+            return [];
+        }
+
+        $propertyNames = $propsNode->getAttribute('names');
+        $properties = array_combine($propertyNames, $propertyNames);
+        foreach ($propertyNames as $propName) {
+            if ($propsNode->hasNode($propName)
+                && ($valueNode = $propsNode->getNode($propName))
+                && $valueNode->hasAttribute('value')
+            ) {
+                $value = $valueNode->getAttribute('value');
+                if (\is_bool($value)) {
+                    $value = $value ? 'true' : 'false';
+                } else {
+                    $value = json_encode($value);
+                }
+                $display = $propName.' = '.$value;
+                $properties[$propName] = [
+                    'name' => $propName,
+                    'display' => $display,
+                    'type' => \is_bool($value) ? 'bool' : 'mixed',
+                    'default' => $value,
+                ];
+            }
+        }
+
+        foreach ($properties as $propertyData) {
+            if (\is_string($propertyData)) {
+                $properties[$propertyData] = [
+                    'name' => $propertyData,
+                    'display' => $propertyData,
+                    'type' => 'mixed',
+                    'default' => null,
+                ];
+            }
+        }
+
+        return $properties;
+    }
+}

--- a/src/TwigComponent/src/ComponentPropertiesExtractor.php
+++ b/src/TwigComponent/src/ComponentPropertiesExtractor.php
@@ -26,7 +26,9 @@ final class ComponentPropertiesExtractor
     }
 
     /**
-     * @return array<array{display: string, name: string, type: string, default: mixed}>
+     * Returns a list of properties from a Component. 
+     *
+     * Warning: We do not recommend using this method at runtime, as it is rather slow.
      */
     public function getComponentProperties(ComponentMetadata $metadata): array
     {

--- a/src/TwigComponent/src/ComponentPropertiesExtractor.php
+++ b/src/TwigComponent/src/ComponentPropertiesExtractor.php
@@ -40,7 +40,7 @@ final class ComponentPropertiesExtractor
     }
 
     /**
-     * @return array<array{display: string, name: string, type: string, default: mixed}>
+     * @return array<string, array{display: string, name: string, type: string, default: mixed}>
      */
     private function getNonAnonymousComponentProperties(ComponentMetadata $metadata): array
     {

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -32,6 +32,7 @@ use Symfony\UX\TwigComponent\CacheWarmer\TwigComponentCacheWarmer;
 use Symfony\UX\TwigComponent\Command\TwigComponentDebugCommand;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentProperties;
+use Symfony\UX\TwigComponent\ComponentPropertiesExtractor;
 use Symfony\UX\TwigComponent\ComponentRenderer;
 use Symfony\UX\TwigComponent\ComponentRendererInterface;
 use Symfony\UX\TwigComponent\ComponentStack;
@@ -134,6 +135,11 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
             ->setDecoratedService(new Reference('twig.configurator.environment'))
             ->setArguments([new Reference('ux.twig_component.twig.environment_configurator.inner')]);
 
+        $container->register('ux.twig_component.extractor_properties', ComponentPropertiesExtractor::class)
+            ->setArguments([
+                new Reference('twig'),
+            ]);
+
         $container->register('ux.twig_component.command.debug', TwigComponentDebugCommand::class)
             ->setArguments([
                 new Parameter('twig.default_path'),
@@ -141,6 +147,7 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                 new Reference('twig'),
                 new AbstractArgument(\sprintf('Added in %s.', TwigComponentPass::class)),
                 $config['anonymous_template_directory'],
+                new Reference('ux.twig_component.extractor_properties'),
             ])
             ->addTag('console.command')
         ;

--- a/src/TwigComponent/tests/Unit/ComponentPropertiesExtractorTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentPropertiesExtractorTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\TwigComponent\ComponentFactory;
+use Symfony\UX\TwigComponent\ComponentPropertiesExtractor;
+use Twig\Environment;
+
+class ComponentPropertiesExtractorTest extends KernelTestCase
+{
+    public function testPropsAreFoundInTwigComponent(): void
+    {
+        /** @var ComponentFactory $factory */
+        $factory = self::getContainer()->get('ux.twig_component.component_factory');
+        $twig = self::getContainer()->get(Environment::class);
+        $metadata = $factory->metadataFor('DivComponent5');
+
+        $extractor = new ComponentPropertiesExtractor($twig);
+        $attributes = $extractor->getComponentProperties($metadata);
+
+        $this->assertEquals([
+            'divComponentName' => [
+                'display' => 'string $divComponentName = "foo"',
+                'name' => 'divComponentName',
+                'type' => 'string',
+                'default' => 'foo',
+            ],
+        ], $attributes);
+    }
+
+    public function testPropsAreFoundInTwigComponentWithoutProps(): void
+    {
+        /** @var ComponentFactory $factory */
+        $factory = self::getContainer()->get('ux.twig_component.component_factory');
+        $twig = self::getContainer()->get(Environment::class);
+        $metadata = $factory->metadataFor('DivComponent6');
+
+        $extractor = new ComponentPropertiesExtractor($twig);
+        $attributes = $extractor->getComponentProperties($metadata);
+
+        $this->assertEmpty($attributes);
+    }
+
+    public function testPropsAreFoundInTwigAnonymousComponent(): void
+    {
+        /** @var ComponentFactory $factory */
+        $factory = self::getContainer()->get('ux.twig_component.component_factory');
+        $twig = self::getContainer()->get(Environment::class);
+        $metadata = $factory->metadataFor('Button');
+
+        $extractor = new ComponentPropertiesExtractor($twig);
+        $attributes = $extractor->getComponentProperties($metadata);
+
+        $expected = [
+            'label' => [
+                'display' => 'label',
+                'name' => 'label',
+                'type' => 'mixed',
+                'default' => null,
+            ],
+            'primary' => [
+                'display' => 'primary = true',
+                'name' => 'primary',
+                'type' => 'mixed',
+                'default' => 'true',
+            ],
+        ];
+        $this->assertEquals($expected, $attributes);
+    }
+
+    public function testPropsAreFoundInTwigAnonymousComponentWithJusteAttributes(): void
+    {
+        /** @var ComponentFactory $factory */
+        $factory = self::getContainer()->get('ux.twig_component.component_factory');
+        $twig = self::getContainer()->get(Environment::class);
+        $metadata = $factory->metadataFor('JustAttributes');
+
+        $extractor = new ComponentPropertiesExtractor($twig);
+        $attributes = $extractor->getComponentProperties($metadata);
+
+        $this->assertEmpty($attributes);
+    }
+
+    public function testPropsAreFoundInTwigAnonymousComponentWithEmptyProps(): void
+    {
+        /** @var ComponentFactory $factory */
+        $factory = self::getContainer()->get('ux.twig_component.component_factory');
+        $twig = self::getContainer()->get(Environment::class);
+        $metadata = $factory->metadataFor('EmptyProps');
+
+        $extractor = new ComponentPropertiesExtractor($twig);
+        $attributes = $extractor->getComponentProperties($metadata);
+
+        $this->assertEmpty($attributes);
+    }
+}

--- a/src/TwigComponent/tests/Unit/ComponentPropertiesExtractorTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentPropertiesExtractorTest.php
@@ -16,6 +16,9 @@ use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentPropertiesExtractor;
 use Twig\Environment;
 
+/**
+ * @author Jean-François Lépine <lepinejeanfrancois@gmail.com>
+ */
 class ComponentPropertiesExtractorTest extends KernelTestCase
 {
     public function testPropsAreFoundInTwigComponent(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | 
| License       | MIT

Hello,

I'm currently trying to build a tool that analyzes `TwigComponent` to document (automatically) the components of a project. A bit like what [StoryBook](https://storybook.js.org/) does, but for Twig.

For this, I need to retrieve the properties of a component. The `TwigComponentDebugCommand` command already does this. This PR extracts the relevant code, and moves it to the new `ComponentPropertiesExtractor` class.

~~A BC is introduced: I need to inject the `ComponentPropertiesExtractor` class into the `TwigComponentDebugCommand`, but the last argument of the constructor is optional. This is normally not a problem: the class is internal~~
~~If necessary, I can keep backward compatibility by building the object directly in the code (rather than injecting it), but in the long run this may introduce testability issues.~~
Edit: fixed thanks to @Kocal suggestion

Thank you for your feedback!