### PR TITLE
Use singular folder pattern like other PHP components codes

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -11,8 +11,8 @@ to familiarize yourself in the `TwigComponent documentation`_.
 
 A real-time product search component might look like this::
 
-    // src/Twig/Components/ProductSearch.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/ProductSearch.php
+    namespace App\Twig\Component;
 
     use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
     use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -109,8 +109,8 @@ documentation to get the basics of Twig components.
 
 Suppose you've already built a basic Twig component::
 
-    // src/Twig/Components/RandomNumber.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/RandomNumber.php
+    namespace App\Twig\Component;
 
     use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -137,7 +137,7 @@ re-rendered live on the frontend), replace the component's
 
 .. code-block:: diff
 
-      // src/Twig/Components/RandomNumber.php
+      // src/Twig/Component/RandomNumber.php
     - use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
     + use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
     + use Symfony\UX\LiveComponent\DefaultActionTrait;
@@ -199,8 +199,8 @@ LiveProps: Stateful Component Properties
 
 Let's make our component more flexible by adding a ``$max`` property::
 
-    // src/Twig/Components/RandomNumber.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/RandomNumber.php
+    namespace App\Twig\Component;
 
     // ...
     use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -299,7 +299,7 @@ Well, actually, we're missing one step. By default, a ``LiveProp`` is
 
 .. code-block:: diff
 
-      // src/Twig/Components/RandomNumber.php
+      // src/Twig/Component/RandomNumber.php
       // ...
 
       class RandomNumber
@@ -1064,8 +1064,8 @@ that, when clicked, sets the min/max numbers back to a default value.
 First, add a method with a ``LiveAction`` attribute above it that does
 the work::
 
-    // src/Twig/Components/RandomNumber.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/RandomNumber.php
+    namespace App\Twig\Component;
 
     // ...
     use Symfony\UX\LiveComponent\Attribute\LiveAction;
@@ -1139,8 +1139,8 @@ normal controller method that you would create with a route.
 
 This means that, for example, you can use action autowiring::
 
-    // src/Twig/Components/RandomNumber.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/RandomNumber.php
+    namespace App\Twig\Component;
 
     // ...
     use Psr\Log\LoggerInterface;
@@ -1192,8 +1192,8 @@ You can also pass arguments to your action by adding each as a
 In your component, to allow each argument to be passed, add
 the ``#[LiveArg]`` attribute::
 
-    // src/Twig/Components/ItemList.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/ItemList.php
+    namespace App\Twig\Component;
 
     // ...
     use Psr\Log\LoggerInterface;
@@ -1233,8 +1233,8 @@ Sometimes, you may want to redirect after an action is executed
 page). You can do that by returning a ``RedirectResponse`` from your
 action::
 
-    // src/Twig/Components/RandomNumber.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/RandomNumber.php
+    namespace App\Twig\Component;
 
     // ...
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -1302,8 +1302,8 @@ You can also specify a modifier parameter to choose which files should be upload
 
 The files will be available in a regular ``$request->files`` files bag::
 
-    // src/Twig/Components/FileUpload.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/FileUpload.php
+    namespace App\Twig\Component;
 
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -1426,7 +1426,7 @@ Ok: time to build that ``PostForm`` component! The Live Components
 package comes with a special trait - ``ComponentWithFormTrait`` - to
 make it easy to deal with forms::
 
-    namespace App\Twig\Components;
+    namespace App\Twig\Component;
 
     use App\Entity\Post;
     use App\Form\PostType;
@@ -2523,8 +2523,8 @@ Changing the URL when a LiveProp changes
 
 If you want the URL to update when a ``LiveProp`` changes, you can do that with the ``url`` option::
 
-    // src/Twig/Components/SearchModule.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/SearchModule.php
+    namespace App\Twig\Component;
 
     use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
     use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -3142,7 +3142,7 @@ Full Embedded Component Example
 Let's look at a full, complex example of an embedded component. Suppose
 you have an ``EditPost``::
 
-    namespace App\Twig\Components;
+    namespace App\Twig\Component;
 
     use App\Entity\Post;
     use Doctrine\ORM\EntityManagerInterface;
