### PR TITLE
[CI] PHPStan: use PHP version from the matrix

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -78,7 +78,7 @@ jobs:
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.1'
+                    php-version: ${{ matrix.php-version }}
                     tools: flex
 
             - name: Install root dependencies


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix 
| License       | MIT

It installed PHP 8.1 instead of using various versions.