### PR TITLE
[LiveComponent] Fix new URL generation when using `LiveProp` with custom `fieldName`

### DIFF
--- a/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
@@ -75,7 +75,7 @@ class LiveComponentMetadata
 
         foreach ($this->getAllLivePropsMetadata($component) as $livePropMetadata) {
             if ($livePropMetadata->urlMapping()) {
-                $urlMappings[$livePropMetadata->getName()] = $livePropMetadata->urlMapping();
+                $urlMappings[$livePropMetadata->calculateFieldName($component, $livePropMetadata->getName())] = $livePropMetadata->urlMapping();
             }
         }
 

--- a/src/LiveComponent/tests/Fixtures/Component/ComponentWithUrlBoundProps.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ComponentWithUrlBoundProps.php
@@ -33,6 +33,12 @@ class ComponentWithUrlBoundProps
     #[LiveProp(url: true)]
     public array $arrayProp = [];
 
+    #[LiveProp(url: new UrlMapping(as: 'arr_alias'))]
+    public array $arrayPropAlias = [];
+
+    #[LiveProp(writable: true, fieldName: 'getArrayFieldName()', url: true)]
+    public array $arrayPropFieldName = [];
+
     #[LiveProp]
     public ?string $unboundProp = null;
 
@@ -112,5 +118,10 @@ class ComponentWithUrlBoundProps
         }
 
         $this->{$propName} = $propValue;
+    }
+
+    public function getArrayFieldName(): string
+    {
+        return 'arr_field_name';
     }
 }

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -144,6 +144,8 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
             'objectPropWithSerializerForHydration' => ['name' => 'objectPropWithSerializerForHydration'],
             'propertyWithModifierAndAlias' => ['name' => 'alias_p'],
             'pathPropForAnotherController' => ['name' => 'pathPropForAnotherController'],
+            'arrayPropAlias' => ['name' => 'arr_alias'],
+            'arr_field_name' => ['name' => 'arr_field_name'],
         ];
 
         $this->assertEquals($expected, $queryMapping);

--- a/src/LiveComponent/tests/Functional/EventListener/LiveUrlSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveUrlSubscriberTest.php
@@ -118,6 +118,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
                 'propValue' => 'bar',
             ],
         ];
+
         yield 'Changes in prop, with two path params but only one prop' => [
             'previousLocation' => '/route_with_two_path_params_but_one_prop/foo/30',
             'expectedLocation' => '/route_with_two_path_params_but_one_prop/bar/30',
@@ -137,6 +138,42 @@ class LiveUrlSubscriberTest extends KernelTestCase
             'args' => [
                 'propName' => 'boundPropWithAlias',
                 'propValue' => 'search term',
+            ],
+        ];
+
+        yield 'Change in query (array)' => [
+            'previousLocation' => '/route_with_prop/foo',
+            'expectedLocation' => '/route_with_prop/foo?arrayProp%5B0%5D=hello&arrayProp%5B1%5D=world',
+            'initialComponentData' => [
+                'pathProp' => 'foo',
+            ],
+            'args' => [
+                'propName' => 'arrayProp',
+                'propValue' => ['hello', 'world'],
+            ],
+        ];
+
+        yield 'Change in query (array & alias)' => [
+            'previousLocation' => '/route_with_prop/foo',
+            'expectedLocation' => '/route_with_prop/foo?arr_alias%5B0%5D=hello&arr_alias%5B1%5D=world',
+            'initialComponentData' => [
+                'pathProp' => 'foo',
+            ],
+            'args' => [
+                'propName' => 'arrayPropAlias',
+                'propValue' => ['hello', 'world'],
+            ],
+        ];
+
+        yield 'Change in query (array & field name)' => [
+            'previousLocation' => '/route_with_prop/foo',
+            'expectedLocation' => '/route_with_prop/foo?arr_field_name%5B0%5D=hello&arr_field_name%5B1%5D=world',
+            'initialComponentData' => [
+                'pathProp' => 'foo',
+            ],
+            'args' => [
+                'propName' => 'arrayPropFieldName',
+                'propValue' => ['hello', 'world'],
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Follows https://github.com/symfony/ux/pull/2673

Related to https://symfony-devs.slack.com/archives/C01FN4EQNLX/p1756395137633869?thread_ts=1756320013.552729&cid=C01FN4EQNLX, I believe this is the ultimate last fix for the `X-Live-Url` generation based on `LiveProp` 😅

I confirm that in <2.28, the URL query params were using the `fieldName` value from `LiveProp` if available, but we missed it (I didn't even know about that, the feature is not documented).