### PR TITLE
[CI] Fix version bump for npm packages

### DIFF
--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -32,7 +32,7 @@ jobs:
           - run: yarn --immutable
 
           - name: Update version of JS packages
-            run: yarn workspaces foreach -A version --immediate "${{ env.VERSION }}"
+            run: yarn workspaces foreach -pA exec "npm version ${{ env.VERSION }} --no-git-tag-version --no-workspaces-update"
 
           - name: Commit changes
             run: |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

The workflow https://github.com/symfony/ux/actions/runs/14282744086/job/40034193882 failed because Yarn wasn't able to tag a new version for each packages for idk what reasons. 
Here we just want something that mutate `version` field from `packages.json` without any operations, let's use `npm version --no-workspaces-update --no-git-tag-version` 