### PR TITLE
[LiveComponent] Release the loading state before any redirect.

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -549,8 +549,8 @@ var HookManager_default = class {
   }
 };
 
-// ../../../node_modules/.pnpm/idiomorph@0.3.0/node_modules/idiomorph/dist/idiomorph.esm.js
-var Idiomorph = function() {
+// ../../../node_modules/idiomorph/dist/idiomorph.esm.js
+var Idiomorph = (function() {
   "use strict";
   let EMPTY_SET = /* @__PURE__ */ new Set();
   let defaults = {
@@ -1093,7 +1093,7 @@ var Idiomorph = function() {
     morph,
     defaults
   };
-}();
+})();
 
 // src/normalize_attributes_for_comparison.ts
 function normalizeAttributesForComparison(element) {
@@ -2045,6 +2045,7 @@ var Component = class {
     if (!controls.shouldRender) {
       return;
     }
+    this.hooks.triggerHook("loading.state:finished", this.element);
     if (backendResponse.response.headers.get("Location")) {
       if (this.isTurboEnabled()) {
         Turbo.visit(backendResponse.response.headers.get("Location"));
@@ -2053,7 +2054,6 @@ var Component = class {
       }
       return;
     }
-    this.hooks.triggerHook("loading.state:finished", this.element);
     const modifiedModelValues = {};
     Object.keys(this.valueStore.getDirtyProps()).forEach((modelName) => {
       modifiedModelValues[modelName] = this.valueStore.get(modelName);

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -359,6 +359,11 @@ export default class Component {
             return;
         }
 
+        // remove the loading behavior now so that when we morphdom
+        // "diffs" the elements, any loading differences will not cause
+        // elements to appear different unnecessarily
+        this.hooks.triggerHook('loading.state:finished', this.element);
+
         if (backendResponse.response.headers.get('Location')) {
             // action returned a redirect
             if (this.isTurboEnabled()) {
@@ -369,11 +374,6 @@ export default class Component {
 
             return;
         }
-
-        // remove the loading behavior now so that when we morphdom
-        // "diffs" the elements, any loading differences will not cause
-        // elements to appear different unnecessarily
-        this.hooks.triggerHook('loading.state:finished', this.element);
 
         /**
          * For any models modified since the last request started, grab


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no 
| Issues        | 
| License       | MIT

This PR attempt to release the loading state before redirecting the user. This one may seems a little weird at first, but it has its use case. 

I just write an export feature that uses a LiveComponent action to build a file. While the export is made, the UI add some classes and/or attributes to convey the "in progress" meaning. When it's done, the user is redirected to a specific controller that initiate the download. Since the redirected page just provide a file attachment, the user stay on the original page (fully expected). But, at this stage, the loading state is never released. By releasing the loading state before the redirect, the UI is made responsive again.
