### PR TITLE
[LiveComponent] Add `keep-alive` modifier to polling plugin

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.28.0
+
+-   Add `keep-alive` modifier to polling plugin
+
 ## 2.27.0
 
 -  Add events assertions in `InteractsWithLiveComponents`:

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2732,6 +2732,16 @@ class PollingPlugin {
                             duration = Number.parseInt(modifier.value);
                         }
                         break;
+                    case 'keep-alive':
+                        document.addEventListener('visibilitychange', () => {
+                            if (document.hidden) {
+                                this.pollingDirector.stopAllPolling();
+                            }
+                            else {
+                                this.pollingDirector.startAllPolling();
+                            }
+                        });
+                        break;
                     default:
                         console.warn(`Unknown modifier "${modifier.name}" in data-poll "${rawPollConfig}".`);
                 }

--- a/src/LiveComponent/assets/src/Component/plugins/PollingPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/PollingPlugin.ts
@@ -53,6 +53,16 @@ export default class implements PluginInterface {
                         }
 
                         break;
+                    case 'keep-alive':
+                        document.addEventListener('visibilitychange', () => {
+                            if (document.hidden) {
+                                this.pollingDirector.stopAllPolling();
+                            } else {
+                                this.pollingDirector.startAllPolling();
+                            }
+                        });
+
+                        break;
                     default:
                         console.warn(`Unknown modifier "${modifier.name}" in data-poll "${rawPollConfig}".`);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #995
| License       | MIT

This is a naive implementation, which I think needs to be discussed.

I think the listener somehow somewhere should be detached when poll disconnects.

And the best solution would be to add it once for all polling, but I don't see how it is doable.