### PR TITLE
[Map] Add new helpers: DistanceUnit, DistanceCalculator, CoordinateUtils

### DIFF
--- a/src/Map/CHANGELOG.md
+++ b/src/Map/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
  
+## 2.23
+
+-  Add `DistanceUnit` to represent distance units (`m`, `km`, `miles`, `nmi`) and
+   ease conversion between units.
+-  Add `DistanceCalculatorInterface` interface and three implementations:
+   `HaversineDistanceCalculator`, `SphericalCosineDistanceCalculator` and `VincentyDistanceCalculator`.
+-  Add `CoordinateUtils` helper, to convert decimal coordinates (`43.2109`) in DMS (`56° 78' 90"`)
+
 ## 2.22
 
 -   Add method `Symfony\UX\Map\Renderer\AbstractRenderer::tapOptions()`, to allow Renderer to modify options before rendering a Map.

--- a/src/Map/src/Distance/DistanceCalculator.php
+++ b/src/Map/src/Distance/DistanceCalculator.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Distance;
+
+use Symfony\UX\Map\Point;
+
+/**
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final readonly class DistanceCalculator implements DistanceCalculatorInterface
+{
+    public function __construct(
+        private DistanceCalculatorInterface $calculator = new VincentyDistanceCalculator(),
+        private DistanceUnit $unit = DistanceUnit::Meter,
+    ) {
+    }
+
+    public function calculateDistance(Point $point1, Point $point2): float
+    {
+        return $this->calculator->calculateDistance($point1, $point2)
+            * $this->unit->getConversionFactor();
+    }
+}

--- a/src/Map/src/Distance/DistanceCalculatorInterface.php
+++ b/src/Map/src/Distance/DistanceCalculatorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Distance;
+
+use Symfony\UX\Map\Point;
+
+/**
+ * Interface for distance calculators.
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+interface DistanceCalculatorInterface
+{
+    /**
+     * Returns the distance between two points given their coordinates.
+     *
+     * @return float the distance between the two points, in meters
+     */
+    public function calculateDistance(Point $point1, Point $point2): float;
+}

--- a/src/Map/src/Distance/DistanceUnit.php
+++ b/src/Map/src/Distance/DistanceUnit.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Distance;
+
+/**
+ * Represents a distance unit used in mapping and geospatial calculations.
+ *
+ * This enum defines common units for measuring distances. Each unit has an associated
+ * conversion factor which is used to convert a value from meters to that unit.
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+enum DistanceUnit: string
+{
+    /**
+     * The "meter" unit.
+     *
+     * This is the International System of Units (SI) base unit for length.
+     */
+    case Meter = 'm';
+
+    /**
+     * The "kilometer" unit.
+     *
+     * This unit is commonly used for longer distances.
+     */
+    case Kilometer = 'km';
+
+    /**
+     * The "mile" unit.
+     *
+     * This unit is widely used in the United States.
+     */
+    case Mile = 'mi';
+
+    /**
+     * The "nautical mile" unit.
+     *
+     * This unit is typically used in navigation.
+     */
+    case NauticalMile = 'nmi';
+
+    /**
+     * Returns the conversion factor to convert this unit to meters.
+     */
+    public function getConversionFactor(): float
+    {
+        return match ($this) {
+            self::Meter => 1.0,
+            self::Kilometer => 0.001,
+            self::Mile => 0.000621371,
+            self::NauticalMile => 0.000539957,
+        };
+    }
+
+    /**
+     * Returns the conversion factor to convert this unit to another unit.
+     */
+    public function getConversionFactorTo(DistanceUnit $unit): float
+    {
+        return $this->getConversionFactor() / $unit->getConversionFactor();
+    }
+
+    /**
+     * Returns the conversion factor to convert another unit to this unit.
+     */
+    public function getConversionFactorFrom(DistanceUnit $unit): float
+    {
+        return $unit->getConversionFactor() / $this->getConversionFactor();
+    }
+}

