### PR TITLE
[Icons] hint about the http client when icon not found

### DIFF
--- a/src/Icons/src/Registry/ChainIconRegistry.php
+++ b/src/Icons/src/Registry/ChainIconRegistry.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\Icons\Registry;
 
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
 use Symfony\UX\Icons\Icon;
 use Symfony\UX\Icons\IconRegistryInterface;
@@ -38,6 +39,11 @@ final class ChainIconRegistry implements IconRegistryInterface
             }
         }
 
-        throw new IconNotFoundException(\sprintf('Icon "%s" not found.', $name));
+        $exceptionExtra = '';
+        if (str_contains($name, ':') && !class_exists(HttpClient::class)) {
+            $exceptionExtra = ' If you want the on-demand registry to fetch the icon from iconfiy, you need to install "symfony/http-client".';
+        }
+
+        throw new IconNotFoundException(\sprintf('Icon "%s" not found.%s', $name, $exceptionExtra));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | -
| Issues        | #2664
| License       | MIT

make exception more helpful when icon is not found.

this is a bit ugly because the iconfiy registry is not added to the chain if the http client is not available, so we can't know what exactly the user intention was.

i added a check for `:` in the name to at least only trigger this when it *could* be an iconfiy icon.