### PR TITLE
[Vue][React][Svelte] Fix components assets compilation on Windows server

### DIFF
--- a/src/React/src/AssetMapper/ReactControllerLoaderAssetCompiler.php
+++ b/src/React/src/AssetMapper/ReactControllerLoaderAssetCompiler.php
@@ -57,7 +57,7 @@ class ReactControllerLoaderAssetCompiler implements AssetCompilerInterface
                 $controllerNameForVariable,
                 $relativeImportPath
             );
-            $componentParts[] = \sprintf('"%s": %s', $name, $controllerNameForVariable);
+            $componentParts[] = \sprintf('"%s": %s', Path::normalize($name), $controllerNameForVariable);
         }
 
         $importCode = implode("\n", $importLines);

--- a/src/Svelte/src/AssetMapper/SvelteControllerLoaderAssetCompiler.php
+++ b/src/Svelte/src/AssetMapper/SvelteControllerLoaderAssetCompiler.php
@@ -57,7 +57,7 @@ class SvelteControllerLoaderAssetCompiler implements AssetCompilerInterface
                 $controllerNameForVariable,
                 $relativeImportPath
             );
-            $componentParts[] = \sprintf('"%s": %s', $name, $controllerNameForVariable);
+            $componentParts[] = \sprintf('"%s": %s', Path::normalize($name), $controllerNameForVariable);
         }
 
         $importCode = implode("\n", $importLines);

--- a/src/Vue/src/AssetMapper/VueControllerLoaderAssetCompiler.php
+++ b/src/Vue/src/AssetMapper/VueControllerLoaderAssetCompiler.php
@@ -57,7 +57,7 @@ class VueControllerLoaderAssetCompiler implements AssetCompilerInterface
                 $controllerNameForVariable,
                 $relativeImportPath
             );
-            $componentParts[] = \sprintf('"%s": %s', $name, $controllerNameForVariable);
+            $componentParts[] = \sprintf('"%s": %s', Path::normalize($name), $controllerNameForVariable);
         }
 
         $importCode = implode("\n", $importLines);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Following #2816, this PR fixes the `controller.js` files generation when the Symfony app is running on Windows server:
```
Testing 
F...                                                                4 / 4 (100%)

Time: 00:01.229, Memory: 30.00 MB

There was 1 failure:

1) Symfony\UX\Vue\Tests\AssetMapper\VueControllerLoaderAssetCompilerTest::testCompileDynamicallyAddsContents
Failed asserting that 'import component_0 from '../../vue/controllers/MyVueController.js';\n
import component_1 from '../../vue/controllers/subdir/DeeperVueController.js';\n
export const components = {"MyVueController": component_0, "subdir\DeeperVueController": component_1};' contains ""subdir/DeeperVueController": component_".

D:\a\ux\ux\src\Vue\tests\AssetMapper\VueControllerLoaderAssetCompilerTest.php:72
```

I was able to set-up a Windows VM to ensure the PR fixes the problem (tip: don't use a remote VM in a train... 🙂) 

Before, you can see that `subfolder\Goodbye` is interpreted as `subfolderGoodbye`, meaning that is not possible to use `subfolder/Goodbye` Vue component (I made a typo in the Twig template, but it has no effect):
<img width="1704" alt="Capture d’écran 2025-07-02 à 09 39 00" src="https://github.com/user-attachments/assets/7b812dfb-cb45-46c3-9ec6-50a691e3e38f" />
With the patch, the path now contains `/` instead of `\`, the component `subfolder/Goodbye` is now usable:
<img width="1704" alt="Capture d’écran 2025-07-02 à 09 58 07" src="https://github.com/user-attachments/assets/3a1195f1-c84b-4c42-9bd1-21fb2b9d66a7" />
