### PR TITLE
[Map] Allows Bridges JavaScript assets to be installed with `npm` when using `file:vendor/symfony/ux-*-map/assets`

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -54,27 +54,6 @@ jobs:
             working-directory: test_apps/encore-app
             dependency-versions: highest
 
-        - name: Manually replacing "workspace:*" references
-          run: |
-            # npm does not support "workspace:*" references, so we need to replace them with the actual package path
-            for PACKAGE_DATA in $(pnpm ls -r --json --depth -1 | jq 'map(select(.private != true))' | jq -c '.[]'); do
-              PACKAGE=$(echo $PACKAGE_DATA | jq -r '.name')
-              PACKAGE_PATH=$(echo $PACKAGE_DATA | jq -r '.path')
-
-              echo "🔍 Searching for \"workspace:*\" references in $PACKAGE_PATH/package.json"
-
-              # Manually replace "workspace:" constraints with the actual package version, it ensure packages can be installed with npm
-              jq -rc '[(.dependencies // {}) + (.devDependencies // {}) | to_entries[] | select(.value == "workspace:*") | .key][]' "$PACKAGE_PATH/package.json" | while read -r PACKAGE_FROM_WORKSPACE ; do
-                echo "ℹ️ Found \"$PACKAGE_FROM_WORKSPACE\" with \"workspace:*\""
-
-                PACKAGE_FROM_WORKSPACE_PATH=$(pnpm ls --filter $PACKAGE_FROM_WORKSPACE --json --depth -1 | jq -r '.[].path')
-                echo "ℹ️ The package \"$PACKAGE_FROM_WORKSPACE\" is located in \"$PACKAGE_FROM_WORKSPACE_PATH\" directory"
-
-                echo "⚒️ Replacing \"$PACKAGE_FROM_WORKSPACE\" with \"file:$PACKAGE_FROM_WORKSPACE_PATH\" in $PACKAGE_PATH/package.json"
-                sed -i "s|\"$PACKAGE_FROM_WORKSPACE\": \"workspace:\*\"|\"$PACKAGE_FROM_WORKSPACE\": \"file:$PACKAGE_FROM_WORKSPACE_PATH\"|g" "$PACKAGE_PATH/package.json"
-              done;
-            done
-
         - working-directory: test_apps/encore-app
           run: npm install --install-links
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@swup/plugin>@swup/prettier-config': link:node_modules/.ignored
   '@swup/plugin>@swup/browserslist-config': link:node_modules/.ignored
+  '@swup/plugin>@swup/prettier-config': link:node_modules/.ignored
   '@swup/plugin>microbundle': link:node_modules/.ignored
   '@swup/plugin>prettier': link:node_modules/.ignored
   '@swup/plugin>shelljs': link:node_modules/.ignored
   '@swup/plugin>shelljs-live': link:node_modules/.ignored
+
+packageExtensionsChecksum: sha256-WAjVn6fGcTN4WZY3qf7RaCWK/tjZAB60w1JyC1Mc7SA=
 
 importers:
 
@@ -285,6 +287,10 @@ importers:
         version: 3.2.4(@types/node@22.16.5)(@vitest/browser@3.2.4)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@22.16.5)(typescript@5.8.3))(terser@5.43.1)
 
   src/Map/src/Bridge/Google/assets:
+    dependencies:
+      '@symfony/ux-map':
+        specifier: workspace:*
+        version: link:../../../../assets
     devDependencies:
       '@googlemaps/js-api-loader':
         specifier: ^1.16.6
@@ -292,9 +298,6 @@ importers:
       '@hotwired/stimulus':
         specifier: ^3.0.0
         version: 3.2.2
-      '@symfony/ux-map':
-        specifier: workspace:*
-        version: link:../../../../assets
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -327,13 +330,14 @@ importers:
         version: 3.2.4(@types/node@22.16.5)(@vitest/browser@3.2.4)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@22.16.5)(typescript@5.8.3))(terser@5.43.1)
 
   src/Map/src/Bridge/Leaflet/assets:
+    dependencies:
+      '@symfony/ux-map':
+        specifier: workspace:*
+        version: link:../../../../assets
     devDependencies:
       '@hotwired/stimulus':
         specifier: ^3.0.0
         version: 3.2.2
-      '@symfony/ux-map':
-        specifier: workspace:*
-        version: link:../../../../assets
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,12 @@ overrides:
   '@swup/plugin>prettier': link:node_modules/.ignored
   '@swup/plugin>shelljs': link:node_modules/.ignored
   '@swup/plugin>shelljs-live': link:node_modules/.ignored
+
+packageExtensions:
+    '@symfony/ux-google-map':
+      dependencies:
+        '@symfony/ux-map': 'workspace:*'
+
+    '@symfony/ux-leaflet-map':
+      dependencies:
+        '@symfony/ux-map': 'workspace:*'

--- a/src/Map/src/Bridge/Google/assets/package.json
+++ b/src/Map/src/Bridge/Google/assets/package.json
@@ -50,7 +50,6 @@
     "devDependencies": {
         "@googlemaps/js-api-loader": "^1.16.6",
         "@hotwired/stimulus": "^3.0.0",
-        "@symfony/ux-map": "workspace:*",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/user-event": "^14.6.1",

--- a/src/Map/src/Bridge/Leaflet/assets/package.json
+++ b/src/Map/src/Bridge/Leaflet/assets/package.json
@@ -49,7 +49,6 @@
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "@symfony/ux-map": "workspace:*",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix https://github.com/symfony/ux/issues/2951, https://github.com/symfony/ux/issues/2737 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Alternative to #2982.

Moving the `"@symfony/ux-map": "workspace:*"` requirements **outside the package.json** allows the Bridges JavaScript assets to be installed with `npm` when `@symfony/ux-leaflet-map` (or `@symfony/ux-google-map`) is using constraint version `file:vendor/symfony/ux-leaflet-map/assets` (or `file:vendor/symfony/ux-google-map/assets`) in the user application.

This is possible to this super feature from pnpm: [packageExtensions](https://pnpm.io/settings#packageextensions), which allows to override some part of package definitions in file `pnpm-workspace.yaml`:
- this file is read by pnpm and understand that `@symfony/ux-map` is a dependency of `@symfony/ux-leaflet-map` and `@symfony/ux-google-map` 🎉 
- this file is totally unknown to npm, no `workspace:*` anymore in any `package.json` 🎉 

It is not possible to defines `packageExtensions.devDependencies`, so I used `packageExtensions.dependencies` instead but that's fine. `@symfony/ux-map` is not referenced in any `package.json` when running `pnpm pack` in `src/Bridge/*/assets`.