### PR TITLE
[Pkg] Ensure UX Map assets are built first

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "src/*/src/Bridge/*/assets"
     ],
     "scripts": {
-        "build": "pnpm run -r --aggregate-output build",
+        "build": "pnpm run --filter @symfony/ux-map build && pnpm run -r --aggregate-output build",
         "test": "pnpm run -r --aggregate-output test",
         "check": "biome check",
         "ci": "biome ci"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Since https://github.com/symfony/ux/pull/2983, I'm starting to see some CI jobs that runs `pnpm build` to fail because the topological order is not respected anymore when using `packageExtensions` (I will see if an issue on pnpm exists). 

See https://github.com/symfony/ux/actions/runs/16974598463/job/48120135015?pr=3000 for example:
```
Run pnpm install --frozen-lockfile && pnpm run build
Scope: all 20 workspace projects
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +424
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 424, reused 424, downloaded 0, added 423
Progress: resolved 424, reused 424, downloaded 0, added 424, done

devDependencies:
+ @biomejs/biome 2.1.2
+ @testing-library/dom 10.4.0
+ @testing-library/jest-dom 6.6.3
+ @types/node 22.16.5
+ lightningcss 1.30.1
+ pkg-types 2.2.0
+ playwright 1.54.1
+ tinyglobby 0.2.14
+ tsup 8.5.0
+ vitest 3.2.4

╭ Warning ─────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   Ignored build scripts: core-js-pure, esbuild, msw, swup.                   │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

Done in 1.9s using pnpm v10.13.1

> @2.27.0 build /home/runner/work/ux/ux
> pnpm run -r --aggregate-output build

Scope: 19 of 20 workspace projects
src/Cropperjs/assets build$ tsx ../../../bin/build_package.ts .
src/Cropperjs/assets build: CLI Building entry: src/controller.ts, src/style.css
src/Cropperjs/assets build: CLI Using tsconfig: ../../../tsconfig.packages.json
src/Cropperjs/assets build: CLI tsup v8.5.0
src/Cropperjs/assets build: CLI Target: es2021
src/Cropperjs/assets build: CLI Cleaning output folder
src/Cropperjs/assets build: ESM Build start
src/Cropperjs/assets build: [Symfony UX] Minified CSS file: /home/runner/work/ux/ux/src/Cropperjs/assets/dist/style.css
src/Cropperjs/assets build: [Symfony UX] Renamed dist/style.css to dist/style.min.css
src/Cropperjs/assets build: ESM dist/controller.js 991.00 B
src/Cropperjs/assets build: ESM dist/style.css     32.00 B
src/Cropperjs/assets build: ESM ⚡️ Build success in 116ms
src/Cropperjs/assets build: DTS Build start
src/Cropperjs/assets build: DTS ⚡️ Build success in 3054ms
src/Cropperjs/assets build: DTS dist/controller.d.ts 369.00 B
src/Cropperjs/assets build: Done
src/Dropzone/assets build$ tsx ../../../bin/build_package.ts .
src/Dropzone/assets build: CLI Building entry: src/controller.ts, src/style.css
src/Dropzone/assets build: CLI Using tsconfig: ../../../tsconfig.packages.json
src/Dropzone/assets build: CLI tsup v8.5.0
src/Dropzone/assets build: CLI Target: es2021
src/Dropzone/assets build: CLI Cleaning output folder
src/Dropzone/assets build: ESM Build start
src/Dropzone/assets build: [Symfony UX] Minified CSS file: /home/runner/work/ux/ux/src/Dropzone/assets/dist/style.css
src/Dropzone/assets build: [Symfony UX] Renamed dist/style.css to dist/style.min.css
src/Dropzone/assets build: ESM dist/controller.js 2.92 KB
src/Dropzone/assets build: ESM dist/style.css     943.00 B
src/Dropzone/assets build: ESM ⚡️ Build success in 78ms
src/Dropzone/assets build: DTS Build start
src/Dropzone/assets build: DTS ⚡️ Build success in 3015ms
src/Dropzone/assets build: DTS dist/controller.d.ts 723.00 B
src/Dropzone/assets build: Done
src/Autocomplete/assets build$ tsx ../../../bin/build_package.ts .
src/Autocomplete/assets build: CLI Building entry: src/controller.ts
src/Autocomplete/assets build: CLI Using tsconfig: ../../../tsconfig.packages.json
src/Autocomplete/assets build: CLI tsup v8.5.0
src/Autocomplete/assets build: CLI Target: es2021
src/Autocomplete/assets build: CLI Cleaning output folder
src/Autocomplete/assets build: ESM Build start
src/Autocomplete/assets build: ESM dist/controller.js 14.99 KB
src/Autocomplete/assets build: ESM ⚡️ Build success in 62ms
src/Autocomplete/assets build: DTS Build start
src/Autocomplete/assets build: DTS ⚡️ Build success in 3635ms
src/Autocomplete/assets build: DTS dist/controller.d.ts 1.95 KB
src/Autocomplete/assets build: Done
src/Chartjs/assets build$ tsx ../../../bin/build_package.ts .
src/Chartjs/assets build: CLI Building entry: src/controller.ts
src/Chartjs/assets build: CLI Using tsconfig: ../../../tsconfig.packages.json
src/Chartjs/assets build: CLI tsup v8.5.0
src/Chartjs/assets build: CLI Target: es2021
src/Chartjs/assets build: CLI Cleaning output folder
src/Chartjs/assets build: ESM Build start
src/Chartjs/assets build: ESM dist/controller.js 2.26 KB
src/Chartjs/assets build: ESM ⚡️ Build success in 56ms
src/Chartjs/assets build: DTS Build start
src/Chartjs/assets build: DTS ⚡️ Build success in 3692ms
src/Chartjs/assets build: DTS dist/controller.d.ts 352.00 B
src/Chartjs/assets build: Done
src/Map/src/Bridge/Google/assets build$ tsx ../../../../../../bin/build_package.ts .
src/Map/src/Bridge/Google/assets build: CLI Building entry: src/map_controller.ts
src/Map/src/Bridge/Google/assets build: CLI Using tsconfig: ../../../../../../tsconfig.packages.json
src/Map/src/Bridge/Google/assets build: CLI tsup v8.5.0
src/Map/src/Bridge/Google/assets build: CLI Target: es2021
src/Map/src/Bridge/Google/assets build: CLI Cleaning output folder
src/Map/src/Bridge/Google/assets build: ESM Build start
Error: /src/Bridge/Google/assets build: ✘ [ERROR] Could not resolve "@symfony/ux-map"
src/Map/src/Bridge/Google/assets build:     src/map_controller.ts:24:49:
src/Map/src/Bridge/Google/assets build:       24 │ import AbstractMapController, { IconTypes } from '@symfony/ux-map';
src/Map/src/Bridge/Google/assets build:          ╵                                                  ~~~~~~~~~~~~~~~~~
src/Map/src/Bridge/Google/assets build:   You can mark the path "@symfony/ux-map" as external to exclude it from the bundle, which will remove this error and leave the unresolved path in the bundle.
src/Map/src/Bridge/Google/assets build: ESM Build failed
src/Map/src/Bridge/Google/assets build: /home/runner/work/ux/ux/node_modules/.pnpm/esbuild@0.25.8/node_modules/esbuild/lib/main.js:1467
src/Map/src/Bridge/Google/assets build:   let error = new Error(text);
src/Map/src/Bridge/Google/assets build:               ^
src/Map/src/Bridge/Google/assets build: Error: Build failed with 1 error:
src/Map/src/Bridge/Google/assets build: src/map_controller.ts:24:49: ERROR: Could not resolve "@symfony/ux-map"
src/Map/src/Bridge/Google/assets build:     at failureErrorWithLog (/home/runner/work/ux/ux/node_modules/.pnpm/esbuild@0.25.8/node_modules/esbuild/lib/main.js:1467:15)
src/Map/src/Bridge/Google/assets build:     at /home/runner/work/ux/ux/node_modules/.pnpm/esbuild@0.25.8/node_modules/esbuild/lib/main.js:926:25
src/Map/src/Bridge/Google/assets build:     at runOnEndCallbacks (/home/runner/work/ux/ux/node_modules/.pnpm/esbuild@0.25.8/node_modules/esbuild/lib/main.js:1307:45)
src/Map/src/Bridge/Google/assets build:     at buildResponseToResult (/home/runner/work/ux/ux/node_modules/.pnpm/esbuild@0.25.8/node_modules/esbuild/lib/main.js:924:7)
src/Map/src/Bridge/Google/assets build:     at /home/runner/work/ux/ux/node_modules/.pnpm/esbuild@0.25.8/node_modules/esbuild/lib/main.js:951:16
src/Map/src/Bridge/Google/assets build:     at responseCallbacks.<computed> (/home/runner/work/ux/ux/node_modules/.pnpm/esbuild@0.25.8/node_modules/esbuild/lib/main.js:603:9)
src/Map/src/Bridge/Google/assets build:     at handleIncomingPacket (/home/runner/work/ux/ux/node_modules/.pnpm/esbuild@0.25.8/node_modules/esbuild/lib/main.js:658:12)
src/Map/src/Bridge/Google/assets build:     at Socket.readFromStdout (/home/runner/work/ux/ux/node_modules/.pnpm/esbuild@0.25.8/node_modules/esbuild/lib/main.js:581:7)
src/Map/src/Bridge/Google/assets build:     at Socket.emit (node:events:518:28)
src/Map/src/Bridge/Google/assets build:     at addChunk (node:internal/streams/readable:561:12) {
src/Map/src/Bridge/Google/assets build:   errors: [Getter/Setter],
src/Map/src/Bridge/Google/assets build:   warnings: [Getter/Setter]
src/Map/src/Bridge/Google/assets build: }
src/Map/src/Bridge/Google/assets build: Node.js v22.11.0
src/Map/src/Bridge/Google/assets build: Failed
/home/runner/work/ux/ux/src/Map/src/Bridge/Google/assets:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @symfony/ux-google-map@2.29.1 build: `tsx ../../../../../../bin/build_package.ts .`
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
```

I suggest to modify the `pnpm build` root script to build UX Map assets first.