### PR TITLE
[Autocomplete]  Force installation of CSS files for AssetMapper

### DIFF
--- a/src/Autocomplete/assets/package.json
+++ b/src/Autocomplete/assets/package.json
@@ -37,7 +37,10 @@
         },
         "importmap": {
             "@hotwired/stimulus": "^3.0.0",
-            "tom-select": "^2.2.2"
+            "tom-select": "^2.2.2",
+            "tom-select/dist/css/tom-select.default.css": "^2.2.2",
+            "tom-select/dist/css/tom-select.bootstrap4.css": "^2.2.2",
+            "tom-select/dist/css/tom-select.bootstrap5.css": "^2.2.2"
         }
     },
     "peerDependencies": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2901
| License       | MIT

Explicitly add missing css files defined in `autoimport` in [`/src/Autocomplete/assets/package.json`](https://github.com/symfony/ux/blob/2.x/src/Autocomplete/assets/package.json#L31-L35)
