### PR TITLE
[Docs][LiveComponent] Fix formatting of the inline code for the text RedirectResponse

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1333,7 +1333,7 @@ Downloading files
 
 Currently, Live Components do not natively support returning file responses directly from a LiveAction. However, you can implement file downloads by redirecting to a route that handles the file response.
 
-Create a LiveAction that generates the URL for the file download and returns a `RedirectResponse`::
+Create a LiveAction that generates the URL for the file download and returns a ``RedirectResponse``::
 
         #[LiveAction]
         public function initiateDownload(UrlGeneratorInterface $urlGenerator): RedirectResponse


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| License       | MIT

Following the  merge of PR #2513, the   double backticks for the inline literal ``RedirectResponse`` are missing.

![image_702](https://github.com/user-attachments/assets/47e16e06-7871-4675-98c4-8147e474fb12)


