### PR TITLE
[Turbo] Pass `turbo_stream_listen` topics to mercure if not defined

### DIFF
--- a/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
+++ b/src/Turbo/src/Bridge/Mercure/TurboStreamListenRenderer.php
@@ -65,11 +65,13 @@ final class TurboStreamListenRenderer implements TurboStreamListenRendererWithOp
         if (isset($eventSourceOptions)) {
             try {
                 $mercure = $this->twig->getExtension(MercureExtension::class);
-                $mercure->mercure($topics, $eventSourceOptions);
 
-                if (isset($eventSourceOptions['withCredentials'])) {
-                    $controllerAttributes['withCredentials'] = $eventSourceOptions['withCredentials'];
+                if ($eventSourceOptions['withCredentials'] ?? false) {
+                    $eventSourceOptions['subscribe'] ??= $topics;
+                    $controllerAttributes['withCredentials'] = true;
                 }
+
+                $mercure->mercure($topics, $eventSourceOptions);
             } catch (RuntimeError $e) {
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no 
| Issues        | See below
| License       | MIT

Currently, the documentation says:

`"If you're using a private hub, you can add { withCredentials: true } as the third argument to turbo_stream_listen() to authenticate with the hub."`

However, this doesn’t actually work because the cookie is not created.
See: [MercureExtension.php#L75](https://github.com/symfony/mercure/blob/304cf84609ef645d63adc65fc6250292909a461b/src/Twig/MercureExtension.php#L75)

To make it work, we need to explicitly specify the topics again. The working call looks like this:
`turbo_stream_listen("topics", "default", { subscribe: 'topics', withCredentials: true }`

So I updated the implementation, adding the `subscribe` key if it's not already defined.

My mistake, sorry :sweat_smile: 