### PR TITLE
[LiveComponent] Fix default option extraction ignores Translatable #2621

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.25.0
 
 -   Add support for [Symfony UID](https://symfony.com/doc/current/components/uid.html) hydration/dehydration
+-   `ComponentWithFormTrait` now correctly checks for a `TranslatableInterface` placeholder for `<select>` elements
 
 ## 2.23.0
 

--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\ClearableErrorsInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\Attribute\PreReRender;
 use Symfony\UX\LiveComponent\Util\LiveFormUtility;
@@ -286,7 +287,8 @@ trait ComponentWithFormTrait
                 )
                 && !$child->vars['expanded']                // is a <select>     (not a radio/checkbox)
                 && !$child->vars['multiple']                // is not multiple
-                && !\is_string($child->vars['placeholder'])  // has no placeholder (empty string is valid)
+                && !\is_string($child->vars['placeholder']) // has no placeholder (empty string is valid)
+                && !$child->vars['placeholder'] instanceof TranslatableInterface // has no placeholder (translatable interface is valid)
             ) {
                 $choices = $child->vars['preferred_choices'] ?: $child->vars['choices']; // preferred_choices has precedence, as they rendered before regular choices
                 do {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #2621
| License       | MIT

Select placeholder in LiveForm will now accept `string` and `TranslatableInterface` from `symfony/translation-contracts`. Therefore mimicking of default browser behaviour will not happen for `TranslatableInterface`.
