### PR TITLE
[CI] Use git diff instead of git status

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
 
             - name: Check if JS dist files are current
               run: |
-                if [[ -n $(git status --porcelain) ]]; then
+                if ! git diff --quiet; then
                   echo "The Git workspace is unclean! Changes detected:"
                   git status --porcelain
                   git diff


### PR DESCRIPTION
The CI often fails on the "check dist files" script because some dist file changed .. with no real content change

This PR replace the `git status --porcelain` with a `git diff --quiet` to ignore this situation.


