### PR TITLE
[CI] Fix and display changed dist files in the CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,21 +47,17 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-yarn-
             - run: yarn --immutable && yarn build
-            - name: Check if js dist files are current
-              id: changes
-              run: |
-                echo "STATUS=$(git status --porcelain)" >> $GITHUB_OUTPUT
 
-            - name: No changes found
-              if: steps.changes.outputs.STATUS == ''
+            - name: Check if JS dist files are current
               run: |
-                echo "git status is clean"
-            - name: Changes were found
-              if: steps.changes.outputs.STATUS != ''
-              run: |
-                echo "JS dist files need to be rebuilt"
-                echo "${{ steps.changes.outputs.STATUS }}"
-                exit 1
+                if [[ -n $(git status --porcelain) ]]; then
+                  echo "The Git workspace is unclean! Changes detected:"
+                  git status --porcelain
+                  git diff
+                  exit 1
+                else
+                  echo "The Git workspace is clean. No changes detected."
+                fi
 
     tests-php-components:
         runs-on: ubuntu-latest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

When working on https://github.com/symfony/stimulus-bridge, I've added a new job CI that shows when dist files are up-to-date or need to be build.

No surprise, I re-used what was on UX, but I found it was not correct: https://github.com/symfony/stimulus-bridge/actions/runs/12743300005/job/35512968204?pr=96
<img width="993" alt="image" src="https://github.com/user-attachments/assets/564c5a93-3aed-4fca-abee-32fd01ec72d2" />

The command that checks if files are up-to-date fails, to me it is not working as expected.

Instead, I've simplified things and added a `git diff` to display the changes: 
<img width="1017" alt="image" src="https://github.com/user-attachments/assets/666112e3-5247-4331-8c8a-edec57b3a9aa" />

WDYT?
