### PR TITLE
[Icons] use the composer suggest section for optional dependencies

### DIFF
--- a/src/Icons/composer.json
+++ b/src/Icons/composer.json
@@ -48,6 +48,10 @@
         "zenstruck/console-test": "^1.5",
         "psr/log": "^2|^3"
     },
+    "suggest": {
+        "symfony/http-client": "To load icons from icon sets",
+        "symfony/ux-twig-component": "To use the <twig:ux:icon> syntax for icons"
+    },
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

Make installing user notice that they might want to install the optional dependencies.