### PR TITLE
[TwigComponent] Fix escaping of Alpine.js attribute keys containing numeric characters

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -80,7 +80,7 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
             //      xml:*, xmlns:*,
             // - special syntax names (Vue.js, Svelte, Alpine.js, ...)
             //      v-*, x-*, @*, :*
-            if (!ctype_alpha(str_replace(['-', '_', ':', '@', '.'], '', $key))) {
+            if (!ctype_alnum(str_replace(['-', '_', ':', '@', '.'], '', $key))) {
                 $key = (string) $this->escaper->escape($key, 'html_attr');
             }
 

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -324,6 +324,7 @@ final class ComponentAttributesTest extends TestCase
         yield ['@click'];
         // Alpine.js
         yield ['x-on:click'];
+        yield ['@input.debounce.500ms'];
     }
 
     public function testThrowsTypeErrorWithoutEscaperRuntime(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

Alpine.js attribute keys like `@input.debounce.500ms` (see https://alpinejs.dev/directives/on#debounce) will now be correctly handled without being escaped.