--- a/src/Map/src/Distance/HaversineDistanceCalculator.php
+++ b/src/Map/src/Distance/HaversineDistanceCalculator.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Distance;
+
+use Symfony\UX\Map\Point;
+
+/**
+ * Haversine formula-based distance calculator.
+ *
+ * This calculator is accurate but slower than the spherical cosine formula.
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final readonly class HaversineDistanceCalculator implements DistanceCalculatorInterface
+{
+    /**
+     * @const float The Earth's radius in meters.
+     */
+    private const EARTH_RADIUS = 6371000.0;
+
+    public function calculateDistance(Point $point1, Point $point2): float
+    {
+        $lat1Rad = deg2rad($point1->getLatitude());
+        $lat2Rad = deg2rad($point2->getLatitude());
+        $deltaLat = deg2rad($point2->getLatitude() - $point1->getLatitude());
+        $deltaLng = deg2rad($point2->getLongitude() - $point1->getLongitude());
+
+        $a = sin($deltaLat / 2) ** 2 + cos($lat1Rad) * cos($lat2Rad) * sin($deltaLng / 2) ** 2;
+        $c = 2 * asin(min(1.0, sqrt($a)));
+
+        return self::EARTH_RADIUS * $c;
+    }
+}

--- a/src/Map/src/Distance/SphericalCosineDistanceCalculator.php
+++ b/src/Map/src/Distance/SphericalCosineDistanceCalculator.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Distance;
+
+use Symfony\UX\Map\Point;
+
+/**
+ * Sphere-based distance calculator using the cosine of the spherical distance.
+ *
+ * This calculator is faster than the Haversine formula, but less accurate.
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final readonly class SphericalCosineDistanceCalculator implements DistanceCalculatorInterface
+{
+    /**
+     * @const float The Earth's radius in meters.
+     */
+    private const EARTH_RADIUS = 6371000.0;
+
+    public function calculateDistance(Point $point1, Point $point2): float
+    {
+        $lat1Rad = deg2rad($point1->getLatitude());
+        $lat2Rad = deg2rad($point2->getLatitude());
+        $lng1Rad = deg2rad($point1->getLongitude());
+        $lng2Rad = deg2rad($point2->getLongitude());
+
+        $cosDistance = sin($lat1Rad) * sin($lat2Rad) + cos($lat1Rad) * cos($lat2Rad) * cos($lng2Rad - $lng1Rad);
+
+        // Correct for floating-point errors.
+        $cosDistance = min(1.0, max(-1.0, $cosDistance));
+        $angle = acos($cosDistance);
+
+        return self::EARTH_RADIUS * $angle;
+    }
+}

--- a/src/Map/src/Distance/VincentyDistanceCalculator.php
+++ b/src/Map/src/Distance/VincentyDistanceCalculator.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Distance;
+
+use Symfony\UX\Map\Point;
+
+/**
+ * Vincenty formula-based distance calculator.
+ *
+ * This calculator is more accurate than the Haversine formula, but slower.
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final readonly class VincentyDistanceCalculator implements DistanceCalculatorInterface
+{
+    /**
+     * WS-84 ellipsoid parameters.
+     */
+    // Major Axis in meters
+    private const A = 6378137.0;
+    // Flattening
+    private const F = 1 / 298.257223563;
+    // Minor Axis in meters
+    private const B = 6356752.314245;
+
+    public function calculateDistance(Point $point1, Point $point2): float
+    {
+        $phi1 = deg2rad($point1->getLatitude());
+        $phi2 = deg2rad($point2->getLatitude());
+        $lambda1 = deg2rad($point1->getLongitude());
+        $lambda2 = deg2rad($point2->getLongitude());
+
+        $L = $lambda2 - $lambda1;
+        $U1 = atan((1 - self::F) * tan($phi1));
+        $U2 = atan((1 - self::F) * tan($phi2));
+        $sinU1 = sin($U1);
+        $cosU1 = cos($U1);
+        $sinU2 = sin($U2);
+        $cosU2 = cos($U2);
+
+        $lambda = $L;
+        $iterLimit = 100;
+        do {
+            $sinLambda = sin($lambda);
+            $cosLambda = cos($lambda);
+            $sinSigma = sqrt(($cosU2 * $sinLambda) ** 2
+                + ($cosU1 * $sinU2 - $sinU1 * $cosU2 * $cosLambda) ** 2);
+
+            if (0.0 === $sinSigma) {
+                return 0.0;
+            }
+
+            $cosSigma = $sinU1 * $sinU2 + $cosU1 * $cosU2 * $cosLambda;
+            $sigma = atan2($sinSigma, $cosSigma);
+            $sinAlpha = $cosU1 * $cosU2 * $sinLambda / $sinSigma;
+            $cosSqAlpha = 1 - $sinAlpha * $sinAlpha;
+            $cos2SigmaM = (0.0 === $cosSqAlpha) ? 0.0 : $cosSigma - 2 * $sinU1 * $sinU2 / $cosSqAlpha;
+            $C = self::F / 16 * $cosSqAlpha * (4 + self::F * (4 - 3 * $cosSqAlpha));
+
+            $lambdaPrev = $lambda;
+            $lambda = $L + (1 - $C) * self::F * $sinAlpha
+                * ($sigma + $C * $sinSigma * ($cos2SigmaM + $C * $cosSigma * (-1 + 2 * $cos2SigmaM * $cos2SigmaM)));
+        } while (abs($lambda - $lambdaPrev) > 1e-12 && --$iterLimit > 0);
+
+        if (0 === $iterLimit) {
+            throw new \RuntimeException('Vincenty formula failed to converge.');
+        }
+
+        $uSq = $cosSqAlpha * (self::A * self::A - self::B * self::B) / (self::B * self::B);
+        $Acoeff = 1 + $uSq / 16384 * (4096 + $uSq * (-768 + $uSq * (320 - 175 * $uSq)));
+        $Bcoeff = $uSq / 1024 * (256 + $uSq * (-128 + $uSq * (74 - 47 * $uSq)));
+        $deltaSigma = $Bcoeff * $sinSigma * ($cos2SigmaM + $Bcoeff / 4 * ($cosSigma * (-1 + 2 * $cos2SigmaM * $cos2SigmaM)
+                    - $Bcoeff / 6 * $cos2SigmaM * (-3 + 4 * $sinSigma * $sinSigma) * (-3 + 4 * $cos2SigmaM * $cos2SigmaM)));
+        $distance = self::B * $Acoeff * ($sigma - $deltaSigma);
+
+        return $distance;
+    }
+}

