### PR TITLE
[Toolkit] Remove old `FileType` references

### DIFF
--- a/src/Toolkit/src/Kit/KitContextRunner.php
+++ b/src/Toolkit/src/Kit/KitContextRunner.php
@@ -12,7 +12,6 @@
 namespace Symfony\UX\Toolkit\Kit;
 
 use Symfony\Component\Filesystem\Path;
-use Symfony\UX\Toolkit\File\FileType;
 use Symfony\UX\TwigComponent\ComponentFactory;
 use Symfony\UX\TwigComponent\ComponentTemplateFinderInterface;
 use Twig\Loader\ChainLoader;

--- a/src/Toolkit/src/Kit/KitSynchronizer.php
+++ b/src/Toolkit/src/Kit/KitSynchronizer.php
@@ -22,7 +22,6 @@ use Symfony\UX\Toolkit\Dependency\StimulusControllerDependency;
 use Symfony\UX\Toolkit\File\ComponentMeta;
 use Symfony\UX\Toolkit\File\Doc;
 use Symfony\UX\Toolkit\File\File;
-use Symfony\UX\Toolkit\File\FileType;
 
 /**
  * @internal

--- a/src/Toolkit/tests/Asset/ComponentTest.php
+++ b/src/Toolkit/tests/Asset/ComponentTest.php
@@ -17,7 +17,6 @@ use Symfony\UX\Toolkit\Dependency\ComponentDependency;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\Version;
 use Symfony\UX\Toolkit\File\File;
-use Symfony\UX\Toolkit\File\FileType;
 
 final class ComponentTest extends TestCase
 {

--- a/src/Toolkit/tests/Asset/StimulusControllerTest.php
+++ b/src/Toolkit/tests/Asset/StimulusControllerTest.php
@@ -16,7 +16,6 @@ namespace Symfony\UX\Toolkit\Tests\Asset;
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\Toolkit\Asset\StimulusController;
 use Symfony\UX\Toolkit\File\File;
-use Symfony\UX\Toolkit\File\FileType;
 
 final class StimulusControllerTest extends TestCase
 {

--- a/src/Toolkit/tests/File/FileTest.php
+++ b/src/Toolkit/tests/File/FileTest.php
@@ -13,7 +13,6 @@ namespace Symfony\UX\Toolkit\Tests\File;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\Toolkit\File\File;
-use Symfony\UX\Toolkit\File\FileType;
 
 final class FileTest extends TestCase
 {

--- a/src/Toolkit/tests/Installer/PoolTest.php
+++ b/src/Toolkit/tests/Installer/PoolTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\Version;
 use Symfony\UX\Toolkit\File\File;
-use Symfony\UX\Toolkit\File\FileType;
 use Symfony\UX\Toolkit\Installer\Pool;
 
 final class PoolTest extends TestCase

--- a/src/Toolkit/tests/Kit/KitFactoryTest.php
+++ b/src/Toolkit/tests/Kit/KitFactoryTest.php
@@ -17,7 +17,6 @@ use Symfony\UX\Toolkit\Dependency\ComponentDependency;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\StimulusControllerDependency;
 use Symfony\UX\Toolkit\File\File;
-use Symfony\UX\Toolkit\File\FileType;
 use Symfony\UX\Toolkit\Kit\KitFactory;
 
 final class KitFactoryTest extends KernelTestCase

--- a/src/Toolkit/tests/Kit/KitTest.php
+++ b/src/Toolkit/tests/Kit/KitTest.php
@@ -14,7 +14,6 @@ namespace Symfony\UX\Toolkit\Tests\Kit;
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\Toolkit\Asset\Component;
 use Symfony\UX\Toolkit\File\File;
-use Symfony\UX\Toolkit\File\FileType;
 use Symfony\UX\Toolkit\Kit\Kit;
 
 final class KitTest extends TestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Follow #2800, again something not caught by Fabbot :( 