### PR TITLE
[Tests] Fix functional tests Turbo (Chrome 137 & dev-tools)

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -56,6 +56,12 @@ jobs:
                   php-version: ${{ matrix.php-version }}
                   tools: flex
 
+            - name: Install root dependencies
+              run: composer install
+
+            - name: Build root packages
+              run: php .github/build-packages.php
+
             - name: Install dependencies with composer
               working-directory: src/Turbo
               run: |

--- a/src/Turbo/phpunit.xml.dist
+++ b/src/Turbo/phpunit.xml.dist
@@ -12,8 +12,11 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="APP_ENV" value="test" force="true" />
+        <env name="APP_DEBUG" value="true" force="true" />
         <env name="KERNEL_CLASS" value="App\Kernel"/>
-        <env name="PANTHER_WEB_SERVER_DIR" value="./tests/app/public"/>
+        <server name="PANTHER_WEB_SERVER_DIR" value="./tests/app/public"/>
+        <server name="PANTHER_DEVTOOLS" value="0"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Maybe I went to quick on #2867, maybe using `<server>` instead of `<env>` matters... 

**EDIT:** it seems that Turbo functional tests were broken since few weeks / months now, because of Chrome 137, see https://github.com/symfony/panther/issues/675.

Passing `PANTHER_DEVTOOLS=0` worked like a charm.