### PR TITLE
[Docs][LiveComponent] Add very simple download files docs

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1335,23 +1335,12 @@ Currently, Live Components do not natively support returning file responses dire
 
 Create a LiveAction that generates the URL for the file download and returns a `RedirectResponse`::
 
-    use Symfony\Component\HttpFoundation\RedirectResponse;
-    use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-    use Symfony\UX\LiveComponent\Attribute\LiveAction;
-
-    // ...
-
-    class MyDownloadButton
-    {
-    // ...
-
         #[LiveAction]
         public function initiateDownload(UrlGeneratorInterface $urlGenerator): RedirectResponse
         {
             $url = $urlGenerator->generate('app_file_download');
             return new RedirectResponse($url);
         }
-    }
 
 .. code-block:: html+twig
 
@@ -3802,7 +3791,7 @@ uses Symfony's test client to render and make requests to your components::
             // authenticate a user ($user is instance of UserInterface)
             $testComponent->actingAs($user);
 
-            // set the '_locale' route parameter (if the component route is localized)  
+            // set the '_locale' route parameter (if the component route is localized)
             $testComponent->setRouteLocale('fr');
 
             // customize the test client

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1364,7 +1364,10 @@ Create a LiveAction that generates the URL for the file download and returns a `
         </button>
     </div>
 
-When Turbo is enabled, it will intercept the redirect and initiate a second request for the download URL. Adding `data-turbo="false"` ensures that the download URL is called only once.
+
+.. tip::
+
+    When Turbo is enabled, if a LiveAction response redirects to another URL, Turbo will make a request to prefetch the content. Here, adding ``data-turbo="false"`` ensures that the download URL is called only once.
 
 .. note::
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1329,40 +1329,40 @@ The files will be available in a regular ``$request->files`` files bag::
 .. _downloads:
 
 Downloading files
------------------------
+-----------------
 
 Currently, Live Components do not natively support returning file responses directly from a LiveAction. However, you can implement file downloads by redirecting to a route that handles the file response.
 
 Create a LiveAction that generates the URL for the file download and returns a `RedirectResponse`::
 
-       use Symfony\Component\HttpFoundation\RedirectResponse;
-       use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-       use Symfony\UX\LiveComponent\Attribute\LiveAction;
+    use Symfony\Component\HttpFoundation\RedirectResponse;
+    use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+    use Symfony\UX\LiveComponent\Attribute\LiveAction;
 
-       // ...
+    // ...
 
-       class MyDownloadButton
-       {
-           // ...
+    class MyDownloadButton
+    {
+    // ...
 
-           #[LiveAction]
-           public function initiateDownload(UrlGeneratorInterface $urlGenerator): RedirectResponse
-           {
-               $url = $urlGenerator->generate('app_file_download');
-               return new RedirectResponse($url);
-           }
-       }
+        #[LiveAction]
+        public function initiateDownload(UrlGeneratorInterface $urlGenerator): RedirectResponse
+        {
+            $url = $urlGenerator->generate('app_file_download');
+            return new RedirectResponse($url);
+        }
+    }
 
 .. code-block:: html+twig
 
-   <div {{ attributes }} data-turbo="false">
-       <button
-           data-action="live#action"
-           data-live-action-param="initiateDownload"
-       >
-           Download
-       </button>
-   </div>
+    <div {{ attributes }} data-turbo="false">
+        <button
+            data-action="live#action"
+            data-live-action-param="initiateDownload"
+        >
+        Download
+        </button>
+    </div>
 
 When Turbo is enabled, it will intercept the redirect and initiate a second request for the download URL. Adding `data-turbo="false"` ensures that the download URL is called only once.
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3791,7 +3791,7 @@ uses Symfony's test client to render and make requests to your components::
             // authenticate a user ($user is instance of UserInterface)
             $testComponent->actingAs($user);
 
-            // set the '_locale' route parameter (if the component route is localized)
+            // set the '_locale' route parameter (if the component route is localized)  
             $testComponent->setRouteLocale('fr');
 
             // customize the test client

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1358,10 +1358,6 @@ Create a LiveAction that generates the URL for the file download and returns a `
 
     When Turbo is enabled, if a LiveAction response redirects to another URL, Turbo will make a request to prefetch the content. Here, adding ``data-turbo="false"`` ensures that the download URL is called only once.
 
-.. note::
-
-   Native support for file downloads in Live Components is under development. For more details, refer to the related `pull request #2483 <https://github.com/symfony/ux/pull/2483>`_.
-
 
 .. _forms:
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1360,7 +1360,7 @@ Create a LiveAction that generates the URL for the file download and returns a `
             data-action="live#action"
             data-live-action-param="initiateDownload"
         >
-        Download
+            Download
         </button>
     </div>
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1326,6 +1326,51 @@ The files will be available in a regular ``$request->files`` files bag::
     need to specify ``multiple`` attribute on HTML element and end ``name``
     with ``[]``.
 
+.. _downloads:
+
+Downloading files
+-----------------------
+
+Currently, Live Components do not natively support returning file responses directly from a LiveAction. However, you can implement file downloads by redirecting to a route that handles the file response.
+
+Create a LiveAction that generates the URL for the file download and returns a `RedirectResponse`::
+
+       use Symfony\Component\HttpFoundation\RedirectResponse;
+       use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+       use Symfony\UX\LiveComponent\Attribute\LiveAction;
+
+       // ...
+
+       class MyDownloadButton
+       {
+           // ...
+
+           #[LiveAction]
+           public function initiateDownload(UrlGeneratorInterface $urlGenerator): RedirectResponse
+           {
+               $url = $urlGenerator->generate('app_file_download');
+               return new RedirectResponse($url);
+           }
+       }
+
+.. code-block:: html+twig
+
+   <div {{ attributes }} data-turbo="false">
+       <button
+           data-action="live#action"
+           data-live-action-param="initiateDownload"
+       >
+           Download
+       </button>
+   </div>
+
+When Turbo is enabled, it will intercept the redirect and initiate a second request for the download URL. Adding `data-turbo="false"` ensures that the download URL is called only once.
+
+.. note::
+
+   Native support for file downloads in Live Components is under development. For more details, refer to the related `pull request #2483 <https://github.com/symfony/ux/pull/2483>`_.
+
+
 .. _forms:
 
 Forms


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| License       | MIT

Motivated by https://github.com/symfony/ux/issues/1516#issuecomment-2599220231 
I don't know if it's enough.
Maybe a dedicated section about the behavior of turbo when a LiveAction of a Live Component is returning a ``RedirectResponse`` should be more appropriate ?
