### PR TITLE
[CI] Fix highest dev jobs

### DIFF
--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -81,6 +81,13 @@ final class Kernel extends BaseKernel
             public function process(ContainerBuilder $container): void
             {
                 $container->removeDefinition('doctrine.orm.listeners.pdo_session_handler_schema_listener');
+
+                if (\PHP_VERSION_ID >= 80400) {
+                    // Workaround for `RuntimeException: Unable to create the Doctrine Proxy directory "". in vendor/symfony/doctrine-bridge/CacheWarmer/ProxyCacheWarmer.php:49`
+                    // when running PHP 8.4 and Doctrine ORM 3.5+.
+                    $container->getDefinition('doctrine.orm.default_configuration')
+                        ->addMethodCall('setProxyDir', ['%doctrine.orm.proxy_dir%']);
+                }
             }
         }, PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
@@ -126,6 +133,9 @@ final class Kernel extends BaseKernel
             ];
         }
         if (null !== $doctrineBundleVersion = InstalledVersions::getVersion('doctrine/doctrine-bundle')) {
+            if (version_compare($doctrineBundleVersion, '2.8.0', '>=')) {
+                $doctrineConfig['orm']['enable_lazy_ghost_objects'] = true;
+            }
             if (\PHP_VERSION_ID >= 80400 && version_compare($doctrineBundleVersion, '2.15.0', '>=')) {
                 $doctrineConfig['orm']['enable_native_lazy_objects'] = true;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Temporary workaround for fixing highest jobs:
```
+ cd src/Autocomplete
+ composer config minimum-stability dev --ansi
+ composer update --no-progress --no-interaction --ansi
Loading composer repositories with package information
Updating dependencies
Lock file operations: 76 installs, 0 updates, 0 removals
  - Locking behat/mink (dev-master 916471d)
  - Locking doctrine/collections (2.4.x-dev 0cc9698)
  - Locking doctrine/dbal (4.4.x-dev 57c983f)
  - Locking doctrine/deprecations (1.1.x-dev fad1854)
  - Locking doctrine/doctrine-bundle (2.16.x-dev 820d574)
  - Locking doctrine/event-manager (2.1.x-dev 5e5da55)
  - Locking doctrine/inflector (2.2.x-dev 6d6c962)
  - Locking doctrine/instantiator (2.0.x-dev 0daa7cf)
  - Locking doctrine/lexer (3.1.x-dev 042e47e)
  - Locking doctrine/orm (3.6.x-dev c1f7a60)
  - Locking doctrine/persistence (4.1.x-dev c392605)
  - Locking doctrine/sql-formatter (1.5.x-dev c894b54)
  - Locking fakerphp/faker (1.24.x-dev f7ac507)
  - Locking masterminds/html5 (2.10.0)
  - Locking mtdowling/jmespath.php (dev-master a2a865e)
  - Locking nikic/php-parser (dev-master f103601)
  - Locking psr/cache (dev-master 588d5ff)
  - Locking psr/clock (1.0.0)
  - Locking psr/container (dev-master 7079847)
  - Locking psr/event-dispatcher (dev-master bbd9eac)
  - Locking psr/log (dev-master f16e1d5)
  - Locking symfony/browser-kit (7.4.x-dev 7f5f0fb)
  - Locking symfony/cache (7.4.x-dev 1b95178)
  - Locking symfony/cache-contracts (dev-main 5d68a57)
  - Locking symfony/clock (8.0.x-dev be52243)
  - Locking symfony/config (7.4.x-dev cd72a1e)
  - Locking symfony/console (7.4.x-dev 0fe6c7f)
  - Locking symfony/css-selector (7.4.x-dev 57500fe)
  - Locking symfony/dependency-injection (7.4.x-dev c1ff387)
  - Locking symfony/deprecation-contracts (dev-main 63afe74)
  - Locking symfony/doctrine-bridge (7.4.x-dev fef1186)
  - Locking symfony/dom-crawler (7.4.x-dev 7b9b135)
  - Locking symfony/error-handler (8.0.x-dev 7540d8d)
  - Locking symfony/event-dispatcher (8.0.x-dev f28a414)
  - Locking symfony/event-dispatcher-contracts (dev-main 59eb412)
  - Locking symfony/filesystem (7.4.x-dev 633c6fd)
  - Locking symfony/finder (7.4.x-dev 57861c3)
  - Locking symfony/form (8.0.x-dev 5320af1)
  - Locking symfony/framework-bundle (7.4.x-dev 11a5ef8)
  - Locking symfony/http-foundation (8.0.x-dev 4f8f710)
  - Locking symfony/http-kernel (7.4.x-dev 2d616d7)
  - Locking symfony/maker-bundle (1.x-dev c86da84)
  - Locking symfony/options-resolver (8.0.x-dev 17b3cb5)
  - Locking symfony/password-hasher (8.0.x-dev 80e7c7e)
  - Locking symfony/phpunit-bridge (8.0.x-dev b77163b)
  - Locking symfony/polyfill-ctype (1.x-dev a3cc8b0)
  - Locking symfony/polyfill-intl-grapheme (1.x-dev 3808721)
  - Locking symfony/polyfill-intl-icu (1.x-dev bfc8fa1)
  - Locking symfony/polyfill-intl-normalizer (1.x-dev 3833d72)
  - Locking symfony/polyfill-mbstring (1.x-dev 6d857f4)
  - Locking symfony/polyfill-php81 (1.x-dev 4a4cfc2)
  - Locking symfony/polyfill-php84 (1.x-dev d8ced4d)
  - Locking symfony/polyfill-php85 (1.x-dev d4e5fcd)
  - Locking symfony/polyfill-uuid (1.x-dev 21533be)
  - Locking symfony/process (7.4.x-dev 410c833)
  - Locking symfony/property-access (8.0.x-dev 74df691)
  - Locking symfony/property-info (8.0.x-dev bde1637)
  - Locking symfony/routing (8.0.x-dev 8d7ffad)
  - Locking symfony/security-bundle (8.0.x-dev db7907a)
  - Locking symfony/security-core (8.0.x-dev 7cc6cd2)
  - Locking symfony/security-csrf (8.0.x-dev 2790fe6)
  - Locking symfony/security-http (8.0.x-dev f99eb69)
  - Locking symfony/service-contracts (dev-main 4511256)
  - Locking symfony/string (8.0.x-dev d7b049d)
  - Locking symfony/translation-contracts (dev-main 65a8bc8)
  - Locking symfony/twig-bridge (8.0.x-dev b068de9)
  - Locking symfony/twig-bundle (8.0.x-dev 5f79218)
  - Locking symfony/type-info (8.0.x-dev cbab7d4)
  - Locking symfony/uid (8.0.x-dev 600055f)
  - Locking symfony/var-dumper (8.0.x-dev f8902df)
  - Locking symfony/var-exporter (7.4.x-dev 2c309a3)
  - Locking twig/twig (3.x-dev b1d2a9c)
  - Locking zenstruck/assert (1.x-dev b9a37a5)
  - Locking zenstruck/browser (1.x-dev 615bed9)
  - Locking zenstruck/callback (1.x-dev 42be837)
  - Locking zenstruck/foundry (2.x-dev 0a65872)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 76 installs, 0 updates, 0 removals
  - Downloading symfony/http-kernel (7.4.x-dev 2d616d7)
  - Downloading symfony/finder (7.4.x-dev 57861c3)
  - Downloading symfony/filesystem (7.4.x-dev 633c6fd)
  - Downloading symfony/var-exporter (7.4.x-dev 2c309a3)
  - Downloading symfony/dependency-injection (7.4.x-dev c1ff387)
  - Downloading symfony/config (7.4.x-dev cd72a1e)
  - Downloading symfony/cache (7.4.x-dev 1b95178)
  - Downloading symfony/framework-bundle (7.4.x-dev 11a5ef8)
  - Downloading doctrine/event-manager (2.1.x-dev 5e5da55)
  - Downloading doctrine/persistence (4.1.x-dev c392605)
  - Downloading symfony/doctrine-bridge (7.4.x-dev fef1186)
  - Downloading doctrine/sql-formatter (1.5.x-dev c894b54)
  - Downloading doctrine/deprecations (1.1.x-dev fad1854)
  - Downloading doctrine/dbal (4.4.x-dev 57c983f)
  - Downloading doctrine/doctrine-bundle (2.16.x-dev 820d574)
  - Downloading doctrine/lexer (3.1.x-dev 042e47e)
  - Downloading doctrine/instantiator (2.0.x-dev 0daa7cf)
  - Downloading doctrine/inflector (2.2.x-dev 6d6c962)
  - Downloading symfony/polyfill-php84 (1.x-dev d8ced4d)
  - Downloading doctrine/collections (2.4.x-dev 0cc9698)
  - Downloading doctrine/orm (3.6.x-dev c1f7a60)
  - Downloading masterminds/html5 (2.10.0)
  - Downloading mtdowling/jmespath.php (dev-master a2a865e)
  - Downloading symfony/process (7.4.x-dev 410c833)
  - Downloading nikic/php-parser (dev-master f103601)
  - Downloading symfony/maker-bundle (1.x-dev c86da84)
  - Downloading symfony/password-hasher (8.0.x-dev 80e7c7e)
  - Downloading symfony/security-core (8.0.x-dev 7cc6cd2)
  - Downloading symfony/security-http (8.0.x-dev f99eb69)
  - Downloading symfony/security-csrf (8.0.x-dev 2790fe6)
  - Downloading symfony/clock (8.0.x-dev be52243)
  - Downloading symfony/security-bundle (8.0.x-dev db7907a)
  - Downloading symfony/polyfill-uuid (1.x-dev 21533be)
  - Downloading symfony/uid (8.0.x-dev 600055f)
  - Downloading zenstruck/callback (1.x-dev 42be837)
  - Downloading zenstruck/assert (1.x-dev b9a37a5)
  - Downloading symfony/dom-crawler (7.4.x-dev 7b9b135)
  - Downloading symfony/css-selector (7.4.x-dev 57500fe)
  - Downloading symfony/browser-kit (7.4.x-dev 7f5f0fb)
  - Downloading behat/mink (dev-master 916471d)
  - Downloading zenstruck/browser (1.x-dev 615bed9)
  - Downloading fakerphp/faker (1.24.x-dev f7ac507)
  - Downloading zenstruck/foundry (2.x-dev 0a65872)
  - Installing symfony/deprecation-contracts (dev-main 63afe74): Extracting archive
  - Installing psr/container (dev-master 7079847): Extracting archive
  - Installing symfony/service-contracts (dev-main 4511256): Extracting archive
  - Installing symfony/routing (8.0.x-dev 8d7ffad): Extracting archive
  - Installing symfony/polyfill-php85 (1.x-dev d4e5fcd): Extracting archive
  - Installing symfony/polyfill-mbstring (1.x-dev 6d857f4): Extracting archive
  - Installing symfony/polyfill-ctype (1.x-dev a3cc8b0): Extracting archive
  - Installing symfony/http-foundation (8.0.x-dev 4f8f710): Extracting archive
  - Installing psr/event-dispatcher (dev-master bbd9eac): Extracting archive
  - Installing symfony/event-dispatcher-contracts (dev-main 59eb412): Extracting archive
  - Installing symfony/event-dispatcher (8.0.x-dev f28a414): Extracting archive
  - Installing symfony/var-dumper (8.0.x-dev f8902df): Extracting archive
  - Installing psr/log (dev-master f16e1d5): Extracting archive
  - Installing symfony/error-handler (8.0.x-dev 7540d8d): Extracting archive
  - Installing symfony/http-kernel (7.4.x-dev 2d616d7): Extracting archive
  - Installing symfony/finder (7.4.x-dev 57861c3): Extracting archive
  - Installing symfony/filesystem (7.4.x-dev 633c6fd): Extracting archive
  - Installing symfony/var-exporter (7.4.x-dev 2c309a3): Extracting archive
  - Installing symfony/dependency-injection (7.4.x-dev c1ff387): Extracting archive
  - Installing symfony/config (7.4.x-dev cd72a1e): Extracting archive
  - Installing psr/cache (dev-master 588d5ff): Extracting archive
  - Installing symfony/cache-contracts (dev-main 5d68a57): Extracting archive
  - Installing symfony/cache (7.4.x-dev 1b95178): Extracting archive
  - Installing symfony/framework-bundle (7.4.x-dev 11a5ef8): Extracting archive
  - Installing doctrine/event-manager (2.1.x-dev 5e5da55): Extracting archive
  - Installing doctrine/persistence (4.1.x-dev c392605): Extracting archive
  - Installing symfony/doctrine-bridge (7.4.x-dev fef1186): Extracting archive
  - Installing symfony/polyfill-intl-normalizer (1.x-dev 3833d72): Extracting archive
  - Installing symfony/polyfill-intl-grapheme (1.x-dev 3808721): Extracting archive
  - Installing symfony/string (8.0.x-dev d7b049d): Extracting archive
  - Installing symfony/console (7.4.x-dev 0fe6c7f): Extracting archive
  - Installing doctrine/sql-formatter (1.5.x-dev c894b54): Extracting archive
  - Installing doctrine/deprecations (1.1.x-dev fad1854): Extracting archive
  - Installing doctrine/dbal (4.4.x-dev 57c983f): Extracting archive
  - Installing doctrine/doctrine-bundle (2.16.x-dev 820d574): Extracting archive
  - Installing doctrine/lexer (3.1.x-dev 042e47e): Extracting archive
  - Installing doctrine/instantiator (2.0.x-dev 0daa7cf): Extracting archive
  - Installing doctrine/inflector (2.2.x-dev 6d6c962): Extracting archive
  - Installing symfony/polyfill-php84 (1.x-dev d8ced4d): Extracting archive
  - Installing doctrine/collections (2.4.x-dev 0cc9698): Extracting archive
  - Installing doctrine/orm (3.6.x-dev c1f7a60): Extracting archive
  - Installing masterminds/html5 (2.10.0): Extracting archive
  - Installing mtdowling/jmespath.php (dev-master a2a865e): Extracting archive
  - Installing psr/clock (1.0.0): Extracting archive
  - Installing symfony/type-info (8.0.x-dev cbab7d4): Extracting archive
  - Installing symfony/property-info (8.0.x-dev bde1637): Extracting archive
  - Installing symfony/property-access (8.0.x-dev 74df691): Extracting archive
  - Installing symfony/polyfill-intl-icu (1.x-dev bfc8fa1): Extracting archive
  - Installing symfony/options-resolver (8.0.x-dev 17b3cb5): Extracting archive
  - Installing symfony/form (8.0.x-dev 5320af1): Extracting archive
  - Installing symfony/process (7.4.x-dev 410c833): Extracting archive
  - Installing nikic/php-parser (dev-master f103601): Extracting archive
  - Installing symfony/maker-bundle (1.x-dev c86da84): Extracting archive
  - Installing symfony/phpunit-bridge (8.0.x-dev b77163b): Extracting archive
  - Installing symfony/polyfill-php81 (1.x-dev 4a4cfc2): Extracting archive
  - Installing symfony/password-hasher (8.0.x-dev 80e7c7e): Extracting archive
  - Installing symfony/security-core (8.0.x-dev 7cc6cd2): Extracting archive
  - Installing symfony/security-http (8.0.x-dev f99eb69): Extracting archive
  - Installing symfony/security-csrf (8.0.x-dev 2790fe6): Extracting archive
  - Installing symfony/clock (8.0.x-dev be52243): Extracting archive
  - Installing symfony/security-bundle (8.0.x-dev db7907a): Extracting archive
  - Installing symfony/translation-contracts (dev-main 65a8bc8): Extracting archive
  - Installing twig/twig (3.x-dev b1d2a9c): Extracting archive
  - Installing symfony/twig-bridge (8.0.x-dev b068de9): Extracting archive
  - Installing symfony/twig-bundle (8.0.x-dev 5f79218): Extracting archive
  - Installing symfony/polyfill-uuid (1.x-dev 21533be): Extracting archive
  - Installing symfony/uid (8.0.x-dev 600055f): Extracting archive
  - Installing zenstruck/callback (1.x-dev 42be837): Extracting archive
  - Installing zenstruck/assert (1.x-dev b9a37a5): Extracting archive
  - Installing symfony/dom-crawler (7.4.x-dev 7b9b135): Extracting archive
  - Installing symfony/css-selector (7.4.x-dev 57500fe): Extracting archive
  - Installing symfony/browser-kit (7.4.x-dev 7f5f0fb): Extracting archive
  - Installing behat/mink (dev-master 916471d): Extracting archive
  - Installing zenstruck/browser (1.x-dev 615bed9): Extracting archive
  - Installing fakerphp/faker (1.24.x-dev f7ac507): Extracting archive
  - Installing zenstruck/foundry (2.x-dev 0a65872): Extracting archive
Generating autoload files
63 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Symfony recipes are disabled: "symfony/flex" not found in the root composer.json

Synchronizing package.json is disabled: "symfony/flex" not found in the root composer.json
+ '[' Autocomplete = LiveComponent ']'
+ vendor/bin/simple-phpunit
No composer.json in current directory, to use the one at /home/runner/work/ux/ux/src/Autocomplete run interactively or set config.use-parent-dir to true
No composer.json found in the current directory, showing available packages from packagist.org
Creating a "phpunit/phpunit" project at "./phpunit-9.6-0"
Installing phpunit/phpunit (9.6.24)
Plugins have been disabled.
  - Installing phpunit/phpunit (9.6.24): Extracting archive
Created project in /home/runner/work/ux/ux/src/Autocomplete/vendor/bin/.phpunit/phpunit-9.6-0
phpspec/prophecy is not required in your composer.json and has not been removed
composer.json has been updated
composer.json has been updated
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 2 updates, 0 removals
  - Upgrading doctrine/instantiator (1.5.0 => 2.0.0)
  - Upgrading nikic/php-parser (v4.19.4 => v5.6.1)
  - Locking symfony/phpunit-bridge (9.6.99)
Writing lock file
Installing dependencies from lock file
Package operations: 28 installs, 0 updates, 0 removals
  - Installing doctrine/instantiator (2.0.0): Extracting archive
  - Installing myclabs/deep-copy (1.13.4): Extracting archive
  - Installing phar-io/version (3.2.1): Extracting archive
  - Installing phar-io/manifest (2.0.4): Extracting archive
  - Installing theseer/tokenizer (1.2.3): Extracting archive
  - Installing sebastian/version (3.0.2): Extracting archive
  - Installing nikic/php-parser (v5.6.1): Extracting archive
  - Installing sebastian/lines-of-code (1.0.4): Extracting archive
  - Installing sebastian/environment (5.1.5): Extracting archive
  - Installing sebastian/complexity (2.0.3): Extracting archive
  - Installing sebastian/code-unit-reverse-lookup (2.0.3): Extracting archive
  - Installing phpunit/php-text-template (2.0.4): Extracting archive
  - Installing phpunit/php-file-iterator (3.0.6): Extracting archive
  - Installing phpunit/php-code-coverage (9.2.32): Extracting archive
  - Installing phpunit/php-invoker (3.1.1): Extracting archive
  - Installing phpunit/php-timer (5.0.3): Extracting archive
  - Installing sebastian/cli-parser (1.0.2): Extracting archive
  - Installing sebastian/code-unit (1.0.8): Extracting archive
  - Installing sebastian/recursion-context (4.0.6): Extracting archive
  - Installing sebastian/exporter (4.0.6): Extracting archive
  - Installing sebastian/diff (4.0.6): Extracting archive
  - Installing sebastian/comparator (4.0.9): Extracting archive
  - Installing sebastian/object-reflector (2.0.4): Extracting archive
  - Installing sebastian/global-state (5.0.8): Extracting archive
  - Installing sebastian/object-enumerator (4.0.4): Extracting archive
  - Installing sebastian/resource-operations (3.0.4): Extracting archive
  - Installing sebastian/type (3.2.1): Extracting archive
  - Installing symfony/phpunit-bridge (9.6.99): Symlinking from ../../../../vendor/symfony/phpunit-bridge
Generating optimized autoload files
25 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Symfony recipes are disabled: "symfony/flex" not found in the root composer.json

Synchronizing package.json is disabled: "symfony/flex" not found in the root composer.json
PHPUnit 9.6.24 by Sebastian Bergmann and contributors.

Testing
ESSSSS......................I...............                      44 / 44 (100%)

Time: 00:12.848, Memory: 62.50 MB

There was 1 error:

1) Symfony\UX\Autocomplete\Tests\Functional\AutocompleteFormRenderingTest::testFieldsRenderWithStimulusController
RuntimeException: Unable to create the Doctrine Proxy directory "". in /home/runner/work/ux/ux/src/Autocomplete/vendor/symfony/doctrine-bridge/CacheWarmer/ProxyCacheWarmer.php:49
Stack trace:
#0 /home/runner/work/ux/ux/src/Autocomplete/vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php(96): Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer->warmUp()
#1 /home/runner/work/ux/ux/src/Autocomplete/vendor/symfony/http-kernel/Kernel.php(546): Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate->warmUp()
#2 /home/runner/work/ux/ux/src/Autocomplete/vendor/symfony/http-kernel/Kernel.php(744): Symfony\Component\HttpKernel\Kernel->initializeContainer()
#3 /home/runner/work/ux/ux/src/Autocomplete/vendor/symfony/http-kernel/Kernel.php(120): Symfony\Component\HttpKernel\Kernel->preBoot()
#4 /home/runner/work/ux/ux/src/Autocomplete/vendor/symfony/framework-bundle/Test/KernelTestCase.php(75): Symfony\Component\HttpKernel\Kernel->boot()
#5 /home/runner/work/ux/ux/src/Autocomplete/vendor/zenstruck/foundry/src/Test/ResetDatabase.php(36): Symfony\Bundle\FrameworkBundle\Test\KernelTestCase::bootKernel()
#6 /home/runner/work/ux/ux/src/Autocomplete/vendor/zenstruck/foundry/src/Persistence/ResetDatabase/ResetDatabaseManager.php(51): Symfony\UX\Autocomplete\Tests\Functional\AutocompleteFormRenderingTest::{closure:Zenstruck\Foundry\Test\ResetDatabase::_resetDatabaseBeforeFirstTest():36}()
#7 /home/runner/work/ux/ux/src/Autocomplete/vendor/zenstruck/foundry/src/Test/ResetDatabase.php(35): Zenstruck\Foundry\Persistence\ResetDatabase\ResetDatabaseManager::resetBeforeFirstTest()
#8 /home/runner/work/ux/ux/src/Autocomplete/vendor/bin/.phpunit/phpunit-9.6-0/src/Framework/TestSuite.php(629): Symfony\UX\Autocomplete\Tests\Functional\AutocompleteFormRenderingTest::_resetDatabaseBeforeFirstTest()
#9 /home/runner/work/ux/ux/src/Autocomplete/vendor/bin/.phpunit/phpunit-9.6-0/src/Framework/TestSuite.php(685): PHPUnit\Framework\TestSuite->run()
#10 /home/runner/work/ux/ux/src/Autocomplete/vendor/bin/.phpunit/phpunit-9.6-0/src/Framework/TestSuite.php(685): PHPUnit\Framework\TestSuite->run()
#11 /home/runner/work/ux/ux/src/Autocomplete/vendor/bin/.phpunit/phpunit-9.6-0/src/TextUI/TestRunner.php(651): PHPUnit\Framework\TestSuite->run()
#12 /home/runner/work/ux/ux/src/Autocomplete/vendor/bin/.phpunit/phpunit-9.6-0/src/TextUI/Command.php(146): PHPUnit\TextUI\TestRunner->run()
#13 /home/runner/work/ux/ux/src/Autocomplete/vendor/bin/.phpunit/phpunit-9.6-0/src/TextUI/Command.php(99): PHPUnit\TextUI\Command->run()
#14 /home/runner/work/ux/ux/src/Autocomplete/vendor/bin/.phpunit/phpunit-9.6-0/phpunit(22): PHPUnit\TextUI\Command::main()
#15 /home/runner/work/ux/ux/src/Autocomplete/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php(461): include('...')
#16 /home/runner/work/ux/ux/src/Autocomplete/vendor/symfony/phpunit-bridge/bin/simple-phpunit(13): require('...')
#17 /home/runner/work/ux/ux/src/Autocomplete/vendor/bin/simple-phpunit(119): include('...')
#18 {main}
ERRORS!
Tests: 44, Assertions: 166, Errors: 1, Skipped: 5, Incomplete: 1.

Remaining indirect deprecation notices (118)

  110x: Class "Doctrine\ORM\Proxy\Autoloader" is deprecated. Use native lazy objects instead. (Autoloader.php:74 called by DoctrineBundle.php:130, https://github.com/doctrine/orm/pull/12005, package doctrine/orm)
    8x in FieldAutocompleterTest::_resetDatabaseBeforeEachTest from Symfony\UX\Autocomplete\Tests\Functional
    7x in CustomAutocompleterTest::_resetDatabaseBeforeEachTest from Symfony\UX\Autocomplete\Tests\Functional
    7x in EntityMetadataTest::_resetDatabaseBeforeEachTest from Symfony\UX\Autocomplete\Tests\Integration\Doctrine
    4x in CustomAutocompleterTest::testItReturnsBasicResults from Symfony\UX\Autocomplete\Tests\Functional
    4x in CustomAutocompleterTest::testItOnlySearchedOnSearchableFields from Symfony\UX\Autocomplete\Tests\Functional
    ...

  2x: Since symfony/framework-bundle 7.3: Not setting the "property_info.with_constructor_extractor" option explicitly is deprecated because its default value will change in version 8.0.
    2x in AutocompleteFormRenderingTest::_resetDatabaseBeforeFirstTest from Symfony\UX\Autocomplete\Tests\Functional

  2x: is_dir(): Passing null to parameter #1 ($filename) of type string is deprecated
    2x in AutocompleteFormRenderingTest::_resetDatabaseBeforeFirstTest from Symfony\UX\Autocomplete\Tests\Functional

  1x: Since doctrine/doctrine-bundle 2.13: Enabling the controller resolver automapping feature has been deprecated. Symfony Mapped Route Parameters should be used as replacement.
    1x in AutocompleteFormRenderingTest::_resetDatabaseBeforeFirstTest from Symfony\UX\Autocomplete\Tests\Functional

  1x: Since zenstruck/foundry 2.5: Not setting "zenstruck_foundry.persistence.flush_once" to true is deprecated. This option will be forced to true in 3.0
    1x in AutocompleteFormRenderingTest::_resetDatabaseBeforeFirstTest from Symfony\UX\Autocomplete\Tests\Functional

  1x: Calling Doctrine\ORM\Configuration::getProxyDir is deprecated and will not be possible in Doctrine ORM 4.0. (Configuration.php:85 called by ProxyCacheWarmer.php:47, https://github.com/doctrine/orm/pull/12005, package doctrine/orm)
    1x in AutocompleteFormRenderingTest::_resetDatabaseBeforeFirstTest from Symfony\UX\Autocomplete\Tests\Functional

  1x: mkdir(): Passing null to parameter #1 ($directory) of type string is deprecated
    1x in AutocompleteFormRenderingTest::_resetDatabaseBeforeFirstTest from Symfony\UX\Autocomplete\Tests\Functional
Job exited with: 2

Error: KO Autocomplete
```

_Caused_ by:
- https://github.com/symfony/doctrine-bridge/blob/0174ad0/CacheWarmer/ProxyCacheWarmer.php#L47-L50
- https://github.com/doctrine/DoctrineBundle/blob/3a854f8/src/DependencyInjection/DoctrineExtension.php#L705-L717

cc @Kbond @derrabus