### PR TITLE
[Icons] Docs: Removing broken link

### DIFF
--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -272,7 +272,7 @@ the ``assets/icons/`` directory. You can think of importing an icon as *locking 
 Locking On-Demand Icons
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-You can *lock* (import) all the `*on-demand* <Icons On-Demand>`_ icons you're using in your project by
+You can *lock* (import) all the *on-demand* icons you're using in your project by
 running the following command:
 
 .. code-block:: terminal


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | 
| License       | MIT

Page: https://symfony.com/bundles/ux-icons/current/index.html#locking-on-demand-icons

The target is just a few paragraphs above, so there's no need for a link IMO.