### PR TITLE
Document and update CI for Corepack manual installation

### DIFF
--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -21,7 +21,7 @@ jobs:
           - name: Extract version from tag
             run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
-          - run: corepack enable
+          - run: npm i -g corepack && corepack enable
           - uses: actions/setup-node@v4
             with:
               cache: 'yarn'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - run: corepack enable
+            - run: npm i -g corepack && corepack enable
             - uses: actions/setup-node@v4
               with:
                 cache: 'yarn'
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - run: corepack enable
+            - run: npm i -g corepack && corepack enable
             - uses: actions/setup-node@v4
               with:
                 cache: 'yarn'
@@ -130,7 +130,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - run: corepack enable
+            - run: npm i -g corepack && corepack enable
             - uses: actions/setup-node@v4
               with:
                 cache: 'yarn'
@@ -156,7 +156,7 @@ jobs:
       steps:
         - uses: actions/checkout@v4
 
-        - run: corepack enable
+        - run: npm i -g corepack && corepack enable
 
         - uses: actions/setup-node@v4
           with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ To set up the development environment, you need the following tools:
 - [PHP](https://www.php.net/downloads.php) 8.1 or higher
 - [Composer](https://getcomposer.org/download/)
 - [Node.js](https://nodejs.org/en/download/package-manager) 22 or higher
+- [Corepack](https://github.com/nodejs/corepack)
 - [Yarn](https://yarnpkg.com/) 4 or higher
 
 With these tools installed, you can install the project dependencies:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Yesterday, the Node.js team decided to stop distributing corepack with Node.js, see https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616

There is no other alternative than Corepack for installing Yarn Berry, see https://yarnpkg.com/getting-started/install

So, I'm adding the `npm i -g corepack` command where we use/mention `corepack enable`. 