### PR TITLE
[CI] Replace "workspace:*" dependencies before publishing on npm

### DIFF
--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -39,6 +39,10 @@ jobs:
               git add .
               git commit -m "Update versions to ${{ env.VERSION }}"
 
+          - name: Replace local "workspace:*" occurrences
+            run: |
+              yarn workspaces foreach -pA exec "sed -i 's/\"workspace:\*\"/\"${{ env.VERSION }}\"/g' package.json"
+
           - name: Publish on NPM
             env:
               NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #2737  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

I tried to re-use `yarn version (...)` commands, but that's a mess and I don't really understand why it does not work as expected 😬 (I can't wait to use pnpm :D) 

So, let's use another solution which replace `"workspace:*"` by the new version (e.g.: `2.25.0`) in `package.json` from our workspaces. 
Running the macOS equivalent command `yarn workspaces foreach -pA exec "sed -i '' 's/\"workspace:\*\"/\"2.25.0\"/g' package.json"` produces this result:
```diff
diff --git a/src/Map/src/Bridge/Google/assets/package.json b/src/Map/src/Bridge/Google/assets/package.json
index 6c0fea00d9b..649b3db6414 100644
--- a/src/Map/src/Bridge/Google/assets/package.json
+++ b/src/Map/src/Bridge/Google/assets/package.json
@@ -50,7 +50,7 @@
     "devDependencies": {
         "@googlemaps/js-api-loader": "^1.16.6",
         "@hotwired/stimulus": "^3.0.0",
-        "@symfony/ux-map": "workspace:*",
+        "@symfony/ux-map": "2.25.0",
         "@types/google.maps": "^3.55.9"
     }
 }
diff --git a/src/Map/src/Bridge/Leaflet/assets/package.json b/src/Map/src/Bridge/Leaflet/assets/package.json
index d89d17d64e4..ad74dedb2bd 100644
--- a/src/Map/src/Bridge/Leaflet/assets/package.json
+++ b/src/Map/src/Bridge/Leaflet/assets/package.json
@@ -49,7 +49,7 @@
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "@symfony/ux-map": "workspace:*",
+        "@symfony/ux-map": "2.25.0",
         "@types/leaflet": "^1.9.12",
         "leaflet": "^1.9.4"
     }

```