### PR TITLE
[React] Mention Webpack Encoure bundle should be installed first

### DIFF
--- a/src/React/doc/index.rst
+++ b/src/React/doc/index.rst
@@ -14,6 +14,7 @@ Symfony UX React supports React 18+.
 
 Installation
 ------------
+Make sure you have WebpackEncore if you are not working with AssetMapper. You can install and configure Webpack Encore through the `Symfony Encore bundle`_. This will modify your ``base.html.twig`` template and create ``assets/app.js``, in addition to adding and modifying other configuration, which will in turn help you get started faster with the UX React bundle.
 
 .. note::
 
@@ -156,3 +157,4 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Symfony UX initiative`: https://ux.symfony.com/
 .. _`Symfony UX React demo`: https://ux.symfony.com/react
 .. _`Turbo`: https://turbo.hotwire.dev/
+.. _`Symfony Encore bundle`: https://symfony.com/doc/current/frontend/encore/installation.html


### PR DESCRIPTION
If not working with AssetMapper.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This will help newcomers not have to remove the UX React bundle if they wanted it to modify what is created through the Webpack Encore bundle.