@@ -3168,7 +3168,7 @@ you have an ``EditPost``::
 
 And a ``MarkdownTextarea``::
 
-    namespace App\Twig\Components;
+    namespace App\Twig\Component;
 
     use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
     use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -3596,7 +3596,7 @@ Then specify this new route on your component:
 
 .. code-block:: diff
 
-    // src/Twig/Components/RandomNumber.php
+    // src/Twig/Component/RandomNumber.php
     use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
     use Symfony\UX\LiveComponent\DefaultActionTrait;
 
@@ -3615,7 +3615,7 @@ You can also control the type of the generated URL:
 
 .. code-block:: diff
 
-      // src/Twig/Components/RandomNumber.php
+      // src/Twig/Component/RandomNumber.php
     + use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
       use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
       use Symfony\UX\LiveComponent\DefaultActionTrait;

--- a/src/Map/doc/index.rst
+++ b/src/Map/doc/index.rst
@@ -586,7 +586,7 @@ and implement the method ``instantiateMap`` to return a ``Map`` instance.
 
 You can interact with the Map by using ``LiveAction`` attribute::
 
-    namespace App\Twig\Components;
+    namespace App\Twig\Component;
 
     use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
     use Symfony\UX\LiveComponent\Attribute\LiveAction;

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -7,8 +7,8 @@ making it easier to render and re-use small template "units" - like an
 
 Every component consists of (1) a class::
 
-    // src/Twig/Components/Alert.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/Alert.php
+    namespace App\Twig\Component;
 
     use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -79,8 +79,8 @@ Let's create a reusable "alert" element that we can use to show success
 or error messages across our site. Step 1 is to create a component class
 and give it the ``AsTwigComponent`` attribute::
 
-    // src/Twig/Components/Alert.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/Alert.php
+    namespace App\Twig\Component;
 
     use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -166,7 +166,7 @@ public property for each:
 
 .. code-block:: diff
 
-      // src/Twig/Components/Alert.php
+      // src/Twig/Component/Alert.php
       // ...
 
       #[AsTwigComponent]
@@ -265,7 +265,7 @@ You can control the template used via the ``AsTwigComponent`` attribute:
 
 .. code-block:: diff
 
-      // src/Twig/Components/Alert.php
+      // src/Twig/Component/Alert.php
       // ...
 
     - #[AsTwigComponent]
@@ -396,8 +396,8 @@ How? Components are *services*, which means autowiring works like
 normal. This example assumes you have a ``Product`` Doctrine entity and
 ``ProductRepository``::
 
-    // src/Twig/Components/FeaturedProducts.php
-    namespace App\Twig\Components;
+    // src/Twig/Component/FeaturedProducts.php
+    namespace App\Twig\Component;
 
     use App\Repository\ProductRepository;
     use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
@@ -457,7 +457,7 @@ The mount() Method
 For more control over how your "props" are handled, you can create a method
 called ``mount()``::
 
-    // src/Twig/Components/Alert.php
+    // src/Twig/Component/Alert.php
     // ...
 
     #[AsTwigComponent]
@@ -497,7 +497,7 @@ PreMount Hook
 If you need to modify/validate data before it's *mounted* on the
 component use a ``PreMount`` hook::
 
-    // src/Twig/Components/Alert.php
+    // src/Twig/Component/Alert.php
     use Symfony\Component\OptionsResolver\OptionsResolver;
     use Symfony\UX\TwigComponent\Attribute\PreMount;
     // ...
@@ -557,7 +557,7 @@ PostMount Hook
 After a component is instantiated and its data mounted, you can run extra
 code via the ``PostMount`` hook::
 
-    // src/Twig/Components/Alert.php
+    // src/Twig/Component/Alert.php
     use Symfony\UX\TwigComponent\Attribute\PostMount;
     // ...
 
@@ -580,7 +580,7 @@ will contain any props passed to the component that have *not* yet been processe
 ``mount()`` method). You can handle these props, remove them from the ``$data``
 and return the array::
 
