### PR TITLE
[Autocomplete] Rethrow `BadRequestHttpException` in case of malformed `extra_options`

### DIFF
--- a/src/Autocomplete/src/Controller/EntityAutocompleteController.php
+++ b/src/Autocomplete/src/Controller/EntityAutocompleteController.php
@@ -76,7 +76,11 @@ final class EntityAutocompleteController
             return [];
         }
 
-        $extraOptions = $this->getDecodedExtraOptions($request->query->getString(self::EXTRA_OPTIONS));
+        try {
+            $extraOptions = $this->getDecodedExtraOptions($request->query->getString(self::EXTRA_OPTIONS));
+        } catch (\JsonException $e) {
+            throw new BadRequestHttpException('The extra options cannot be parsed.', $e);
+        }
 
         if (!\array_key_exists(AutocompleteChoiceTypeExtension::CHECKSUM_KEY, $extraOptions)) {
             throw new BadRequestHttpException('The extra options are missing the checksum.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | N/A
| License       | MIT

Currently it's enough just to manually edit extra_options in URL to a random string and then get a 500 error while polluting logs. I think it's better to swallow it and properly exit with 400 status.