### PR TITLE
[LiveComponent] Fix BC Break when defining `LiveProp` properties with PHPDoc type and no-native type, when using TypeInfo

### DIFF
--- a/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\LiveComponent\Metadata;
 
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
@@ -130,8 +131,12 @@ class LiveComponentMetadataFactory implements ResetInterface
                 // Otherwise, we can use the TypeResolver to convert the ReflectionType to a Type
                 $type = $this->typeResolver->resolve($reflectionType);
             } else {
-                // If no type is available, we default to mixed
-                $type = Type::mixed();
+                try {
+                    $type = $this->typeResolver->resolve($property);
+                } catch (UnsupportedException) {
+                    // If no type is available, we default to mixed
+                    $type = Type::mixed();
+                }
             }
 
             return new LivePropMetadata($property->getName(), $liveProp, $type);

--- a/src/LiveComponent/tests/Fixtures/Dto/DummyUsingPhpDoc.php
+++ b/src/LiveComponent/tests/Fixtures/Dto/DummyUsingPhpDoc.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Dto;
+
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Enum\ColorEnum;
+
+class DummyUsingPhpDoc
+{
+    /**
+     * @var ColorEnum|null
+     */
+    #[LiveProp]
+    public $color;
+}

--- a/src/LiveComponent/tests/Fixtures/Enum/ColorEnum.php
+++ b/src/LiveComponent/tests/Fixtures/Enum/ColorEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Enum;
+
+enum ColorEnum: string
+{
+    case Green = 'green';
+    case Red = 'red';
+}

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -25,6 +25,7 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Component\Component3;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Address;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\BlogPostWithSerializationContext;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\CustomerDetails;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\DummyUsingPhpDoc;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Embeddable2;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\HoldsArrayOfDtos;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Money;
@@ -38,6 +39,7 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity1;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\Entity2;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\ProductFixtureEntity;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\User;
+use Symfony\UX\LiveComponent\Tests\Fixtures\Enum\ColorEnum;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Enum\EmptyStringEnum;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Enum\IntEnum;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Enum\StringEnum;
@@ -1518,6 +1520,22 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 ->assertDehydratesTo(['id' => '01AN4Z07BY79KA1307SR9X4MV3'])
                 ->assertObjectAfterHydration(function (object $object) {
                     self::assertEquals(new Ulid('01AN4Z07BY79KA1307SR9X4MV3'), $object->id);
+                })
+            ;
+        }];
+
+        yield 'Dehydrates correctly with phpdoc typehint' => [function () {
+            $input = new DummyUsingPhpDoc();
+            $input->color = ColorEnum::Green;
+
+            return HydrationTest::create(new class {
+                #[LiveProp]
+                public DummyUsingPhpDoc $input;
+            })
+                ->mountWith(['input' => $input])
+                ->assertDehydratesTo(['input' => ['color' => 'green']])
+                ->assertObjectAfterHydration(function (object $object) {
+                    self::assertEquals(ColorEnum::Green, $object->input->color);
                 })
             ;
         }];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2963
| License       | MIT
