### PR TITLE
[Icons] Check for empty paths before calling Finder in `ux:icons:lock`

### DIFF
--- a/src/Icons/src/Twig/IconFinder.php
+++ b/src/Icons/src/Twig/IconFinder.php
@@ -67,12 +67,14 @@ final class IconFinder
     private function templateFiles(LoaderInterface $loader): iterable
     {
         if ($loader instanceof FilesystemLoader) {
-            $paths = [];
+            $paths = $loader->getPaths();
             foreach ($loader->getNamespaces() as $namespace) {
                 $paths = [...$paths, ...$loader->getPaths($namespace)];
             }
-            foreach ((new Finder())->files()->in($paths)->name('*.twig') as $file) {
-                yield (string) $file;
+            if ($paths) {
+                foreach ((new Finder())->files()->in($paths)->name('*.twig') as $file) {
+                    yield (string) $file;
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Issues        | Fix #2719