--- a/src/Map/src/Point.php
+++ b/src/Map/src/Point.php
@@ -33,6 +33,16 @@ final readonly class Point
         }
     }
 
+    public function getLatitude(): float
+    {
+        return $this->latitude;
+    }
+
+    public function getLongitude(): float
+    {
+        return $this->longitude;
+    }
+
     /**
      * @return array{lat: float, lng: float}
      */

--- a/src/Map/src/Utils/CoordinateUtils.php
+++ b/src/Map/src/Utils/CoordinateUtils.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Utils;
+
+/**
+ * Utility class to convert between decimal and DMS coordinates.
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class CoordinateUtils
+{
+    /**
+     * Converts a decimal coordinate to DMS (degrees, minutes, seconds).
+     *
+     * CoordinateUtils::decimalToDMS(48.8588443)
+     *      --> [48, 51, 31.8388]
+     *
+     * @param float $decimal the decimal coordinate to convert to DMS
+     *
+     * @return array{0: int, 1: int, 2: float}
+     */
+    public static function decimalToDMS(float $decimal): array
+    {
+        $sign = $decimal < 0 ? -1 : 1;
+        $decimal = abs($decimal);
+        $degrees = (int) $decimal * $sign;
+        $minutes = (int) (($decimal - abs($degrees)) * 60);
+        $seconds = ($decimal - abs($degrees) - $minutes / 60) * 3600;
+
+        return [$degrees, $minutes, round($seconds, 6)];
+    }
+
+    /**
+     * Converts a DMS (degrees, minutes, seconds) coordinate to decimal.
+     *
+     *  CoordinateUtils::DMSToDecimal(48, 51, 31.8388)
+     *      --> 48.8588443
+     *
+     * @param int   $degrees the degrees part of the DMS coordinate
+     * @param int   $minutes the minutes part of the DMS coordinate
+     * @param float $seconds the seconds part of the DMS coordinate
+     *
+     * @return float the decimal coordinate
+     */
+    public static function DMSToDecimal(int $degrees, int $minutes, float $seconds): float
+    {
+        $sign = $degrees < 0 ? -1 : 1;
+        $degrees = abs($degrees);
+        $decimal = $degrees + $minutes / 60 + $seconds / 3600;
+
+        return round($decimal * $sign, 6);
+    }
+}

