### PR TITLE
[React] Fix importmap to require `react-dom/client`

### DIFF
--- a/src/React/assets/package.json
+++ b/src/React/assets/package.json
@@ -35,7 +35,7 @@
         "importmap": {
             "@hotwired/stimulus": "^3.0.0",
             "react": "^18.0",
-            "react-dom": "^18.0",
+            "react-dom/client": "^18.0",
             "@symfony/ux-react": "path:%PACKAGE%/dist/loader.js"
         }
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Following #2944, where the code changed from `import require$$0 from 'react-dom';` to `import { createRoot } from "react-dom/client";`.

I forgot to update the `importmap` entry and add `react-dom/client` dependency.
