### PR TITLE
[CI] Reduce number of PHPStan jobs

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -46,17 +46,18 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '8.1', '8.2', '8.3', '8.4']
+                php-version: ['8.1']
                 dependency-version: ['']
                 symfony-version: ['']
                 minimum-stability: ['stable']
                 include:
+                    # dev packages (probably not needed to have multiple such jobs)
+                    - minimum-stability: 'dev'
+                      php-version: 8.4
                     # lowest deps
-                    -   php-version: '8.1'
-                        dependency-version: 'lowest'
+                    - dependency-version: 'lowest'
                     # LTS version of Symfony
-                    -   php-version: '8.1'
-                        symfony-version: '6.4.*'
+                    - symfony-version: '6.4.*'
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
@@ -78,7 +79,7 @@ jobs:
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: ${{ matrix.php-version }}
+                    php-version: 8.1
                     tools: flex
 
             - name: Install root dependencies


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

After some reflexions, I don't think there is a need to run PHPStan over all supported PHP versions, only the lowest one we support (8.1) and highest one (8.4) is enough. 

Playing with dependency versions, stability, and Symfony versions still make sense