### PR TITLE
[Map][Translator][Turbo] Ensure TypeScript code is valid

### DIFF
--- a/bin/rollup.js
+++ b/bin/rollup.js
@@ -108,6 +108,7 @@ function getRollupConfiguration({ packageRoot, inputFiles }) {
             typescript({
                 filterRoot: '.',
                 tsconfig: path.join(__dirname, '..', 'tsconfig.json'),
+                noEmitOnError: true,
                 include: [
                     'src/**/*.ts',
                     // TODO: Remove for the next major release

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
         "src/*/src/Bridge/*/assets"
     ],
     "scripts": {
-        "build": "yarn workspaces foreach -Apt run build",
-        "test": "yarn workspaces foreach -Apt run test",
+        "build": "yarn workspaces foreach -Ap --topological-dev run build",
+        "test": "yarn workspaces foreach -Ap --topological-dev run test",
         "check": "biome check",
         "ci": "biome ci"
     },

--- a/src/Map/src/Bridge/Google/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Google/assets/dist/map_controller.js
@@ -113,6 +113,9 @@ class map_controller extends default_1 {
             libraries = ['core', ...libraries.filter((library) => library !== 'core')];
             const librariesImplementations = await Promise.all(libraries.map((library) => loader.importLibrary(library)));
             librariesImplementations.map((libraryImplementation, index) => {
+                if (typeof libraryImplementation !== 'object' || libraryImplementation === null) {
+                    return;
+                }
                 const library = libraries[index];
                 if (['marker', 'places', 'geometry', 'journeySharing', 'drawing', 'visualization'].includes(library)) {
                     _google.maps[library] = libraryImplementation;

--- a/src/Map/src/Bridge/Google/assets/package.json
+++ b/src/Map/src/Bridge/Google/assets/package.json
@@ -40,6 +40,7 @@
     "devDependencies": {
         "@googlemaps/js-api-loader": "^1.16.6",
         "@hotwired/stimulus": "^3.0.0",
+        "@symfony/ux-map": "workspace:*",
         "@types/google.maps": "^3.55.9"
     }
 }

--- a/src/Map/src/Bridge/Google/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Google/assets/src/map_controller.ts
@@ -71,11 +71,16 @@ export default class extends AbstractMapController<
                 libraries.map((library) => loader.importLibrary(library))
             );
             librariesImplementations.map((libraryImplementation, index) => {
+                if (typeof libraryImplementation !== 'object' || libraryImplementation === null) {
+                    return;
+                }
+
                 const library = libraries[index];
 
                 // The following libraries are in a sub-namespace
                 if (['marker', 'places', 'geometry', 'journeySharing', 'drawing', 'visualization'].includes(library)) {
-                    _google.maps[library] = libraryImplementation;
+                    // @ts-ignore
+                    _google.maps[library] = libraryImplementation as any;
                 } else {
                     _google.maps = { ..._google.maps, ...libraryImplementation };
                 }

--- a/src/Map/src/Bridge/Leaflet/assets/package.json
+++ b/src/Map/src/Bridge/Leaflet/assets/package.json
@@ -39,6 +39,7 @@
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
+        "@symfony/ux-map": "workspace:*",
         "@types/leaflet": "^1.9.12",
         "leaflet": "^1.9.4"
     }

--- a/src/Translator/assets/dist/formatters/formatter.d.ts
+++ b/src/Translator/assets/dist/formatters/formatter.d.ts
@@ -1,1 +1,1 @@
-export declare function format(id: string, parameters: Record<string, string | number>, locale: string): string;
+export declare function format(id: string, parameters: Record<string, string | number | Date>, locale: string): string;

--- a/src/Translator/assets/dist/formatters/intl-formatter.d.ts
+++ b/src/Translator/assets/dist/formatters/intl-formatter.d.ts
@@ -1,1 +1,1 @@
-export declare function formatIntl(id: string, parameters: Record<string, string | number>, locale: string): string;
+export declare function formatIntl(id: string, parameters: Record<string, string | number | Date>, locale: string): string;

--- a/src/Translator/assets/dist/utils.d.ts
+++ b/src/Translator/assets/dist/utils.d.ts
@@ -1,1 +1,1 @@
-export declare function strtr(string: string, replacePairs: Record<string, string | number>): string;
+export declare function strtr(string: string, replacePairs: Record<string, string | number | Date>): string;

--- a/src/Translator/assets/src/formatters/formatter.ts
+++ b/src/Translator/assets/src/formatters/formatter.ts
@@ -47,7 +47,7 @@ import { strtr } from '../utils';
  * @param parameters An array of parameters for the message
  * @param locale     The locale
  */
-export function format(id: string, parameters: Record<string, string | number>, locale: string): string {
+export function format(id: string, parameters: Record<string, string | number | Date>, locale: string): string {
     if (null === id || '' === id) {
         return '';
     }

--- a/src/Translator/assets/src/formatters/intl-formatter.ts
+++ b/src/Translator/assets/src/formatters/intl-formatter.ts
@@ -7,7 +7,7 @@ import { IntlMessageFormat } from 'intl-messageformat';
  * @param parameters An array of parameters for the message
  * @param locale     The locale
  */
-export function formatIntl(id: string, parameters: Record<string, string | number>, locale: string): string {
+export function formatIntl(id: string, parameters: Record<string, string | number | Date>, locale: string): string {
     if (id === '') {
         return '';
     }
@@ -23,5 +23,5 @@ export function formatIntl(id: string, parameters: Record<string, string | numbe
         }
     });
 
-    return intlMessage.format(parameters);
+    return intlMessage.format(parameters) as string;
 }

--- a/src/Translator/assets/src/utils.ts
+++ b/src/Translator/assets/src/utils.ts
@@ -6,7 +6,7 @@
  * @param string The string to replace in
  * @param replacePairs The pairs of characters to replace
  */
-export function strtr(string: string, replacePairs: Record<string, string | number>): string {
+export function strtr(string: string, replacePairs: Record<string, string | number | Date>): string {
     const regex: Array<string> = Object.entries(replacePairs).map(([from]) => {
         return from.replace(/([-[\]{}()*+?.\\^$|#,])/g, '\\$1');
     });

--- a/src/Turbo/assets/package.json
+++ b/src/Turbo/assets/package.json
@@ -38,6 +38,7 @@
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "@hotwired/turbo": "^7.1.0 || ^8.0"
+        "@hotwired/turbo": "^7.1.0 || ^8.0",
+        "@types/hotwired__turbo": "^8.0.4"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3042,6 +3042,7 @@ __metadata:
   dependencies:
     "@hotwired/stimulus": "npm:^3.0.0"
     "@hotwired/turbo": "npm:^7.1.0 || ^8.0"
+    "@types/hotwired__turbo": "npm:^8.0.4"
   peerDependencies:
     "@hotwired/stimulus": ^3.0.0
     "@hotwired/turbo": ^7.1.1 || ^8.0
@@ -3277,6 +3278,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/b1d32c5ae7bd52cf60e29df20407904c4312a39612e7ec2ee23c1e3731c1cfe31d97c6941bf6cb52f5f929d50d86d92dd506436b63fafa833181d439b628885e
+  languageName: node
+  linkType: hard
+
+"@types/hotwired__turbo@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@types/hotwired__turbo@npm:8.0.4"
+  checksum: 10c0/87fb69ea0dab21fd2a6e3e6d18cdaf679e3d7c8ea1f6f2b59d05c24a96cf3faf80a4c0ce5f57161afea9b61f2cc542f9e33cbdc6475fc4003d79516a94cedb5c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2888,6 +2888,7 @@ __metadata:
   dependencies:
     "@googlemaps/js-api-loader": "npm:^1.16.6"
     "@hotwired/stimulus": "npm:^3.0.0"
+    "@symfony/ux-map": "workspace:*"
     "@types/google.maps": "npm:^3.55.9"
   peerDependencies:
     "@googlemaps/js-api-loader": ^1.16.6
@@ -2913,6 +2914,7 @@ __metadata:
   resolution: "@symfony/ux-leaflet-map@workspace:src/Map/src/Bridge/Leaflet/assets"
   dependencies:
     "@hotwired/stimulus": "npm:^3.0.0"
+    "@symfony/ux-map": "workspace:*"
     "@types/leaflet": "npm:^1.9.12"
     leaflet: "npm:^1.9.4"
   peerDependencies:
@@ -2939,7 +2941,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@symfony/ux-map@workspace:src/Map/assets":
+"@symfony/ux-map@workspace:*, @symfony/ux-map@workspace:src/Map/assets":
   version: 0.0.0-use.local
   resolution: "@symfony/ux-map@workspace:src/Map/assets"
   dependencies:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR aims to fail the build (and the CI) when TypeScript code contain issues.

I also fixed existing issues in Map, Translator, and Turbo code.


Before:
```
Cleaning up the "/home/runner/work/ux/ux/src/Chartjs/assets/dist" directory...
Building JavaScript files from @symfony/ux-chartjs package...
Done in 3.175 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/Autocomplete/assets/dist" directory...
Building JavaScript files from @symfony/ux-autocomplete package...
Done in 3.179 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/Cropperjs/assets/dist" directory...
Building JavaScript files from @symfony/ux-cropperjs package...
Minifying CSS...
Done in 2.377 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/Dropzone/assets/dist" directory...
Building JavaScript files from @symfony/ux-dropzone package...
Minifying CSS...
Done in 2.434 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/LazyImage/assets/dist" directory...
Building JavaScript files from @symfony/ux-lazy-image package...
Done in 2.438 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/LiveComponent/assets/dist" directory...
Building JavaScript files from @symfony/ux-live-component package...
Minifying CSS...
Done in 3.861 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/Map/assets/dist" directory...
Building JavaScript files from @symfony/ux-map package...
Done in 2.515 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/Map/src/Bridge/Google/assets/dist" directory...
Building JavaScript files from @symfony/ux-google-map package...
Done in 2.509 seconds.
[plugin typescript] src/map_controller.ts (12:35): @rollup/plugin-typescript TS2307: Cannot find module '@symfony/ux-map' or its corresponding type declarations.
[plugin typescript] src/map_controller.ts (19:8): @rollup/plugin-typescript TS2307: Cannot find module '@symfony/ux-map' or its corresponding type declarations.
[plugin typescript] src/map_controller.ts (78:21): @rollup/plugin-typescript TS7053: Element implicitly has an 'any' type because expression of type 'Library' can't be used to index type 'typeof maps'.
  Property 'streetView' does not exist on type 'typeof maps'.
[plugin typescript] src/map_controller.ts (80:55): @rollup/plugin-typescript TS2698: Spread types may only be created from object types.
[plugin typescript] src/map_controller.ts (89:30): @rollup/plugin-typescript TS2339: Property 'hasCenterValue' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (89:53): @rollup/plugin-typescript TS2339: Property 'centerValue' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (90:37): @rollup/plugin-typescript TS2339: Property 'centerValue' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (95:30): @rollup/plugin-typescript TS2339: Property 'hasZoomValue' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (95:51): @rollup/plugin-typescript TS2339: Property 'zoomValue' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (96:35): @rollup/plugin-typescript TS2339: Property 'zoomValue' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (101:14): @rollup/plugin-typescript TS2339: Property 'dispatch' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (125:42): @rollup/plugin-typescript TS2339: Property 'element' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (148:18): @rollup/plugin-typescript TS2551: Property 'createInfoWindow' does not exist on type 'default'. Did you mean 'doCreateInfoWindow'?
[plugin typescript] src/map_controller.ts (176:18): @rollup/plugin-typescript TS2551: Property 'createInfoWindow' does not exist on type 'default'. Did you mean 'doCreateInfoWindow'?
[plugin typescript] src/map_controller.ts (204:18): @rollup/plugin-typescript TS2551: Property 'createInfoWindow' does not exist on type 'default'. Did you mean 'doCreateInfoWindow'?
[plugin typescript] src/map_controller.ts (264:18): @rollup/plugin-typescript TS2339: Property 'markers' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (269:14): @rollup/plugin-typescript TS2339: Property 'markers' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (269:31): @rollup/plugin-typescript TS7006: Parameter 'marker' implicitly has an 'any' type.
[plugin typescript] src/map_controller.ts (296:14): @rollup/plugin-typescript TS2339: Property 'infoWindows' does not exist on type 'default'.
[plugin typescript] src/map_controller.ts (296:35): @rollup/plugin-typescript TS7006: Parameter 'otherInfoWindow' implicitly has an 'any' type.
Cleaning up the "/home/runner/work/ux/ux/src/Map/src/Bridge/Leaflet/assets/dist" directory...
Building JavaScript files from @symfony/ux-leaflet-map package...
Done in 2.459 seconds.
"leaflet/dist/leaflet.min.css" is imported by "src/map_controller.ts", but could not be resolved – treating it as an external dependency.
Cleaning up the "/home/runner/work/ux/ux/src/Notify/assets/dist" directory...
Building JavaScript files from @symfony/ux-notify package...
Done in 2.381 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/React/assets/dist" directory...
Building JavaScript files from @symfony/ux-react package...
Done in 2.498 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/StimulusBundle/assets/dist" directory...
Building JavaScript files from @symfony/stimulus-bundle package...
Done in 2.444 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/Svelte/assets/dist" directory...
Building JavaScript files from @symfony/ux-svelte package...
Done in 2.453 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/Swup/assets/dist" directory...
Building JavaScript files from @symfony/ux-swup package...
Done in 2.254 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/TogglePassword/assets/dist" directory...
Building JavaScript files from @symfony/ux-toggle-password package...
Minifying CSS...
Done in 2.489 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/Translator/assets/dist" directory...
Building JavaScript files from @symfony/ux-translator package...
Done in 2.351 seconds.
[plugin typescript] src/formatters/intl-formatter.ts (26:5): @rollup/plugin-typescript TS2[32](https://github.com/symfony/ux/actions/runs/13231659169/job/36929714748#step:5:37)2: Type 'string | number | (string | number)[]' is not assignable to type 'string'.
  Type 'number' is not assignable to type 'string'.
[plugin typescript] src/translator.ts (152:57): @rollup/plugin-typescript TS2[34](https://github.com/symfony/ux/actions/runs/13231659169/job/36929714748#step:5:39)5: Argument of type 'ParametersType' is not assignable to parameter of type 'Record<string, string | number>'.
  Type 'Record<string, string | number | Date>' is not assignable to type 'Record<string, string | number>'.
    'string' index signatures are incompatible.
      Type 'string | number | Date' is not assignable to type 'string | number'.
[plugin typescript] src/translator.ts (166:49): @rollup/plugin-typescript TS2345: Argument of type 'ParametersType' is not assignable to parameter of type 'Record<string, string | number>'.
  Type 'Record<string, string | number | Date>' is not assignable to type 'Record<string, string | number>'.
Cleaning up the "/home/runner/work/ux/ux/src/Turbo/assets/dist" directory...
Building JavaScript files from @symfony/ux-turbo package...
Done in 2.2[49](https://github.com/symfony/ux/actions/runs/13231659169/job/36929714748#step:5:54) seconds.
[plugin typescript] src/turbo_stream_controller.ts (11:61): @rollup/plugin-typescript TS7016: Could not find a declaration file for module '@hotwired/turbo'. '/home/runner/work/ux/ux/node_modules/@hotwired/turbo/dist/turbo.es2017-umd.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/hotwired__turbo` if it exists or add a new declaration (.d.ts) file containing `declare module '@hotwired/turbo';`
Cleaning up the "/home/runner/work/ux/ux/src/Typed/assets/dist" directory...
Building JavaScript files from @symfony/ux-typed package...
Done in 2.228 seconds.
Cleaning up the "/home/runner/work/ux/ux/src/Vue/assets/dist" directory...
Building JavaScript files from @symfony/ux-vue package...
Done in 1.970 seconds.
Done in 30s 328ms
```

After:
```
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Chartjs/assets/dist" directory...
Building JavaScript files from @symfony/ux-chartjs package...
Done in 2.830 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Autocomplete/assets/dist" directory...
Building JavaScript files from @symfony/ux-autocomplete package...
Done in 2.967 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Cropperjs/assets/dist" directory...
Building JavaScript files from @symfony/ux-cropperjs package...
Minifying CSS...
Done in 2.[39](https://github.com/Kocal/symfony-ux/actions/runs/13252531380/job/36993303948?pr=2562#step:5:44)2 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Dropzone/assets/dist" directory...
Building JavaScript files from @symfony/ux-dropzone package...
Minifying CSS...
Done in 2.[42](https://github.com/Kocal/symfony-ux/actions/runs/13252531380/job/36993303948?pr=2562#step:5:47)8 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/LazyImage/assets/dist" directory...
Building JavaScript files from @symfony/ux-lazy-image package...
Done in 2.472 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/LiveComponent/assets/dist" directory...
Building JavaScript files from @symfony/ux-live-component package...
Minifying CSS...
Done in 3.855 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Map/assets/dist" directory...
Building JavaScript files from @symfony/ux-map package...
Done in 2.[47](https://github.com/Kocal/symfony-ux/actions/runs/13252531380/job/36993303948?pr=2562#step:5:52)1 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Notify/assets/dist" directory...
Building JavaScript files from @symfony/ux-notify package...
Done in 2.392 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/React/assets/dist" directory...
Building JavaScript files from @symfony/ux-react package...
Done in 2.597 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/StimulusBundle/assets/dist" directory...
Building JavaScript files from @symfony/stimulus-bundle package...
Done in 2.[48](https://github.com/Kocal/symfony-ux/actions/runs/13252531380/job/36993303948?pr=2562#step:5:53)4 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Svelte/assets/dist" directory...
Building JavaScript files from @symfony/ux-svelte package...
Done in 2.470 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Swup/assets/dist" directory...
Building JavaScript files from @symfony/ux-swup package...
Done in 2.264 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/TogglePassword/assets/dist" directory...
Building JavaScript files from @symfony/ux-toggle-password package...
Minifying CSS...
Done in 2.[57](https://github.com/Kocal/symfony-ux/actions/runs/13252531380/job/36993303948?pr=2562#step:5:62)2 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Translator/assets/dist" directory...
Building JavaScript files from @symfony/ux-translator package...
Done in 2.[58](https://github.com/Kocal/symfony-ux/actions/runs/13252531380/job/36993303948?pr=2562#step:5:63)1 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Turbo/assets/dist" directory...
Building JavaScript files from @symfony/ux-turbo package...
Done in 2.296 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Typed/assets/dist" directory...
Building JavaScript files from @symfony/ux-typed package...
Done in 2.273 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Vue/assets/dist" directory...
Building JavaScript files from @symfony/ux-vue package...
Done in 2.083 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Map/src/Bridge/Google/assets/dist" directory...
Building JavaScript files from @symfony/ux-google-map package...
Done in 2.579 seconds.
Cleaning up the "/home/runner/work/symfony-ux/symfony-ux/src/Map/src/Bridge/Leaflet/assets/dist" directory...
Building JavaScript files from @symfony/ux-leaflet-map package...
Done in 2.742 seconds.
"leaflet/dist/leaflet.min.css" is imported by "src/map_controller.ts", but could not be resolved – treating it as an external dependency.
Done in 30s [68](https://github.com/Kocal/symfony-ux/actions/runs/13252531380/job/36993303948?pr=2562#step:5:73)6ms
```