### PR TITLE
[Map] Fix 2.23/2.24 changelog

### DIFF
--- a/src/Map/CHANGELOG.md
+++ b/src/Map/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -  Installing the package in a Symfony app using Flex won't add the `@symfony/ux-map` dependency to the `package.json` file anymore.
 -  Add `Icon` to customize a `Marker` icon (URL or SVG content)
+-  Add parameter `id` to `Marker`, `Polygon` and `Polyline` constructors
+-  Add method `Map::removeMarker(string|Marker $markerOrId)`
+-  Add method `Map::removePolygon(string|Polygon $polygonOrId)`
+-  Add method `Map::removePolyline(string|Polyline $polylineOrId)`
 
 ## 2.23
 
@@ -12,10 +16,6 @@
 -  Add `DistanceCalculatorInterface` interface and three implementations:
    `HaversineDistanceCalculator`, `SphericalCosineDistanceCalculator` and `VincentyDistanceCalculator`.
 -  Add `CoordinateUtils` helper, to convert decimal coordinates (`43.2109`) in DMS (`56° 78' 90"`)
--  Add parameter `id` to `Marker`, `Polygon` and `Polyline` constructors
--  Add method `Map::removeMarker(string|Marker $markerOrId)`
--  Add method `Map::removePolygon(string|Polygon $polygonOrId)`
--  Add method `Map::removePolyline(string|Polyline $polylineOrId)`
 
 ## 2.22
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Chore  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

The following features were removed from the changelog as they are not present in the 2.23 release:

-  `id` to `Marker`, `Polygon` and `Polyline` constructors
-  `Map::removeMarker(string|Marker $markerOrId)`
-  `Map::removePolygon(string|Polygon $polygonOrId)`
-  `Map::removePolyline(string|Polyline $polylineOrId)`