-    // src/Twig/Components/Alert.php
+    // src/Twig/Component/Alert.php
     #[AsTwigComponent]
     class Alert
     {

--- a/ux.symfony.com/src/Twig/Components/Alert.php
+++ b/ux.symfony.com/src/Twig/Components/Alert.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 

--- a/ux.symfony.com/src/Twig/Components/BootstrapModal.php
+++ b/ux.symfony.com/src/Twig/Components/BootstrapModal.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 

--- a/ux.symfony.com/src/Twig/Components/ChangelogItem.php
+++ b/ux.symfony.com/src/Twig/Components/ChangelogItem.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 

--- a/ux.symfony.com/src/Twig/Components/DinoChart.php
+++ b/ux.symfony.com/src/Twig/Components/DinoChart.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Service\DinoStatsService;
 use Symfony\UX\Chartjs\Builder\ChartBuilderInterface;

--- a/ux.symfony.com/src/Twig/Components/DocsLink.php
+++ b/ux.symfony.com/src/Twig/Components/DocsLink.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;

--- a/ux.symfony.com/src/Twig/Components/FoodVote.php
+++ b/ux.symfony.com/src/Twig/Components/FoodVote.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Entity\Food;
 use App\Repository\FoodRepository;

--- a/ux.symfony.com/src/Twig/Components/HomepageTerminalSwapper.php
+++ b/ux.symfony.com/src/Twig/Components/HomepageTerminalSwapper.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Model\UxPackage;
 use App\Service\UxPackageRepository;

--- a/ux.symfony.com/src/Twig/Components/InlineEditFood.php
+++ b/ux.symfony.com/src/Twig/Components/InlineEditFood.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Entity\Food;
 use Doctrine\ORM\EntityManagerInterface;

--- a/ux.symfony.com/src/Twig/Components/InvoiceCreator.php
+++ b/ux.symfony.com/src/Twig/Components/InvoiceCreator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Entity\Invoice;
 use App\Entity\InvoiceItem;

--- a/ux.symfony.com/src/Twig/Components/InvoiceCreatorLineItem.php
+++ b/ux.symfony.com/src/Twig/Components/InvoiceCreatorLineItem.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Entity\Product;
 use App\Repository\ProductRepository;

--- a/ux.symfony.com/src/Twig/Components/MealPlanner.php
+++ b/ux.symfony.com/src/Twig/Components/MealPlanner.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Form\MealPlannerForm;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/ux.symfony.com/src/Twig/Components/NewCategoryForm.php
+++ b/ux.symfony.com/src/Twig/Components/NewCategoryForm.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Entity\Category;
 use Doctrine\ORM\EntityManagerInterface;

--- a/ux.symfony.com/src/Twig/Components/NewProductForm.php
+++ b/ux.symfony.com/src/Twig/Components/NewProductForm.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Entity\Category;
 use App\Entity\Product;

--- a/ux.symfony.com/src/Twig/Components/ProductGrid.php
+++ b/ux.symfony.com/src/Twig/Components/ProductGrid.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Service\EmojiCollection;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;

--- a/ux.symfony.com/src/Twig/Components/ProductGrid2.php
+++ b/ux.symfony.com/src/Twig/Components/ProductGrid2.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Service\EmojiCollection;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;

--- a/ux.symfony.com/src/Twig/Components/RegistrationForm.php
+++ b/ux.symfony.com/src/Twig/Components/RegistrationForm.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Form\RegistrationFormType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/ux.symfony.com/src/Twig/Components/Terminal.php
+++ b/ux.symfony.com/src/Twig/Components/Terminal.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Util\SourceCleaner;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;

--- a/ux.symfony.com/src/Twig/Components/TodoListForm.php
+++ b/ux.symfony.com/src/Twig/Components/TodoListForm.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use App\Entity\TodoList;
 use App\Form\TodoListFormType;

--- a/ux.symfony.com/src/Twig/Components/UploadFiles.php
+++ b/ux.symfony.com/src/Twig/Components/UploadFiles.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Twig\Components;
+namespace App\Twig\Component;
 
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;

--- a/ux.symfony.com/templates/demos/live_component/auto_validating_form.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/auto_validating_form.html.twig
@@ -1,7 +1,7 @@
 {% extends 'demos/live_demo.html.twig' %}
 
 {% block code_block_left %}
-    <twig:CodeBlock filename="src/Twig/Components/RegistrationForm.php" height="400px" />
+    <twig:CodeBlock filename="src/Twig/Component/RegistrationForm.php" height="400px" />
 {% endblock %}
 
 {% block code_block_right %}

--- a/ux.symfony.com/templates/demos/live_component/bootstrap.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/bootstrap.html.twig
@@ -1,7 +1,7 @@
 {% extends 'demos/live_demo.html.twig' %}
 
 {% block code_block_left %}
-    <twig:CodeBlock filename="src/Twig/Components/TodoListForm.php" height="400px" />
+    <twig:CodeBlock filename="src/Twig/Component/TodoListForm.php" height="400px" />
 {% endblock %}
 
 {% block code_block_right %}

--- a/ux.symfony.com/templates/demos/live_component/chartjs.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/chartjs.html.twig
@@ -1,7 +1,7 @@
 {% extends 'demos/live_demo.html.twig' %}
 
 {% block code_block_left %}
-    <twig:CodeBlock filename="src/Twig/Components/DinoChart.php" height="400px" />
+    <twig:CodeBlock filename="src/Twig/Component/DinoChart.php" height="400px" />
 {% endblock %}
 
 {% block code_block_right %}

--- a/ux.symfony.com/templates/demos/live_component/dependent_form_fields.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/dependent_form_fields.html.twig
@@ -2,7 +2,7 @@
 
 {% block code_block_full %}
     <twig:Code:TabbedCodeBlocks :files="[
-        'src/Twig/Components/MealPlanner.php',
+        'src/Twig/Component/MealPlanner.php',
         'templates/components/MealPlanner.html.twig',
         'src/Form/MealPlannerForm.php',
     ]" />

