### PR TITLE
[TwigComponent] Fix Twig 3.21 deprecations (getExpressionParser)

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentTokenParser.php
+++ b/src/TwigComponent/src/Twig/ComponentTokenParser.php
@@ -33,7 +33,12 @@ final class ComponentTokenParser extends AbstractTokenParser
     public function parse(Token $token): Node
     {
         $stream = $this->parser->getStream();
-        $componentName = $this->componentName($this->parser->getExpressionParser()->parseExpression());
+        if (method_exists($this->parser, 'parseExpression')) {
+            // Since Twig 3.21
+            $componentName = $this->componentName($this->parser->parseExpression());
+        } else {
+            $componentName = $this->componentName($this->parser->getExpressionParser()->parseExpression());
+        }
 
         [$propsExpression, $only] = $this->parseArguments();
 
@@ -98,7 +103,12 @@ final class ComponentTokenParser extends AbstractTokenParser
         $variables = null;
 
         if ($stream->nextIf(Token::NAME_TYPE, 'with')) {
-            $variables = $this->parser->getExpressionParser()->parseExpression();
+            if (method_exists($this->parser, 'parseExpression')) {
+                // Since Twig 3.21
+                $variables = $this->parser->parseExpression();
+            } else {
+                $variables = $this->parser->getExpressionParser()->parseExpression();
+            }
         }
 
         $only = false;

--- a/src/TwigComponent/src/Twig/PropsTokenParser.php
+++ b/src/TwigComponent/src/Twig/PropsTokenParser.php
@@ -33,7 +33,12 @@ class PropsTokenParser extends AbstractTokenParser
             $name = $stream->expect(Token::NAME_TYPE)->getValue();
 
             if ($stream->nextIf(Token::OPERATOR_TYPE, '=')) {
-                $values[$name] = $parser->getExpressionParser()->parseExpression();
+                if (method_exists($parser, 'parseExpression')) {
+                    // Since Twig 3.21
+                    $values[$name] = $parser->parseExpression();
+                } else {
+                    $values[$name] = $parser->getExpressionParser()->parseExpression();
+                }
             }
 
             $names[] = $name;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT


Following https://github.com/twigphp/Twig/pull/4543