### PR TITLE
[CI] Cache Composer dependencies

### DIFF
--- a/.github/actions/install-root-dependencies/action.yaml
+++ b/.github/actions/install-root-dependencies/action.yaml
@@ -1,0 +1,21 @@
+name: Install root dependencies
+runs:
+  using: composite
+  steps:
+    -   name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        shell: bash
+
+    - name: Cache root Composer dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-root-${{ hashFiles('composer.json') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-root-
+
+    - name: Install root Composer dependencies
+      run: composer install
+      shell: bash

--- a/.github/actions/install-website-dependencies/action.yaml
+++ b/.github/actions/install-website-dependencies/action.yaml
@@ -1,0 +1,27 @@
+name: Install website dependencies
+inputs:
+  dependency-version:
+    description: 'The version of dependencies to install. Can be "locked" or "highest"'
+    default: 'locked'
+    required: false
+runs:
+  using: composite
+  steps:
+    -   name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        shell: bash
+
+    - name: Cache website Composer dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-website-${{ inputs.dependency-version }}-${{ hashFiles('ux.symfony.com/composer.json') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-website-${{ inputs.dependency-version }}-
+
+    - name: Install website Composer dependencies
+      run: composer ${{ inputs.dependency-version == 'highest' && 'update' || 'install' }}
+      shell: bash
+      working-directory: ux.symfony.com

--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -45,8 +45,20 @@ jobs:
 
         - uses: shivammathur/setup-php@v2
 
-        - name: Install root dependencies
-          run: composer install
+        - name: Get Composer Cache Directory
+          id: composer-cache
+          run: |
+            echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+        - name: Cache Testing apps dependencies
+          uses: actions/cache@v4
+          with:
+            path: ${{ steps.composer-cache.outputs.dir }}
+            key: ${{ runner.os }}-composer-testing-app-${{ matrix.ux-packages-source }}-${{ hashFiles('test_apps/**/composer.json') }}
+            restore-keys: |
+              ${{ runner.os }}-composer-testing-app-${{ matrix.ux-packages-source }}-
+
+        - uses: ./.github/actions/install-root-dependencies
 
         - name: Build root packages
           run: php .github/build-packages.php

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -83,8 +83,7 @@ jobs:
                     php-version: 8.1
                     tools: flex
 
-            - name: Install root dependencies
-              run: composer install
+            - uses: ./.github/actions/install-root-dependencies
 
             - name: Build root packages
               run: php .github/build-packages.php

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -10,6 +10,10 @@ on:
             - '.github/workflows/functional-tests.yml'
             - 'src/Turbo/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
     turbo-tests:
         runs-on: ubuntu-latest
@@ -56,8 +60,20 @@ jobs:
                   php-version: ${{ matrix.php-version }}
                   tools: flex
 
-            - name: Install root dependencies
-              run: composer install
+            -   name: Get Composer Cache Directory
+                id: composer-cache
+                run: |
+                    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache packages dependencies
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-turbo-${{ matrix.php-version }}-${{ matrix.dependency-version }}-${{ matrix.symfony-version }}-${{ matrix.minimum-stability }}-${{ hashFiles('src/**/composer.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-turbo-${{ matrix.php-version }}-
+
+            - uses: ./.github/actions/install-root-dependencies
 
             - name: Build root packages
               run: php .github/build-packages.php

--- a/.github/workflows/toolkit-kits-code-quality.yaml
+++ b/.github/workflows/toolkit-kits-code-quality.yaml
@@ -15,13 +15,23 @@ jobs:
             - uses: actions/checkout@v4
 
             - uses: shivammathur/setup-php@v2
+
+            - name: Get Composer Cache Directory
+              id: composer-cache
+              run: |
+                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache dependencies
+              uses: actions/cache@v4
               with:
-                php-version: 8.3
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: ${{ runner.os }}-composer-kits-${{ hashFiles('composer.json') }}
+                restore-keys: |
+                  ${{ runner.os }}-composer-kits-
 
             - name: Install composer packages
-              uses: ramsey/composer-install@v3
-              with:
-                working-directory: src/Toolkit
+              run: composer install
+              working-directory: src/Toolkit
 
             - name: Check kits code style
               run: php vendor/bin/twig-cs-fixer check kits

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -68,8 +68,20 @@ jobs:
                 php-version: ${{ matrix.php-version }}
                 tools: flex
 
-            - name: Install root dependencies
-              run: composer install
+            - name: Get Composer Cache Directory
+              id: composer-cache
+              run: |
+                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache packages dependencies
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-packages-${{ matrix.php-version }}-${{ matrix.dependency-version }}-${{ matrix.symfony-version }}-${{ matrix.minimum-stability }}-${{ hashFiles('src/**/composer.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-packages-${{ matrix.php-version }}-
+
+            - uses: ./.github/actions/install-root-dependencies
 
             - name: Build root packages
               run: php .github/build-packages.php

--- a/.github/workflows/ux.symfony.com.yaml
+++ b/.github/workflows/ux.symfony.com.yaml
@@ -26,14 +26,14 @@ jobs:
                 working-directory: ux.symfony.com
         steps:
             -   uses: actions/checkout@v4
+
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: '8.3'
                     tools: php-cs-fixer
-            -   name: Install dependencies
-                uses: ramsey/composer-install@v3
-                with:
-                    working-directory: ux.symfony.com
+
+            -   uses: ./.github/actions/install-website-dependencies
+
             -   name: php-cs-fixer
                 run: php-cs-fixer check --diff
 
@@ -45,13 +45,13 @@ jobs:
                 working-directory: ux.symfony.com
         steps:
             -   uses: actions/checkout@v4
+
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: '8.3'
-            -   name: Install dependencies
-                uses: ramsey/composer-install@v3
-                with:
-                    working-directory: ux.symfony.com
+
+            -   uses: ./.github/actions/install-website-dependencies
+
             -   name: twig-cs-fixer
                 run: vendor/bin/twig-cs-fixer lint templates --report=github
 
@@ -63,24 +63,26 @@ jobs:
                 working-directory: ux.symfony.com
         steps:
             -   uses: actions/checkout@v4
+
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: '8.3'
-            -   name: Install root dependencies
-                uses: ramsey/composer-install@v3
-                with:
-                    working-directory: ${{ github.workspace }}
+
+            -   uses: ./.github/actions/install-root-dependencies
+
             -   name: Build root packages
                 run: php .github/build-packages.php
                 working-directory: ${{ github.workspace }}
-            -   name: Install dependencies
-                uses: ramsey/composer-install@v3
+
+            -   uses: ./.github/actions/install-website-dependencies
                 with:
-                    working-directory: ux.symfony.com
                     dependency-versions: 'highest'
+
             -   name: Importmap dependencies
                 run: php bin/console importmap:install
+
             -   name: Build Sass assets
                 run: php bin/console sass:build
+
             -   name: Tests
                 run: vendor/bin/phpunit


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Following https://github.com/symfony/ux/pull/2780#issuecomment-2918360074.
Also, sometimes the CI fails because Composer is not able to download files (e.g.: https://github.com/symfony/ux/actions/runs/15955763737/job/45001822817?pr=2880):
```
Chartjs                                                                       8s
+ cd src/Chartjs
+ composer config minimum-stability stable --ansi
+ composer update --no-progress --no-interaction --ansi
Loading composer repositories with package information
Restricting packages listed in "symfony/symfony" to ">=5.4"
Updating dependencies
Lock file operations: 30 installs, 0 updates, 0 removals
  - Locking psr/cache (3.0.0)
  - Locking psr/container (2.0.2)
  - Locking psr/event-dispatcher (1.0.0)
  - Locking psr/log (3.0.2)
  - Locking symfony/cache (v7.3.1)
  - Locking symfony/cache-contracts (v3.6.0)
  - Locking symfony/config (v7.3.0)
  - Locking symfony/dependency-injection (v7.3.1)
  - Locking symfony/deprecation-contracts (v3.6.0)
  - Locking symfony/error-handler (v7.3.1)
  - Locking symfony/event-dispatcher (v7.3.0)
  - Locking symfony/event-dispatcher-contracts (v3.6.0)
  - Locking symfony/filesystem (v7.3.0)
  - Locking symfony/finder (v7.3.0)
  - Locking symfony/framework-bundle (v7.3.1)
  - Locking symfony/http-foundation (v7.3.1)
  - Locking symfony/http-kernel (v7.3.1)
  - Locking symfony/phpunit-bridge (v7.3.1)
  - Locking symfony/polyfill-ctype (v1.32.0)
  - Locking symfony/polyfill-mbstring (v1.32.0)
  - Locking symfony/polyfill-php83 (v1.32.0)
  - Locking symfony/routing (v7.3.0)
  - Locking symfony/service-contracts (v3.6.0)
  - Locking symfony/stimulus-bundle (dev-d0e37bc4d9669c4d60476e89be536b695a5eea7c)
  - Locking symfony/translation-contracts (v3.6.0)
  - Locking symfony/twig-bridge (v7.3.0)
  - Locking symfony/twig-bundle (v7.3.1)
  - Locking symfony/var-dumper (v7.3.1)
  - Locking symfony/var-exporter (v7.3.0)
  - Locking twig/twig (v3.21.1)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 30 installs, 0 updates, 0 removals
  - Downloading psr/log (3.0.2)
  - Downloading psr/cache (3.0.0)
  - Downloading symfony/cache-contracts (v3.6.0)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.6.0)
  - Downloading symfony/deprecation-contracts (v3.6.0)
  - Downloading symfony/routing (v7.3.0)
  - Downloading symfony/polyfill-php83 (v1.32.0)
  - Downloading symfony/http-foundation (v7.3.1)
  - Downloading symfony/event-dispatcher (v7.3.0)
  - Downloading symfony/var-dumper (v7.3.1)
  - Downloading symfony/error-handler (v7.3.1)
  - Downloading symfony/http-kernel (v7.3.1)
  - Downloading symfony/var-exporter (v7.3.0)
  - Downloading psr/container (2.0.2)
  - Downloading symfony/service-contracts (v3.6.0)
  - Downloading symfony/dependency-injection (v7.3.1)
  - Downloading symfony/config (v7.3.0)
  - Downloading symfony/cache (v7.3.1)
  - Downloading symfony/framework-bundle (v7.3.1)
  - Downloading symfony/phpunit-bridge (v7.3.1)
  - Downloading twig/twig (v3.21.1)
  - Downloading symfony/translation-contracts (v3.6.0)
  - Downloading symfony/twig-bridge (v7.3.0)
  - Downloading symfony/twig-bundle (v7.3.1)
  - Installing psr/log (3.0.2): Extracting archive
  - Installing psr/cache (3.0.0): Extracting archive
  - Installing symfony/cache-contracts (v3.6.0): Extracting archive
  - Installing psr/event-dispatcher (1.0.0): Extracting archive
  - Installing symfony/event-dispatcher-contracts (v3.6.0): Extracting archive
  - Installing symfony/deprecation-contracts (v3.6.0): Extracting archive
  - Installing symfony/routing (v7.3.0): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.32.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.32.0): Extracting archive
  - Installing symfony/polyfill-php83 (v1.32.0): Extracting archive
  - Installing symfony/http-foundation (v7.3.1): Extracting archive
  - Installing symfony/event-dispatcher (v7.3.0): Extracting archive
  - Installing symfony/var-dumper (v7.3.1): Extracting archive
  - Installing symfony/error-handler (v7.3.1): Extracting archive
  - Installing symfony/http-kernel (v7.3.1): Extracting archive
  - Installing symfony/finder (v7.3.0): Extracting archive
  - Installing symfony/filesystem (v7.3.0): Extracting archive
  - Installing symfony/var-exporter (v7.3.0): Extracting archive
  - Installing psr/container (2.0.2): Extracting archive
  - Installing symfony/service-contracts (v3.6.0): Extracting archive
  - Installing symfony/dependency-injection (v7.3.1): Extracting archive
  - Installing symfony/config (v7.3.0): Extracting archive
  - Installing symfony/cache (v7.3.1): Extracting archive
  - Installing symfony/framework-bundle (v7.3.1): Extracting archive
  - Installing symfony/phpunit-bridge (v7.3.1): Extracting archive
  - Installing twig/twig (v3.21.1): Extracting archive
  - Installing symfony/stimulus-bundle (dev-d0e37bc4d9669c4d60476e89be536b695a5eea7c): Symlinking from /home/runner/work/ux/ux/src/StimulusBundle
  - Installing symfony/translation-contracts (v3.6.0): Extracting archive
  - Installing symfony/twig-bridge (v7.3.0): Extracting archive
  - Installing symfony/twig-bundle (v7.3.1): Extracting archive
Generating autoload files
25 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Symfony recipes are disabled: "symfony/flex" not found in the root composer.json

Synchronizing package.json is disabled: "symfony/flex" not found in the root composer.json
+ '[' Chartjs = LiveComponent ']'
+ vendor/bin/simple-phpunit
No composer.json in current directory, to use the one at /home/runner/work/ux/ux/src/Chartjs run interactively or set config.use-parent-dir to true
No composer.json found in the current directory, showing available packages from packagist.org
Creating a "phpunit/phpunit" project at "./phpunit-9.6-0"
Installing phpunit/phpunit (9.6.23)
Plugins have been disabled.
  - Installing phpunit/phpunit (9.6.23): Extracting archive
    Failed to extract phpunit/phpunit: (9) /usr/bin/unzip -qq /home/runner/work/ux/ux/src/Chartjs/vendor/bin/.phpunit/phpunit-9.6-0/vendor/composer/tmp-1e96655e7e40c6414bae34763a287620.zip -d /home/runner/work/ux/ux/src/Chartjs/vendor/bin/.phpunit/phpunit-9.6-0/vendor/composer/843828ba

[/home/runner/work/ux/ux/src/Chartjs/vendor/bin/.phpunit/phpunit-9.6-0/vendor/composer/tmp-1e96655e7e40c6414bae34763a287620.zip]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /home/runner/work/ux/ux/src/Chartjs/vendor/bin/.phpunit/phpunit-9.6-0/vendor/composer/tmp-1e96655e7e40c6414bae34763a287620.zip or
        /home/runner/work/ux/ux/src/Chartjs/vendor/bin/.phpunit/phpunit-9.6-0/vendor/composer/tmp-1e96655e7e40c6414bae34763a287620.zip.zip, and cannot find /home/runner/work/ux/ux/src/Chartjs/vendor/bin/.phpunit/phpunit-9.6-0/vendor/composer/tmp-1e96655e7e40c6414bae34763a287620.zip.ZIP, period.

    The archive may contain identical file names with different capitalization (which fails on case insensitive filesystems)
    Unzip with unzip command failed, falling back to ZipArchive class
    Additional debug info, please report to 
https://github.com/composer/composer/issues/11148 if you see this:
File size: 368640
File SHA1: 065415eca247fecabf97b30dde4afc12668e6b7c
First 100 bytes (hex): 504b03040a000000000011bda15a0000000000000000000000002200090073656261737469616e626572676d616e6e2d706870756e69742d343364326362312f5554050001e2681468504b03040a000000080011bda15a345bf22154090000be20000032
Last 100 bytes (hex): 0ad41e9d9e102716760d90f98dbdebfc7a8695c1884038e9066a4bfa2ffb92be25ce902979f995bc381c159b0eacd2fa828551646f94b1cbb5b9be51a6355ed8e5d95dd828b1c7f3ed32edce6894d9e3c3769956bf328ab47ba35da2c53fccf66af1a9e1
Origin URL: https://api.github.com/repos/sebastianbergmann/phpunit/zipball/43d2cb18d0675c38bd44982a5d1d88f6d53d8d95
Response Headers: []
    Install of phpunit/phpunit failed

Error: '/home/runner/work/ux/ux/src/Chartjs/vendor/bin/.phpunit/phpunit-9.6-0/vendor/composer/tmp-1e96655e7e40c6414bae34763a287620.zip' is not a zip archive.
In ZipDownloader.php line 255:

  '/home/runner/work/ux/ux/src/Chartjs/vendor/bin/.phpunit/phpunit-9.6-0/vendor/composer/tmp-1e96655e7e40c6414bae3476  
  3a287620.zip' is not a zip archive.                                                                                  


create-project [-s|--stability STABILITY] [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--repository REPOSITORY] [--repository-url REPOSITORY-URL] [--add-repository] [--dev] [--no-dev] [--no-custom-installers] [--no-scripts] [--no-progress] [--no-secure-http] [--keep-vcs] [--remove-vcs] [--no-install] [--no-audit] [--audit-format AUDIT-FORMAT] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--ask] [--] [<package> [<directory> [<version>]]]
Job exited with: 19
```