--- a/ux.symfony.com/templates/demos/live_component/form_collection_type.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/form_collection_type.html.twig
@@ -1,7 +1,7 @@
 {% extends 'demos/live_demo.html.twig' %}
 
 {% block code_block_left %}
-    <twig:CodeBlock filename="src/Twig/Components/TodoListForm.php" height="400px" />
+    <twig:CodeBlock filename="src/Twig/Component/TodoListForm.php" height="400px" />
 {% endblock %}
 
 {% block code_block_right %}

--- a/ux.symfony.com/templates/demos/live_component/infinite_scroll.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/infinite_scroll.html.twig
@@ -26,7 +26,7 @@
 
     <section class="py-5" style="padding-top: 6rem;">
         <div class="container container-xxl">
-            <twig:Code:CodeWithExplanationRow filename="src/Twig/Components/ProductGrid.php" reversed sticky style="--bs-gutter-x: 4rem;">
+            <twig:Code:CodeWithExplanationRow filename="src/Twig/Component/ProductGrid.php" reversed sticky style="--bs-gutter-x: 4rem;">
 This component is quite standard: the page number as a `LiveProp`, a `LiveAction`
 to load the next page, and a `getItems` method to retrieve the page results.
 

--- a/ux.symfony.com/templates/demos/live_component/inline_edit.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/inline_edit.html.twig
@@ -1,7 +1,7 @@
 {% extends 'demos/live_demo.html.twig' %}
 
 {% block code_block_left %}
-    <twig:CodeBlock filename="src/Twig/Components/InlineEditFood.php" height="400px" />
+    <twig:CodeBlock filename="src/Twig/Component/InlineEditFood.php" height="400px" />
 {% endblock %}
 
 {% block code_block_right %}

--- a/ux.symfony.com/templates/demos/live_component/invoice.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/invoice.html.twig
@@ -1,7 +1,7 @@
 {% extends 'demos/live_demo.html.twig' %}
 
 {% block code_block_full %}
-    <twig:Code:CodeWithExplanationRow filename="src/Twig/Components/InvoiceCreator.php" sticky class="pt-5">
+    <twig:Code:CodeWithExplanationRow filename="src/Twig/Component/InvoiceCreator.php" sticky class="pt-5">
 ## Main Component
 
 This main component keeps track of the `Invoice` (which may be new) and
@@ -30,7 +30,7 @@ data: `productId`, `quantity`, and `isEditing`. It also passes a `key`,
 which is needed so LiveComponents can track which row is which.
     </twig:Code:CodeWithExplanationRow>
 
