### PR TITLE
[CI] Fix links to changed dist files

### DIFF
--- a/.github/generate-dist-files-size-diff.mjs
+++ b/.github/generate-dist-files-size-diff.mjs
@@ -7,8 +7,8 @@ Usage:
 ```shell
 BASE_DIST_FILES='{"src/Autocomplete/assets/dist/controller.js":{"size":15382,"size_gz":3716},"src/Chartjs/assets/dist/controller.js":{"size":2281,"size_gz":771},"src/Cropperjs/assets/dist/controller.js":{"size":1044,"size_gz":475}}' \
 PR_DIST_FILES='{"src/Chartjs/assets/dist/controller.js":{"size":1281,"size_gz":171},"src/Cropperjs/assets/dist/controller.js":{"size":1044,"size_gz":475},"src/Cropperjs/assets/dist/style.min.css":{"size":32,"size_gz":66},"src/Dropzone/assets/dist/controller.js":{"size":3199,"size_gz":816},"src/Map/src/Bridge/Google/assets/dist/foo.js":{"size":3199,"size_gz":816}}' \
-GITHUB_REPOSITORY='symfony/ux' \
-GITHUB_HEAD_REF='my-branch-name' \
+BASE_REPO_NAME='kocal/symfony-ux' \
+BASE_REF_NAME='my-branch-name' \
   node .github/generate-dist-files-size-diff.mjs
 ```
  */
@@ -21,12 +21,12 @@ if (!process.env.PR_DIST_FILES) {
     throw new Error('Missing or invalid "PR_DIST_FILES" env variable.');
 }
 
-if (!process.env.GITHUB_REPOSITORY) {
-    throw new Error('Missing or invalid "GITHUB_REPOSITORY" env variable.');
+if (!process.env.BASE_REPO_NAME) {
+    throw new Error('Missing or invalid "BASE_REPO_NAME" env variable.');
 }
 
-if (!process.env.GITHUB_HEAD_REF) {
-    throw new Error('Missing or invalid "GITHUB_HEAD_REF" env variable.');
+if (!process.env.BASE_REF_NAME) {
+    throw new Error('Missing or invalid "BASE_REF_NAME" env variable.');
 }
 
 /**
@@ -67,7 +67,7 @@ function formatDiffPercent(percent) {
 }
 
 export function main() {
-    const repoUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}`;
+    const repoUrl = `https://github.com/${process.env.BASE_REPO_NAME}`;
     /** @type {Record<string, {size: number, size_gz: number}>} */
     const base = JSON.parse(process.env.BASE_DIST_FILES);
     /** @type {Record<string, {size: number, size_gz: number}>} */
@@ -108,7 +108,7 @@ export function main() {
                         meta: {
                             packageName,
                             bridgeName,
-                            url: isBridge ? `${repoUrl}/tree/${process.env.GITHUB_HEAD_REF}/src/${packageName}/src/Bridge/${bridgeName}/assets/dist` : `${repoUrl}/tree/${process.env.GITHUB_HEAD_REF}/src/${packageName}/assets/dist`,
+                            url: isBridge ? `${repoUrl}/tree/${process.env.BASE_REF_NAME}/src/${packageName}/src/Bridge/${bridgeName}/assets/dist` : `${repoUrl}/tree/${process.env.BASE_REF_NAME}/src/${packageName}/assets/dist`,
                         }, files: new Set(),
                     });
                 }
@@ -126,7 +126,7 @@ export function main() {
                     },
                     meta: {
                         fileNameShort: file.replace(isBridge ? `src/${file.split('/')[1]}/src/Bridge/${file.split('/')[4]}/assets/dist/` : `src/${file.split('/')[1]}/assets/dist/`, ''),
-                        fileNameUrl: `${repoUrl}/blob/${process.env.GITHUB_HEAD_REF}/${file}`,
+                        fileNameUrl: `${repoUrl}/blob/${process.env.BASE_REF_NAME}/${file}`,
                     },
                 });
             }

--- a/.github/workflows/dist-files-size-diff.yaml
+++ b/.github/workflows/dist-files-size-diff.yaml
@@ -50,6 +50,8 @@ jobs:
             env:
                 BASE_DIST_FILES: ${{ steps.base-dist-files.outputs.files }}
                 PR_DIST_FILES: ${{ steps.pr-dist-files.outputs.files }}
+                BASE_REPO_NAME: ${{ github.event.pull_request.base.repo.full_name }}
+                BASE_REF_NAME: ${{ github.event.pull_request.base.ref }}
             with:
               result-encoding: string
               script: |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

I noticed that URLs to changed dist files are invalid, they refer to the current repository `symfony/ux` instead of the repository where the PR has been created:
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/88edac81-1a0a-4514-8d19-9f8a65f4a9c8" />
