### PR TITLE
[LiveComponent] Fix missing _route on live components batch requests

### DIFF
--- a/src/LiveComponent/src/Controller/BatchActionController.php
+++ b/src/LiveComponent/src/Controller/BatchActionController.php
@@ -38,6 +38,7 @@ final class BatchActionController
                 '_component_action_args' => $action['args'] ?? [],
                 '_mounted_component' => $_mounted_component,
                 '_live_component' => $serviceId,
+                '_route' => $request->attributes->get('_route'),
             ]);
 
             $response = $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #1022
| License       | MIT


The `_route` param get overwritten for Live Component Batch Requests, persist this param to the sub requests

`Symfony\UX\LiveComponent\Controller\BatchActionController`
```
$request->duplicate(attributes: [
                '_controller' => [$serviceId, $name],
                '_component_action_args' => $action['args'] ?? [],
                '_mounted_component' => $_mounted_component,
                '_live_component' => $serviceId,
            ]

$response = $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);

```
Duplicate overwrites all attributes in the sub request, missing one important attribute _route, add it to the array in order to know where the request comes from.



