### PR TITLE
[TwigComponent] Fix `ComponentAttributes` rendering when using `StimulusAttributes` as default attributes

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.25.2
+
+-   Fix `ComponentAttributes` rendering when using `StimulusAttributes` as default attributes
+
 ## 2.25.1
 
 -   [SECURITY] `ComponentAttributes` now requires a `Twig\Runtime\EscaperRuntime`

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -144,7 +144,7 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
     public function defaults(iterable $attributes): self
     {
         if ($attributes instanceof StimulusAttributes) {
-            $attributes = $attributes->toEscapedArray();
+            $attributes = $attributes->toArray();
         }
 
         if ($attributes instanceof \Traversable) {

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -143,7 +143,7 @@ final class ComponentAttributesTest extends TestCase
         ], new EscaperRuntime());
 
         $stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
-        $stimulusAttributes->addController('foo', ['name' => 'ryan', 'some_array' => ['a', 'b']]);
+        $stimulusAttributes->addController('foo', ['name' => 'ryan', 'some_array' => ['a', 'b'], 'some_array_with_keys' => ['key1' => 'value1', 'key2' => 'value2']]);
         $attributes = $attributes->defaults($stimulusAttributes);
 
         $this->assertEquals([
@@ -151,8 +151,10 @@ final class ComponentAttributesTest extends TestCase
             'data-controller' => 'foo live',
             'data-live-data-value' => '{}',
             'data-foo-name-value' => 'ryan',
-            'data-foo-some-array-value' => '[&quot;a&quot;,&quot;b&quot;]',
+            'data-foo-some-array-value' => '["a","b"]',
+            'data-foo-some-array-with-keys-value' => '{"key1":"value1","key2":"value2"}',
         ], $attributes->all());
+        $this->assertSame(' data-controller="foo live" data-foo-name-value="ryan" data-foo-some-array-value="[&quot;a&quot;,&quot;b&quot;]" data-foo-some-array-with-keys-value="{&quot;key1&quot;:&quot;value1&quot;,&quot;key2&quot;:&quot;value2&quot;}" class="foo" data-live-data-value="{}"', (string) $attributes);
     }
 
     public function testCanAddStimulusActionViaStimulusAttributes(): void
@@ -175,6 +177,7 @@ final class ComponentAttributesTest extends TestCase
             'class' => 'foo',
             'data-action' => 'foo#barMethod live#foo',
         ], $attributes->all());
+        $this->assertSame(' data-action="foo#barMethod live#foo" class="foo"', (string) $attributes);
     }
 
     public function testBooleanBehaviour(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Fix #2756 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

We missed the case where we can inject `StimulusAttributes` when using `attributes.defaults()`, as documented in https://symfony.com/bundles/ux-twig-component/current/index.html#component-attributes

It looks like our tests weren't solid enough, since we asserted on `all()` instead of the rendered string. 