### PR TITLE
[LiveComponent] Fix BC break when using `PropertyTypeExtractorInterface::getType()` on a `#[LiveProp]` property `x` when getter `getX` exists

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -191,6 +191,7 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             ->setArguments([
                 new Reference('ux.twig_component.component_factory'),
                 new Reference('property_info'),
+                new Reference('type_info.resolver', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
             ->addTag('kernel.reset', ['method' => 'reset'])
         ;

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
@@ -13,9 +13,9 @@ namespace Symfony\UX\LiveComponent\Metadata;
 
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
-use Symfony\Component\TypeInfo\Type\IntersectionType;
-use Symfony\Component\TypeInfo\Type\NullableType;
-use Symfony\Component\TypeInfo\Type\UnionType;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\TwigComponent\ComponentFactory;
@@ -33,7 +33,11 @@ class LiveComponentMetadataFactory implements ResetInterface
     public function __construct(
         private ComponentFactory $componentFactory,
         private PropertyTypeExtractorInterface $propertyTypeExtractor,
+        private ?TypeResolver $typeResolver = null,
     ) {
+        if (method_exists($this->propertyTypeExtractor, 'getType') && !$this->typeResolver) {
+            throw new \LogicException('Symfony TypeInfo is required to use LiveProps. Try running "composer require symfony/type-info".');
+        }
     }
 
     public function getMetadata(string $name): LiveComponentMetadata
@@ -77,13 +81,13 @@ class LiveComponentMetadataFactory implements ResetInterface
 
     public function createLivePropMetadata(string $className, string $propertyName, \ReflectionProperty $property, LiveProp $liveProp): LivePropMetadata|LegacyLivePropMetadata
     {
+        $reflectionType = $property->getType();
+        if ($reflectionType instanceof \ReflectionUnionType || $reflectionType instanceof \ReflectionIntersectionType) {
+            throw new \LogicException(\sprintf('Union or intersection types are not supported for LiveProps. You may want to change the type of property %s in %s.', $property->getName(), $property->getDeclaringClass()->getName()));
+        }
+
         // BC layer when "symfony/type-info" is not available
         if (!method_exists($this->propertyTypeExtractor, 'getType')) {
-            $type = $property->getType();
-            if ($type instanceof \ReflectionUnionType || $type instanceof \ReflectionIntersectionType) {
-                throw new \LogicException(\sprintf('Union or intersection types are not supported for LiveProps. You may want to change the type of property %s in %s.', $property->getName(), $property->getDeclaringClass()->getName()));
-            }
-
             $infoTypes = $this->propertyTypeExtractor->getTypes($className, $propertyName) ?? [];
 
             $collectionValueType = null;
@@ -96,14 +100,16 @@ class LiveComponentMetadataFactory implements ResetInterface
                 }
             }
 
-            if (null === $type && null === $collectionValueType && isset($infoTypes[0])) {
+            if (null === $reflectionType && null === $collectionValueType && isset($infoTypes[0])) {
+                // If it's an "advanced" type (like a Collection), let's use the PropertyTypeExtractor to get the Type
                 $infoType = LegacyType::BUILTIN_TYPE_OBJECT === $infoTypes[0]->getBuiltinType() ? $infoTypes[0]->getClassName() : $infoTypes[0]->getBuiltinType();
                 $isTypeBuiltIn = null === $infoTypes[0]->getClassName();
                 $isTypeNullable = $infoTypes[0]->isNullable();
             } else {
-                $infoType = $type?->getName();
-                $isTypeBuiltIn = $type?->isBuiltin() ?? false;
-                $isTypeNullable = $type?->allowsNull() ?? true;
+                // Otherwise, we can use the ReflectionType to get the Type
+                $infoType = $reflectionType?->getName();
+                $isTypeBuiltIn = $reflectionType?->isBuiltin() ?? false;
+                $isTypeNullable = $reflectionType?->allowsNull() ?? true;
             }
 
             return new LegacyLivePropMetadata(
@@ -115,10 +121,17 @@ class LiveComponentMetadataFactory implements ResetInterface
                 $collectionValueType
             );
         } else {
-            $type = $this->propertyTypeExtractor->getType($className, $property->getName());
+            $infoType = $this->propertyTypeExtractor->getType($className, $property->getName());
 
-            if ($type instanceof UnionType && !$type instanceof NullableType || $type instanceof IntersectionType) {
-                throw new \LogicException(\sprintf('Union or intersection types are not supported for LiveProps. You may want to change the type of property "%s" in "%s".', $propertyName, $className));
+            if ($infoType instanceof CollectionType) {
+                // If it's an "advanced" type (like CollectionType), let's use the PropertyTypeExtractor to get the Type
+                $type = $infoType;
+            } elseif (null !== $reflectionType) {
+                // Otherwise, we can use the TypeResolver to convert the ReflectionType to a Type
+                $type = $this->typeResolver->resolve($reflectionType);
+            } else {
+                // If no type is available, we default to mixed
+                $type = Type::mixed();
             }
 
             return new LivePropMetadata($property->getName(), $liveProp, $type);

--- a/src/LiveComponent/tests/Fixtures/Component/FormWithUserInterfaceComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/FormWithUserInterfaceComponent.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormInterface;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\ComponentWithFormTrait;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\User;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Form\UserFormType;
+
+#[AsLiveComponent('form_with_user_interface', template: 'components/form_with_user_interface.html.twig')]
+class FormWithUserInterfaceComponent extends AbstractController
+{
+    use ComponentWithFormTrait;
+    use DefaultActionTrait;
+
+    #[LiveProp]
+    public User $user;
+
+    protected function instantiateForm(): FormInterface
+    {
+        return $this->createForm(UserFormType::class, $this->user);
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Entity/User.php
+++ b/src/LiveComponent/tests/Fixtures/Entity/User.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+#[ORM\Entity]
+class User implements UserInterface
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    public $id;
+
+    #[ORM\Column(type: 'string', length: 180, unique: true)]
+    public $username;
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function eraseCredentials(): void
+    {
+        // no-op
+    }
+
+    public function getUsername(): string
+    {
+        return $this->getUserIdentifier();
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getPassword(): ?string
+    {
+        return null;
+    }
+
+    public function getSalt(): ?string
+    {
+        return null;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/Form/UserFormType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/UserFormType.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\User;
+
+class UserFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('username', TextType::class)
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/form_with_user_interface.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/form_with_user_interface.html.twig
@@ -1,0 +1,3 @@
+<div{{ attributes }}>
+    {{ form(form) }}
+</div>

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -15,12 +15,16 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Component\FormWithCollectionTypeComponent;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\User;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Factory\CategoryFixtureEntityFactory;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Form\BlogPostFormType;
 use Symfony\UX\LiveComponent\Tests\LiveComponentTestHelper;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
+
+use function Zenstruck\Foundry\Persistence\persist;
+use function Zenstruck\Foundry\Persistence\refresh;
 
 /**
  * @author Jakub Caban <kuba.iluvatar@gmail.com>
@@ -449,5 +453,39 @@ class ComponentWithFormTest extends KernelTestCase
             ])
             ->assertElementAttributeContains('form', 'data-model', 'on(change)|*')
         ;
+    }
+
+    public function testFormWithLivePropContainingAnEntityImplementingAnInterface(): void
+    {
+        $user = persist(User::class, ['username' => 'Fabien']);
+        self::assertInstanceOf(User::class, $user);
+        self::assertEquals(1, $user->id);
+        self::assertEquals('Fabien', $user->username);
+
+        $mounted = $this->mountComponent('form_with_user_interface', [
+            'user' => $user,
+        ]);
+
+        $dehydrated = $this->dehydrateComponent($mounted)->getProps();
+
+        $this->browser()
+            ->post('/_components/form_with_user_interface', [
+                'body' => [
+                    'data' => json_encode([
+                        'props' => $dehydrated,
+                        'updated' => [
+                            'user_form.username' => 'Nicolas',
+                            'validatedFields' => ['user_form.username'],
+                        ],
+                    ]),
+                ],
+            ])
+            ->assertStatus(200)
+            ->assertElementAttributeContains('form', 'data-model', 'on(change)|*')
+        ;
+
+        refresh($user);
+        self::assertEquals(1, $user->id);
+        self::assertEquals('Nicolas', $user->username);
     }
 }

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -37,6 +37,7 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Embeddable1;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity1;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity2;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\ProductFixtureEntity;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\User;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Enum\EmptyStringEnum;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Enum\IntEnum;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Enum\StringEnum;
@@ -331,6 +332,27 @@ final class LiveComponentHydratorTest extends KernelTestCase
                     self::assertSame(
                         $entity1->id,
                         $object->entity1->id
+                    );
+                })
+            ;
+        }];
+
+        yield 'Persisted entity: (de)hydration works correctly to/from id, when the entity implements an interface' => [function () {
+            $user = persist(User::class, [
+                'username' => 'Fabien',
+            ]);
+            \assert($user instanceof User);
+
+            return HydrationTest::create(new class {
+                #[LiveProp]
+                public User $user;
+            })
+                ->mountWith(['user' => $user])
+                ->assertDehydratesTo(['user' => $user->id])
+                ->assertObjectAfterHydration(function (object $object) use ($user) {
+                    self::assertSame(
+                        $user->id,
+                        $object->user->id
                     );
                 })
             ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #2888 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Prevent:
```
1) Symfony\UX\LiveComponent\Tests\Functional\Form\ComponentWithFormTest::testFormWithLivePropContainingAnEntityImplementingAnInterface
LogicException: Cannot dehydrate value typed as interface "Symfony\UX\LiveComponent\Tests\Fixtures\Entity\User" on component "Symfony\UX\LiveComponent\Tests\Fixtures\Component\FormWithUserInterfaceComponent". Change this to a concrete type that can be dehydrated. Or set the hydrateWith/dehydrateWith options in LiveProp or set "useSerializerForHydration: true" on the LiveProp to use the serializer.
```

Given the LiveComponent:
```php
<?php

/*
 * This file is part of the Symfony package.
 *
 * (c) Fabien Potencier <fabien@symfony.com>
 *
 * For the full copyright and license information, please view the LICENSE
 * file that was distributed with this source code.
 */

namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;

use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\Form\FormInterface;
use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
use Symfony\UX\LiveComponent\Attribute\LiveProp;
use Symfony\UX\LiveComponent\ComponentWithFormTrait;
use Symfony\UX\LiveComponent\DefaultActionTrait;
use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\User;
use Symfony\UX\LiveComponent\Tests\Fixtures\Form\UserFormType;

#[AsLiveComponent('form_with_user_interface', template: 'components/form_with_user_interface.html.twig')]
class FormWithUserInterfaceComponent extends AbstractController
{
    use ComponentWithFormTrait;
    use DefaultActionTrait;

    #[LiveProp]
    public User $user;

    protected function instantiateForm(): FormInterface
    {
        return $this->createForm(UserFormType::class, $this->user);
    }
}

```

Dumping `$propMetadata` in `\Symfony\UX\LiveComponent\LiveComponentHydrator::dehydrateValue` gives: 
```
Symfony\UX\LiveComponent\Metadata\LivePropMetadata {#240
  -name: "user"
  -liveProp: Symfony\UX\LiveComponent\Attribute\LiveProp {#230
    -writable: false
    -hydrateWith: null
    -dehydrateWith: null
    -useSerializerForHydration: false
    -serializationContext: []
    -fieldName: null
    -format: null
    -updateFromParent: false
    -onUpdated: null
    -url: false
    -modifier: null
  }
  -type: Symfony\Component\TypeInfo\Type\NullableType {#4197
    -types: array:2 [
      0 => Symfony\Component\TypeInfo\Type\ObjectType {#5811
        -className: "Symfony\Component\Security\Core\User\UserInterface"
      }
      1 => Symfony\Component\TypeInfo\Type\BuiltinType {#4208
        -typeIdentifier: Symfony\Component\TypeInfo\TypeIdentifier {#5983
          +name: "NULL"
          +value: "null"
        }
      }
    ]
    -type: Symfony\Component\TypeInfo\Type\ObjectType {#5811}
  }
}
```

The class name is the `UserInterface` and not `User` 🤔 

## To tests it

- With PropertyInfo only: `sfcp req symfony/property-info:^6.4 -W && sfp vendor/bin/simple-phpunit tests/Functional/Form/ComponentWithFormTest.php --filter "testFormWithLivePropContainingAnEntityImplementingAnInterface"`
- With PropertyInfo & Type: `sfcp req 'symfony/property-info:7.2.*' 'symfony/type-info:7.2.*' && sfp vendor/bin/simple-phpunit tests/Functional/Form/ComponentWithFormTest.php --filter "testFormWithLivePropContainingAnEntityImplementingAnInterface"`