### PR TITLE
[LiveComponent] Document how to pass a value to an event listener from Twig.

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2776,6 +2776,16 @@ You can also pass extra (scalar) data to the listeners::
         ]);
     }
 
+From a Twig template:
+
+  .. code-block:: html+twig
+
+       <button
+           data-action="live#emit"
+           data-live-event-param="productAdded"
+           data-live-product-param="123"
+       >
+
 In your listeners, you can access this by adding a matching argument
 name with ``#[LiveArg]`` in front::
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Issues        | -
| License       | MIT

The document is missing an important use case related to Event dispatching and listeners.
There is no documentation about how to pass data from a Twig template to an event listener method within the component. This PR adds an example.