### PR TITLE
[Toolkit] Fix deprecation Kernel > 7.3

### DIFF
--- a/src/Toolkit/tests/Fixtures/Kernel.php
+++ b/src/Toolkit/tests/Fixtures/Kernel.php
@@ -45,6 +45,10 @@ final class Kernel extends BaseKernel
             'property_access' => true,
             'http_client' => true,
             'handle_all_throwables' => true,
+
+            ...(self::VERSION_ID >= 70300 ? [
+                'property_info' => ['with_constructor_extractor' => false],
+            ] : []),
         ]);
 
         $container->extension('twig', [


### PR DESCRIPTION
Fix

```
  2x: Since symfony/framework-bundle 7.3: Not setting the "with_constructor_extractor" option explicitly is deprecated because its default value will change in version 8.0.
    2x in DebugKitCommandTest::testShouldBeAbleToDebug from Symfony\UX\Toolkit\Tests\Command
```
