### PR TITLE
[Icons] Add support for <title> and <desc> elements in SVG for accessibility

### DIFF
--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -481,13 +481,13 @@ of the following attributes: ``aria-label``, ``aria-labelledby`` or ``title``.
 
         <twig:ux:icon name="user-profile" aria-hidden="false" />
 
-## Accessibility: Descriptive Titles and Descriptions
+**Accessibility: Descriptive Titles and Descriptions**
 
-.. versionadded:: NEXT\_VERSION
+.. versionadded:: 2.28
 
-The `ux_icon()` function and the `<twig:ux:icon>` component now support accessible SVG metadata via the `title` and `desc` attributes.
+The `ux_icon()` function and the `<twig:ux:icon>` component now support accessible SVG metadata via the `title` and `desc` attributes in 2.28.
 
-These are automatically injected into the `<svg>` markup as child elements, and properly referenced using `aria-labelledby` for improved screen reader support.
+These are automatically injected into the ``<svg>`` markup as child elements, and properly referenced using ``aria-labelledby`` for improved screen reader support.
 
 **How it works:**
 
@@ -495,7 +495,6 @@ When you pass a `title` and/or `desc` attribute, they are rendered inside the `<
 
 .. code-block:: html+twig
 
-```
 {{ ux_icon('bi:plus-square-dotted', {
     width: '16px',
     height: '16px',
@@ -503,19 +502,24 @@ When you pass a `title` and/or `desc` attribute, they are rendered inside the `<
     title: 'Add Stock',
     desc: 'This icon indicates stock entry functionality.'
 }) }}
-```
 
 Renders:
 
 .. code-block:: html
 
-```
 <svg class="text-success" width="16px" height="16px" aria-labelledby="icon-title-abc icon-desc-def">
     <title id="icon-title-abc">Add Stock</title>
     <desc id="icon-desc-def">This icon indicates stock entry functionality.</desc>
     <!-- inner SVG content -->
 </svg>
-```
+
+.. note::
+
+    - If ``aria-labelledby`` is already defined in your attributes, it will **not** be overwritten.
+    - ``role="img"`` is **not added automatically**. You may choose to include it if your use case requires.
+    - When neither ``title``, ``desc``, ``aria-label``, nor ``aria-labelledby`` are provided, ``aria-hidden="true"`` will still be automatically applied.
+
+This feature brings UX Icons in line with modern accessibility recommendations and helps developers build more inclusive user interfaces.
 
 To learn more about accessible SVG elements:
 

--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -493,7 +493,7 @@ These are automatically injected into the ``<svg>`` markup as child elements, an
 
 When you pass a `title` and/or `desc` attribute, they are rendered inside the `<svg>` as follows:
 
-.. code-block:: html+twig
+.. code-block:: twig
 
 {{ ux_icon('bi:plus-square-dotted', {
     width: '16px',

--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -481,6 +481,47 @@ of the following attributes: ``aria-label``, ``aria-labelledby`` or ``title``.
 
         <twig:ux:icon name="user-profile" aria-hidden="false" />
 
+## Accessibility: Descriptive Titles and Descriptions
+
+.. versionadded:: NEXT\_VERSION
+
+The `ux_icon()` function and the `<twig:ux:icon>` component now support accessible SVG metadata via the `title` and `desc` attributes.
+
+These are automatically injected into the `<svg>` markup as child elements, and properly referenced using `aria-labelledby` for improved screen reader support.
+
+**How it works:**
+
+When you pass a `title` and/or `desc` attribute, they are rendered inside the `<svg>` as follows:
+
+.. code-block:: html+twig
+
+```
+{{ ux_icon('bi:plus-square-dotted', {
+    width: '16px',
+    height: '16px',
+    class: 'text-success',
+    title: 'Add Stock',
+    desc: 'This icon indicates stock entry functionality.'
+}) }}
+```
+
+Renders:
+
+.. code-block:: html
+
+```
+<svg class="text-success" width="16px" height="16px" aria-labelledby="icon-title-abc icon-desc-def">
+    <title id="icon-title-abc">Add Stock</title>
+    <desc id="icon-desc-def">This icon indicates stock entry functionality.</desc>
+    <!-- inner SVG content -->
+</svg>
+```
+
+To learn more about accessible SVG elements:
+
+- `MDN: <title>`\_ — [https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title)
+- `MDN: <desc>`\_ — [https://developer.mozilla.org/en-US/docs/Web/SVG/Element/desc](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/desc)
+
 Performance
 -----------
 

--- a/src/Icons/src/Icon.php
+++ b/src/Icons/src/Icon.php
@@ -139,27 +139,53 @@ final class Icon implements \Stringable
     public function toHtml(): string
     {
         $htmlAttributes = '';
-        foreach ($this->attributes as $name => $value) {
+        $innerSvg = $this->innerSvg;
+        $attributes = $this->attributes;
+
+        // Extract and remove title/desc attributes if present
+        $title = $attributes['title'] ?? null;
+        $desc = $attributes['desc'] ?? null;
+        unset($attributes['title'], $attributes['desc']);
+
+        // Prepare <title> and <desc> elements
+        $labelledByIds = [];
+        $a11yContent = '';
+
+        if ($title) {
+            $titleId = 'title-' . bin2hex(random_bytes(4));
+            $labelledByIds[] = $titleId;
+            $a11yContent .= sprintf('<title id="%s">%s</title>', $titleId, htmlspecialchars((string) $title, ENT_QUOTES));
+        }
+
+        if ($desc) {
+            $descId = 'desc-' . bin2hex(random_bytes(4));
+            $labelledByIds[] = $descId;
+            $a11yContent .= sprintf('<desc id="%s">%s</desc>', $descId, htmlspecialchars((string) $desc, ENT_QUOTES));
+        }
+
+        // Only add aria-labelledby if not already present and we have content
+        if ($a11yContent !== '' && !isset($attributes['aria-labelledby'])) {
+            $attributes['aria-labelledby'] = implode(' ', $labelledByIds);
+        }
+
+        // Build final attributes string
+        foreach ($attributes as $name => $value) {
             if (false === $value) {
                 continue;
             }
 
-            // Special case for aria-* attributes
-            // https://www.w3.org/TR/wai-aria-1.1/#state_prop_def
             if (true === $value && str_starts_with($name, 'aria-')) {
                 $value = 'true';
             }
 
             $htmlAttributes .= ' '.$name;
+
             if (true === $value) {
                 continue;
             }
 
-            $value = htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+            $value = htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             $htmlAttributes .= '="'.$value.'"';
-        }
-
-        return '<svg'.$htmlAttributes.'>'.$this->innerSvg.'</svg>';
     }
 
     public function getInnerSvg(): string

--- a/src/Icons/src/Icon.php
+++ b/src/Icons/src/Icon.php
@@ -141,51 +141,66 @@ final class Icon implements \Stringable
         $htmlAttributes = '';
         $innerSvg = $this->innerSvg;
         $attributes = $this->attributes;
-
+    
         // Extract and remove title/desc attributes if present
         $title = $attributes['title'] ?? null;
         $desc = $attributes['desc'] ?? null;
         unset($attributes['title'], $attributes['desc']);
-
-        // Prepare <title> and <desc> elements
+    
         $labelledByIds = [];
         $a11yContent = '';
-
+    
+        // Check if aria-labelledby should be added automatically
+        $shouldSetLabelledBy = !isset($attributes['aria-labelledby']) && ($title || $desc);
+    
         if ($title) {
-            $titleId = 'title-' . bin2hex(random_bytes(4));
-            $labelledByIds[] = $titleId;
-            $a11yContent .= sprintf('<title id="%s">%s</title>', $titleId, htmlspecialchars((string) $title, ENT_QUOTES));
+            if ($shouldSetLabelledBy) {
+                $titleId = 'title-' . bin2hex(random_bytes(4));
+                $labelledByIds[] = $titleId;
+                $a11yContent .= sprintf('<title id="%s">%s</title>', $titleId, htmlspecialchars((string) $title, ENT_QUOTES));
+            } else {
+                $a11yContent .= sprintf('<title>%s</title>', htmlspecialchars((string) $title, ENT_QUOTES));
+            }
         }
-
+    
         if ($desc) {
-            $descId = 'desc-' . bin2hex(random_bytes(4));
-            $labelledByIds[] = $descId;
-            $a11yContent .= sprintf('<desc id="%s">%s</desc>', $descId, htmlspecialchars((string) $desc, ENT_QUOTES));
+            if ($shouldSetLabelledBy) {
+                $descId = 'desc-' . bin2hex(random_bytes(4));
+                $labelledByIds[] = $descId;
+                $a11yContent .= sprintf('<desc id="%s">%s</desc>', $descId, htmlspecialchars((string) $desc, ENT_QUOTES));
+            } else {
+                $a11yContent .= sprintf('<desc>%s</desc>', htmlspecialchars((string) $desc, ENT_QUOTES));
+            }
         }
-
-        // Only add aria-labelledby if not already present and we have content
-        if ($a11yContent !== '' && !isset($attributes['aria-labelledby'])) {
+    
+        if ($shouldSetLabelledBy) {
             $attributes['aria-labelledby'] = implode(' ', $labelledByIds);
         }
-
+    
         // Build final attributes string
         foreach ($attributes as $name => $value) {
-            if (false === $value) {
+            if ($value === false) {
                 continue;
             }
-
-            if (true === $value && str_starts_with($name, 'aria-')) {
+    
+            // Special case for aria-* attributes
+            // https://www.w3.org/TR/wai-aria-1.1/#state_prop_def
+            if ($value === true && str_starts_with($name, 'aria-')) {
                 $value = 'true';
             }
-
-            $htmlAttributes .= ' '.$name;
-
-            if (true === $value) {
+    
+            $htmlAttributes .= ' ' . $name;
+    
+            if ($value === true) {
                 continue;
             }
-
-            $value = htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-            $htmlAttributes .= '="'.$value.'"';
+    
+            $value = htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+            $htmlAttributes .= '="' . $value . '"';
+        }
+    
+        // Inject <title> and <desc> before inner content
+        return '<svg' . $htmlAttributes . '>' . $a11yContent . $innerSvg . '</svg>';
     }
 
     public function getInnerSvg(): string

--- a/src/Icons/src/Icon.php
+++ b/src/Icons/src/Icon.php
@@ -141,18 +141,18 @@ final class Icon implements \Stringable
         $htmlAttributes = '';
         $innerSvg = $this->innerSvg;
         $attributes = $this->attributes;
-    
+
         // Extract and remove title/desc attributes if present
         $title = $attributes['title'] ?? null;
         $desc = $attributes['desc'] ?? null;
         unset($attributes['title'], $attributes['desc']);
-    
+
         $labelledByIds = [];
         $a11yContent = '';
-    
+
         // Check if aria-labelledby should be added automatically
         $shouldSetLabelledBy = !isset($attributes['aria-labelledby']) && ($title || $desc);
-    
+
         if ($title) {
             if ($shouldSetLabelledBy) {
                 $titleId = 'title-' . bin2hex(random_bytes(4));
@@ -162,7 +162,7 @@ final class Icon implements \Stringable
                 $a11yContent .= sprintf('<title>%s</title>', htmlspecialchars((string) $title, ENT_QUOTES));
             }
         }
-    
+
         if ($desc) {
             if ($shouldSetLabelledBy) {
                 $descId = 'desc-' . bin2hex(random_bytes(4));
@@ -172,34 +172,31 @@ final class Icon implements \Stringable
                 $a11yContent .= sprintf('<desc>%s</desc>', htmlspecialchars((string) $desc, ENT_QUOTES));
             }
         }
-    
+
         if ($shouldSetLabelledBy) {
             $attributes['aria-labelledby'] = implode(' ', $labelledByIds);
         }
-    
-        // Build final attributes string
+
         foreach ($attributes as $name => $value) {
-            if ($value === false) {
+            if (false === $value) {
                 continue;
             }
-    
+
             // Special case for aria-* attributes
             // https://www.w3.org/TR/wai-aria-1.1/#state_prop_def
-            if ($value === true && str_starts_with($name, 'aria-')) {
+            if (true === $value && str_starts_with($name, 'aria-')) {
                 $value = 'true';
             }
-    
-            $htmlAttributes .= ' ' . $name;
-    
-            if ($value === true) {
+
+            $htmlAttributes .= ' '.$name;
+            if (true === $value) {
                 continue;
             }
-    
+
             $value = htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
-            $htmlAttributes .= '="' . $value . '"';
+            $htmlAttributes .= '="'.$value.'"';
         }
-    
-        // Inject <title> and <desc> before inner content
+
         return '<svg' . $htmlAttributes . '>' . $a11yContent . $innerSvg . '</svg>';
     }
 

--- a/src/Icons/tests/Unit/IconAccessibilityTest.php
+++ b/src/Icons/tests/Unit/IconAccessibilityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Symfony\UX\Icons\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Icons\Icon;
+
+class IconAccessibilityTest extends TestCase
+{
+    public function testTitleIsIncludedInOutput()
+    {
+        $icon = new Icon('<path d="M0 0h24v24H0z" fill="none"/>', ['title' => 'Test Icon']);
+        $html = $icon->toHtml();
+        $this->assertMatchesRegularExpression('/<title( id="[^"]*")?>Test Icon<\/title>/', $html);
+    }
+
+    public function testDescIsIncludedInOutput()
+    {
+        $icon = new Icon('<circle cx="12" cy="12" r="10"/>', ['desc' => 'This is a test circle']);
+        $html = $icon->toHtml();
+        $this->assertMatchesRegularExpression('/<desc( id="[^"]*")?>This is a test circle<\/desc>/', $html);
+    }
+
+    public function testTitleAndDescWithCustomAriaLabelledBy()
+    {
+        $attributes = [
+            'title' => 'My Line',
+            'desc' => 'This is a diagonal line',
+            'aria-labelledby' => 'custom-id',
+        ];
+        $icon = new Icon('<line x1="0" y1="0" x2="10" y2="10"/>', $attributes);
+
+        $html = $icon->toHtml();
+        $this->assertStringContainsString('<title>My Line</title>', $html);
+        $this->assertStringContainsString('<desc>This is a diagonal line</desc>', $html);
+        $this->assertStringContainsString('aria-labelledby="custom-id"', $html);
+    }
+
+    public function testToStringReturnsHtml()
+    {
+        $icon = new Icon('<path d="M0 0h24v24H0z"/>');
+        $this->assertSame($icon->toHtml(), (string) $icon);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | 
| License       | MIT

When passing title and/or desc as attributes to ux_icon(), they are now embedded directly into the SVG as <title> and <desc> child elements.

Each <title> and <desc> element is given a unique id and automatically referenced via aria-labelledby, if no such attribute was already set.

This ensures compliance with accessibility best practices for inline SVG content.
See:

    https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title

    https://developer.mozilla.org/en-US/docs/Web/SVG/Element/desc


Example Usage:

```
{{ ux_icon('bi:plus-square-dotted', {
    width: '16px',
    height: '16px',
    class: 'text-success',
    title: 'Add Stock',
    desc: 'This icon indicates stock entry functionality.'
}) }}
```

Renders:


```
<svg class="text-success" width="16px" height="16px" aria-labelledby="icon-title-abc icon-desc-def">
    <title id="icon-title-abc">Add Stock</title>
    <desc id="icon-desc-def">This icon indicates stock entry functionality.</desc>
    <!-- inner SVG content -->
</svg>
```