### PR TITLE
Explicitly import Vitest APIs instead of relying on globals

### DIFF
--- a/src/Autocomplete/assets/test/controller.test.ts
+++ b/src/Autocomplete/assets/test/controller.test.ts
@@ -11,7 +11,7 @@ import { Application } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import type TomSelect from 'tom-select';
-import { vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import createFetchMock from 'vitest-fetch-mock';
 import AutocompleteController, {
     type AutocompleteConnectOptions,

--- a/src/Chartjs/assets/test/controller.test.ts
+++ b/src/Chartjs/assets/test/controller.test.ts
@@ -9,6 +9,7 @@
 
 import { Application } from '@hotwired/stimulus';
 import { waitFor } from '@testing-library/dom';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import ChartjsController from '../src/controller';
 
 // Kept track of globally, but just used in one test.

--- a/src/Cropperjs/assets/test/controller.test.ts
+++ b/src/Cropperjs/assets/test/controller.test.ts
@@ -9,6 +9,7 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import CropperjsController from '../src/controller';
 

--- a/src/Dropzone/assets/test/controller.test.ts
+++ b/src/Dropzone/assets/test/controller.test.ts
@@ -10,6 +10,7 @@
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import user from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import DropzoneController from '../src/controller';
 

--- a/src/LazyImage/assets/test/controller.test.ts
+++ b/src/LazyImage/assets/test/controller.test.ts
@@ -9,6 +9,7 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import LazyImageController from '../src/controller';
 

--- a/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
+++ b/src/LiveComponent/assets/test/Backend/RequestBuilder.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import RequestBuilder from '../../src/Backend/RequestBuilder';
 
 describe('buildRequest', () => {

--- a/src/LiveComponent/assets/test/Component/index.test.ts
+++ b/src/LiveComponent/assets/test/Component/index.test.ts
@@ -1,5 +1,6 @@
 import { waitFor } from '@testing-library/dom';
 import { Response } from 'node-fetch';
+import { describe, expect, it } from 'vitest';
 import type { BackendAction, BackendInterface } from '../../src/Backend/Backend';
 import BackendRequest from '../../src/Backend/BackendRequest';
 import type BackendResponse from '../../src/Backend/BackendResponse';
@@ -13,7 +14,7 @@ interface MockBackend extends BackendInterface {
 const makeTestComponent = (): { component: Component; backend: MockBackend } => {
     const backend: MockBackend = {
         actions: [],
-        makeRequest(data: any, actions: BackendAction[]): BackendRequest {
+        makeRequest(_data: any, actions: BackendAction[]): BackendRequest {
             this.actions = actions;
 
             return new BackendRequest(

--- a/src/LiveComponent/assets/test/ComponentRegistry.test.ts
+++ b/src/LiveComponent/assets/test/ComponentRegistry.test.ts
@@ -1,4 +1,5 @@
 import { Response } from 'node-fetch';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { BackendInterface } from '../src/Backend/Backend';
 import BackendRequest from '../src/Backend/BackendRequest';
 import Component from '../src/Component';

--- a/src/LiveComponent/assets/test/Directive/directives_parser.test.ts
+++ b/src/LiveComponent/assets/test/Directive/directives_parser.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { type Directive, parseDirectives } from '../../src/Directive/directives_parser';
 
 const assertDirectiveEquals = (actual: Directive, expected: any) => {

--- a/src/LiveComponent/assets/test/Directive/get_model_binding.test.ts
+++ b/src/LiveComponent/assets/test/Directive/get_model_binding.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { parseDirectives } from '../../src/Directive/directives_parser';
 import getModelBinding from '../../src/Directive/get_model_binding';
 

--- a/src/LiveComponent/assets/test/Rendering/ChangingItemsTracker.test.ts
+++ b/src/LiveComponent/assets/test/Rendering/ChangingItemsTracker.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import ChangingItemsTracker from '../../src/Rendering/ChangingItemsTracker';
 
 describe('ChangingItemsTracker', () => {

--- a/src/LiveComponent/assets/test/Rendering/ElementChanges.test.ts
+++ b/src/LiveComponent/assets/test/Rendering/ElementChanges.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import ElementChanges from '../../src/Rendering/ElementChanges';
 
 describe('ElementChanges', () => {

--- a/src/LiveComponent/assets/test/Rendering/ExternalMutationTracker.test.ts
+++ b/src/LiveComponent/assets/test/Rendering/ExternalMutationTracker.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { htmlToElement } from '../../src/dom_utils';
 import ExternalMutationTracker from '../../src/Rendering/ExternalMutationTracker';
 

--- a/src/LiveComponent/assets/test/UnsyncedInputContainer.test.ts
+++ b/src/LiveComponent/assets/test/UnsyncedInputContainer.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { UnsyncedInputContainer } from '../src/Component/UnsyncedInputsTracker';
 import { htmlToElement } from '../src/dom_utils';
 

--- a/src/LiveComponent/assets/test/Util/getElementAsTagText.test.ts
+++ b/src/LiveComponent/assets/test/Util/getElementAsTagText.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { htmlToElement } from '../../src/dom_utils';
 import getElementAsTagText from '../../src/Util/getElementAsTagText';
 

--- a/src/LiveComponent/assets/test/ValueStore.test.ts
+++ b/src/LiveComponent/assets/test/ValueStore.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import ValueStore from '../src/Component/ValueStore';
 
 describe('ValueStore', () => {

--- a/src/LiveComponent/assets/test/controller/action.test.ts
+++ b/src/LiveComponent/assets/test/controller/action.test.ts
@@ -9,6 +9,7 @@
 
 import { getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createTest, initComponent, shutdownTests } from '../tools';
 
 describe('LiveController Action Tests', () => {

--- a/src/LiveComponent/assets/test/controller/basic.test.ts
+++ b/src/LiveComponent/assets/test/controller/basic.test.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import { afterEach, describe, expect, it } from 'vitest';
 import Component from '../../src/Component';
 import { findComponents } from '../../src/ComponentRegistry';
 import { htmlToElement } from '../../src/dom_utils';

--- a/src/LiveComponent/assets/test/controller/child-model.test.ts
+++ b/src/LiveComponent/assets/test/controller/child-model.test.ts
@@ -9,6 +9,7 @@
 
 import { getByTestId, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createTest, initComponent, shutdownTests } from '../tools';
 
 describe('Component parent -> child data-model binding tests', () => {

--- a/src/LiveComponent/assets/test/controller/child.test.ts
+++ b/src/LiveComponent/assets/test/controller/child.test.ts
@@ -10,6 +10,7 @@
 import { Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
 import { findChildren } from '../../src/ComponentRegistry';
 import {
     createTest,

--- a/src/LiveComponent/assets/test/controller/dispatch-event.test.ts
+++ b/src/LiveComponent/assets/test/controller/dispatch-event.test.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import { afterEach, describe, expect, it } from 'vitest';
 import { createTest, initComponent, shutdownTests } from '../tools';
 
 describe('LiveController Event Dispatching Tests', () => {

--- a/src/LiveComponent/assets/test/controller/emit.test.ts
+++ b/src/LiveComponent/assets/test/controller/emit.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { getByText, waitFor } from '@testing-library/dom';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createTest, initComponent, shutdownTests } from '../tools';
 
 describe('LiveController Emit Tests', () => {

--- a/src/LiveComponent/assets/test/controller/error.test.ts
+++ b/src/LiveComponent/assets/test/controller/error.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { getByText, waitFor } from '@testing-library/dom';
+import { afterEach, describe, expect, it } from 'vitest';
 import type BackendResponse from '../../src/Backend/BackendResponse';
 import { createTest, initComponent, shutdownTests } from '../tools';
 
@@ -108,7 +109,7 @@ describe('LiveController Error Handling', () => {
             .expectActionCalled('save');
 
         let isHookCalled = false;
-        test.component.on('response:error', (backendResponse: BackendResponse, controls) => {
+        test.component.on('response:error', (_backendResponse: BackendResponse, controls) => {
             isHookCalled = true;
             controls.displayError = false;
         });

--- a/src/LiveComponent/assets/test/controller/loading.test.ts
+++ b/src/LiveComponent/assets/test/controller/loading.test.ts
@@ -9,6 +9,7 @@
 
 import { getByTestId, getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createTest, initComponent, shutdownTests } from '../tools';
 
 describe('LiveController data-loading Tests', () => {
@@ -21,7 +22,7 @@ describe('LiveController data-loading Tests', () => {
             { food: 'pizza' },
             (data: any) => `
             <div ${initComponent(data)}>
-                <span>I like: ${data.food}</span> 
+                <span>I like: ${data.food}</span>
                 <span data-loading="show" data-testid="loading-element">Loading...</span>
             </div>
         `
@@ -53,7 +54,7 @@ describe('LiveController data-loading Tests', () => {
             { food: 'pizza' },
             (data: any) => `
             <div ${initComponent(data)} data-loading="addClass(opacity-20)">
-                <span>I like: ${data.food}</span> 
+                <span>I like: ${data.food}</span>
                 <button data-action="live#$render">Re-Render</button>
             </div>
         `
@@ -84,7 +85,7 @@ describe('LiveController data-loading Tests', () => {
         const test = await createTest(
             {},
             (data: any) => `
-            <div ${initComponent(data)}> 
+            <div ${initComponent(data)}>
                 <span data-loading="action(save)|show" data-testid="loading-element">Loading...</span>
 
                 <button data-action="live#action" data-live-action-param="save">Save</button>
@@ -131,7 +132,7 @@ describe('LiveController data-loading Tests', () => {
         const test = await createTest(
             { comments: '', user: { email: '' } },
             (data: any) => `
-            <div ${initComponent(data)}> 
+            <div ${initComponent(data)}>
                 <textarea data-model="comments"></textarea>
                 <span data-loading="model(comments)|show" data-testid="comments-loading">Comments change loading...</span>
 
@@ -185,7 +186,7 @@ describe('LiveController data-loading Tests', () => {
         const test = await createTest(
             {},
             (data: any) => `
-            <div ${initComponent(data)}> 
+            <div ${initComponent(data)}>
                 <span data-loading="action(otherAction)|show" data-testid="loading-element">Loading...</span>
 
                 <button data-action="live#action" data-live-action-param="debounce(50)|save">Save</button>
@@ -215,7 +216,7 @@ describe('LiveController data-loading Tests', () => {
         const test = await createTest(
             {},
             (data: any) => `
-           <div ${initComponent(data)}> 
+           <div ${initComponent(data)}>
                <span data-loading="action(save)|delay(50)|show" data-testid="loading-element">Loading...</span>
 
                <button data-action="live#action" data-live-action-param="save">Save</button>

--- a/src/LiveComponent/assets/test/controller/model.test.ts
+++ b/src/LiveComponent/assets/test/controller/model.test.ts
@@ -9,6 +9,7 @@
 
 import { getByLabelText, getByTestId, getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createTest, initComponent, shutdownTests } from '../tools';
 
 describe('LiveController data-model Tests', () => {

--- a/src/LiveComponent/assets/test/controller/poll.test.ts
+++ b/src/LiveComponent/assets/test/controller/poll.test.ts
@@ -9,6 +9,7 @@
 
 import { waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createTest, initComponent, shutdownTests } from '../tools';
 
 describe('LiveController polling Tests', () => {

--- a/src/LiveComponent/assets/test/controller/query-binding.test.ts
+++ b/src/LiveComponent/assets/test/controller/query-binding.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { getByText, waitFor } from '@testing-library/dom';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createTest, expectCurrentSearch, initComponent, setCurrentSearch, shutdownTests } from '../tools';
 
 describe('LiveController query string binding', () => {

--- a/src/LiveComponent/assets/test/controller/render-with-external-changes.test.ts
+++ b/src/LiveComponent/assets/test/controller/render-with-external-changes.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { getByTestId } from '@testing-library/dom';
+import { afterEach, describe, expect, it } from 'vitest';
 import { htmlToElement } from '../../src/dom_utils';
 import { createTest, initComponent, shutdownTests } from '../tools';
 

--- a/src/LiveComponent/assets/test/controller/render.test.ts
+++ b/src/LiveComponent/assets/test/controller/render.test.ts
@@ -9,6 +9,7 @@
 
 import { getByTestId, getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
 import { htmlToElement } from '../../src/dom_utils';
 import { createTest, initComponent, shutdownTests } from '../tools';
 
@@ -51,7 +52,7 @@ describe('LiveController rendering Tests', () => {
                     We want the first to finish, to see if it overwrites our value
                 -->
                 <textarea data-model="norender|comment">${data.comment}</textarea>
-                
+
                 Title: "${data.title}"
                 Comment: "${data.comment}"
 
@@ -213,7 +214,7 @@ describe('LiveController rendering Tests', () => {
             (data: any) => `
             <div ${initComponent(data)}>
                 <div data-live-ignore>Inside Ignore Name: <span>${data.firstName}</span></div>
-                
+
                 Outside Ignore Name: ${data.firstName}
 
                 <button data-action="live#$render">Reload</button>
@@ -249,7 +250,7 @@ describe('LiveController rendering Tests', () => {
                 <div id="${data.containerId}">
                     <div data-live-ignore>Inside Ignore Name: <span>${data.firstName}</span></div>
                 </div>
-                
+
                 Outside Ignore Name: ${data.firstName}
 
                 <button data-action="live#$render">Reload</button>
@@ -491,8 +492,8 @@ describe('LiveController rendering Tests', () => {
             // correctly delayed, the "first render finish" and "second render
             // start" times could be the same, because no time has passed.
             const sleep = (milliseconds: number) => {
-                const startTime = new Date().getTime();
-                while (new Date().getTime() < startTime + milliseconds);
+                const startTime = Date.now();
+                while (Date.now() < startTime + milliseconds);
             };
             sleep(10);
         });
@@ -585,7 +586,7 @@ describe('LiveController rendering Tests', () => {
                         <option value="2">Two</option>
                         <option value="3">Three</option>
                     </select>
-                    
+
                     <select id="select_option_2">
                         <option value="">Choose option 2</option>
                         <option value="1_1">One - One</option>
@@ -610,7 +611,7 @@ describe('LiveController rendering Tests', () => {
                             <option value="2" selected>Two</option>
                             <option value="3">Three</option>
                         </select>
-                        
+
                         <select id="select_option_2">
                             <option value="">Choose option 2</option>
                             <option value="2_1">Two - One</option>

--- a/src/LiveComponent/assets/test/dom_utils.test.ts
+++ b/src/LiveComponent/assets/test/dom_utils.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import Backend from '../src/Backend/Backend';
 import Component from '../src/Component';
 import ValueStore from '../src/Component/ValueStore';

--- a/src/LiveComponent/assets/test/normalize_attributes_for_comparison.test.ts
+++ b/src/LiveComponent/assets/test/normalize_attributes_for_comparison.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { htmlToElement } from '../src/dom_utils';
 import { normalizeAttributesForComparison } from '../src/normalize_attributes_for_comparison';
 

--- a/src/LiveComponent/assets/test/string_utils.test.ts
+++ b/src/LiveComponent/assets/test/string_utils.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { combineSpacedArray, normalizeModelName } from '../src/string_utils';
 
 describe('combinedSpacedArray', () => {

--- a/src/LiveComponent/assets/test/tools.ts
+++ b/src/LiveComponent/assets/test/tools.ts
@@ -1,6 +1,7 @@
 import { Application } from '@hotwired/stimulus';
 import { waitFor } from '@testing-library/dom';
 import { Response } from 'node-fetch';
+import { expect } from 'vitest';
 import type { BackendAction, BackendInterface, ChildrenFingerprints } from '../src/Backend/Backend';
 import BackendRequest from '../src/Backend/BackendRequest';
 import Component from '../src/Component';

--- a/src/LiveComponent/assets/test/url_utils.test.ts
+++ b/src/LiveComponent/assets/test/url_utils.test.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { HistoryStrategy, UrlUtils } from '../src/url_utils';
 
 describe('url_utils', () => {

--- a/src/Map/assets/test/abstract_map_controller.test.ts
+++ b/src/Map/assets/test/abstract_map_controller.test.ts
@@ -1,5 +1,6 @@
 import { Application } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import AbstractMapController from '../src/abstract_map_controller.ts';
 

--- a/src/Map/src/Bridge/Google/assets/test/map_controller.test.ts
+++ b/src/Map/src/Bridge/Google/assets/test/map_controller.test.ts
@@ -9,17 +9,18 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../../../../test/stimulus-helpers';
 import GoogleController from '../src/map_controller';
 
 // Controller used to check the actual controller was properly booted
 class CheckController extends Controller {
     connect() {
-        this.element.addEventListener('ux:map:pre-connect', (event) => {
+        this.element.addEventListener('ux:map:pre-connect', (_event) => {
             this.element.classList.add('pre-connected');
         });
 
-        this.element.addEventListener('ux:map:connect', (event) => {
+        this.element.addEventListener('ux:map:connect', (_event) => {
             this.element.classList.add('connected');
         });
     }

--- a/src/Map/src/Bridge/Leaflet/assets/test/map_controller.test.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/test/map_controller.test.ts
@@ -9,17 +9,18 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../../../../test/stimulus-helpers';
 import LeafletController from '../src/map_controller';
 
 // Controller used to check the actual controller was properly booted
 class CheckController extends Controller {
     connect() {
-        this.element.addEventListener('ux:map:pre-connect', (event) => {
+        this.element.addEventListener('ux:map:pre-connect', (_event) => {
             this.element.classList.add('pre-connected');
         });
 
-        this.element.addEventListener('ux:map:connect', (event) => {
+        this.element.addEventListener('ux:map:connect', (_event) => {
             this.element.classList.add('connected');
         });
     }

--- a/src/Notify/assets/test/controller.test.ts
+++ b/src/Notify/assets/test/controller.test.ts
@@ -9,7 +9,7 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
-import { vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import NotifyController from '../src/controller';
 

--- a/src/React/assets/test/register_controller.test.tsx
+++ b/src/React/assets/test/register_controller.test.tsx
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { registerReactControllerComponents } from '../src/register_controller';
 // @ts-ignore
 import MyJsxComponent from './fixtures/MyJsxComponent';

--- a/src/React/assets/test/render_controller.test.tsx
+++ b/src/React/assets/test/render_controller.test.tsx
@@ -9,7 +9,7 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
-import React from 'react';
+import { describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import ReactController from '../src/render_controller';
 

--- a/src/StimulusBundle/assets/test/loader.test.ts
+++ b/src/StimulusBundle/assets/test/loader.test.ts
@@ -1,5 +1,6 @@
 import { Application, Controller } from '@hotwired/stimulus';
 import { waitFor } from '@testing-library/dom';
+import { describe, expect, it } from 'vitest';
 // load from dist because the source TypeScript file points directly to controllers.js,
 // which does not actually exist in the source code
 import { loadControllers } from '../dist/loader';

--- a/src/Svelte/assets/test/register_controller.test.ts
+++ b/src/Svelte/assets/test/register_controller.test.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { registerSvelteControllerComponents } from '../src/register_controller';
 import MyComponent from './fixtures/MyComponent.svelte';
 

--- a/src/Svelte/assets/test/render_controller.test.ts
+++ b/src/Svelte/assets/test/render_controller.test.ts
@@ -9,6 +9,7 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
+import { afterEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import SvelteController from '../src/render_controller';
 import MyComponent from './fixtures/MyComponent.svelte';

--- a/src/Swup/assets/test/controller.test.ts
+++ b/src/Swup/assets/test/controller.test.ts
@@ -9,6 +9,7 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
+import { afterEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import SwupController from '../src/controller';
 

--- a/src/TogglePassword/assets/test/controller.test.ts
+++ b/src/TogglePassword/assets/test/controller.test.ts
@@ -10,6 +10,7 @@
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, getByText, waitFor } from '@testing-library/dom';
 import user from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import TogglePasswordController from '../src/controller';
 

--- a/src/Translator/assets/test/formatters/formatter.test.ts
+++ b/src/Translator/assets/test/formatters/formatter.test.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import { describe, expect, test } from 'vitest';
 import { format } from '../../src/formatters/formatter';
 
 describe('Formatter', () => {

--- a/src/Translator/assets/test/formatters/intl-formatter.test.ts
+++ b/src/Translator/assets/test/formatters/intl-formatter.test.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import { describe, expect, test } from 'vitest';
 import { formatIntl } from '../../src/formatters/intl-formatter';
 
 describe('Intl Formatter', () => {

--- a/src/Translator/assets/test/translator.test.ts
+++ b/src/Translator/assets/test/translator.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, test } from 'vitest';
 import {
     getLocale,
     type Message,

--- a/src/Translator/assets/test/utils.test.ts
+++ b/src/Translator/assets/test/utils.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'vitest';
 import { strtr } from '../src/utils';
 
 describe('Utils', () => {

--- a/src/Turbo/assets/test/turbo_controller.test.ts
+++ b/src/Turbo/assets/test/turbo_controller.test.ts
@@ -9,6 +9,7 @@
 
 import { Application } from '@hotwired/stimulus';
 import { getByTestId } from '@testing-library/dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import TurboController from '../src/turbo_controller';
 

--- a/src/Turbo/assets/test/turbo_stream_controller.test.ts
+++ b/src/Turbo/assets/test/turbo_stream_controller.test.ts
@@ -9,7 +9,7 @@
 
 import { Application } from '@hotwired/stimulus';
 import { getByTestId } from '@testing-library/dom';
-import { vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import TurboStreamController from '../src/turbo_stream_controller';
 

--- a/src/Typed/assets/test/controller.test.ts
+++ b/src/Typed/assets/test/controller.test.ts
@@ -9,6 +9,7 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import TypedController from '../src/controller';
 

--- a/src/Vue/assets/test/register_controller.test.ts
+++ b/src/Vue/assets/test/register_controller.test.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { registerVueControllerComponents } from '../src/register_controller';
 import Hello from './fixtures/Hello.vue';
 import Goodbye from './fixtures-lazy/Goodbye.vue';

--- a/src/Vue/assets/test/render_controller.test.ts
+++ b/src/Vue/assets/test/render_controller.test.ts
@@ -9,6 +9,7 @@
 
 import { Application, Controller } from '@hotwired/stimulus';
 import { getByTestId, waitFor } from '@testing-library/dom';
+import { describe, expect, it } from 'vitest';
 import { clearDOM, mountDOM } from '../../../../test/stimulus-helpers';
 import VueController from '../src/render_controller';
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -7,4 +7,4 @@
  * file that was distributed with this source code.
  */
 
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "module": "esnext",
         "moduleResolution": "node",
         "resolveJsonModule": true,
-        "types": ["vitest/globals", "@testing-library/jest-dom"]
+        "types": ["@testing-library/jest-dom"]
     },
     "include": ["bin/**/*.ts"]
 }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -3,7 +3,6 @@ import path from 'path';
 
 export default defineConfig({
     test: {
-        globals: true,
         environment: 'jsdom',
         setupFiles: [path.join(__dirname, 'test', 'setup.js')],
         coverage: {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Purely internal.

With Vitest, it is "recommended" to not use globals ([disabled by default](https://vitest.dev/config/#globals)) and instead relying on explicit `import`.

Even if it means to add more code in the codebase, “Explicit is better than implicit”, and global types definitions can be a mess sometimes.