### PR TITLE
[Map][Leaflet] Fix InfoWindow auto-opening

### DIFF
--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
@@ -307,7 +307,7 @@ var map_controller_default = class extends abstract_map_controller_default {
       if (autoClose) {
         this.closePopups();
       }
-      element.openPopup();
+      setTimeout(() => element.openPopup(), 0);
     }
     const popup = element.getPopup();
     if (!popup) {

--- a/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
@@ -266,7 +266,7 @@ export default class extends AbstractMapController<
                 this.closePopups();
             }
 
-            element.openPopup();
+            setTimeout(() => element.openPopup(), 0);
         }
 
         const popup = element.getPopup();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

While writing E2E tests for UX Map, I noticed that I wasn't able to automatically open an InfoWindow (Popup) when using Leaflet, with `opened: true`


<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
