### PR TITLE
[Toolkit] Add components metadata (for dependencies)

### DIFF
--- a/src/Toolkit/kits/shadcn/templates/components/Alert.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Alert.meta.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "twig/extra-bundle"
+        },
+        {
+            "type": "php",
+            "package": "twig/html-extra:^3.12.0"
+        },
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Alert/Description.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Alert/Description.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Alert/Title.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Alert/Title.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/AspectRatio.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/AspectRatio.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "twig/extra-bundle"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Avatar.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Avatar.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Avatar/Image.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Avatar/Image.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Avatar/Text.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Avatar/Text.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Badge.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Badge.meta.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "twig/extra-bundle"
+        },
+        {
+            "type": "php",
+            "package": "twig/html-extra:^3.12.0"
+        },
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Breadcrumb.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Breadcrumb.meta.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": []
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Ellipsis.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Ellipsis.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Item.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Item.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Link.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Link.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/List.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/List.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Page.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Page.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Separator.html.twig
+++ b/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Separator.html.twig
@@ -5,6 +5,6 @@
     aria-hidden="true"
 >
     {%- block content -%}
-        <twig:ux:Icon name="mdi:chevron-right" />
+        <twig:ux:icon name="mdi:chevron-right" />
     {%- endblock %}
 </li>

--- a/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Separator.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Breadcrumb/Separator.meta.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "symfony/ux-icons"
+        },
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Button.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Button.meta.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "twig/extra-bundle"
+        },
+        {
+            "type": "php",
+            "package": "twig/html-extra:^3.12.0"
+        },
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Card.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Card.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Card/Content.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Card/Content.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Card/Description.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Card/Description.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Card/Footer.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Card/Footer.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Card/Header.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Card/Header.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Card/Title.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Card/Title.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Checkbox.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Checkbox.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Input.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Input.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Label.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Label.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination/Content.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination/Content.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination/Ellipsis.html.twig
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination/Ellipsis.html.twig
@@ -3,6 +3,6 @@
     class="{{ 'flex h-9 w-9 items-center justify-center ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes.without('class') }}
 >
-    <twig:UX:Icon name="lucide:more-horizontal" class="size-4" />
+    <twig:ux:icon name="lucide:more-horizontal" class="size-4" />
     <span class="sr-only">More pages</span>
 </span>

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination/Ellipsis.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination/Ellipsis.meta.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "symfony/ux-icons"
+        },
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination/Item.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination/Item.meta.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": []
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination/Link.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination/Link.meta.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": []
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination/Next.html.twig
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination/Next.html.twig
@@ -5,5 +5,5 @@
     {{ ...attributes.without('class') }}
 >
     <span>Next</span>
-    <twig:UX:Icon name="lucide:chevron-right" class="size-4" />
+    <twig:ux:icon name="lucide:chevron-right" class="size-4" />
 </twig:Pagination:Link>

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination/Next.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination/Next.meta.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "symfony/ux-icons"
+        },
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination/Previous.html.twig
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination/Previous.html.twig
@@ -4,6 +4,6 @@
     class="{{ 'gap-1 pl-2.5 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ ...attributes.without('class') }}
 >
-    <twig:UX:Icon name="lucide:chevron-left" class="size-4" />
+    <twig:ux:icon name="lucide:chevron-left" class="size-4" />
     <span>Previous</span>
 </twig:Pagination:Link>

--- a/src/Toolkit/kits/shadcn/templates/components/Pagination/Previous.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Pagination/Previous.meta.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "symfony/ux-icons"
+        },
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Progress.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Progress.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Select.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Select.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Separator.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Separator.meta.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "twig/extra-bundle"
+        },
+        {
+            "type": "php",
+            "package": "twig/html-extra:^3.12.0"
+        },
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Skeleton.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Skeleton.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Switch.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Switch.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Table.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Table.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Table/Body.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Table/Body.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Table/Caption.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Table/Caption.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Table/Cell.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Table/Cell.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Table/Footer.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Table/Footer.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Table/Head.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Table/Head.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Table/Header.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Table/Header.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Table/Row.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Table/Row.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/templates/components/Textarea.meta.json
+++ b/src/Toolkit/kits/shadcn/templates/components/Textarea.meta.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../schemas/component.json",
+    "dependencies": [
+        {
+            "type": "php",
+            "package": "tales-from-a-dev/twig-tailwind-extra"
+        }
+    ]
+}

