### PR TITLE
[Docs] Fix missing dynamic attributes on `<twig:ux:map>` example

### DIFF
--- a/src/Map/doc/index.rst
+++ b/src/Map/doc/index.rst
@@ -288,9 +288,9 @@ Alternatively, you can use the ``<twig:ux:map />`` component.
 .. code-block:: html+twig
 
     <twig:ux:map
-        center="[51.5074, 0.1278]"
+        :center="[51.5074, 0.1278]"
         zoom="3"
-        markers='[
+        :markers='[
             {"position": [51.5074, 0.1278], "title": "London"},
             {"position": [48.8566, 2.3522], "title": "Paris"},
             {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Docs?         | yes
| Issues        | Fix #... 
| License       | MIT

The twig component example from the documentation is missing the dynamic annotation before the center and markers attributes creating an error as the arrays aren't decoded

![image](https://github.com/user-attachments/assets/a18a5fc3-922d-4032-8cb3-d05e6b06207c)
