### PR TITLE
[Icons] Docs: Deleting "search" codeblock

### DIFF
--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -140,36 +140,6 @@ the prefix of a specific icon set:
 
      php bin/console ux:icons:search tabler arrow
 
-Search Icons
-~~~~~~~~~~~~
-
-You can also search for icons within a specific icon set. To search for "arrow"
-icons in the "Tabler Icons" set, use the following command:
-
-.. code-block:: terminal
-
-    $ php bin/console ux:icons:search tabler arrow
-
-    Searching Tabler Icons icons "arrow"...
-    Found 64 icons.
-     ------------------------------------------ ------------------------------------------
-      tabler:archery-arrow                       tabler:arrow-autofit-up
-      tabler:arrow-back                          tabler:arrow-back-up
-      tabler:arrow-badge-down                    tabler:arrow-badge-up
-      tabler:arrow-badge-up-filled               tabler:arrow-bar-both
-      tabler:arrow-bar-down                      tabler:arrow-bar-left
-      tabler:arrow-bar-right                     tabler:arrow-bar-to-up
-      tabler:arrow-bar-up                        tabler:arrow-bear-left
-      tabler:arrow-big-down                      tabler:arrow-big-down-filled
-      tabler:arrow-big-down-line                 tabler:arrow-big-left
-      tabler:arrow-big-left-filled               tabler:arrow-big-left-line
-      tabler:arrow-big-right                     tabler:arrow-big-right-filled
-      tabler:arrow-big-right-line                tabler:arrow-big-up
-     ------------------------------------------ ------------------------------------------
-
-     Page 1/3. Continue? (yes/no) [yes]:
-     >
-
 HTML Syntax
 ~~~~~~~~~~~
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | 
| License       | MIT

Page: https://symfony.com/bundles/ux-icons/current/index.html#search-icon-sets

Reasons:
* I don't think that somebody will search for icons in a terminal window (i.e. without preview).
* If somebody wants after all, the command is shown at the end of the previous code block.