### PR TITLE
[LiveComponent] Fix LiveUrlSubscriber throw `MethodNotAllowed` 

### DIFF
--- a/src/LiveComponent/src/Util/UrlFactory.php
+++ b/src/LiveComponent/src/Util/UrlFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\LiveComponent\Util;
 
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouterInterface;
@@ -43,7 +44,7 @@ class UrlFactory
 
         try {
             $newUrl = $this->createPath($previousUrl, $pathMappedProps);
-        } catch (ResourceNotFoundException|MissingMandatoryParametersException) {
+        } catch (ResourceNotFoundException|MethodNotAllowedException|MissingMandatoryParametersException) {
             return null;
         }
 

--- a/src/LiveComponent/tests/Unit/Util/UrlFactoryTest.php
+++ b/src/LiveComponent/tests/Unit/Util/UrlFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\LiveComponent\Tests\Unit\Util;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouterInterface;
@@ -135,6 +136,19 @@ class UrlFactoryTest extends TestCase
             ->method('match')
             ->with($previousUrl)
             ->willThrowException(new ResourceNotFoundException());
+        $factory = new UrlFactory($router);
+
+        $this->assertNull($factory->createFromPreviousAndProps($previousUrl, [], []));
+    }
+
+    public function testMethodNotAllowedException()
+    {
+        $previousUrl = '/foo/bar';
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('match')
+            ->with($previousUrl)
+            ->willThrowException(new MethodNotAllowedException(['GET']));
         $factory = new UrlFactory($router);
 
         $this->assertNull($factory->createFromPreviousAndProps($previousUrl, [], []));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #2960
| License       | MIT

> [!WARNING]
> Not sure this is enough, but If anyone wants to build on it, feel free - wont be around tomorrow.

---

The new LiveUrlSubscriber calls the Router to match the previous Url.

At that instant, the RoutingContext is most of the time in POST, and so calling router->match($previousUrl) would throw a MethodNotAllowedException

---

Most recent commit ([Catch MethodNotAllowedException](https://github.com/symfony/ux/commit/1da8a7bc2c785a59f2dce822a19b4bce21f7c196)) fixes _**this**_ issue ... but I think we have probably other use cases where it would not work.


My previous commit (reverted in the current state) [Force RequestsContext to "GET"](https://github.com/symfony/ux/commit/e81aad2e65138f8c2a5e6340d1c18ff3a8e4abbc) seems a more promising lead.

And the first one (reverted too in current state) [No LiveProps no change](https://github.com/symfony/ux/commit/1da8a7bc2c785a59f2dce822a19b4bce21f7c196)  was to avoid entirely the generation when no props were extracted from URL... sadly i don't think it's enough to say "no props should now be used in URL".. ? 


---

Thank you @zacharylund  for the investigation and @jmsche for the perfect reproducer