### PR TITLE
[CI] Drop explicit Yarn dependencies caching steps for actions/setup-node

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,16 +17,9 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - run: corepack enable
-            - name: Get yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v4
-              id: yarn-cache
+            - uses: actions/setup-node@v4
               with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
+                cache: 'yarn'
             - run: yarn --immutable
             - run: yarn ci
 
@@ -36,16 +29,12 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - run: corepack enable
-            - name: Get yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v4
-              id: yarn-cache
+            - uses: actions/setup-node@v4
               with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
+                cache: 'yarn'
+                cache-dependency-path: |
+                  yarn.lock
+                  **/package.json
             - run: yarn --immutable && yarn build
             - name: Check if js dist files are current
               id: changes
@@ -134,16 +123,12 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - run: corepack enable
-            - name: Get yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v4
-              id: yarn-cache
+            - uses: actions/setup-node@v4
               with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
+                cache: 'yarn'
+                cache-dependency-path: |
+                  yarn.lock
+                  **/package.json
             - run: yarn --immutable
             - run: yarn playwright install
             - run: yarn test


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

While working on the UX's CI, I noticed that we manually handle Yarn cache (2 _longs_ steps). 

Instead, we can use `actions/setup-node` and `cache: yarn` to lighten the workflow file and ease the maintenance.
