### PR TITLE
[Map] Replace deprecation Vitest option `browser.name` to `browser.instances`

### DIFF
--- a/src/Map/src/Bridge/Google/assets/vitest.config.mjs
+++ b/src/Map/src/Bridge/Google/assets/vitest.config.mjs
@@ -21,7 +21,7 @@ export default mergeConfig(
             browser: {
                 enabled: true,
                 provider: 'playwright', // or 'webdriverio'
-                name: 'chromium', // browser name is required
+                instances: [{ browser: 'chromium' }],
                 headless: true,
             },
         },

--- a/src/Map/src/Bridge/Leaflet/assets/vitest.config.mjs
+++ b/src/Map/src/Bridge/Leaflet/assets/vitest.config.mjs
@@ -22,7 +22,7 @@ export default mergeConfig(
             browser: {
                 enabled: true,
                 provider: 'playwright', // or 'webdriverio'
-                name: 'chromium', // browser name is required
+                instances: [{ browser: 'chromium' }],
                 headless: true,
             },
         },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

I saw this in our CI:
> src/Map/src/Bridge/Leaflet/assets test:  Vitest  No browser "instances" were defined. Running tests in "chromium" browser. The "browser.name" field is deprecated since Vitest 3. Read more: https://vitest.dev/guide/browser/config#browser-instances

https://vitest.dev/guide/browser/config.html#browser-name
