### PR TITLE
[LiveComponent] Fix `#[LiveProp(writable: true, url: true)]` that was not updated as a query parameter

### DIFF
--- a/src/LiveComponent/src/Util/UrlFactory.php
+++ b/src/LiveComponent/src/Util/UrlFactory.php
@@ -36,14 +36,8 @@ class UrlFactory
             return null;
         }
 
-        // Make sure to handle only path and query
-        $previousUrl = $parsed['path'] ?? '';
-        if (isset($parsed['query'])) {
-            $previousUrl .= '?'.$parsed['query'];
-        }
-
         try {
-            $newUrl = $this->createPath($previousUrl, $pathMappedProps);
+            $newUrl = $this->createPath($parsed['path'] ?? '', $pathMappedProps);
         } catch (ResourceNotFoundException|MethodNotAllowedException|MissingMandatoryParametersException) {
             return null;
         }
@@ -60,10 +54,27 @@ class UrlFactory
 
     private function createPath(string $previousUrl, array $props): string
     {
-        return $this->router->generate(
-            $this->router->match($previousUrl)['_route'] ?? '',
+        $newPath = $this->router->generate(
+            $this->matchRoute($previousUrl),
             $props
         );
+
+        return $newPath;
+    }
+
+    private function matchRoute(string $previousUrl): string
+    {
+        $context = $this->router->getContext();
+        $tmpContext = clone $context;
+        $tmpContext->setMethod('GET');
+        $this->router->setContext($tmpContext);
+        try {
+            $match = $this->router->match($previousUrl);
+        } finally {
+            $this->router->setContext($context);
+        }
+
+        return $match['_route'] ?? '';
     }
 
     private function replaceQueryString($url, array $props): string

--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -217,7 +217,7 @@ final class Kernel extends BaseKernel
         $routes->add('homepage', '/')->controller('kernel::index');
         $routes->add('alternate_live_route', '/alt/{_live_component}/{_live_action}')->defaults(['_live_action' => 'get']);
         $routes->add('localized_route', '/locale/{_locale}/{_live_component}/{_live_action}')->defaults(['_live_action' => 'get']);
-        $routes->add('route_with_prop', '/route_with_prop/{pathProp}');
+        $routes->add('route_with_prop', '/route_with_prop/{pathProp}')->methods(['GET']);
         $routes->add('route_with_alias_prop', '/route_with_alias_prop/{pathAlias}');
     }
 }

--- a/src/LiveComponent/tests/Unit/Util/UrlFactoryTest.php
+++ b/src/LiveComponent/tests/Unit/Util/UrlFactoryTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\UX\LiveComponent\Util\UrlFactory;
 
@@ -40,10 +41,10 @@ class UrlFactoryTest extends TestCase
 
         yield 'keep_url_with_query_parameters' => [
             'input' => ['previousUrl' => 'https://symfony.com/foo/bar?prop1=val1&prop2=val2'],
-            '/foo/bar?prop1=val1&prop2=val2',
+            'expectedUrl' => '/foo/bar?prop1=val1&prop2=val2',
             'routerStubData' => [
-                'previousUrl' => '/foo/bar?prop1=val1&prop2=val2',
-                'newUrl' => '/foo/bar?prop1=val1&prop2=val2',
+                'previousUrl' => '/foo/bar',
+                'newUrl' => '/foo/bar',
             ],
         ];
 
@@ -61,6 +62,10 @@ class UrlFactoryTest extends TestCase
                 'queryMappedProps' => ['prop1' => 'val1', 'prop2' => 'val2'],
             ],
             'expectedUrl' => '/foo/bar?prop1=val1&prop3=oldValue&prop2=val2',
+            'routerStubData' => [
+                'previousUrl' => '/foo/bar',
+                'newUrl' => '/foo/bar',
+            ],
         ];
 
         yield 'add_path_parameters' => [
@@ -178,7 +183,13 @@ class UrlFactoryTest extends TestCase
         array $props = [],
     ): RouterInterface {
         $matchedRoute = 'default';
+        $context = $this->createMock(RequestContext::class);
         $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('getContext')
+            ->willReturn($context);
+        $router->expects(self::exactly(2))
+            ->method('setContext');
         $router->expects(self::once())
             ->method('match')
             ->with($previousUrl)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2960 Fix #2975
| License       | MIT

Follows https://github.com/symfony/ux/pull/2673

Hi,
The LiveUrl feature in 2.28 introduced a few bugs and I would like to fix some :

* The symfony matcher uses the current method to find the route. The UrlFactory must temporarily replace it by a GET. Will fix the MethodNotAllowedException bug of #2960 #2975 
* The symfony matcher should not be given the query, only the path.
