### PR TITLE
[Tests] Configure `doctrine.orm.enable_native_lazy_objects` to fix deprecation in PHP 8.4+

### DIFF
--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\Autocomplete\Tests\Fixtures;
 
+use Composer\InstalledVersions;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Fixtures\Form\CategoryWithCallbackAsCustomValue;
@@ -104,7 +105,7 @@ final class Kernel extends BaseKernel
             'auto_refresh_proxies' => false,
         ]);
 
-        $config = [
+        $doctrineConfig = [
             'dbal' => ['url' => '%env(resolve:DATABASE_URL)%'],
             'orm' => [
                 'auto_generate_proxy_classes' => true,
@@ -122,11 +123,17 @@ final class Kernel extends BaseKernel
         ];
         if (class_exists(AssociationMapping::class)) {
             // Doctrine ORM >= 3.0
-            $config['orm']['controller_resolver'] = [
+            $doctrineConfig['orm']['controller_resolver'] = [
                 'auto_mapping' => true,
             ];
         }
-        $c->extension('doctrine', $config);
+        if (null !== $doctrineBundleVersion = InstalledVersions::getVersion('doctrine/doctrine-bundle')) {
+            if (\PHP_VERSION_ID >= 80400 && version_compare($doctrineBundleVersion, '2.15.0', '>=')) {
+                $doctrineConfig['orm']['enable_native_lazy_objects'] = true;
+            }
+        }
+
+        $c->extension('doctrine', $doctrineConfig);
 
         $c->extension('security', [
             'password_hashers' => [

--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -186,6 +186,9 @@ final class Kernel extends BaseKernel
             if (version_compare($doctrineBundleVersion, '2.12.0', '>=')) {
                 $doctrineConfig['orm']['controller_resolver']['auto_mapping'] = false;
             }
+            if (\PHP_VERSION_ID >= 80400 && version_compare($doctrineBundleVersion, '2.15.0', '>=')) {
+                $doctrineConfig['orm']['enable_native_lazy_objects'] = true;
+            }
         }
 
         $c->extension('doctrine', $doctrineConfig);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Fix https://github.com/symfony/ux/actions/runs/15787680645/job/44507502967?pr=2712
