### PR TITLE
[Vue] Update dev dependency `@vitejs/plugin-vue`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,8 +711,8 @@ importers:
         specifier: ^1.16
         version: 1.18.8
       '@vitejs/plugin-vue':
-        specifier: ^4.4.0
-        version: 4.6.2(vite@5.4.19(@types/node@22.16.5)(lightningcss@1.30.1)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))
+        specifier: ^6.0.0
+        version: 6.0.1(vite@5.4.19(@types/node@22.16.5)(lightningcss@1.30.1)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -1336,6 +1336,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
+  '@rolldown/pluginutils@1.0.0-beta.29':
+    resolution: {integrity: sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==}
+
   '@rollup/rollup-android-arm-eabi@4.45.1':
     resolution: {integrity: sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==}
     cpu: [arm]
@@ -1596,11 +1599,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitejs/plugin-vue@4.6.2':
-    resolution: {integrity: sha512-kqf7SGFoG+80aZG6Pf+gsZIVvGSCKE98JbiWqcCV9cThtg91Jav0yvYFC9Zb+jKetNGF6ZKeoaxgZfND21fWKw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  '@vitejs/plugin-vue@6.0.1':
+    resolution: {integrity: sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.0.0 || ^5.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.2.25
 
   '@vitest/browser@3.2.4':
@@ -3445,6 +3448,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+  '@rolldown/pluginutils@1.0.0-beta.29': {}
+
   '@rollup/rollup-android-arm-eabi@4.45.1':
     optional: true
 
@@ -3712,8 +3717,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@4.6.2(vite@5.4.19(@types/node@22.16.5)(lightningcss@1.30.1)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@5.4.19(@types/node@22.16.5)(lightningcss@1.30.1)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 5.4.19(@types/node@22.16.5)(lightningcss@1.30.1)(terser@5.43.1)
       vue: 3.5.17(typescript@5.8.3)
 

--- a/src/Vue/assets/package.json
+++ b/src/Vue/assets/package.json
@@ -49,7 +49,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/user-event": "^14.6.1",
         "@types/webpack-env": "^1.16",
-        "@vitejs/plugin-vue": "^4.4.0",
+        "@vitejs/plugin-vue": "^6.0.0",
         "jsdom": "^26.1.0",
         "tslib": "^2.8.1",
         "tsx": "^4.20.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | no
| License       | MIT

esbuild 0.21.5 require by vite 5.4.19, require by plugin-vue 4.6.2 contains security vulnerabilities

It's necessary to upgrade to esbuild to 0.25.0+, so plugin-vue must be in 5.1.5+ in order to have vite 6+ which is the first version that require esbuild 0.25.0+

It's a recurring dependabot alerts for me, example : https://github.com/fastfony/fastfony/security/dependabot/1

<img width="1246" height="722" alt="Capture d’écran 2025-08-06 à 00 03 48" src="https://github.com/user-attachments/assets/3253530c-0dea-4eef-beda-96f1c6e5b437" />


I have tested this upgrade on Fastfony with a fork of ux-vue repo and seems to no BC appears.
