### PR TITLE
[TwigComponent]: Add the ability to spread attributes from the `...` attribute

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.26.0
+
+-   Add the ability to spread attributes from the `...` attribute
+
 ## 2.25.2
 
 -   Fix `ComponentAttributes` rendering when using `StimulusAttributes` as default attributes

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -26,6 +26,11 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
     private const ALPINE_REGEX = '#^x-([a-z]+):[^:]+$#';
     private const VUE_REGEX = '#^v-([a-z]+):[^:]+$#';
 
+    private const SPREADABLE_ATTRIBUTE = '...';
+
+    /** @var array<string, string|bool> */
+    private array $attributes = [];
+
     /** @var array<string,true> */
     private array $rendered = [];
 
@@ -33,9 +38,10 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
      * @param array<string, string|bool> $attributes
      */
     public function __construct(
-        private array $attributes,
+        array $attributes,
         private readonly EscaperRuntime $escaper,
     ) {
+        $this->attributes = $this->handleAttributes($attributes);
     }
 
     public function __toString(): string
@@ -101,6 +107,31 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
     public function __clone(): void
     {
         $this->rendered = [];
+    }
+
+    private function handleAttributes(array $attributes): array
+    {
+        $spreadAttributes = $attributes[self::SPREADABLE_ATTRIBUTE] ?? null;
+
+        if (!$spreadAttributes) {
+            return $attributes;
+        }
+
+        if ($spreadAttributes instanceof StimulusAttributes) {
+            $spreadAttributes = $spreadAttributes->toArray();
+        }
+
+        if ($spreadAttributes instanceof \Traversable) {
+            $spreadAttributes = iterator_to_array($spreadAttributes);
+        }
+
+        if (!\is_array($spreadAttributes)) {
+            throw new \InvalidArgumentException(\sprintf('The "%s" attribute must be an array, "%s" given.', self::SPREADABLE_ATTRIBUTE, get_debug_type($spreadAttributes)));
+        }
+
+        unset($attributes[self::SPREADABLE_ATTRIBUTE]);
+
+        return [...$attributes, ...$spreadAttributes];
     }
 
     public function render(string $attribute): ?string

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -113,12 +113,6 @@ final class ComponentFactory implements ResetInterface
         $attributes = $data[$attributesVar] ?? [];
         unset($data[$attributesVar]);
 
-        foreach ($data as $key => $value) {
-            if ($value instanceof \Stringable) {
-                $data[$key] = (string) $value;
-            }
-        }
-
         return new MountedComponent(
             $componentMetadata->getName(),
             $component,


### PR DESCRIPTION
[TwigComponent]: Add the ability to spread attributes from the `...` attribute  

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

As a front-end developer working primarily with Twig, I frequently create components that require nested attributes. However, there's currently no way to pass an array of attributes with a prefix.

For example, given a component:

```twig
<twig:Card>[...]</twig:Card>
```

I can currently write:

```twig
<twig:Card {{ ...myAttributes }}>[...]</twig:Card>
```

or:

```twig
<twig:Card attributes="{{ myAttributes }}">[...]</twig:Card>
```

But I **can't** do:

```twig
<twig:Card nested:{{ ...myAttributes }}>[...]</twig:Card>
```

or:

```twig
<twig:Card nested:attributes="{{ myAttributes }}">[...]</twig:Card>
```

That's why I'm proposing support for a new spread-like syntax using `...` to allow passing an array of attributes (`array`, `Traversable`, or `StimulusAttributes`) with a prefix.

### Real-world use case:

I have a Twig extension (`App\Twig\Extension\ConfirmExtension`) that provides a `confirm()` function returning a `StimulusAttributes` object.

I also have a component `<twig:TableRow/>` that contains a delete button.

Currently, I **cannot** write:

```twig
<twig:TableRow btn:{{ ...confirm() }} />
```

With this PR, my proposed syntax would allow the following:

```twig
<twig:TableRow btn:...="{{ confirm() }}" />
```

This improves flexibility and developer experience when working with prefixed dynamic attributes in Twig components.
