### PR TITLE
[Icons] explain svg colors and improve example configuration

### DIFF
--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -109,6 +109,13 @@ To keep your design consistent and easily adjustable, consider defining a
 :ref:`default attribute <icons_default_attributes>`. This allows you to control
 the size of all your icons from a single place.
 
+Icon Color
+~~~~~~~~~~
+
+Typically, SVG icons use ``fill="currentColor"`` to inherit the color of the containing element.
+You can set the color in CSS on the container or directly on the SVG element/class.
+
+
 Icon Sets
 ~~~~~~~~~
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

I got mislead by the configuration examples setting the `fill` attribute on the `<svg>` element. All icons i looked have `<path>` elements that reference `currentColor` for either fill or outline. and `currentColor` in the context of CSS is the `color` attribute of the element. thus, to change the color of an icon, we need to set the CSS color. changing the `fill` attribute on the top level `<svg>` has no effect.

I am not 100% sure if this is always true, maybe the section i add needs to be less assertive or explain in which cases it is correct.