### PR TITLE
[Site][Toolkit] Add manual installation steps for Component installation (and some website tweaks) 

### DIFF
--- a/ux.symfony.com/assets/styles/app.scss
+++ b/ux.symfony.com/assets/styles/app.scss
@@ -128,7 +128,6 @@ $utilities: map-remove(
 @import "components/Button";
 @import "components/Browser";
 @import "components/Changelog";
-@import "components/CodePreview_Tabs";
 @import "components/DataList";
 @import "components/DemoContainer";
 @import "components/DemoCard";
@@ -153,6 +152,7 @@ $utilities: map-remove(
 @import "components/Terminal";
 @import "components/TerminalCommand";
 @import "components/ThemeSwitcher";
+@import "components/Toolkit_Tabs";
 @import "components/Wysiwyg";
 
 // Utilities

--- a/ux.symfony.com/assets/styles/components/_Terminal.scss
+++ b/ux.symfony.com/assets/styles/components/_Terminal.scss
@@ -6,6 +6,7 @@
     border-radius: .75rem;
     position: relative;
     font-size: 12px;
+    display: grid; // Ensure the Terminal overflow its parent if "pre" contains a very-long-line of the same highlighted element (e.g.: a long string)
 }
 
 .Terminal_light {
@@ -162,6 +163,7 @@
         overflow: visible;
     }
     scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, .8) transparent;
     pre {
         background: none;
     }
@@ -170,15 +172,15 @@
     }
 }
 
