### PR TITLE
[LiveComponent] Optimize `LiveComponentStack::getCurrentLiveComponent()`

### DIFF
--- a/src/LiveComponent/src/Util/LiveComponentStack.php
+++ b/src/LiveComponent/src/Util/LiveComponentStack.php
@@ -24,6 +24,9 @@ use Symfony\UX\TwigComponent\MountedComponent;
  */
 final class LiveComponentStack extends ComponentStack
 {
+    /** @var array<class-string, bool> */
+    private array $cacheLiveComponents = [];
+
     public function __construct(private readonly ComponentStack $componentStack)
     {
     }
@@ -31,7 +34,8 @@ final class LiveComponentStack extends ComponentStack
     public function getCurrentLiveComponent(): ?MountedComponent
     {
         foreach ($this->componentStack as $mountedComponent) {
-            if ($this->isLiveComponent($mountedComponent->getComponent()::class)) {
+            $componentClass = $mountedComponent->getComponent()::class;
+            if ($this->cacheLiveComponents[$componentClass] ??= $this->isLiveComponent($componentClass)) {
                 return $mountedComponent;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Using Reflection during runtime is costly. Here I suggest using static caching to prevent unnecessary usages of Reflection.

I've re-used reproducer from #2812, but with 50 rows (otherwise I can't create a Blackfire Profile), and it reduced the rendering time by 200ms, https://blackfire.io/profiles/compare/7aa62248-9332-40b3-b6fa-58756cb17232/graph 
<img width="1341" alt="image" src="https://github.com/user-attachments/assets/d03148c5-521e-4501-937c-54d9e90ece73" />


**EDIT:** see https://github.com/symfony/ux/pull/2821#issuecomment-2943045842