### PR TITLE
[Translator][Tests] Minor fixes in tests context

### DIFF
--- a/src/Translator/.gitignore
+++ b/src/Translator/.gitignore
@@ -3,3 +3,5 @@
 /composer.lock
 /phpunit.xml
 /.phpunit.result.cache
+
+/var

--- a/src/Translator/src/TranslationsDumper.php
+++ b/src/Translator/src/TranslationsDumper.php
@@ -34,6 +34,7 @@ class TranslationsDumper
 {
     private array $excludedDomains = [];
     private array $includedDomains = [];
+    private array $alreadyGeneratedConstants = [];
 
     public function __construct(
         private string $dumpDir,
@@ -184,16 +185,14 @@ TS
 
     private function generateConstantName(string $translationId): string
     {
-        static $alreadyGenerated = [];
-
         $translationId = s($translationId)->ascii()->snake()->upper()->replaceMatches('/^(\d)/', '_$1')->toString();
         $prefix = 0;
         do {
             $constantName = $translationId.($prefix > 0 ? '_'.$prefix : '');
             ++$prefix;
-        } while ($alreadyGenerated[$constantName] ?? false);
+        } while ($this->alreadyGeneratedConstants[$constantName] ?? false);
 
-        $alreadyGenerated[$constantName] = true;
+        $this->alreadyGeneratedConstants[$constantName] = true;
 
         return $constantName;
     }

--- a/src/Translator/tests/CacheWarmer/TranslationsCacheWarmerTest.php
+++ b/src/Translator/tests/CacheWarmer/TranslationsCacheWarmerTest.php
@@ -28,7 +28,7 @@ final class TranslationsCacheWarmerTest extends TestCase
 
     public static function tearDownAfterClass(): void
     {
-        @unlink(self::$cacheDir);
+        @rmdir(self::$cacheDir);
     }
 
     public function test()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Cherry-picked from #2867, the following fixes only apply inside tests context, it does not have impact in real-life scenarios:
1. The static variable `$alreadyGenerated` now becomes a private property `alreadyGeneratedConstants. When tests were executed randomly in #2867, it was impossible to assert on generated translations files because constants names were kept in static cache even when the class `TranslationsDumper` was initialized for each test.
2. `self::$cacheDir` is a directory, so using `rmdir` is the best way to go instead of `unlink`
