### PR TITLE
[Map] Document `workspace:*` issue with `npm install` and `file:vendor/symfony/ux-*-map/assets`

### DIFF
--- a/src/Map/src/Bridge/Google/README.md
+++ b/src/Map/src/Bridge/Google/README.md
@@ -10,16 +10,35 @@ Install the bridge using Composer and Symfony Flex:
 composer require symfony/ux-google-map
 ```
 
-If you're using WebpackEncore, install your assets and restart Encore (not
-needed if you're using AssetMapper):
+If you're using WebpackEncore, install your assets with a JavaScript packages manager that supports `workspace:` protocol
+like [pnpm](https://pnpm.io/) or [Yarn](https://yarnpkg.com/), and restart Encore (not needed if you're using AssetMapper):
 
 ```shell
-npm install --force
-npm run watch
+# with pnpm
+pnpm install --force
+pnpm run watch
+
+# or with Yarn
+yarn install --force
+yarn run watch
 ```
 
 > [!NOTE]
 > Alternatively, [@symfony/ux-google-map package](https://www.npmjs.com/package/@symfony/ux-google-map) can be used to install the JavaScript assets without requiring PHP.
+
+> [!IMPORTANT]
+> **Q: Why can't I use `npm` to install dependency from `vendor:symfony/ux-google-map`? What is `workspace:` protocol?**
+>
+> Internally, UX Google Map uses the [pnpm's workspace feature](https://pnpm.io/workspaces) to reference `@symfony/ux-map` package as a **development** dependency.
+>
+> When running `npm install` with `"@symfony/ux-google-map": "file:vendor/symfony/ux-google-map/assets"` in your `package.json`, npm is not smart enough to ignore the `devDependencies` section from `vendor/symfony/ux-google-map/assets/package.json` file, leading to the following error:
+> ```
+> npm error code EUNSUPPORTEDPROTOCOL
+> npm error Unsupported URL Type "workspace:": workspace:*
+> ```
+> To fix this, we can recommend you to use a better JavaScript package manager like [pnpm](https://pnpm.io/) or [Yarn](https://yarnpkg.com/), which supports `workspace` protocol.
+>
+> Related issues: https://github.com/symfony/ux/issues/2737, https://github.com/symfony/ux/issues/2951
 
 ## DSN example
 

--- a/src/Map/src/Bridge/Leaflet/README.md
+++ b/src/Map/src/Bridge/Leaflet/README.md
@@ -10,16 +10,35 @@ Install the bridge using Composer and Symfony Flex:
 composer require symfony/ux-leaflet-map
 ```
 
-If you're using WebpackEncore, install your assets and restart Encore (not
-needed if you're using AssetMapper):
+If you're using WebpackEncore, install your assets with a JavaScript packages manager that supports `workspace:` protocol
+like [pnpm](https://pnpm.io/) or [Yarn](https://yarnpkg.com/), and restart Encore (not needed if you're using AssetMapper):
 
 ```shell
-npm install --force
-npm run watch
+# with pnpm
+pnpm install --force
+pnpm run watch
+
+# or with Yarn
+yarn install --force
+yarn run watch
 ```
 
 > [!NOTE]
 > Alternatively, [@symfony/ux-leaflet-map package](https://www.npmjs.com/package/@symfony/ux-leaflet-map) can be used to install the JavaScript assets without requiring PHP.
+
+> [!IMPORTANT]
+> **Q: Why can't I use `npm` to install dependency from `vendor:symfony/ux-leaflet-map`? What is `workspace:` protocol?**
+>
+> Internally, UX Leaflet Map uses the [pnpm's workspace feature](https://pnpm.io/workspaces) to reference `@symfony/ux-map` package as a **development** dependency.
+>
+> When running `npm install` with `"@symfony/ux-leaflet-map": "file:vendor/symfony/ux-leaflet-map/assets"` in your `package.json`, npm is not smart enough to ignore the `devDependencies` section from `vendor/symfony/ux-leaflet-map/assets/package.json` file, leading to the following error:
+> ```
+> npm error code EUNSUPPORTEDPROTOCOL
+> npm error Unsupported URL Type "workspace:": workspace:*
+> ```
+> To fix this, we can recommend you to use a better JavaScript package manager like [pnpm](https://pnpm.io/) or [Yarn](https://yarnpkg.com/), which supports `workspace` protocol.
+>
+> Related issues: https://github.com/symfony/ux/issues/2737, https://github.com/symfony/ux/issues/2951
 
 ## DSN example
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Fix #2951, #2737 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Added some documentation explaining the issue with unsupported protocol `workspace:*` with UX Map bridges, and how to deal with it. 

This is not ideal, but better that nothing for the moment
