### PR TITLE
[CI] Replace ramsey/composer-install by `composer install` in app-tests workflow

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -45,19 +45,15 @@ jobs:
         - uses: shivammathur/setup-php@v2
 
         - name: Install root dependencies
-          uses: ramsey/composer-install@v3
-          with:
-            working-directory: ${{ github.workspace }}
+          run: composer install
 
         - name: Build root packages
           run: php .github/build-packages.php
-          working-directory: ${{ github.workspace }}
 
         # We always install PHP deps because we of the UX Translator, which requires `var/translations` to exists
-        - uses: ramsey/composer-install@v3
-          with:
-            dependency-versions: 'highest'
-            working-directory: test_apps/encore-app
+        - name: Install App dependenies
+          run: composer update
+          working-directory: test_apps/encore-app
 
         - if: matrix.ux-packages-source == 'php-vendor'
           name: Refresh dependencies from vendor/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

In #2607, https://github.com/symfony/ux/actions/runs/15297531864/job/43030093028?pr=2607 is shown as failed because step `Run Encore (dev)`, but in reality it fails before but that's not shown:
![image](https://github.com/user-attachments/assets/70d2d886-63c0-4147-a4e7-91447a5870a9)

With this change (which also remove a dependency), I hope the error to be well shown
