### PR TITLE
[Map] Do not override `fitBoundsToMarkers` when using LiveComponent

### DIFF
--- a/src/Map/CHANGELOG.md
+++ b/src/Map/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.27
+
+-   The `fitBoundsToMarkers` option is not overridden anymore when using the `Map` LiveComponent, but now respects the value you defined.
+    You may encounter unwanted behavior when adding/removing elements to the map.
+    To use the previous behavior, you must call `$this->getMap()->fitBoundsToMarkers(false)` in your LiveComponent's live actions
+
 ## 2.26
 
 -  Add support for creating `Polygon` with holes, by passing an array of `array<Point>` as `points` parameter to the `Polygon` constructor, e.g.:

--- a/src/Map/doc/index.rst
+++ b/src/Map/doc/index.rst
@@ -628,7 +628,7 @@ You can interact with the Map by using ``LiveAction`` attribute::
         {
             return (new Map())
                 ->center(new Point(48.8566, 2.3522))
-                ->zoom(7)
+                ->fitBoundsToMarkers()
                 ->addMarker(new Marker(position: new Point(48.8566, 2.3522), title: 'Paris', infoWindow: new InfoWindow('Paris')))
                 ->addMarker(new Marker(position: new Point(45.75, 4.85), title: 'Lyon', infoWindow: new InfoWindow('Lyon')))
             ;
@@ -654,6 +654,9 @@ You can retrieve the map instance using the ``getMap()`` method, and change the 
 
             // Change the map zoom
             $this->getMap()->zoom(6);
+
+            // To prevent the Map from automatically fitting the bounds to the markers after adding a new element, disable the option `fitBoundsToMarkers`:
+            $this->getMap()->fitBoundsToMarkers(false);
 
             // Add a new marker
             $this->getMap()->addMarker(new Marker(position: new Point(43.2965, 5.3698), title: 'Marseille', infoWindow: new InfoWindow('Marseille')));

--- a/src/Map/src/Map.php
+++ b/src/Map/src/Map.php
@@ -167,18 +167,12 @@ final class Map
      */
     public static function fromArray(array $map): self
     {
-        $map['fitBoundsToMarkers'] = true;
-
         if (isset($map['options'])) {
             $map['options'] = [] === $map['options'] ? null : MapOptionsNormalizer::denormalize($map['options']);
         }
 
         if (isset($map['center'])) {
             $map['center'] = Point::fromArray($map['center']);
-        }
-
-        if (isset($map['zoom']) || isset($map['center'])) {
-            $map['fitBoundsToMarkers'] = false;
         }
 
         $map['markers'] ??= [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Fix #2774  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
