### PR TITLE
Prevent `yarn watch` to exit if TypeScript plugin is unable to compile

### DIFF
--- a/bin/build_package.js
+++ b/bin/build_package.js
@@ -22,6 +22,7 @@ const args = parseArgs({
 
 async function main() {
     const packageRoot = path.resolve(process.cwd(), args.positionals[0]);
+    const isWatch = args.values.watch || false;
 
     if (!fs.existsSync(packageRoot)) {
         console.error(`The package directory "${packageRoot}" does not exist.`);
@@ -86,9 +87,9 @@ async function main() {
         process.exit(1);
     }
 
-    const rollupConfig = getRollupConfiguration({ packageRoot, inputFiles: inputScriptFiles });
+    const rollupConfig = getRollupConfiguration({ packageRoot, inputFiles: inputScriptFiles, isWatch });
 
-    if (args.values.watch) {
+    if (isWatch) {
         console.log(
             `Watching for JavaScript${inputStyleFile ? ' and CSS' : ''} files modifications in "${srcDir}" directory...`
         );
@@ -103,9 +104,13 @@ async function main() {
         }
 
         const watcher = rollup.watch(rollupConfig);
-        watcher.on('event', ({ result }) => {
-            if (result) {
-                result.close();
+        watcher.on('event', (event) => {
+            if (event.code === 'ERROR') {
+                console.error('Error during build:', event.error);
+            }
+
+            if (event.result) {
+                event.result.close();
             }
         });
         watcher.on('change', async (id, { event }) => {

--- a/bin/rollup.js
+++ b/bin/rollup.js
@@ -72,8 +72,9 @@ const moveTypescriptDeclarationsPlugin = (packageRoot) => ({
 /**
  * @param {String} packageRoot
  * @param {Array<String>} inputFiles
+ * @param {Boolean} isWatch
  */
-function getRollupConfiguration({ packageRoot, inputFiles }) {
+function getRollupConfiguration({ packageRoot, inputFiles, isWatch }) {
     const packagePath = path.join(packageRoot, 'package.json');
     const packageData = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
     const peerDependencies = [
@@ -108,7 +109,7 @@ function getRollupConfiguration({ packageRoot, inputFiles }) {
             typescript({
                 filterRoot: '.',
                 tsconfig: path.join(__dirname, '..', 'tsconfig.json'),
-                noEmitOnError: true,
+                noEmitOnError: !isWatch,
                 include: [
                     'src/**/*.ts',
                     // TODO: Remove for the next major release


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #2850 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
