### PR TITLE
[Dropzone] Inform the user of the number of files he uploads

### DIFF
--- a/src/Dropzone/CHANGELOG.md
+++ b/src/Dropzone/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.23
+
+-   Support multiple files preview
+
 ## 2.20
 
 -   Enable file replacement via "drag-and-drop"

--- a/src/Dropzone/assets/dist/controller.js
+++ b/src/Dropzone/assets/dist/controller.js
@@ -32,19 +32,25 @@ class default_1 extends Controller {
         this.dispatchEvent('clear');
     }
     onInputChange(event) {
-        const file = event.target.files[0];
-        if (typeof file === 'undefined') {
+        const files = event.target.files;
+        if (!files.length) {
             return;
         }
         this.inputTarget.style.display = 'none';
         this.placeholderTarget.style.display = 'none';
-        this.previewFilenameTarget.textContent = file.name;
+        const firstFile = files[0];
+        let displayText = firstFile.name;
+        if (files.length > 1) {
+            const additionalFiles = files.length - 1;
+            displayText += ` +${additionalFiles} ${additionalFiles === 1 ? 'file' : 'files'}`;
+        }
+        this.previewFilenameTarget.textContent = displayText;
         this.previewTarget.style.display = 'flex';
         this.previewImageTarget.style.display = 'none';
-        if (file.type && file.type.indexOf('image') !== -1) {
-            this._populateImagePreview(file);
+        if (firstFile.type && firstFile.type.indexOf('image') !== -1) {
+            this._populateImagePreview(firstFile);
         }
-        this.dispatchEvent('change', file);
+        this.dispatchEvent('change', files);
     }
     _populateImagePreview(file) {
         if (typeof FileReader === 'undefined') {

--- a/src/Dropzone/assets/src/controller.ts
+++ b/src/Dropzone/assets/src/controller.ts
@@ -65,8 +65,8 @@ export default class extends Controller {
     }
 
     onInputChange(event: any) {
-        const file = event.target.files[0];
-        if (typeof file === 'undefined') {
+        const files = event.target.files;
+        if (!files.length) {
             return;
         }
 
@@ -74,17 +74,23 @@ export default class extends Controller {
         this.inputTarget.style.display = 'none';
         this.placeholderTarget.style.display = 'none';
 
-        // Show the filename in preview
-        this.previewFilenameTarget.textContent = file.name;
+        // Show the filename in preview with additional files count if needed
+        const firstFile = files[0];
+        let displayText = firstFile.name;
+        if (files.length > 1) {
+            const additionalFiles = files.length - 1;
+            displayText += ` +${additionalFiles} ${additionalFiles === 1 ? 'file' : 'files'}`;
+        }
+        this.previewFilenameTarget.textContent = displayText;
         this.previewTarget.style.display = 'flex';
 
-        // If the file is an image, load it and display it as preview
+        // If the first file is an image, load it and display it as preview
         this.previewImageTarget.style.display = 'none';
-        if (file.type && file.type.indexOf('image') !== -1) {
-            this._populateImagePreview(file);
+        if (firstFile.type && firstFile.type.indexOf('image') !== -1) {
+            this._populateImagePreview(firstFile);
         }
 
-        this.dispatchEvent('change', file);
+        this.dispatchEvent('change', files);
     }
 
     _populateImagePreview(file: Blob) {

--- a/src/Dropzone/assets/test/controller.test.ts
+++ b/src/Dropzone/assets/test/controller.test.ts
@@ -65,6 +65,39 @@ describe('DropzoneController', () => {
                          data-testid="preview-filename"></div>
                 </div>
             </div>
+            <div class="dropzone-container" data-controller="check dropzone" data-testid="container-multiple"> 
+                <input type="file"
+                       style="display: none"
+                       multiple="multiple"
+                       data-dropzone-target="input"
+                       data-testid="input-multiple" />
+        
+                <div class="dropzone-placeholder" 
+                     data-dropzone-target="placeholder" 
+                     data-testid="placeholder-multiple">
+                    Placeholder
+                </div>
+        
+                <div class="dropzone-preview"
+                     data-dropzone-target="preview"
+                     data-testid="preview-multiple"
+                     style="display: none">
+                     
+                    <button type="button"
+                            class="dropzone-preview-button"
+                            data-dropzone-target="previewClearButton"
+                            data-testid="button-multiple"></button>
+        
+                    <div class="dropzone-preview-image"
+                         data-dropzone-target="previewImage"
+                         data-testid="preview-image-multiple"
+                         style="display: none"></div>
+        
+                    <div class="dropzone-preview-filename"
+                         data-dropzone-target="previewFilename" 
+                         data-testid="preview-filename-multiple"></div>
+                </div>
+            </div>
         `);
     });
 
@@ -120,7 +153,7 @@ describe('DropzoneController', () => {
         const file = new File(['hello'], 'hello.png', { type: 'image/png' });
 
         user.upload(input, file);
-        expect(input.files[0]).toStrictEqual(file);
+        await waitFor(() => expect(input.files[0]).toStrictEqual(file));
 
         // The dropzone should be in preview mode
         await waitFor(() => expect(getByTestId(container, 'input')).toHaveStyle({ display: 'none' }));
@@ -128,7 +161,7 @@ describe('DropzoneController', () => {
 
         // The event should have been dispatched
         expect(dispatched).not.toBeNull();
-        expect(dispatched.detail).toStrictEqual(file);
+        expect(dispatched.detail[0]).toStrictEqual(file);
     });
 
     it('on drag', async () => {
@@ -152,5 +185,42 @@ describe('DropzoneController', () => {
         await waitFor(() => expect(getByTestId(container, 'input')).toHaveStyle({ display: 'none' }));
         await waitFor(() => expect(getByTestId(container, 'placeholder')).toHaveStyle({ display: 'none' }));
         await waitFor(() => expect(getByTestId(container, 'preview')).toHaveStyle({ display: 'block' }));
+    });
+
+    it('multiple files chosen', async () => {
+        startStimulus();
+        await waitFor(() => expect(getByTestId(container, 'container-multiple')).toHaveClass('connected'));
+
+        // Attach a listener to ensure the event is dispatched
+        let dispatched = null;
+        getByTestId(container, 'container-multiple').addEventListener('dropzone:change', (event) => {
+            dispatched = event;
+        });
+
+        // Select multiple files
+        const input = getByTestId(container, 'input-multiple');
+        const file1 = new File(['hello1'], 'hello1.png', { type: 'image/png' });
+        const file2 = new File(['hello2'], 'hello2.txt', { type: 'text/plain' });
+        const files = [file1, file2];
+
+        user.upload(input, files);
+
+        // The dropzone should be in preview mode
+        await waitFor(() => expect(getByTestId(container, 'input-multiple')).toHaveStyle({ display: 'none' }));
+        await waitFor(() => expect(getByTestId(container, 'placeholder-multiple')).toHaveStyle({ display: 'none' }));
+        await waitFor(() => expect(getByTestId(container, 'preview-multiple')).toHaveStyle({ display: 'flex' }));
+
+        // The event should have been dispatched with both files
+        expect(dispatched).not.toBeNull();
+        expect(dispatched.detail[0]).toStrictEqual(file1);
+        expect(dispatched.detail[1]).toStrictEqual(file2);
+
+        // Check preview content shows first file name plus count
+        const previewFilename = getByTestId(container, 'preview-filename-multiple');
+        expect(previewFilename.textContent).toBe('hello1.png +1 file');
+
+        // Only the first file (image) should show preview
+        const previewImage = getByTestId(container, 'preview-image-multiple');
+        await waitFor(() => expect(previewImage).toHaveStyle({ display: 'block' }));
     });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Docs?         |no <!-- required for new features -->
| Issues        | #2567<!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Hi, I was implementing a multiple file dropzone in one of my projects, and i was facing the same problem mentioned in #2567.
I was thinking for a solution, should we make a preview of all files if they're images ?
Sounds an interesting idea first, but if users upload a lot of images, it could be very ugly to manage the preview. Also, i was worried about avoiding regression for projects that are already in production and to break some custom dropzone styles.

The solution i used for my project is to show the number of extra files user uploads. I was inspired by the original file type field, it just shows us the number of files, according to the stylized dropzone of symfony ux, the first element (if it is an image) display a preview, and we write to user the number of extra files he uploads.

Here a screenshot of three fields : 
-dropzone with single file 
-dropzone with 3 files
-standard file type field with 3 files
![Capture d’écran 2025-03-19 à 09 11 17](https://github.com/user-attachments/assets/b95d6322-73d9-4e3c-ad35-7147880a8a96)