### PR TITLE
[LiveComponent] Fix query string decoding with no `=`

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2798,7 +2798,7 @@ function fromQueryString(search) {
     const entries = search.split('&').map((i) => i.split('='));
     const data = {};
     entries.forEach(([key, value]) => {
-        value = decodeURIComponent(value.replace(/\+/g, '%20'));
+        value = decodeURIComponent(String(value || '').replace(/\+/g, '%20'));
         if (!key.includes('[')) {
             data[key] = value;
         }

--- a/src/LiveComponent/assets/src/url_utils.ts
+++ b/src/LiveComponent/assets/src/url_utils.ts
@@ -104,7 +104,7 @@ function fromQueryString(search: string) {
     const data: any = {};
 
     entries.forEach(([key, value]) => {
-        value = decodeURIComponent(value.replace(/\+/g, '%20'));
+        value = decodeURIComponent(String(value || '').replace(/\+/g, '%20'));
 
         if (!key.includes('[')) {
             data[key] = value;

--- a/src/LiveComponent/assets/test/url_utils.test.ts
+++ b/src/LiveComponent/assets/test/url_utils.test.ts
@@ -115,6 +115,32 @@ describe('url_utils', () => {
                 expect(urlUtils.search).toEqual('');
             });
         });
+
+        describe('fromQueryString', () => {
+            const urlUtils: UrlUtils = new UrlUtils(window.location.href);
+
+            beforeEach(() => {
+                // Reset search before each test
+                urlUtils.search = '';
+            });
+
+            it('parses a query string with value', () => {
+                urlUtils.search = '?param1=value1';
+                expect(urlUtils.get('param1')).toEqual('value1');
+            });
+
+            it('parses a query string with empty value', () => {
+                urlUtils.search = '?param1=&param2=value2';
+                expect(urlUtils.get('param1')).toEqual('');
+                expect(urlUtils.get('param2')).toEqual('value2');
+            });
+
+            it('parses a query string without equal sign', () => {
+                urlUtils.search = '?param1&param2=value2';
+                expect(urlUtils.get('param1')).toEqual('');
+                expect(urlUtils.get('param2')).toEqual('value2');
+            });
+        });
     });
 
     describe('HistoryStrategy', () => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2826 (when released and a website update)
| License       | MIT

The root cause of #2826 is in fact a bug  in LiveComponent ... that i'm very surprised no one already experienced oO

In url_utils: fromQueryString missed a nullcheck. Triggering a TypeError.

`
?foo&bar=
`