--- a/src/Map/tests/Distance/DistanceCalculatorTest.php
+++ b/src/Map/tests/Distance/DistanceCalculatorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Tests\Distance;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Map\Distance\DistanceCalculator;
+use Symfony\UX\Map\Distance\DistanceCalculatorInterface;
+use Symfony\UX\Map\Distance\HaversineDistanceCalculator;
+use Symfony\UX\Map\Distance\SphericalCosineDistanceCalculator;
+use Symfony\UX\Map\Distance\VincentyDistanceCalculator;
+use Symfony\UX\Map\Point;
+
+class DistanceCalculatorTest extends TestCase
+{
+    public function testCalculateDistanceUseCalculator(): void
+    {
+        $calculator = new class implements DistanceCalculatorInterface {
+            public function calculateDistance(Point $point1, Point $point2): float
+            {
+                return $point1->getLatitude() + $point2->getLongitude();
+            }
+        };
+
+        $distanceCalculator = new DistanceCalculator($calculator);
+        $this->assertSame(0.0, $distanceCalculator->calculateDistance(new Point(0.0, 0.0), new Point(0.0, 0.0)));
+        $this->assertSame(90.0, $distanceCalculator->calculateDistance(new Point(45.0, 0.0), new Point(0.0, 45.0)));
+    }
+
+    /**
+     * Test that the non-reference calculators (Haversine and Spherical Cosine)
+     * produce results close to the reference (Vincenty) within an acceptable margin.
+     *
+     * @dataProvider distanceAccuracyProvider
+     */
+    public function testAccuracyAgainstVincenty(Point $point1, Point $point2, float $tolerance): void
+    {
+        $vincenty = new VincentyDistanceCalculator();
+        $referenceDistance = $vincenty->calculateDistance($point1, $point2);
+
+        $calculators = [
+            new HaversineDistanceCalculator(),
+            new SphericalCosineDistanceCalculator(),
+        ];
+
+        foreach ($calculators as $calculator) {
+            $distance = $calculator->calculateDistance($point1, $point2);
+            $difference = abs($referenceDistance - $distance);
+
+            $this->assertLessThanOrEqual($tolerance, $difference, \sprintf('%s difference (%.2f m) exceeds tolerance (%.2f m).', $calculator::class, $difference, $tolerance));
+        }
+    }
+
+    /**
+     * @return array<array{Point, Point, float}>
+     */
+    public static function distanceAccuracyProvider(): array
+    {
+        return [
+            'Short distance: around the equator (111.32m)' => [
+                new Point(0.0, 0.0),
+                new Point(0.0, 0.001),
+                .25,
+            ],
+            'Small distance: Highbury to Emirates (445.61m)' => [
+                new Point(51.55703, -0.10280),
+                new Point(51.55509, -0.10844),
+                2.5,
+            ],
+            'Moderate distance: Rennes to Saint-Malo (64.537 km)' => [
+                new Point(48.1173, -1.6778),
+                new Point(48.6497, -2.0258),
+                50.0,
+            ],
+            'Moderate distance: Paris to London  (343.556 km)' => [
+                new Point(48.8566, 2.3522),
+                new Point(51.5074, -0.1278),
+                500.0,
+            ],
+            'Long distance: Metropolis to Gotham City (1,144.291 km)' => [
+                new Point(40.7128, -74.0060),
+                new Point(41.8781, -87.6298),
+                5000.0,
+            ],
+            'Long distance: New York to Los Angeles (3,935.746 km)' => [
+                new Point(40.7128, -74.0060),
+                new Point(34.0522, -118.2437),
+                10000.0,
+            ],
+        ];
+    }
+}

