### PR TITLE
 Re-configure LF eof in git

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,9 @@ trim_trailing_whitespace = true
 [*.{php,html,twig}]
 indent_style = space
 indent_size = 4
+
+[*.md]
+max_line_length = 80
+
+[COMMIT_EDITMSG]
+max_line_length = 0

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

I went too quickly in https://github.com/Kocal/symfony-ux/commit/01bea6519d567bf2179044465174f62df0c0ae74 and I removed the whole `.gitattributes` instead of only old related things to Yarn Berry

This should fix the Windows CI (https://github.com/symfony/ux/actions/runs/17148124854/job/48648241720?pr=3038)