-    <twig:Code:CodeWithExplanationRow filename="src/Twig/Components/InvoiceCreatorLineItem.php" sticky class="pt-5">
+    <twig:Code:CodeWithExplanationRow filename="src/Twig/Component/InvoiceCreatorLineItem.php" sticky class="pt-5">
 ## Child Component
 
 The child component for each "line item". This handles validating, saving,

--- a/ux.symfony.com/templates/demos/live_component/product_form.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/product_form.html.twig
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block code_block_full %}
-    <twig:Code:CodeWithExplanationRow filename="src/Twig/Components/NewProductForm.php" sticky>
+    <twig:Code:CodeWithExplanationRow filename="src/Twig/Component/NewProductForm.php" sticky>
 ## New Product Form
 
 Live component with a form, `ValidatableComponentTrait` and a
@@ -31,7 +31,7 @@ and `data-bs-target="#new-category-modal"`.
     </twig:Code:CodeWithExplanationRow>
 
     <twig:Code:CodeWithExplanationRow
-        filename="src/Twig/Components/NewCategoryForm.php" sticky
+        filename="src/Twig/Component/NewCategoryForm.php" sticky
     >
 ## New Category Form
 
@@ -45,7 +45,7 @@ the new `Category` to the database and then does two important things:
     </twig:Code:CodeWithExplanationRow>
 
     <twig:Code:TabbedCodeBlocks :files="[
-        'src/Twig/Components/BootstrapModal.php',
+        'src/Twig/Component/BootstrapModal.php',
         'templates/components/BootstrapModal.html.twig',
         'assets/controllers/bootstrap-modal-controller.js',
     ]" />

--- a/ux.symfony.com/templates/demos/live_component/upload.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/upload.html.twig
@@ -1,7 +1,7 @@
 {% extends 'demos/live_demo.html.twig' %}
 
 {% block code_block_left %}
-    <twig:CodeBlock filename="src/Twig/Components/UploadFiles.php" height="400px" />
+    <twig:CodeBlock filename="src/Twig/Component/UploadFiles.php" height="400px" />
 {% endblock %}
 
 {% block code_block_right %}

--- a/ux.symfony.com/templates/demos/live_component/voting.html.twig
+++ b/ux.symfony.com/templates/demos/live_component/voting.html.twig
@@ -1,7 +1,7 @@
 {% extends 'demos/live_demo.html.twig' %}
 
 {% block code_block_left %}
-    <twig:CodeBlock filename="src/Twig/Components/FoodVote.php" height="400px" />
+    <twig:CodeBlock filename="src/Twig/Component/FoodVote.php" height="400px" />
 {% endblock %}
 
 {% block code_block_right %}

--- a/ux.symfony.com/templates/ux_packages/live_component.html.twig
+++ b/ux.symfony.com/templates/ux_packages/live_component.html.twig
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block code_block_left %}
-    <twig:CodeBlock filename="src/Twig/Components/Package/SearchPackages.php" />
+    <twig:CodeBlock filename="src/Twig/Component/Package/SearchPackages.php" />
 {% endblock %}
 
 {% block code_block_right %}

--- a/ux.symfony.com/templates/ux_packages/twig_component.html.twig
+++ b/ux.symfony.com/templates/ux_packages/twig_component.html.twig
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block code_block_left %}
-    <twig:CodeBlock filename="src/Twig/Components/Alert.php" height="330px"/>
+    <twig:CodeBlock filename="src/Twig/Component/Alert.php" height="330px"/>
 {% endblock %}
 
 {% block code_block_right %}

--- a/ux.symfony.com/tests/Twig/Components/ChangelogItemTest.php
+++ b/ux.symfony.com/tests/Twig/Components/ChangelogItemTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Tests\Twig\Components;
+namespace App\Tests\Twig\Component;
 
-use App\Twig\Components\ChangelogItem;
+use App\Twig\Component\ChangelogItem;
 use PHPUnit\Framework\TestCase;
 
 class ChangelogItemTest extends TestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no
| Issues        | Fix coherence pattern naming
| License       | MIT

opening this PR mostly as RFC
other code in sf document to create special code (messenger message, event listener|subscriber, etc) inside folders in singular form not plural
does It makes sens for twig component to follow this pattern ?
