### PR TITLE
[Icons] Fallback to default dimensions 16/16 when Icon's dimensions on Iconify are missing

### DIFF
--- a/src/Icons/src/Iconify.php
+++ b/src/Icons/src/Iconify.php
@@ -34,6 +34,10 @@ final class Iconify
     // -safe margin
     private const MAX_ICONS_QUERY_LENGTH = 400;
 
+    // https://github.com/iconify/iconify/blob/00cc144b040b838bd86474ab83f0e50e6c6a12a1/packages/utils/src/icon/defaults.ts#L23-L30
+    private const DEFAULT_ICON_WIDTH = 16;
+    private const DEFAULT_ICON_HEIGHT = 16;
+
     private HttpClientInterface $http;
     private \ArrayObject $sets;
     private int $maxIconsQueryLength;
@@ -81,13 +85,10 @@ final class Iconify
 
         $height = $data['icons'][$name]['height'] ?? $data['height'] ?? $this->sets()[$prefix]['height'] ?? null;
         $width = $data['icons'][$name]['width'] ?? $data['width'] ?? $this->sets()[$prefix]['width'] ?? null;
-        if (null === $width && null === $height) {
-            throw new \RuntimeException(\sprintf('The icon "%s:%s" does not have a width or height.', $prefix, $nameArg));
-        }
 
         return new Icon($data['icons'][$name]['body'], [
             'xmlns' => self::ATTR_XMLNS_URL,
-            'viewBox' => \sprintf('0 0 %s %s', $width ?? $height, $height ?? $width),
+            'viewBox' => \sprintf('0 0 %s %s', $width ?? $height ?? self::DEFAULT_ICON_WIDTH, $height ?? $width ?? self::DEFAULT_ICON_HEIGHT),
         ]);
     }
 
@@ -135,7 +136,7 @@ final class Iconify
 
             $icons[$iconName] = new Icon($iconData['body'], [
                 'xmlns' => self::ATTR_XMLNS_URL,
-                'viewBox' => \sprintf('0 0 %d %d', $width ?? $height, $height ?? $width),
+                'viewBox' => \sprintf('0 0 %d %d', $width ?? $height ?? self::DEFAULT_ICON_WIDTH, $height ?? $width ?? self::DEFAULT_ICON_HEIGHT),
             ]);
         }
 

--- a/src/Icons/tests/Unit/IconifyTest.php
+++ b/src/Icons/tests/Unit/IconifyTest.php
@@ -119,7 +119,7 @@ class IconifyTest extends TestCase
         $this->assertEquals('0 0 17 17', $icon->getAttributes()['viewBox']);
     }
 
-    public function testFetchIconThrowsWhenViewBoxCannotBeComputed()
+    public function testFetchIconSetsDefaultViewBoxTo16()
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -138,10 +138,11 @@ class IconifyTest extends TestCase
             ]),
         );
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The icon "bi:heart" does not have a width or height.');
+        $icon = $iconify->fetchIcon('bi', 'heart');
 
-        $iconify->fetchIcon('bi', 'heart');
+        $this->assertIsArray($icon->getAttributes());
+        $this->assertArrayHasKey('viewBox', $icon->getAttributes());
+        $this->assertEquals('0 0 16 16', $icon->getAttributes()['viewBox']);
     }
 
     public function testFetchIconThrowsWhenStatusCodeNot200()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no 
| Issues        | Fix #3016 
| License       | MIT

Set default viewBox size to 0 0 16 16 when not specified in Iconify icon set as per their documentation specifies : https://iconify.design/docs/types/iconify-json.html#icon to avoid exception being thrown when rendering via ux_icon() or <twig:ux:icon /> 