-@media screen and (min-width: 768px) {
-    .Terminal_content::-webkit-scrollbar {
-        display: none;
-    }
-    .Terminal_content {
-        --webkit-scrollbar-width: none;
-        scrollbar-width: none;
-    }
-}
+// @media screen and (min-width: 768px) {
+//     .Terminal_content::-webkit-scrollbar {
+//         display: none;
+//     }
+//     .Terminal_content {
+//         --webkit-scrollbar-width: none;
+//         scrollbar-width: none;
+//     }
+// }
 
 .Terminal_expand {
     position: absolute;

--- a/ux.symfony.com/assets/styles/components/_Toolkit_Tabs.scss
+++ b/ux.symfony.com/assets/styles/components/_Toolkit_Tabs.scss
@@ -1,13 +1,13 @@
-.CodePreview_Tabs {
+.Toolkit_Tabs {
 }
 
-.CodePreview_TabHead {
+.Toolkit_TabHead {
   display: flex;
   flex-direction: row;
   margin-bottom: 1rem
 }
 
-.CodePreview_TabControl {
+.Toolkit_TabControl {
   border-bottom: 3px solid transparent;
   color: var(--bs-primary-color);
   padding: 0 1rem;
@@ -18,24 +18,24 @@
   margin-bottom: -1px;
 }
 
-.CodePreview_TabControl.active {
+.Toolkit_TabControl.active {
   border-color: var(--bs-secondary-color);
 }
 
-.CodePreview_TabPanel {
+.Toolkit_TabPanel {
     position: relative;
 }
 
-.CodePreview_TabPanel:not(.active) {
+.Toolkit_TabPanel:not(.active) {
   display: none;
 }
 
-.CodePreview_TabPanel:has(.CodePreview_Preview) {
+.Toolkit_TabPanel:has(.Toolkit_Preview) {
     border: 1px solid var(--bs-border-color);
     border-radius: .75rem
 }
 
-.CodePreview_Loader {
+.Toolkit_Loader {
     width: 100%;
     display: flex;
     justify-content: center;
@@ -48,7 +48,7 @@
     }
 }
 
-.CodePreview_Preview {
+.Toolkit_Preview {
     width: 100%;
     transition: opacity .250s linear;
     border-radius: .75rem;

--- a/ux.symfony.com/src/Service/CommonMark/ConverterFactory.php
+++ b/ux.symfony.com/src/Service/CommonMark/ConverterFactory.php
@@ -12,6 +12,7 @@
 namespace App\Service\CommonMark;
 
 use App\Service\CommonMark\Extension\CodeBlockRenderer\CodeBlockRenderer;
+use App\Service\Toolkit\ToolkitService;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
@@ -28,8 +29,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 final class ConverterFactory
 {
     public function __construct(
-        private readonly UrlGeneratorInterface $urlGenerator,
-        private readonly UriSigner $uriSigner,
+        private readonly ToolkitService $toolkitService,
     ) {
     }
 
@@ -57,7 +57,7 @@ final class ConverterFactory
             ->addExtension(new ExternalLinkExtension())
             ->addExtension(new MentionExtension())
             ->addExtension(new FrontMatterExtension())
-            ->addRenderer(FencedCode::class, new CodeBlockRenderer($this->urlGenerator, $this->uriSigner))
+            ->addRenderer(FencedCode::class, new CodeBlockRenderer($this->toolkitService))
         ;
 
         return $converter;

--- a/ux.symfony.com/src/Service/CommonMark/ConverterFactory.php
+++ b/ux.symfony.com/src/Service/CommonMark/ConverterFactory.php
@@ -19,8 +19,6 @@ use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
 use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\Mention\MentionExtension;
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
-use Symfony\Component\HttpFoundation\UriSigner;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/ux.symfony.com/src/Service/CommonMark/Extension/CodeBlockRenderer/CodeBlockRenderer.php
+++ b/ux.symfony.com/src/Service/CommonMark/Extension/CodeBlockRenderer/CodeBlockRenderer.php
@@ -62,9 +62,7 @@ final readonly class CodeBlockRenderer implements NodeRendererInterface
         return <<<HTML
             <div class="Terminal terminal-code" style="margin-bottom: 1rem;">
                 <div class="Terminal_body">
-                    <div class="Terminal_content" style="max-height: 450px;">
-                        {$output}
-                    </div>
+                    <div class="Terminal_content" style="max-height: 450px;">{$output}</div>
                 </div>
             </div>
         HTML;

--- a/ux.symfony.com/src/Service/CommonMark/Extension/CodeBlockRenderer/CodeBlockRenderer.php
+++ b/ux.symfony.com/src/Service/CommonMark/Extension/CodeBlockRenderer/CodeBlockRenderer.php
@@ -11,20 +11,19 @@
 
 namespace App\Service\CommonMark\Extension\CodeBlockRenderer;
 
+use App\Enum\ToolkitKitId;
+use App\Service\Toolkit\ToolkitService;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
-use Symfony\Component\HttpFoundation\UriSigner;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Tempest\Highlight\Highlighter;
 use Tempest\Highlight\WebTheme;
 
 final readonly class CodeBlockRenderer implements NodeRendererInterface
 {
     public function __construct(
-        private UrlGeneratorInterface $urlGenerator,
-        private UriSigner $uriSigner,
+         private ToolkitService $toolkitService,
     ) {
     }
 
@@ -38,39 +37,13 @@ final readonly class CodeBlockRenderer implements NodeRendererInterface
         $infoWords = $node->getInfoWords();
         $language = $infoWords[0] ?? 'txt';
         $options = isset($infoWords[1]) && json_validate($infoWords[1]) ? json_decode($infoWords[1], true) : [];
+        $kitId = ToolkitKitId::tryFrom($options['kit'] ?? null);
         $preview = $options['preview'] ?? false;
-        $kit = $options['kit'] ?? null;
-        $height = $options['height'] ?? '150px';
 
-        $code = $node->getLiteral();
+        $output = $this->highlightCode($code = $node->getLiteral(), $language);
 
-        $output = $this->highlightCode($code, $language);
-
-        if ($preview && $kit) {
-            $previewUrl = $this->uriSigner->sign($this->urlGenerator->generate('app_toolkit_component_preview', [
-                'kitId' => $kit,
-                'code' => $code,
-                'height' => $height,
-            ], UrlGeneratorInterface::ABSOLUTE_URL));
-
-            $output = <<<HTML
-<div class="CodePreview_Tabs" data-controller="tabs" data-tabs-tab-value="preview" data-tabs-active-class="active">
-    <nav class="CodePreview_TabHead" role="tablist" style="border-bottom: 1px solid var(--bs-border-color)">
-        <button class="CodePreview_TabControl" data-action="tabs#show" data-tabs-target="control" data-tabs-tab-param="preview" role="tab" aria-selected="true">Preview</button>
-        <button class="CodePreview_TabControl" data-action="tabs#show" data-tabs-target="control" data-tabs-tab-param="code" role="tab" aria-selected="false">Code</button>
-    </nav>
-    <div class="CodePreview_TabBody">
-        <div class="CodePreview_TabPanel active" data-tabs-target="tab" data-tab="preview" role="tabpanel">
-            <div class="CodePreview_Loader" style="height: {$height};">
-                <svg width="18" height="18" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
-                <span>Loading...</span>
-            </div>
-            <iframe class="CodePreview_Preview loading" src="{$previewUrl}" style="height: {$height};" loading="lazy" onload="this.previousElementSibling.style.display = 'none'; this.classList.remove('loading')"></iframe>
-        </div>
-        <div class="CodePreview_TabPanel" data-tabs-target="tab" data-tab="code" role="tabpanel">{$output}</div>
-    </div>
-</div>
-HTML;
+        if ($kitId && $preview) {
+            $output = $this->toolkitService->renderComponentPreviewCodeTabs($kitId, $code, $output, $options['height'] ?? '150px');
         }
 
         return $output;

--- a/ux.symfony.com/src/Service/CommonMark/Extension/CodeBlockRenderer/CodeBlockRenderer.php
+++ b/ux.symfony.com/src/Service/CommonMark/Extension/CodeBlockRenderer/CodeBlockRenderer.php
@@ -23,7 +23,7 @@ use Tempest\Highlight\WebTheme;
 final readonly class CodeBlockRenderer implements NodeRendererInterface
 {
     public function __construct(
-         private ToolkitService $toolkitService,
+        private ToolkitService $toolkitService,
     ) {
     }
 
@@ -40,7 +40,7 @@ final readonly class CodeBlockRenderer implements NodeRendererInterface
         $kitId = ToolkitKitId::tryFrom($options['kit'] ?? null);
         $preview = $options['preview'] ?? false;
 
-        $output = $this->highlightCode($code = $node->getLiteral(), $language);
+        $output = $this->highlightCode($language, $code = $node->getLiteral());
 
         if ($kitId && $preview) {
             $output = $this->toolkitService->renderComponentPreviewCodeTabs($kitId, $code, $output, $options['height'] ?? '150px');
@@ -49,7 +49,7 @@ final readonly class CodeBlockRenderer implements NodeRendererInterface
         return $output;
     }
 
-    private function highlightCode(string $code, string $language): string
+    public static function highlightCode(string $language, string $code, string $style = 'margin-bottom: 1rem'): string
     {
         $highlighter = new Highlighter();
 
@@ -60,7 +60,7 @@ final readonly class CodeBlockRenderer implements NodeRendererInterface
             : '<pre data-lang="'.$language.'" class="notranslate">'.$parsed.'</pre>';
 
         return <<<HTML
-            <div class="Terminal terminal-code" style="margin-bottom: 1rem;">
+            <div class="Terminal terminal-code" style="$style">
                 <div class="Terminal_body">
                     <div class="Terminal_content" style="max-height: 450px;">{$output}</div>
                 </div>

--- a/ux.symfony.com/src/Service/Toolkit/ToolkitService.php
+++ b/ux.symfony.com/src/Service/Toolkit/ToolkitService.php
@@ -12,10 +12,13 @@
 namespace App\Service\Toolkit;
 
 use App\Enum\ToolkitKitId;
+use App\Util\SourceCleaner;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\Toolkit\Asset\Component;
+use Symfony\UX\Toolkit\Installer\PoolResolver;
 use Symfony\UX\Toolkit\Kit\Kit;
 use Symfony\UX\Toolkit\Registry\RegistryFactory;
 use function Symfony\Component\String\s;
@@ -77,6 +80,41 @@ class ToolkitService
         ]);
     }
 
+    public function renderInstallationSteps(ToolkitKitId $kitId, Component $component): string
+    {
+        $kit = $this->getKit($kitId);
+        $pool = (new PoolResolver)->resolveForComponent($kit, $component);
+
+        $manual = '<p>The UX Toolkit is not mandatory to install a component. You can install it manually by following the next steps:</p>';
+        $manual .= '<ol style="display: grid; gap: 1rem;">';
+        $manual .= '<li><strong>Copy the files into your Symfony app:</strong>';
+        foreach ($pool->getFiles() as $file) {
+            $manual .= sprintf(
+                "<details><summary><code>%s</code></summary>\n%s\n</details>",
+                $file->relativePathNameToKit,
+                sprintf("\n```%s\n%s\n```", pathinfo($file->relativePathNameToKit, PATHINFO_EXTENSION), trim(file_get_contents(Path::join($kit->path, $file->relativePathNameToKit))))
+            );
+        }
+        $manual .= '</li>';
+
+        if ($phpPackageDependencies = $pool->getPhpPackageDependencies()) {
+            $manual .= '<li><strong>If necessary, install the following Composer dependencies:</strong>';
+            $manual .= self::generateTerminal('shell', SourceCleaner::processTerminalLines('composer require ' . implode(' ', $phpPackageDependencies)));
+            $manual .= '</li>';
+        }
+
+        $manual .= '<li><strong>And the most important, enjoy!</strong></li>';
+        $manual .= '</ol>';
+
+        return $this->generateTabs([
+            'Automatic' => sprintf(
+                '<p>Ensure the Symfony UX Toolkit is installed in your Symfony app:</p>%s<p>Then, run the following command to install the component and its dependencies:</p>%s',
+                self::generateTerminal('shell', SourceCleaner::processTerminalLines('composer require --dev symfony/ux-toolkit'), 'margin-bottom: 1rem'),
+                self::generateTerminal('shell', SourceCleaner::processTerminalLines("bin/console ux:toolkit:install-component {$component->name} --kit {$kitId->value}"), 'margin-bottom: 1rem'),
+            ),
+            'Manual' => $manual,
+        ]);
+    }
 
     /**
      * @param non-empty-array<string, string> $tabs
@@ -102,5 +140,18 @@ class ToolkitService
     <div class="Toolkit_TabBody">{$tabsPanels}</div>
 </div>
 HTML;
+    }
+
+    private static function generateTerminal(string $language, string $content, string $style = ''): string
+    {
+        return <<<HTML
+            <div class="Terminal terminal-code" style="$style">
+                <div class="Terminal_body">
+                    <div class="Terminal_content">
+                        <pre><code class="language-{$language}">{$content}</code></pre>
+                    </div>
+                </div>
+            </div>
+            HTML;
     }
 }

--- a/ux.symfony.com/src/Service/Toolkit/ToolkitService.php
+++ b/ux.symfony.com/src/Service/Toolkit/ToolkitService.php
@@ -13,15 +13,20 @@ namespace App\Service\Toolkit;
 
 use App\Enum\ToolkitKitId;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\Toolkit\Asset\Component;
 use Symfony\UX\Toolkit\Kit\Kit;
 use Symfony\UX\Toolkit\Registry\RegistryFactory;
+use function Symfony\Component\String\s;
 
 class ToolkitService
 {
     public function __construct(
         #[Autowire(service: 'ux_toolkit.registry.registry_factory')]
-        private RegistryFactory $registryFactory,
+        private readonly RegistryFactory $registryFactory,
+        private readonly UriSigner $uriSigner,
+        private readonly UrlGeneratorInterface $urlGenerator
     ) {
     }
 
@@ -53,5 +58,49 @@ class ToolkitService
     public function getDocumentableComponents(Kit $kit): array
     {
         return array_filter($kit->getComponents(), fn (Component $component) => $component->doc);
+    }
+
+    public function renderComponentPreviewCodeTabs(ToolkitKitId $kitId, string $code, string $highlightedCode, string $height): string
+    {
+        $previewUrl = $this->urlGenerator->generate('app_toolkit_component_preview', ['kitId' => $kitId->value, 'code' => $code, 'height' => $height], UrlGeneratorInterface::ABSOLUTE_URL);
+        $previewUrl = $this->uriSigner->sign($previewUrl);
+
+        return self::generateTabs([
+            'Preview' => <<<HTML
+                <div class="Toolkit_Loader" style="height: {$height};">
+                    <svg width="18" height="18" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                    <span>Loading...</span>
+                </div>
+                <iframe class="Toolkit_Preview loading" src="{$previewUrl}" style="height: {$height};" loading="lazy" onload="this.previousElementSibling.style.display = 'none'; this.classList.remove('loading')"></iframe>
+            HTML,
+            'Code' => $highlightedCode
+        ]);
+    }
+
+
+    /**
+     * @param non-empty-array<string, string> $tabs
+     */
+    private static function generateTabs(array $tabs): string
+    {
+        $activeTabId = null;
+        $tabsControls = '';
+        $tabsPanels = '';
+
+        foreach ($tabs as $tabText => $tabContent) {
+            $tabId = hash('xxh3', $tabText);
+            $activeTabId ??= $tabId;
+            $isActive = $activeTabId === $tabId;
+
+            $tabsControls .= sprintf('<button class="Toolkit_TabControl" data-action="tabs#show" data-tabs-target="control" data-tabs-tab-param="%s" role="tab" aria-selected="%s">%s</button>', $tabId, $isActive ? 'true' : 'false', trim($tabText));
+            $tabsPanels .= sprintf('<div class="Toolkit_TabPanel %s" data-tabs-target="tab" data-tab="%s" role="tabpanel">%s</div>', $isActive ? 'active' : '', $tabId, $tabContent);
+        }
+
+        return <<<HTML
+<div class="Toolkit_Tabs" data-controller="tabs" data-tabs-tab-value="{$activeTabId}" data-tabs-active-class="active">
+    <nav class="Toolkit_TabHead" role="tablist" style="border-bottom: 1px solid var(--bs-border-color)">{$tabsControls}</nav>
+    <div class="Toolkit_TabBody">{$tabsPanels}</div>
+</div>
+HTML;
     }
 }

--- a/ux.symfony.com/src/Twig/Components/Toolkit/ComponentDoc.php
+++ b/ux.symfony.com/src/Twig/Components/Toolkit/ComponentDoc.php
@@ -13,13 +13,9 @@ namespace App\Twig\Components\Toolkit;
 
 use App\Enum\ToolkitKitId;
 use App\Service\Toolkit\ToolkitService;
-use App\Util\SourceCleaner;
-use Symfony\Component\HttpFoundation\UriSigner;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\String\AbstractString;
 use Symfony\UX\Toolkit\Asset\Component;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
-use Tempest\Highlight\Highlighter;
 
 use function Symfony\Component\String\s;
 
@@ -29,7 +25,8 @@ class ComponentDoc
     public ToolkitKitId $kitId;
     public Component $component;
 
-    public function __construct(private readonly ToolkitService $toolkitService) {
+    public function __construct(private readonly ToolkitService $toolkitService)
+    {
     }
 
     public function getContent(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT


Another PR started in the plane :D 


![IMG_2736 - copie](https://github.com/user-attachments/assets/b07dabcf-0662-439d-b7b8-9a93a6993d26)

--- 

This one add manual installation steps in the documentation, letting people see files they will install before (or without) installing the UX Toolkit:

https://github.com/user-attachments/assets/93ec2f2c-1a2b-4637-a9fa-f92fa4273f3d

