### PR TITLE
[LiveComponent] Update 'Submitting the Form via a LiveAction'

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1552,7 +1552,8 @@ Next, tell the ``form`` element to use this action:
         }
     }) }}
 
-Now, when the form is submitted, it will execute the ``save()`` method
+Now, when the form is submitted, the ``live#action:prevent`` catches the form submission event and prevents the regular HTTP form submission.
+it will execute the ``save()`` method
 via Ajax. If the form fails validation, it will re-render with the
 errors. And if it's successful, it will redirect.
 


### PR DESCRIPTION
This pull request includes a change to the documentation in the `src/LiveComponent/doc/index.rst` file. The change clarifies the behavior of the form submission process when using the `live#action:prevent` attribute (section '[Submitting the Form via a LiveAction](https://symfony.com/bundles/ux-live-component/current/index.html#submitting-the-form-via-a-liveaction)')

Documentation update:

* [`src/LiveComponent/doc/index.rst`](diffhunk://#diff-7d696ea207268370ed11caa0ec0da8274e6f31095e0a167f61c1ef27cdf5a45eL1555-R1556): Updated the description to explain that the `live#action:prevent` attribute catches the form submission event and prevents the regular HTTP form submission.