### PR TITLE
[Site] Trim Icon's DataList's `<dd>` to get a better copy value

### DIFF
--- a/ux.symfony.com/templates/components/DataList.html.twig
+++ b/ux.symfony.com/templates/components/DataList.html.twig
@@ -8,9 +8,9 @@
                 <dd>
                     {%- if value.href|default %}
                         <a href="{{ value.href }}">{{ value.title }}</a>
-                    {% else %}
+                    {% else -%}
                         {{ value.title ?? value }}
-                    {% endif -%}
+                    {%- endif -%}
                 </dd>
             </div>
         {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #2831 
| License       | MIT

On Icon's modal, there is a space at the end of DD's HTML element:

![image](https://github.com/user-attachments/assets/e17bda6f-3880-4de0-bc68-6e3c3d06e31d)

So when double-click on it and copy it, we'll copy this space as well. 

This PR fixes that space.

Before:

![image](https://github.com/user-attachments/assets/271f16aa-d436-4a50-b66f-51ce7848805b)

After:

![image](https://github.com/user-attachments/assets/36c9a507-ca5c-43df-8ec2-ec68649ce18b)
