### PR TITLE
[TwigComponent] Fix ComponentTokenParser on 32-bits

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentTokenParser.php
+++ b/src/TwigComponent/src/Twig/ComponentTokenParser.php
@@ -118,6 +118,14 @@ final class ComponentTokenParser extends AbstractTokenParser
             $this->lineAndFileCounts[$fileAndLine] = 0;
         }
 
-        return crc32($fileAndLine).++$this->lineAndFileCounts[$fileAndLine];
+        $index = crc32($fileAndLine).++$this->lineAndFileCounts[$fileAndLine];
+
+        if (4 === \PHP_INT_SIZE) {
+            // On 32-bit PHP, the index can be negative or greater than PHP_INT_MAX
+            // we need to convert it to a positive 32-bit integer
+            $index = fmod(abs($index), \PHP_INT_MAX) + 1;
+        }
+
+        return (int) $index;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #2568
| License       | MIT

- 64-bit users get the original behavior
- 32-bit users get the fix to prevent overflow issues

