### PR TITLE
[StimulusBundle] Make the JS package private

### DIFF
--- a/src/StimulusBundle/assets/README.md
+++ b/src/StimulusBundle/assets/README.md
@@ -2,9 +2,10 @@
 
 JavaScript assets of the [symfony/stimulus-bundle](https://packagist.org/packages/symfony/stimulus-bundle) PHP package.
 
-This package is private and is not intended to be published on npm or installed.
+## Installation
 
-If you're looking for a npm package to integrate Stimulus in your Symfony application, you may be looking for the [`@symfony/stimulus-bridge`](https://www.npmjs.com/package/@symfony/stimulus-bridge) package.
+Due to compatibility issues with JSDelivr causing the package not to work as expected, the package is not yet released on NPM.
+Read more at [symfony/ux#2708](https://github.com/symfony/ux/issues/2708).
 
 ## Resources
 

--- a/src/StimulusBundle/assets/package.json
+++ b/src/StimulusBundle/assets/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@symfony/stimulus-bundle",
     "description": "Integration of @hotwired/stimulus into Symfony",
+    "private": "true",
     "license": "MIT",
     "version": "2.24.0",
     "keywords": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

This PR follows #2708

The npm package `@symfony/stimulus-bundle` was accidentally published on npm when I was working on the "Symfony UX on NPM" project, but when I realized it was to late to unpublish it.

Today, I was able to unpublish the package from npm. I'm now making the package **private**, so it won't be released anymore (until a solution is implemented)

I would be very happy to re-publish this package again when  https://github.com/symfony/ux/issues/2708#issuecomment-2848816170 will be fixed.