### PR TITLE
fix missing }, reformat so it's visible

### DIFF
--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -240,7 +240,10 @@ And with outlets:
 
 .. code-block:: html+twig
 
-    <div {{ stimulus_controller('chart', { 'name': 'Likes', 'data': [1, 2, 3, 4] }, { 'loading': 'spinner' }, { 'other': '.target' ) }}>
+    <div {{ stimulus_controller('chart',
+            { 'name': 'Likes', 'data': [1, 2, 3, 4] },
+            { 'loading': 'spinner' },
+            { 'other': '.target' } ) }}>
         Hello
     </div>
 


### PR DESCRIPTION
```twig
<div {{ stimulus_controller('chart',
            { 'name': 'Likes', 'data': [1, 2, 3, 4] }, 
            { 'loading': 'spinner' }, 
            { 'other': '.target' } ) }}>
```

Currently, the 'outlet' part is cut off:

![image](https://github.com/user-attachments/assets/f52b4b61-87b7-417d-9445-353798b23c1b)
