### PR TITLE
[TwigComponent][Docs] add explicit string cast on string assertions

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1342,7 +1342,7 @@ You can test how your component is mounted and rendered using the
                 data: ['foo' => 'bar'],
             );
 
-            $this->assertStringContainsString('bar', $rendered);
+            $this->assertStringContainsString('bar', (string) $rendered);
 
             // use the crawler
             $this->assertCount(5, $rendered->crawler()->filter('ul li'));
@@ -1360,7 +1360,7 @@ You can test how your component is mounted and rendered using the
                 ],
             );
 
-            $this->assertStringContainsString('bar', $rendered);
+            $this->assertStringContainsString('bar', (string) $rendered);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Following the examples from the documentation, I realized that if we use the `TestLiveComponent::render` method in `assertStringContainsString` and if we use strict types, then it throw an error because we try to assert a `RenderedComponent` object instead of a string. 

I think that explicitly adding the cast can help.
