### PR TITLE
[LiveComponent][ComponentWithFormTrait] Force recreation of FormView on PreReRender hook to synchronize FormInstance and FormView.

### DIFF
--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -110,12 +110,12 @@ trait ComponentWithFormTrait
     {
         if ($this->shouldAutoSubmitForm) {
             $this->submitForm($this->isValidated);
+        } else {
+            // Recreate the FormView because it has been created by the submitForm() with a FormInterface whose values may
+            // have changed. Basically synchronizes FormView and FormInstance to reflect all manual changes made to the
+            // latter between form submit and the components re-render.
+            $this->getFormView(true);
         }
-
-        // Recreate the FormView because it has been created by the submitForm() with a FormInterface whose values may
-        // have changed. Basically synchronizes FormView and FormInstance to reflect all manual changes made to the
-        // latter between form submit and the components re-render.
-        $this->getFormView(true);
     }
 
     public function getFormView(bool $forceCreate = false): FormView

--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -111,11 +111,16 @@ trait ComponentWithFormTrait
         if ($this->shouldAutoSubmitForm) {
             $this->submitForm($this->isValidated);
         }
+
+        // Recreate the FormView because it has been created by the submitForm() with a FormInterface whose values may
+        // have changed. Basically synchronizes FormView and FormInstance to reflect all manual changes made to the
+        // latter between form submit and the components re-render.
+        $this->getFormView(true);
     }
 
-    public function getFormView(): FormView
+    public function getFormView(bool $forceCreate = false): FormView
     {
-        if (null === $this->formView) {
+        if ($forceCreate || null === $this->formView) {
             $this->formView = $this->getForm()->createView();
             $this->useNameAttributesAsModelName();
         }

--- a/src/LiveComponent/tests/Fixtures/Component/FormWithCollectionTypeComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/FormWithCollectionTypeComponent.php
@@ -12,7 +12,9 @@
 namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
@@ -40,6 +42,14 @@ class FormWithCollectionTypeComponent extends AbstractController
     protected function instantiateForm(): FormInterface
     {
         return $this->createForm(BlogPostFormType::class, $this->post);
+    }
+
+    #[LiveAction]
+    public function submitAndAddErrorToForm(): void
+    {
+        $this->submitForm();
+        $this->getForm()->addError(new FormError("manually added form error"));
+        throw new UnprocessableEntityHttpException();
     }
 
     #[LiveAction]

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -156,6 +156,33 @@ class ComponentWithFormTest extends KernelTestCase
         ;
     }
 
+    public function testFormViewSynchronizesWithFormInstance(): void
+    {
+        /** @var FormFactoryInterface $formFactory */
+        $formFactory = self::getContainer()->get('form.factory');
+
+        $form = $formFactory->create(BlogPostFormType::class);
+        // make sure validation does not fail on content constraint (min 100 characters)
+        $validContent = implode('a', range(0, 100));
+        $form->submit(['title' => 'Title', 'content' => $validContent]);
+
+        $mounted = $this->mountComponent('form_with_collection_type', [
+            'form' => $form->createView(),
+        ]);
+        $dehydratedProps = $this->dehydrateComponent($mounted)->getProps();
+
+        $this->browser()
+            // post to action, which will manually add a FormError to the FormInstance after submit
+            ->post('/_components/form_with_collection_type/submitAndAddErrorToForm', [
+                'body' => ['data' => json_encode(['props' => $dehydratedProps])],
+            ])
+            // action always throws 422
+            ->assertStatus(422)
+            // assert manually added error within LiveAction after submit is rendered in template
+            ->assertContains('manually added form error')
+        ;
+    }
+
     public function testHandleCheckboxChanges(): void
     {
         $category = CategoryFixtureEntityFactory::createMany(5);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #1981
| License       | MIT


ComponentWithFormTrait will now recreate the existing FormView in its PreReRender-Hook `submitFormOnRender()` to synchronize FormView and FormInstance to reflect any manual changes to the FormInstance.
This primarily solves the Problem of manually added FormErrors not being rendered.
