### PR TITLE
[CI] Re-add PHP-CS-Fixer

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -29,6 +29,17 @@ jobs:
             - run: yarn --immutable
             - run: yarn ci
 
+    coding-style-php:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v4
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.1'
+            -   run: composer install
+            -   name: php-cs-fixer
+                run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
+
     phpstan:
         name: PHPStan
         runs-on: ubuntu-latest

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -23,10 +23,10 @@ use Symfony\Component\Serializer\Exception\ExceptionInterface as SerializerExcep
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\TypeInfo\Type;
-use Symfony\Component\TypeInfo\TypeIdentifier;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;

--- a/src/LiveComponent/src/Util/TypeHelper.php
+++ b/src/LiveComponent/src/Util/TypeHelper.php
@@ -58,11 +58,11 @@ final class TypeHelper
             foreach ($value as $key => $itemValue) {
                 $valueType = $type->getShape()[$key]['type'] ?? false;
 
-                if ($valueType && !TypeHelper::accepts($valueType, $itemValue)) {
+                if ($valueType && !self::accepts($valueType, $itemValue)) {
                     return false;
                 }
 
-                if (!$valueType && ($type->isSealed() || !TypeHelper::accepts($type->getExtraKeyType(), $key) || !TypeHelper::accepts($type->getExtraValueType(), $itemValue))) {
+                if (!$valueType && ($type->isSealed() || !self::accepts($type->getExtraKeyType(), $key) || !self::accepts($type->getExtraValueType(), $itemValue))) {
                     return false;
                 }
             }
@@ -73,6 +73,7 @@ final class TypeHelper
         // Also supports EnumType and BackedEnumType
         if ($type instanceof Type\ObjectType) {
             $className = $type->getClassName();
+
             return $value instanceof $className;
         }
 
@@ -110,7 +111,7 @@ final class TypeHelper
             if (is_iterable($value)) {
                 foreach ($value as $k => $v) {
                     // key or value do not match
-                    if (!TypeHelper::accepts($keyType, $k) || !TypeHelper::accepts($valueType, $v)) {
+                    if (!self::accepts($keyType, $k) || !self::accepts($valueType, $v)) {
                         return false;
                     }
                 }

--- a/src/Map/src/Polygon.php
+++ b/src/Map/src/Polygon.php
@@ -21,7 +21,7 @@ use Symfony\UX\Map\Exception\InvalidArgumentException;
 final class Polygon implements Element
 {
     /**
-     * @param array<Point>|array<array<Point>> $points A list of point representing the polygon, or a list of paths (each path is an array of points) representing a polygon with holes.
+     * @param array<Point>|array<array<Point>> $points a list of point representing the polygon, or a list of paths (each path is an array of points) representing a polygon with holes
      * @param array<string, mixed>             $extra  Extra data, can be used by the developer to store additional information and use them later JavaScript side
      */
     public function __construct(
@@ -76,7 +76,7 @@ final class Polygon implements Element
 
         $polygon['points'] = isset($polygon['points'][0]['lat'], $polygon['points'][0]['lng'])
             ? array_map(Point::fromArray(...), $polygon['points'])
-            : array_map(fn(array $points) => array_map(Point::fromArray(...), $points), $polygon['points']);
+            : array_map(fn (array $points) => array_map(Point::fromArray(...), $points), $polygon['points']);
 
         if (isset($polygon['infoWindow'])) {
             $polygon['infoWindow'] = InfoWindow::fromArray($polygon['infoWindow']);

--- a/src/Toolkit/src/File/ComponentMeta.php
+++ b/src/Toolkit/src/File/ComponentMeta.php
@@ -24,17 +24,17 @@ final class ComponentMeta
 {
     public static function fromJson(string $json): self
     {
-        $data = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        $data = json_decode($json, true, flags: \JSON_THROW_ON_ERROR);
         unset($data['$schema']);
 
         $dependencies = [];
         foreach ($data['dependencies'] ?? [] as $i => $dependency) {
             if (!isset($dependency['type'])) {
-                throw new \InvalidArgumentException(sprintf('The dependency type is missing for dependency #%d, add "type" key.', $i));
+                throw new \InvalidArgumentException(\sprintf('The dependency type is missing for dependency #%d, add "type" key.', $i));
             }
 
             if ('php' === $dependency['type']) {
-                $package = $dependency['package'] ?? throw new \InvalidArgumentException(sprintf('The package name is missing for dependency #%d.', $i));
+                $package = $dependency['package'] ?? throw new \InvalidArgumentException(\sprintf('The package name is missing for dependency #%d.', $i));
                 if (str_contains($package, ':')) {
                     [$name, $version] = explode(':', $package, 2);
                     $dependencies[] = new PhpPackageDependency($name, new Version($version));
@@ -60,7 +60,7 @@ final class ComponentMeta
      * @param list<DependencyInterface> $dependencies
      */
     private function __construct(
-        public readonly array $dependencies
+        public readonly array $dependencies,
     ) {
     }
 }

--- a/src/Toolkit/src/Kit/KitSynchronizer.php
+++ b/src/Toolkit/src/Kit/KitSynchronizer.php
@@ -75,11 +75,11 @@ final class KitSynchronizer
 
             $meta = null;
             if ($this->filesystem->exists($metaJsonFile = Path::join($file->getPath(), str_replace('.html.twig', '.meta.json', $file->getBasename())))) {
-                $metaJson = file_get_contents($metaJsonFile) ?: throw new \RuntimeException(sprintf('Unable to get contents from file "%s".', $metaJsonFile));
+                $metaJson = file_get_contents($metaJsonFile) ?: throw new \RuntimeException(\sprintf('Unable to get contents from file "%s".', $metaJsonFile));
                 try {
                     $meta = ComponentMeta::fromJson($metaJson);
                 } catch (\Throwable $e) {
-                    throw new \RuntimeException(sprintf('Unable to parse component "%s" meta from JSON file "%s".', $componentName, $metaJsonFile), previous: $e);
+                    throw new \RuntimeException(\sprintf('Unable to parse component "%s" meta from JSON file "%s".', $componentName, $metaJsonFile), previous: $e);
                 }
             }
 
@@ -132,7 +132,7 @@ final class KitSynchronizer
                         if (!$component->hasDependency(new PhpPackageDependency($package))) {
                             throw new \RuntimeException(\sprintf('Component "%s" uses "%s" UX Twig component, but the composer package "%s" is not listed as a dependency in meta file.', $component->name, $componentReferenceName, $package));
                         }
-                    } else if (null === $componentReference = $kit->getComponent($componentReferenceName)) {
+                    } elseif (null === $componentReference = $kit->getComponent($componentReferenceName)) {
                         throw new \RuntimeException(\sprintf('Component "%s" not found in component "%s" (file "%s")', $componentReferenceName, $component->name, $file->relativePathNameToKit));
                     } else {
                         $component->addDependency(new ComponentDependency($componentReference->name));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Follow #2802, #2074, #2014 and more. 

I feel like Fabbot **only runs on modified files** for a given PR, but sometimes it does not really help (e.g.: if you untouched files contain old references to a deleted class).

This behavior is understandable for symfony/symfony, which contains a tons of code and is super active, but that's not the case symfony/ux, we have very less code and less activity.

**EDIT:** Well, I'm still not sure... PHP-CS-Fixer is showing me fixes for `src/LiveComponent/src/Util/TypeHelper.php`, added in #2778, but it was totally ignored by Fabbot... 😫  

So, I suggest to re-add PHP-CS-Fixer run in the CI to ensure all files are correctly CS-fixed.


