### PR TITLE
[LiveComponent] Update css to cover more data-loading use cases

### DIFF
--- a/src/LiveComponent/assets/dist/live.min.css
+++ b/src/LiveComponent/assets/dist/live.min.css
@@ -1,1 +1,1 @@
-[data-loading=""],[data-loading=show],[data-loading=delay\|show]{display:none}
+[data-loading=""],[data-loading=show],[data-loading*=\|show]{display:none}

--- a/src/LiveComponent/assets/styles/live.css
+++ b/src/LiveComponent/assets/styles/live.css
@@ -1,3 +1,3 @@
-[data-loading=""], [data-loading="show"], [data-loading="delay|show"] {
+[data-loading=""], [data-loading="show"], [data-loading*="|show"] {
     display: none;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT


This update fixes the default display of loaders in Live Components by extending the CSS selector to also target attributes like `data-loading="action(saveForm)|show"` or `data-loading="delay(500)|show"` or even both combined.
This ensures that loaders remain hidden on initial render or dynamic component insertion, preventing unwanted visual flashes or unwanted displaying of the element that should not be displayed.

Example
Previously, an element like
`<span data-loading="action(save)|show">Loading…</span>`
could be visible in some cases, like loading a new stimulus controller when the component refresh.
It doesn't change the previous behavior, it just covers more cases.