### PR TITLE
[LiveComponent] fix: `LiveComponentHydrator::hydrateValue()` cannot hydrate null values

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Add support for [Symfony UID](https://symfony.com/doc/current/components/uid.html) hydration/dehydration
 -   `ComponentWithFormTrait` now correctly checks for a `TranslatableInterface` placeholder for `<select>` elements
+-   Fix `LiveComponentHydrator::hydrateValue()` to hydrate null values
 
 ## 2.23.0
 

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -282,6 +282,10 @@ final class LiveComponentHydrator
                 throw new \LogicException(\sprintf('The "%s::%s" object should be hydrated with the Serializer, but no type could be guessed.', $parentObject::class, $propMetadata->getName()));
             }
 
+            if (null === $value && $propMetadata->allowsNull()) {
+                return null;
+            }
+
             return $this->serializer->denormalize($value, $type, 'json', $propMetadata->serializationContext());
         }
 

--- a/src/LiveComponent/tests/Unit/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Unit/LiveComponentHydratorTest.php
@@ -14,8 +14,12 @@ namespace Symfony\UX\LiveComponent\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadataFactory;
+use Symfony\UX\LiveComponent\Metadata\LivePropMetadata;
 
 final class LiveComponentHydratorTest extends TestCase
 {
@@ -31,5 +35,31 @@ final class LiveComponentHydratorTest extends TestCase
             $this->createMock(NormalizerInterface::class),
             '',
         );
+    }
+
+    public function testItCanHydrateWithNullValues()
+    {
+        $hydrator = new LiveComponentHydrator(
+            [],
+            $this->createMock(PropertyAccessorInterface::class),
+            $this->createMock(LiveComponentMetadataFactory::class),
+            new Serializer(normalizers: [new ObjectNormalizer()]),
+            'foo',
+        );
+
+        $hydratedValue = $hydrator->hydrateValue(
+            null,
+            new LivePropMetadata('foo', new LiveProp(useSerializerForHydration: true), typeName: Foo::class, isBuiltIn: false, allowsNull: true, collectionValueType: null),
+            parentObject: new \stdClass() // not relevant in this test
+        );
+
+        self::assertNull($hydratedValue);
+    }
+}
+
+class Foo
+{
+    public function __construct(private int $id)
+    {
     }
 }


### PR DESCRIPTION
Hello,

such live prop cannot currently be hydrated by `LiveComponentHydrator::hydrateValue()` because nullability is not handled and the serializer is asked to deserialize `null` into `MyDTO`

```php
    #[LiveProp(writable: true, useSerializerForHydration: true)]
    public ?MyDTO $myDTO = null;
```

this PR fixes this problem

NB: all the failures in the CI are unrelated to this fix