### PR TITLE
[Turbo] Add stream format with request listener

### DIFF
--- a/src/Turbo/config/services.php
+++ b/src/Turbo/config/services.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\UX\Turbo\Broadcaster\BroadcasterInterface;
 use Symfony\UX\Turbo\Broadcaster\IdAccessor;
 use Symfony\UX\Turbo\Broadcaster\ImuxBroadcaster;
 use Symfony\UX\Turbo\Broadcaster\TwigBroadcaster;
 use Symfony\UX\Turbo\Doctrine\BroadcastListener;
+use Symfony\UX\Turbo\Request\RequestListener;
 use Symfony\UX\Turbo\Twig\TwigExtension;
 
 /*
@@ -55,5 +57,8 @@ return static function (ContainerConfigurator $container): void {
             ])
             ->tag('doctrine.event_listener', ['event' => 'onFlush'])
             ->tag('doctrine.event_listener', ['event' => 'postFlush'])
+
+        ->set('turbo.kernel.request_listener', RequestListener::class)
+            ->tag('kernel.event_listener', ['event' => KernelEvents::REQUEST, 'priority' => 256])
     ;
 };

--- a/src/Turbo/src/Request/RequestListener.php
+++ b/src/Turbo/src/Request/RequestListener.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Request;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\UX\Turbo\TurboBundle;
+
+/**
+ * Registers the Turbo request format for all requests.
+ *
+ * @author Alexander Hofbauer <a.hofbauer@fify.at>
+ */
+final class RequestListener
+{
+    public function __invoke(): void
+    {
+        (new Request())->setFormat(TurboBundle::STREAM_FORMAT, TurboBundle::STREAM_MEDIA_TYPE);
+    }
+}

--- a/src/Turbo/src/TurboBundle.php
+++ b/src/Turbo/src/TurboBundle.php
@@ -14,7 +14,6 @@ namespace Symfony\UX\Turbo;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -24,11 +23,6 @@ final class TurboBundle extends Bundle
 {
     public const STREAM_FORMAT = 'turbo_stream';
     public const STREAM_MEDIA_TYPE = 'text/vnd.turbo-stream.html';
-
-    public function boot(): void
-    {
-        (new Request())->setFormat(self::STREAM_FORMAT, self::STREAM_MEDIA_TYPE);
-    }
 
     public function build(ContainerBuilder $container): void
     {

--- a/src/Turbo/tests/Request/RequestListenerTest.php
+++ b/src/Turbo/tests/Request/RequestListenerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Request;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\UX\Turbo\TurboBundle;
+
+/**
+ * Tests the Turbo request listener.
+ *
+ * @author Alexander Hofbauer <a.hofbauer@fify.at>
+ */
+class RequestListenerTest extends WebTestCase
+{
+    public function testAddsTurboRequestFormat(): void
+    {
+        $client = static::createClient(server: [
+            'HTTP_ACCEPT' => 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml',
+        ]);
+
+        // simulate worker mode
+        $client->disableReboot();
+
+        // request twice to test if listener is always called
+        $this->assertPreferredFormat();
+        $this->assertPreferredFormat();
+    }
+
+    private function assertPreferredFormat(): void
+    {
+        /** @var KernelBrowser $client */
+        $client = static::getClient();
+
+        $client->request('POST', '/turboRequest');
+
+        $response = $client->getResponse()->getContent();
+
+        $expectedJson = json_encode([
+            'preferred_format' => TurboBundle::STREAM_FORMAT,
+        ]);
+
+        $this->assertJsonStringEqualsJsonString($expectedJson ?: '', $response ?: '');
+    }
+}

--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -29,6 +29,7 @@ use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -144,6 +145,7 @@ class Kernel extends BaseKernel
         $routes->add('artists', '/artists')->controller('kernel::artists');
         $routes->add('artist', '/artists/{id}')->controller('kernel::artist');
         $routes->add('artist_from_song', '/artistFromSong')->controller('kernel::artistFromSong');
+        $routes->add('turbo_request', '/turboRequest')->controller('kernel::turboRequest');
     }
 
     public function getProjectDir(): string
@@ -311,5 +313,12 @@ class Kernel extends BaseKernel
         return new Response($twig->render('artist_from_song.html.twig', [
             'song' => $song,
         ]));
+    }
+
+    public function turboRequest(Request $request): Response
+    {
+        return new JsonResponse([
+            'preferred_format' => $request->getPreferredFormat(),
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #2549
| License       | MIT

BundleInterface::boot() is only called when booting a worker and not on every request. So on FrankenPHP for example Turbo requests would never return a stream when checking with `if ($request->getPreferredFormat() === TurboBundle::STREAM_FORMAT`.

This replaces `TurboBundle::boot()` with a request listener to register the format on every request.