### PR TITLE
[LiveComponent] Move PropertyInfo to the require section

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -29,6 +29,7 @@
         "php": ">=8.1",
         "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/property-access": "^5.4.5|^6.0|^7.0",
+        "symfony/property-info": "^5.4|^6.0|^7.0",
         "symfony/stimulus-bundle": "^2.9",
         "symfony/ux-twig-component": "^2.8",
         "twig/twig": "^3.8.0"
@@ -46,7 +47,6 @@
         "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/options-resolver": "^5.4|^6.0|^7.0",
         "symfony/phpunit-bridge": "^6.1|^7.0",
-        "symfony/property-info": "^5.4|^6.0|^7.0",
         "symfony/security-bundle": "^5.4|^6.0|^7.0",
         "symfony/serializer": "^5.4|^6.0|^7.0",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Issues        | 
| License       | MIT

Move `symfony/property-info` from `require-dev` to `require`, as it's always needed.

/cc @Kocal 