--- a/src/Map/tests/Distance/DistanceUnitTest.php
+++ b/src/Map/tests/Distance/DistanceUnitTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Tests\Distance;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Map\Distance\DistanceUnit;
+
+class DistanceUnitTest extends TestCase
+{
+    public function testConversionFactorIsPositive()
+    {
+        foreach (DistanceUnit::cases() as $unit) {
+            $this->assertGreaterThan(0, $unit->getConversionFactor());
+        }
+    }
+
+    public function testConversionFactorToMeterIsSameAsConversionFactor()
+    {
+        foreach (DistanceUnit::cases() as $unit) {
+            $this->assertEquals($unit->getConversionFactor(), $unit->getConversionFactorTo(DistanceUnit::Meter));
+        }
+    }
+
+    /**
+     * @dataProvider provideConvertedUnits
+     */
+    public function testConversionFactorFrom(DistanceUnit $unit, DistanceUnit $otherUnit, float $expected): void
+    {
+        $this->assertEqualsWithDelta($expected, $unit->getConversionFactorFrom($otherUnit), 0.001);
+    }
+
+    public static function provideConvertedUnits(): iterable
+    {
+        yield 'Kilometer to Kilometer' => [DistanceUnit::Kilometer, DistanceUnit::Kilometer, 1.0];
+        yield 'Kilometer to Meter' => [DistanceUnit::Kilometer, DistanceUnit::Meter, 1000.0];
+        yield 'Kilometer to Mile' => [DistanceUnit::Kilometer, DistanceUnit::Mile, 0.621371];
+        yield 'Kilometer to Nautical Mile' => [DistanceUnit::Kilometer, DistanceUnit::NauticalMile, 0.539957];
+
+        yield 'Meter to Kilometer' => [DistanceUnit::Meter, DistanceUnit::Kilometer, 0.001];
+        yield 'Meter to Meter' => [DistanceUnit::Meter, DistanceUnit::Meter, 1.0];
+        yield 'Meter to Mile' => [DistanceUnit::Meter, DistanceUnit::Mile, 0.000621371];
+        yield 'Meter to Nautical Mile' => [DistanceUnit::Meter, DistanceUnit::NauticalMile, 0.000539957];
+
+        yield 'Mile to Kilometer' => [DistanceUnit::Mile, DistanceUnit::Kilometer, 1.609344];
+        yield 'Mile to Meter' => [DistanceUnit::Mile, DistanceUnit::Meter, 1609.344];
+        yield 'Mile to Mile' => [DistanceUnit::Mile, DistanceUnit::Mile, 1.0];
+        yield 'Mile to Nautical Mile' => [DistanceUnit::Mile, DistanceUnit::NauticalMile, 0.868976];
+
+        yield 'Nautical Mile to Kilometer' => [DistanceUnit::NauticalMile, DistanceUnit::Kilometer, 1.852];
+        yield 'Nautical Mile to Meter' => [DistanceUnit::NauticalMile, DistanceUnit::Meter, 1852.0];
+        yield 'Nautical Mile to Mile' => [DistanceUnit::NauticalMile, DistanceUnit::Mile, 1.15078];
+        yield 'Nautical Mile to Nautical Mile' => [DistanceUnit::NauticalMile, DistanceUnit::NauticalMile, 1.0];
+    }
+}

--- a/src/Map/tests/PointTest.php
+++ b/src/Map/tests/PointTest.php
@@ -36,6 +36,20 @@ class PointTest extends TestCase
         new Point($latitude, $longitude);
     }
 
+    public function testGetLatitude(): void
+    {
+        $point = new Point(48.8566, 2.3533);
+
+        self::assertSame(48.8566, $point->getLatitude());
+    }
+
+    public function testGetLongitude(): void
+    {
+        $point = new Point(48.8566, 2.3533);
+
+        self::assertSame(2.3533, $point->getLongitude());
+    }
+
     public function testToArray(): void
     {
         $point = new Point(48.8566, 2.3533);

--- a/src/Map/tests/Utils/CoordinateUtilsTest.php
+++ b/src/Map/tests/Utils/CoordinateUtilsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Map\Utils;
+
+use PHPUnit\Framework\TestCase;
+
+class CoordinateUtilsTest extends TestCase
+{
+    public function testDecimalToDMSConvertsCorrectly(): void
+    {
+        $result = CoordinateUtils::decimalToDMS(48.8588443);
+        $this->assertSame([48, 51, 31.83948], $result);
+    }
+
+    public function testDecimalToDMSHandlesNegativeValues(): void
+    {
+        $result = CoordinateUtils::decimalToDMS(-48.8588443);
+        $this->assertSame([-48, 51, 31.83948], $result);
+    }
+
+    public function testDMSToDecimalConvertsCorrectly(): void
+    {
+        $result = CoordinateUtils::DMSToDecimal(48, 51, 31.8388);
+        $this->assertSame(48.858844, $result);
+    }
+
+    public function testDMSToDecimalHandlesNegativeValues(): void
+    {
+        $result = CoordinateUtils::DMSToDecimal(-48, 51, 31.8388);
+        $this->assertSame(-48.858844, $result);
+    }
+
+    public function testDMSToDecimalHandlesZeroValues(): void
+    {
+        $result = CoordinateUtils::DMSToDecimal(0, 0, 0.0);
+        $this->assertSame(0.0, $result);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Fix #
| License       | MIT

To ease the work on distances while managing maps, this PR introduce some new tools

- `DistanceUnit` enum, that contains the most common distance units and their conversion ratios
- A `DistanceCalculatorInterface`, and 3 implementations (most commonly used formulas)
- A `DistanceCalculator` final service, that defaults to Vincenty formula and Meter unit
- A `CoordinateUtils` helper to convert DMS coordinates (`48° 7′ 3″ N`) in decimal ones (`48.1175 N`)

Also, added `getLatitude()` and `getLongitude()` on `Point`, avoiding the use of toArray()
