### PR TITLE
[TwigComponent][Perf] Add option to disable the dump of components

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.32
+
+-  Add option `profiler.collect_components` to control component data collection
+   in the profiler (enabled in debug mode by default)
+
 ## 2.30
 
 -  Ensure compatibility with PHP 8.5

--- a/src/TwigComponent/config/debug.php
+++ b/src/TwigComponent/config/debug.php
@@ -28,7 +28,7 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service('ux.twig_component.component_logger_listener'),
             service('twig'),
-            abstract_arg('profiler dump components'),
+            abstract_arg('profiler collect components'),
         ])
         ->tag('data_collector', [
             'template' => '@TwigComponent/Collector/twig_component.html.twig',

--- a/src/TwigComponent/config/debug.php
+++ b/src/TwigComponent/config/debug.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symfony\UX\TwigComponent\DataCollector\TwigComponentDataCollector;
 use Symfony\UX\TwigComponent\EventListener\TwigComponentLoggerListener;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container) {
@@ -27,6 +28,7 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service('ux.twig_component.component_logger_listener'),
             service('twig'),
+            abstract_arg('profiler dump components'),
         ])
         ->tag('data_collector', [
             'template' => '@TwigComponent/Collector/twig_component.html.twig',

--- a/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
+++ b/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
@@ -35,6 +35,7 @@ final class TwigComponentDataCollector extends AbstractDataCollector implements 
     public function __construct(
         private readonly TwigComponentLoggerListener $logger,
         private readonly Environment $twig,
+        private readonly bool $dumpComponents = true,
     ) {
         $this->hasStub = class_exists(ClassStub::class);
     }
@@ -130,11 +131,14 @@ final class TwigComponentDataCollector extends AbstractDataCollector implements 
                     'input_props' => $mountedComponent->getInputProps(),
                     'attributes' => $mountedComponent->getAttributes()->all(),
                     'template_index' => $event->getTemplateIndex(),
-                    'component' => $mountedComponent->getComponent(),
                     'depth' => \count($ongoingRenders),
                     'children' => [],
                     'render_start' => $profile[0],
                 ];
+
+                if ($this->dumpComponents) {
+                    $renders[$renderId]['component'] = $mountedComponent->getComponent();
+                }
 
                 if ($parentId = end($ongoingRenders)) {
                     $renders[$parentId]['children'][] = $renderId;

--- a/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
+++ b/src/TwigComponent/src/DataCollector/TwigComponentDataCollector.php
@@ -35,7 +35,7 @@ final class TwigComponentDataCollector extends AbstractDataCollector implements 
     public function __construct(
         private readonly TwigComponentLoggerListener $logger,
         private readonly Environment $twig,
-        private readonly bool $dumpComponents = true,
+        private readonly bool $collectComponents = true,
     ) {
         $this->hasStub = class_exists(ClassStub::class);
     }
@@ -136,7 +136,7 @@ final class TwigComponentDataCollector extends AbstractDataCollector implements 
                     'render_start' => $profile[0],
                 ];
 
-                if ($this->dumpComponents) {
+                if ($this->collectComponents) {
                     $renders[$renderId]['component'] = $mountedComponent->getComponent();
                 }
 

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -150,10 +150,11 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
         $container->setAlias('console.command.stimulus_component_debug', 'ux.twig_component.command.debug')
             ->setDeprecated('symfony/ux-twig-component', '2.13', '%alias_id%');
 
-        if ($container->getParameter('kernel.debug') && $config['profiler']) {
+        if ($config['profiler']['enabled']) {
             $loader->load('debug.php');
+
             $container->getDefinition('ux.twig_component.data_collector')
-                ->setArgument(2, $config['profiler_dump_components'] ?? true);
+                ->setArgument(2, $config['profiler']['collect_components']);
         }
 
         $loader->load('cache.php');
@@ -217,13 +218,13 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                 ->scalarNode('anonymous_template_directory')
                     ->info('Defaults to `components`')
                 ->end()
-                ->booleanNode('profiler')
-                    ->info('Enables the profiler for Twig Component (in debug mode)')
-                    ->defaultValue('%kernel.debug%')
-                ->end()
-                ->booleanNode('profiler_dump_components')
-                    ->info('Dump components in the Twig Component profiler panel')
-                    ->defaultTrue()
+                ->arrayNode('profiler')
+                    ->info('Enables the profiler for Twig Component')
+                    ->canBeEnabled()
+                    ->children()
+                        ->booleanNode('enabled')->defaultValue('%kernel.debug%')->end()
+                        ->booleanNode('collect_components')->info('Collect components instances')->defaultTrue()->end()
+                    ->end()
                 ->end()
                 ->scalarNode('controllers_json')
                     ->setDeprecated('symfony/ux-twig-component', '2.18', 'The "twig_component.controllers_json" config option is deprecated, and will be removed in 3.0.')

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -152,6 +152,8 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
 
         if ($container->getParameter('kernel.debug') && $config['profiler']) {
             $loader->load('debug.php');
+            $container->getDefinition('ux.twig_component.data_collector')
+                ->setArgument(2, $config['profiler_dump_components'] ?? true);
         }
 
         $loader->load('cache.php');
@@ -218,6 +220,10 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                 ->booleanNode('profiler')
                     ->info('Enables the profiler for Twig Component (in debug mode)')
                     ->defaultValue('%kernel.debug%')
+                ->end()
+                ->booleanNode('profiler_dump_components')
+                    ->info('Dump components in the Twig Component profiler panel')
+                    ->defaultTrue()
                 ->end()
                 ->scalarNode('controllers_json')
                     ->setDeprecated('symfony/ux-twig-component', '2.18', 'The "twig_component.controllers_json" config option is deprecated, and will be removed in 3.0.')

--- a/src/TwigComponent/templates/Collector/twig_component.html.twig
+++ b/src/TwigComponent/templates/Collector/twig_component.html.twig
@@ -293,10 +293,12 @@
                         <th scope="row">Attributes</th>
                         <td colspan="4">{{ profiler_dump(render.attributes) }}</td>
                     </tr>
+                    {% if render.component is defined %}
                     <tr>
                         <th scope="row">Component</th>
                         <td colspan="4">{{ profiler_dump(render.component) }}</td>
                     </tr>
+                    {% endif %}
                 </tbody>
             </table>
         {% endfor %}

--- a/src/TwigComponent/tests/Unit/DataCollector/TwigComponentDataCollectorTest.php
+++ b/src/TwigComponent/tests/Unit/DataCollector/TwigComponentDataCollectorTest.php
@@ -14,9 +14,16 @@ namespace Symfony\UX\TwigComponent\Tests\Unit\DataCollector;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\UX\TwigComponent\ComponentAttributes;
+use Symfony\UX\TwigComponent\ComponentMetadata;
 use Symfony\UX\TwigComponent\DataCollector\TwigComponentDataCollector;
+use Symfony\UX\TwigComponent\Event\PostRenderEvent;
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
 use Symfony\UX\TwigComponent\EventListener\TwigComponentLoggerListener;
+use Symfony\UX\TwigComponent\MountedComponent;
 use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Runtime\EscaperRuntime;
 
 /**
  * @author Simon André <smn.andre@gmail.com>
@@ -35,7 +42,7 @@ class TwigComponentDataCollectorTest extends TestCase
         $this->assertSame([], $dataCollector->getData());
     }
 
-    public function testLateCollect()
+    public function testLateCollectWithNoCollectedData()
     {
         $logger = new TwigComponentLoggerListener();
         $twig = $this->createMock(Environment::class);
@@ -52,6 +59,44 @@ class TwigComponentDataCollectorTest extends TestCase
         $this->assertEmpty($dataCollector->getRenders());
 
         $this->assertEquals(0.0, $dataCollector->getRenderTime());
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testLateCollectWithCollectedData(bool $collectComponents)
+    {
+        $logger = new TwigComponentLoggerListener();
+        $twig = new Environment(new ArrayLoader());
+        $dataCollector = new TwigComponentDataCollector($logger, $twig, $collectComponents);
+
+        // Trigger some events to be logged
+        $mounted = new MountedComponent('foo', new \stdClass(), new ComponentAttributes([], new EscaperRuntime()));
+        $eventA = new PreRenderEvent($mounted, new ComponentMetadata(['key' => 'foo', 'template' => 'bar']), []);
+        $logger->onPreRender($eventA);
+        $eventB = new PostRenderEvent($mounted);
+        $logger->onPostRender($eventB);
+
+        $dataCollector->lateCollect();
+
+        $this->assertSame(1, $dataCollector->getComponentCount());
+        $this->assertIsIterable($dataCollector->getComponents());
+        $this->assertNotEmpty($dataCollector->getComponents());
+
+        $this->assertSame(1, $dataCollector->getRenderCount());
+        $this->assertIsIterable($dataCollector->getRenders());
+        $this->assertNotEmpty($dataCollector->getRenders());
+
+        foreach ($dataCollector->getRenders() as $render) {
+            if ($collectComponents) {
+                $this->assertNotNull($render['component']);
+            } else {
+                $this->assertNull($render['component']);
+            }
+        }
+
+        $this->assertGreaterThan(0.0, $dataCollector->getRenderTime());
     }
 
     public function testReset()

--- a/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
@@ -40,7 +40,7 @@ class TwigComponentExtensionTest extends TestCase
         $this->assertTrue($container->getDefinition('ux.twig_component.data_collector')->getArgument(2));
     }
 
-    public function testDataCollectorWithDumpComponentsDisabled()
+    public function testDataCollectorWithCollectComponentsDisabled()
     {
         $container = $this->createContainer();
         $container->setParameter('kernel.debug', true);
@@ -48,7 +48,9 @@ class TwigComponentExtensionTest extends TestCase
         $container->loadFromExtension('twig_component', [
             'defaults' => [],
             'anonymous_template_directory' => 'components/',
-            'profiler_dump_components' => false,
+            'profiler' => [
+                'collect_components' => false,
+            ],
         ]);
         $this->compileContainer($container);
 
@@ -65,21 +67,6 @@ class TwigComponentExtensionTest extends TestCase
             'defaults' => [],
             'anonymous_template_directory' => 'components/',
             'profiler' => false,
-        ]);
-        $this->compileContainer($container);
-
-        $this->assertFalse($container->hasDefinition('ux.twig_component.data_collector'));
-    }
-
-    public function testDataCollectorWithoutDebugMode()
-    {
-        $container = $this->createContainer();
-        $container->setParameter('kernel.debug', false);
-        $container->registerExtension(new TwigComponentExtension());
-        $container->loadFromExtension('twig_component', [
-            'defaults' => [],
-            'anonymous_template_directory' => 'components/',
-            'profiler' => true,
         ]);
         $this->compileContainer($container);
 

--- a/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
@@ -37,6 +37,23 @@ class TwigComponentExtensionTest extends TestCase
         $this->compileContainer($container);
 
         $this->assertTrue($container->hasDefinition('ux.twig_component.data_collector'));
+        $this->assertTrue($container->getDefinition('ux.twig_component.data_collector')->getArgument(2));
+    }
+
+    public function testDataCollectorWithDumpComponentsDisabled()
+    {
+        $container = $this->createContainer();
+        $container->setParameter('kernel.debug', true);
+        $container->registerExtension(new TwigComponentExtension());
+        $container->loadFromExtension('twig_component', [
+            'defaults' => [],
+            'anonymous_template_directory' => 'components/',
+            'profiler_dump_components' => false,
+        ]);
+        $this->compileContainer($container);
+
+        $this->assertTrue($container->hasDefinition('ux.twig_component.data_collector'));
+        $this->assertFalse($container->getDefinition('ux.twig_component.data_collector')->getArgument(2));
     }
 
     public function testDataCollectorWithDebugModeCanBeDisabled()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no 
| Issues        | -
| License       | MIT

This PR removes the component object dumping from the Symfony UX Twig Component profiler to address memory consumption issues.

IMHO, the component dump is not necessary in the profiler as it can be quite verbose and memory-intensive. When detailed component inspection is needed, it's preferable to dump the component manually in the specific context where debugging is required.
