### PR TITLE
Update mercure doc configuration

### DIFF
--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -516,10 +516,14 @@ Otherwise, configure Mercure Hub(s) to use:
 
 .. code-block:: yaml
 
-    # config/packages/turbo.yaml
-    turbo:
-        mercure:
-            hubs: [default]
+    # config/packages/mercure.yaml
+    mercure:
+        default:
+            url: '%env(MERCURE_URL)%'
+            public_url: '%env(MERCURE_PUBLIC_URL)%'
+            jwt:
+                secret: '%env(MERCURE_JWT_SECRET)%'
+                publish: '*'
 
 Let's create our chat::
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #2518 
| License       | MIT

The turbo-mercure-bundle does not exist anymore, so mercure configuration is enough to have mercure and turbo working together 
