### PR TITLE
[Toolkit] Remove Kit "authors"

### DIFF
--- a/src/Toolkit/kits/shadcn/manifest.json
+++ b/src/Toolkit/kits/shadcn/manifest.json
@@ -3,6 +3,5 @@
     "description": "Component based on the Shadcn UI library, one of the most popular design systems in JavaScript world.",
     "license": "MIT",
     "homepage": "https://ux.symfony.com/components",
-    "authors": ["Shadcn", "Symfony Community"],
     "ux-icon": "simple-icons:shadcnui"
 }

--- a/src/Toolkit/src/Command/CreateKitCommand.php
+++ b/src/Toolkit/src/Command/CreateKitCommand.php
@@ -65,17 +65,6 @@ class CreateKitCommand extends Command
         });
         $kitHomepage = $io->askQuestion($question);
 
-        // Get the kit author name
-        $question = new Question("What's the name of the author?");
-        $question->setValidator(function (?string $value) {
-            if (empty($value)) {
-                throw new \Exception('The author name cannot be empty.');
-            }
-
-            return $value;
-        });
-        $kitAuthorName = $io->askQuestion($question);
-
         // Get the kit license
         $question = new Question('What is the license of your kit?');
         $question->setValidator(function (string $value) {
@@ -91,7 +80,6 @@ class CreateKitCommand extends Command
         $this->filesystem->dumpFile('manifest.json', json_encode([
             'name' => $kitName,
             'homepage' => $kitHomepage,
-            'authors' => [$kitAuthorName],
             'license' => $kitLicense,
         ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
         $this->filesystem->dumpFile('templates/components/Button.html.twig', <<<TWIG

--- a/src/Toolkit/src/Command/DebugKitCommand.php
+++ b/src/Toolkit/src/Command/DebugKitCommand.php
@@ -69,7 +69,6 @@ EOF
         $io->definitionList(
             ['Name' => $kit->name],
             ['Homepage' => $kit->homepage],
-            ['Authors' => implode(', ', $kit->authors)],
             ['License' => $kit->license],
             new TableSeparator(),
             ['Path' => $kit->path],

--- a/src/Toolkit/src/Kit/Kit.php
+++ b/src/Toolkit/src/Kit/Kit.php
@@ -24,19 +24,17 @@ use Symfony\UX\Toolkit\Asset\StimulusController;
 final class Kit
 {
     /**
-     * @param non-empty-string                               $path
-     * @param non-empty-string                               $name
-     * @param non-empty-string|null                          $homepage
-     * @param list<array{name: string, email?: string}>|null $authors
-     * @param non-empty-string|null                          $license
-     * @param list<Component>                                $components
-     * @param list<StimulusController>                       $stimulusControllers
+     * @param non-empty-string         $path
+     * @param non-empty-string         $name
+     * @param non-empty-string|null    $homepage
+     * @param non-empty-string|null    $license
+     * @param list<Component>          $components
+     * @param list<StimulusController> $stimulusControllers
      */
     public function __construct(
         public readonly string $path,
         public readonly string $name,
         public readonly ?string $homepage = null,
-        public readonly array $authors = [],
         public readonly ?string $license = null,
         public readonly ?string $description = null,
         public readonly ?string $uxIcon = null,

--- a/src/Toolkit/src/Kit/KitFactory.php
+++ b/src/Toolkit/src/Kit/KitFactory.php
@@ -51,7 +51,6 @@ final class KitFactory
             path: $absolutePath,
             name: $manifest['name'] ?? throw new \InvalidArgumentException('Manifest file is missing "name" key.'),
             homepage: $manifest['homepage'] ?? throw new \InvalidArgumentException('Manifest file is missing "homepage" key.'),
-            authors: $manifest['authors'] ?? throw new \InvalidArgumentException('Manifest file is missing "authors" key.'),
             license: $manifest['license'] ?? throw new \InvalidArgumentException('Manifest file is missing "license" key.'),
             description: $manifest['description'] ?? null,
             uxIcon: $manifest['ux-icon'] ?? null,

--- a/src/Toolkit/tests/Command/DebugKitCommandTest.php
+++ b/src/Toolkit/tests/Command/DebugKitCommandTest.php
@@ -27,7 +27,6 @@ class DebugKitCommandTest extends KernelTestCase
             // Kit details
             ->assertOutputContains('Name       Shadcn')
             ->assertOutputContains('Homepage   https://ux.symfony.com/components')
-            ->assertOutputContains('Authors    Shadcn, Symfony Community')
             ->assertOutputContains('License    MIT')
             // A component details
             ->assertOutputContains(<<<'EOF'

--- a/src/Toolkit/tests/Fixtures/kits/with-circular-components-dependencies/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/with-circular-components-dependencies/manifest.json
@@ -2,6 +2,5 @@
     "name": "With Circular Components Dependencies",
     "description": "Kit used as a test fixture.",
     "license": "MIT",
-    "homepage": "https://ux.symfony.com/",
-    "authors": ["Symfony UX Community"]
+    "homepage": "https://ux.symfony.com/"
 }

--- a/src/Toolkit/tests/Fixtures/kits/with-stimulus-controllers/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/with-stimulus-controllers/manifest.json
@@ -2,6 +2,5 @@
     "name": "With Stimulus Controllers",
     "description": "Kit used as a test fixture.",
     "license": "MIT",
-    "homepage": "https://ux.symfony.com/",
-    "authors": ["Symfony UX Community"]
+    "homepage": "https://ux.symfony.com/"
 }

--- a/src/Toolkit/tests/Kit/KitTest.php
+++ b/src/Toolkit/tests/Kit/KitTest.php
@@ -24,7 +24,7 @@ final class KitTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid kit name "-foobar".');
 
-        new Kit(__DIR__, '-foobar', 'https://example.com', [], 'MIT');
+        new Kit(__DIR__, '-foobar', 'https://example.com', 'MIT');
     }
 
     public function testShouldFailIfKitPathIsNotAbsolute(): void
@@ -32,12 +32,12 @@ final class KitTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('Kit path "./%s" is not absolute.', __DIR__));
 
-        new Kit(\sprintf('./%s', __DIR__), 'foo', 'https://example.com', [], 'MIT');
+        new Kit(\sprintf('./%s', __DIR__), 'foo', 'https://example.com', 'MIT');
     }
 
     public function testCanAddComponentsToTheKit(): void
     {
-        $kit = new Kit(__DIR__, 'foo', 'https://example.com', [], 'MIT');
+        $kit = new Kit(__DIR__, 'foo', 'https://example.com', 'MIT');
         $kit->addComponent(new Component('Table', [new File(FileType::Twig, 'Table.html.twig', 'Table.html.twig')], null));
         $kit->addComponent(new Component('Table:Row', [new File(FileType::Twig, 'Table/Row.html.twig', 'Table/Row.html.twig')], null));
 
@@ -49,14 +49,14 @@ final class KitTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Component "Table" is already registered in the kit.');
 
-        $kit = new Kit(__DIR__, 'foo', 'https://example.com', [], 'MIT');
+        $kit = new Kit(__DIR__, 'foo', 'https://example.com', 'MIT');
         $kit->addComponent(new Component('Table', [new File(FileType::Twig, 'Table.html.twig', 'Table.html.twig')], null));
         $kit->addComponent(new Component('Table', [new File(FileType::Twig, 'Table.html.twig', 'Table.html.twig')], null));
     }
 
     public function testCanGetComponentByName(): void
     {
-        $kit = new Kit(__DIR__, 'foo', 'https://example.com', [], 'MIT');
+        $kit = new Kit(__DIR__, 'foo', 'https://example.com', 'MIT');
         $kit->addComponent(new Component('Table', [new File(FileType::Twig, 'Table.html.twig', 'Table.html.twig')], null));
         $kit->addComponent(new Component('Table:Row', [new File(FileType::Twig, 'Table/Row.html.twig', 'Table/Row.html.twig')], null));
 
@@ -66,7 +66,7 @@ final class KitTest extends TestCase
 
     public function testShouldReturnNullIfComponentIsNotFound(): void
     {
-        $kit = new Kit(__DIR__, 'foo', 'https://example.com', [], 'MIT');
+        $kit = new Kit(__DIR__, 'foo', 'https://example.com', 'MIT');
 
         $this->assertNull($kit->getComponent('Table:Cell'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

At the moment, knowing the "authors" kit has no interest at all and is not well implemented.

Let's keep things simple and remove it, we can re-add it later if necessary.