### PR TITLE
Fix TwigComponents test when high-deps

### DIFF
--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -425,7 +425,7 @@ final class ComponentExtensionTest extends KernelTestCase
     public function testComponentWithConflictBetweenPropsFromTemplateAndClass(): void
     {
         $this->expectException(RuntimeError::class);
-        $this->expectExceptionMessage('Cannot define prop "name" in template "components/Conflict.html.twig". Property already defined in component class "Symfony\UX\TwigComponent\Tests\Fixtures\Component\Conflict".');
+        $this->expectExceptionMessage('Cannot define prop "name" in template "components/Conflict.html.twig". Property already defined in component class "Symfony\UX\TwigComponent\Tests\Fixtures\Component\Conflict"');
 
         self::getContainer()->get(Environment::class)->render('component_with_conflict_between_props_from_template_and_class.html.twig');
     }

--- a/src/TwigComponent/tests/Integration/EmbeddedComponentTest.php
+++ b/src/TwigComponent/tests/Integration/EmbeddedComponentTest.php
@@ -162,7 +162,7 @@ final class EmbeddedComponentTest extends KernelTestCase
     {
         // Twig renamed "array" into "sequence" in 3.11
         $this->expectExceptionMessage('Key "$this" for ');
-        $this->expectExceptionMessage('with keys "app, __embedded" does not exist.');
+        $this->expectExceptionMessage('with keys "app, __embedded" does not exist');
         self::render('embedded_component_hierarchy_exception.html.twig');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes/no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This PR fixes the following broken checks in high-deps:
```
1) Symfony\UX\TwigComponent\Tests\Integration\ComponentExtensionTest::testComponentWithConflictBetweenPropsFromTemplateAndClass
Failed asserting that exception message 'Cannot define prop "name" in template "components/Conflict.html.twig". Property already defined in component class "Symfony\UX\TwigComponent\Tests\Fixtures\Component\Conflict" in "components/Conflict.html.twig" at line 1.' contains 'Cannot define prop "name" in template "components/Conflict.html.twig". Property already defined in component class "Symfony\UX\TwigComponent\Tests\Fixtures\Component\Conflict".'.

2) Symfony\UX\TwigComponent\Tests\Integration\EmbeddedComponentTest::testAccessingTheHierarchyTooHighThrowsAnException
Failed asserting that exception message 'Key "this" for sequence/mapping with keys "app, __embedded" does not exist in "embedded_component_hierarchy_exception.html.twig" at line 2.' contains 'with keys "app, __embedded" does not exist.'.
```


https://github.com/symfony/ux/actions/runs/13929938771/job/38984295237