### PR TITLE
[LiveComponent] Update doc on how to use submitForm

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3732,9 +3732,9 @@ uses Symfony's test client to render and make requests to your components::
                 ->set('count', 99)
             ;
 
-            // Submit form data
+            // Submit form data ('my_form' for your MyFormType form)
             $testComponent
-                ->submitForm(['form' => ['input' => 'value']], 'save');
+                ->submitForm(['my_form' => ['input' => 'value']], 'save');
 
             $this->assertStringContainsString('Count: 99', $testComponent->render());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Issues        | Fix #2509  
| License       | MIT

As described in the issue, I struggled a bit with the usage of the submitForm helper for testing a LiveComponent due to the name of the form used not being correct see #2509.

I propose a small update to the documentation to make it more clear how the formName should be used into the call of submitForm