--- a/src/Toolkit/schemas/component.json
+++ b/src/Toolkit/schemas/component.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Component Meta Schema",
+    "type": "object",
+    "required": ["dependencies"],
+    "properties": {
+        "dependencies": {
+            "type": "array",
+            "description": "List of dependencies required by the component",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "required": ["type", "package"],
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["php"],
+                                "description": "PHP package dependency"
+                            },
+                            "package": {
+                                "type": "string",
+                                "description": "Package name and optional version constraint"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/Toolkit/src/Asset/Component.php
+++ b/src/Toolkit/src/Asset/Component.php
@@ -16,6 +16,7 @@ use Symfony\UX\Toolkit\Dependency\ComponentDependency;
 use Symfony\UX\Toolkit\Dependency\DependencyInterface;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\StimulusControllerDependency;
+use Symfony\UX\Toolkit\File\ComponentMeta;
 use Symfony\UX\Toolkit\File\Doc;
 use Symfony\UX\Toolkit\File\File;
 
@@ -34,12 +35,17 @@ final class Component
         public readonly string $name,
         public readonly array $files,
         public ?Doc $doc = null,
+        public ?ComponentMeta $meta = null,
         private array $dependencies = [],
     ) {
         Assert::componentName($name);
 
         if ([] === $files) {
             throw new \InvalidArgumentException(\sprintf('The component "%s" must have at least one file.', $name));
+        }
+
+        foreach ($this->meta?->dependencies ?? [] as $dependency) {
+            $this->addDependency($dependency);
         }
     }
 
@@ -74,5 +80,16 @@ final class Component
     public function getDependencies(): array
     {
         return $this->dependencies;
+    }
+
+    public function hasDependency(DependencyInterface $dependency): bool
+    {
+        foreach ($this->dependencies as $existingDependency) {
+            if ($existingDependency->isEquivalentTo($dependency)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Toolkit/src/Command/CreateKitCommand.php
+++ b/src/Toolkit/src/Command/CreateKitCommand.php
@@ -101,7 +101,7 @@ class CreateKitCommand extends Command
 </button>
 TWIG
         );
-        $this->filesystem->dumpFile('docs/components/Button.md', <<<TWIG
+        $this->filesystem->dumpFile('docs/components/Button.md', <<<MARKDOWN
 # Button
 
 The Button component is a versatile component that allows you to create clickable buttons with various styles and states.
@@ -136,8 +136,12 @@ $ bin/console ux:toolkit:install-component Button --kit github.com/user/my-ux-to
 <twig:Button variant="secondary">Secondary</twig:Button>
 ```
 
-TWIG
+MARKDOWN
         );
+        $this->filesystem->dumpFile('docs/components/Button.meta.json', json_encode([
+            '$schema' => '../vendor/symfony/ux-toolkit/schemas/component.schema.json',
+            'dependencies' => (object) [],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
 
         $io->success('Your kit has been scaffolded, enjoy!');
 

--- a/src/Toolkit/src/Dependency/ComponentDependency.php
+++ b/src/Toolkit/src/Dependency/ComponentDependency.php
@@ -31,6 +31,15 @@ final class ComponentDependency implements DependencyInterface
         Assert::componentName($this->name);
     }
 
+    public function isEquivalentTo(DependencyInterface $dependency): bool
+    {
+        if (!$dependency instanceof self) {
+            return false;
+        }
+
+        return $this->name === $dependency->name;
+    }
+
     public function __toString(): string
     {
         return $this->name;

--- a/src/Toolkit/src/Dependency/DependencyInterface.php
+++ b/src/Toolkit/src/Dependency/DependencyInterface.php
@@ -20,4 +20,5 @@ namespace Symfony\UX\Toolkit\Dependency;
  */
 interface DependencyInterface extends \Stringable
 {
+    public function isEquivalentTo(self $dependency): bool;
 }

--- a/src/Toolkit/src/Dependency/PhpPackageDependency.php
+++ b/src/Toolkit/src/Dependency/PhpPackageDependency.php
@@ -32,6 +32,15 @@ final class PhpPackageDependency implements DependencyInterface
         Assert::phpPackageName($name);
     }
 
+    public function isEquivalentTo(DependencyInterface $dependency): bool
+    {
+        if (!$dependency instanceof self) {
+            return false;
+        }
+
+        return $this->name === $dependency->name;
+    }
+
     public function isHigherThan(self $dependency): bool
     {
         if (null === $this->constraintVersion || null === $dependency->constraintVersion) {

--- a/src/Toolkit/src/Dependency/StimulusControllerDependency.php
+++ b/src/Toolkit/src/Dependency/StimulusControllerDependency.php
@@ -31,6 +31,15 @@ final class StimulusControllerDependency implements DependencyInterface
         Assert::stimulusControllerName($this->name);
     }
 
+    public function isEquivalentTo(DependencyInterface $dependency): bool
+    {
+        if (!$dependency instanceof self) {
+            return false;
+        }
+
+        return $this->name === $dependency->name;
+    }
+
     public function __toString(): string
     {
         return $this->name;

--- a/src/Toolkit/src/File/ComponentMeta.php
+++ b/src/Toolkit/src/File/ComponentMeta.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\File;
+
+use Symfony\UX\Toolkit\Dependency\DependencyInterface;
+use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
+use Symfony\UX\Toolkit\Dependency\Version;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class ComponentMeta
+{
+    public static function fromJson(string $json): self
+    {
+        $data = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        unset($data['$schema']);
+
+        $dependencies = [];
+        foreach ($data['dependencies'] ?? [] as $i => $dependency) {
+            if (!isset($dependency['type'])) {
+                throw new \InvalidArgumentException(sprintf('The dependency type is missing for dependency #%d, add "type" key.', $i));
+            }
+
+            if ('php' === $dependency['type']) {
+                $package = $dependency['package'] ?? throw new \InvalidArgumentException(sprintf('The package name is missing for dependency #%d.', $i));
+                if (str_contains($package, ':')) {
+                    [$name, $version] = explode(':', $package, 2);
+                    $dependencies[] = new PhpPackageDependency($name, new Version($version));
+                } else {
+                    $dependencies[] = new PhpPackageDependency($package);
+                }
+            } else {
+                throw new \InvalidArgumentException(\sprintf('The dependency type "%s" is not supported.', $dependency['type']));
+            }
+        }
+        unset($data['dependencies']);
+
+        if ([] !== $unused = array_keys($data)) {
+            throw new \InvalidArgumentException(\sprintf('The following key(s) are not supported: "%s".', implode('", "', $unused)));
+        }
+
+        return new self(
+            $dependencies
+        );
+    }
+
+    /**
+     * @param list<DependencyInterface> $dependencies
+     */
+    private function __construct(
+        public readonly array $dependencies
+    ) {
+    }
+}

--- a/src/Toolkit/src/Kit/KitSynchronizer.php
+++ b/src/Toolkit/src/Kit/KitSynchronizer.php
@@ -19,7 +19,7 @@ use Symfony\UX\Toolkit\Asset\StimulusController;
 use Symfony\UX\Toolkit\Dependency\ComponentDependency;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\StimulusControllerDependency;
-use Symfony\UX\Toolkit\Dependency\Version;
+use Symfony\UX\Toolkit\File\ComponentMeta;
 use Symfony\UX\Toolkit\File\Doc;
 use Symfony\UX\Toolkit\File\File;
 use Symfony\UX\Toolkit\File\FileType;
@@ -40,6 +40,11 @@ final class KitSynchronizer
      * @see https://regex101.com/r/inIBID/1
      */
     private const RE_STIMULUS_CONTROLLER_REFERENCES = '/data-controller=(["\'])(?P<controllersName>.+?)\1/';
+
+    private const UX_COMPONENTS_PACKAGES = [
+        'ux:icon' => 'symfony/ux-icons',
+        'ux:map' => 'symfony/ux-map',
+    ];
 
     public function __construct(
         private readonly Filesystem $filesystem,
@@ -68,6 +73,17 @@ final class KitSynchronizer
             $relativePathNameToKit = $file->getRelativePathname();
             $relativePathName = str_replace($componentsPath.\DIRECTORY_SEPARATOR, '', $relativePathNameToKit);
             $componentName = $this->extractComponentName($relativePathName);
+
+            $meta = null;
+            if ($this->filesystem->exists($metaJsonFile = Path::join($file->getPath(), str_replace('.html.twig', '.meta.json', $file->getBasename())))) {
+                $metaJson = file_get_contents($metaJsonFile) ?: throw new \RuntimeException(sprintf('Unable to get contents from file "%s".', $metaJsonFile));
+                try {
+                    $meta = ComponentMeta::fromJson($metaJson);
+                } catch (\Throwable $e) {
+                    throw new \RuntimeException(sprintf('Unable to parse component "%s" meta from JSON file "%s".', $componentName, $metaJsonFile), previous: $e);
+                }
+            }
+
             $component = new Component(
                 name: $componentName,
                 files: [new File(
@@ -75,6 +91,7 @@ final class KitSynchronizer
                     relativePathNameToKit: $relativePathNameToKit,
                     relativePathName: $relativePathName,
                 )],
+                meta: $meta,
             );
 
             $kit->addComponent($component);
@@ -108,26 +125,17 @@ final class KitSynchronizer
             $fileContent = file_get_contents($filePath);
 
             if (FileType::Twig === $file->type) {
-                if (str_contains($fileContent, 'html_cva')) {
-                    $component->addDependency(new PhpPackageDependency('twig/extra-bundle'));
-                    $component->addDependency(new PhpPackageDependency('twig/html-extra', new Version('3.12.0')));
-                }
-
-                if (str_contains($fileContent, 'tailwind_merge')) {
-                    $component->addDependency(new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra'));
-                }
-
                 if (str_contains($fileContent, '<twig:') && preg_match_all(self::RE_TWIG_COMPONENT_REFERENCES, $fileContent, $matches)) {
                     foreach ($matches[1] as $componentReferenceName) {
                         if ($componentReferenceName === $component->name) {
                             continue;
                         }
 
-                        if ('ux:icon' === strtolower($componentReferenceName)) {
-                            $component->addDependency(new PhpPackageDependency('symfony/ux-icons'));
-                        } elseif ('ux:map' === strtolower($componentReferenceName)) {
-                            $component->addDependency(new PhpPackageDependency('symfony/ux-map'));
-                        } elseif (null === $componentReference = $kit->getComponent($componentReferenceName)) {
+                        if (null !== $package = self::UX_COMPONENTS_PACKAGES[strtolower($componentReferenceName)] ?? null) {
+                            if (!$component->hasDependency(new PhpPackageDependency($package))) {
+                                throw new \RuntimeException(\sprintf('Component "%s" uses "%s" UX Twig component, but the composer package "%s" is not listed as a dependency in meta file.', $component->name, $componentReferenceName, $package));
+                            }
+                        } else if (null === $componentReference = $kit->getComponent($componentReferenceName)) {
                             throw new \RuntimeException(\sprintf('Component "%s" not found in component "%s" (file "%s")', $componentReferenceName, $component->name, $file->relativePathNameToKit));
                         } else {
                             $component->addDependency(new ComponentDependency($componentReference->name));

--- a/src/Toolkit/tests/Command/DebugKitCommandTest.php
+++ b/src/Toolkit/tests/Command/DebugKitCommandTest.php
@@ -32,9 +32,9 @@ class DebugKitCommandTest extends KernelTestCase
             ->assertOutputContains(<<<'EOF'
 +--------------+----------------------- Component: "Avatar" --------------------------------------+
 | File(s)      | templates/components/Avatar.html.twig (Twig)                                     |
-| Dependencies | Avatar:Image                                                                     |
+| Dependencies | tales-from-a-dev/twig-tailwind-extra                                             |
+|              | Avatar:Image                                                                     |
 |              | Avatar:Text                                                                      |
-|              | tales-from-a-dev/twig-tailwind-extra                                             |
 +--------------+----------------------------------------------------------------------------------+
 EOF
             );

--- a/src/Toolkit/tests/Kit/KitFactoryTest.php
+++ b/src/Toolkit/tests/Kit/KitFactoryTest.php
@@ -56,6 +56,7 @@ final class KitFactoryTest extends KernelTestCase
         $this->assertNotNull($table);
         $this->assertNotEmpty($table->files);
         $this->assertEquals([
+            new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra'),
             new ComponentDependency('Table:Body'),
             new ComponentDependency('Table:Caption'),
             new ComponentDependency('Table:Cell'),
@@ -63,7 +64,6 @@ final class KitFactoryTest extends KernelTestCase
             new ComponentDependency('Table:Head'),
             new ComponentDependency('Table:Header'),
             new ComponentDependency('Table:Row'),
-            new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra'),
         ], $table->getDependencies());
         $this->assertNotNull($table->doc);
         $this->assertStringContainsString(<<<'EOF'

--- a/src/Toolkit/tests/Kit/KitSynchronizerTest.php
+++ b/src/Toolkit/tests/Kit/KitSynchronizerTest.php
@@ -42,11 +42,12 @@ final class KitSynchronizerTest extends KernelTestCase
 
         $this->assertEquals([
             new PhpPackageDependency('twig/extra-bundle'),
-            new PhpPackageDependency('twig/html-extra', new Version('3.12.0')),
+            new PhpPackageDependency('twig/html-extra', new Version('^3.12.0')),
             new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra'),
         ], $kit->getComponent('Button')->getDependencies());
 
         $this->assertEquals([
+            new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra'),
             new ComponentDependency('Table:Body'),
             new ComponentDependency('Table:Caption'),
             new ComponentDependency('Table:Cell'),
@@ -54,7 +55,6 @@ final class KitSynchronizerTest extends KernelTestCase
             new ComponentDependency('Table:Head'),
             new ComponentDependency('Table:Header'),
             new ComponentDependency('Table:Row'),
-            new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra'),
         ], $kit->getComponent('Table')->getDependencies());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Components metadata are defined aside their component, e.g.: `Alert.meta.json` for `Alert.html.twig`.
These JSON files contain, for the moment, a list of PHP Dependencies needed to correctly render a component.
