### PR TITLE
[Map] add definition to after create events in controller

### DIFF
--- a/src/Map/assets/dist/abstract_map_controller.js
+++ b/src/Map/assets/dist/abstract_map_controller.js
@@ -43,7 +43,7 @@ class default_1 extends Controller {
     createInfoWindow({ definition, element, }) {
         this.dispatchEvent('info-window:before-create', { definition, element });
         const infoWindow = this.doCreateInfoWindow({ definition, element });
-        this.dispatchEvent('info-window:after-create', { infoWindow, element });
+        this.dispatchEvent('info-window:after-create', { infoWindow, definition, element });
         this.infoWindows.push(infoWindow);
         return infoWindow;
     }
@@ -74,7 +74,7 @@ class default_1 extends Controller {
         return ({ definition }) => {
             this.dispatchEvent(eventBefore, { definition });
             const drawing = factory({ definition });
-            this.dispatchEvent(eventAfter, { [type]: drawing });
+            this.dispatchEvent(eventAfter, { [type]: drawing, definition });
             draws.set(definition['@id'], drawing);
             return drawing;
         };

--- a/src/Map/assets/src/abstract_map_controller.ts
+++ b/src/Map/assets/src/abstract_map_controller.ts
@@ -206,7 +206,7 @@ export default abstract class<
     }): InfoWindow {
         this.dispatchEvent('info-window:before-create', { definition, element });
         const infoWindow = this.doCreateInfoWindow({ definition, element });
-        this.dispatchEvent('info-window:after-create', { infoWindow, element });
+        this.dispatchEvent('info-window:after-create', { infoWindow, definition, element });
 
         this.infoWindows.push(infoWindow);
 
@@ -334,7 +334,7 @@ export default abstract class<
         return ({ definition }: { definition: WithIdentifier<any> }) => {
             this.dispatchEvent(eventBefore, { definition });
             const drawing = factory({ definition }) as Draw;
-            this.dispatchEvent(eventAfter, { [type]: drawing });
+            this.dispatchEvent(eventAfter, { [type]: drawing, definition });
 
             draws.set(definition['@id'], drawing);
 

--- a/src/Map/src/Bridge/Google/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Google/assets/dist/map_controller.js
@@ -44,7 +44,7 @@ class default_1 extends Controller {
     createInfoWindow({ definition, element, }) {
         this.dispatchEvent('info-window:before-create', { definition, element });
         const infoWindow = this.doCreateInfoWindow({ definition, element });
-        this.dispatchEvent('info-window:after-create', { infoWindow, element });
+        this.dispatchEvent('info-window:after-create', { infoWindow, definition, element });
         this.infoWindows.push(infoWindow);
         return infoWindow;
     }
@@ -75,7 +75,7 @@ class default_1 extends Controller {
         return ({ definition }) => {
             this.dispatchEvent(eventBefore, { definition });
             const drawing = factory({ definition });
-            this.dispatchEvent(eventAfter, { [type]: drawing });
+            this.dispatchEvent(eventAfter, { [type]: drawing, definition });
             draws.set(definition['@id'], drawing);
             return drawing;
         };

--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
@@ -45,7 +45,7 @@ class default_1 extends Controller {
     createInfoWindow({ definition, element, }) {
         this.dispatchEvent('info-window:before-create', { definition, element });
         const infoWindow = this.doCreateInfoWindow({ definition, element });
-        this.dispatchEvent('info-window:after-create', { infoWindow, element });
+        this.dispatchEvent('info-window:after-create', { infoWindow, definition, element });
         this.infoWindows.push(infoWindow);
         return infoWindow;
     }
@@ -76,7 +76,7 @@ class default_1 extends Controller {
         return ({ definition }) => {
             this.dispatchEvent(eventBefore, { definition });
             const drawing = factory({ definition });
-            this.dispatchEvent(eventAfter, { [type]: drawing });
+            this.dispatchEvent(eventAfter, { [type]: drawing, definition });
             draws.set(definition['@id'], drawing);
             return drawing;
         };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |
| Docs?         | no
| Issues        | Fix 
| License       | MIT

Hi,
The [documentation](https://symfony.com/bundles/ux-map/current/index.html#advanced-passing-extra-data-from-php-to-the-stimulus-controller )states that the definition should be accessible in the <type>:after-create events in the map controllers.