### PR TITLE
[Toolkit] Add npm & importmap package dependencies

### DIFF
--- a/src/Toolkit/kits/shadcn/Alert/manifest.json
+++ b/src/Toolkit/kits/shadcn/Alert/manifest.json
@@ -9,15 +9,16 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "twig/extra-bundle"
+            "name": "twig/extra-bundle"
         },
         {
             "type": "php",
-            "package": "twig/html-extra:^3.12.0"
+            "name": "twig/html-extra",
+            "version": "^3.12.0"
         },
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/AspectRatio/manifest.json
+++ b/src/Toolkit/kits/shadcn/AspectRatio/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "twig/extra-bundle"
+            "name": "twig/extra-bundle"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Avatar/manifest.json
+++ b/src/Toolkit/kits/shadcn/Avatar/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Badge/manifest.json
+++ b/src/Toolkit/kits/shadcn/Badge/manifest.json
@@ -9,15 +9,16 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "twig/extra-bundle"
+            "name": "twig/extra-bundle"
         },
         {
             "type": "php",
-            "package": "twig/html-extra:^3.12.0"
+            "name": "twig/html-extra",
+            "version": "^3.12.0"
         },
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Breadcrumb/manifest.json
+++ b/src/Toolkit/kits/shadcn/Breadcrumb/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Button/manifest.json
+++ b/src/Toolkit/kits/shadcn/Button/manifest.json
@@ -9,15 +9,16 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "twig/extra-bundle"
+            "name": "twig/extra-bundle"
         },
         {
             "type": "php",
-            "package": "twig/html-extra:^3.12.0"
+            "name": "twig/html-extra",
+            "version": "^3.12.0"
         },
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Card/manifest.json
+++ b/src/Toolkit/kits/shadcn/Card/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Checkbox/manifest.json
+++ b/src/Toolkit/kits/shadcn/Checkbox/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Input/manifest.json
+++ b/src/Toolkit/kits/shadcn/Input/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Label/manifest.json
+++ b/src/Toolkit/kits/shadcn/Label/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Pagination/manifest.json
+++ b/src/Toolkit/kits/shadcn/Pagination/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Progress/manifest.json
+++ b/src/Toolkit/kits/shadcn/Progress/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Select/manifest.json
+++ b/src/Toolkit/kits/shadcn/Select/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Separator/manifest.json
+++ b/src/Toolkit/kits/shadcn/Separator/manifest.json
@@ -9,15 +9,16 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "twig/extra-bundle"
+            "name": "twig/extra-bundle"
         },
         {
             "type": "php",
-            "package": "twig/html-extra:^3.12.0"
+            "name": "twig/html-extra",
+            "version": "^3.12.0"
         },
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Skeleton/manifest.json
+++ b/src/Toolkit/kits/shadcn/Skeleton/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Switch/manifest.json
+++ b/src/Toolkit/kits/shadcn/Switch/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Table/manifest.json
+++ b/src/Toolkit/kits/shadcn/Table/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/kits/shadcn/Textarea/manifest.json
+++ b/src/Toolkit/kits/shadcn/Textarea/manifest.json
@@ -9,7 +9,7 @@
     "dependencies": [
         {
             "type": "php",
-            "package": "tales-from-a-dev/twig-tailwind-extra"
+            "name": "tales-from-a-dev/twig-tailwind-extra"
         }
     ]
 }

--- a/src/Toolkit/schema-kit-recipe-v1.json
+++ b/src/Toolkit/schema-kit-recipe-v1.json
@@ -34,15 +34,53 @@
                     {
                         "description": "A dependency on a PHP package",
                         "type": "object",
-                        "required": ["type", "package"],
+                        "required": ["type", "name"],
                         "properties": {
                             "type": {
                                 "type": "string",
                                 "enum": ["php"]
                             },
+                            "name": {
+                                "type": "string",
+                                "description": "Package name and optional version constraint (e.g., 'vendor/package')"
+                            },
+                            "version": {
+                                "type": "string",
+                                "description": "Optional version constraint (e.g., '^1.0')"
+                            }
+                        }
+                    },
+                    {
+                        "description": "A dependency on an NPM package",
+                        "type": "object",
+                        "required": ["type", "name"],
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["npm"]
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Package name and optional version constraint (e.g., 'vendor/package')"
+                            },
+                            "version": {
+                                "type": "string",
+                                "description": "Optional version constraint (e.g., '^1.0')"
+                            }
+                        }
+                    },
+                    {
+                        "description": "A dependency on an Importmap package",
+                        "type": "object",
+                        "required": ["type", "package"],
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["importmap"]
+                            },
                             "package": {
                                 "type": "string",
-                                "description": "Package name and optional version constraint (e.g., 'vendor/package:^1.0')"
+                                "description": "Importmap package name (e.g., 'lodash', 'bootstrap/dist/css/bootstrap.min.css')"
                             }
                         }
                     },

--- a/src/Toolkit/src/Assert.php
+++ b/src/Toolkit/src/Assert.php
@@ -55,4 +55,19 @@ final class Assert
             throw new \InvalidArgumentException(\sprintf('Invalid PHP package name "%s".', $name));
         }
     }
+
+    /**
+     * Assert that the NPM package name is valid (ex: "react", "@hotwired/stimulus", etc.).
+     *
+     * @param non-empty-string $name
+     *
+     * @throws \InvalidArgumentException if the NPM package name is invalid
+     */
+    public static function npmPackageName(string $name): void
+    {
+        // Taken from https://github.com/dword-design/package-name-regex/blob/master/src/index.ts
+        if (1 !== preg_match('/^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/', $name)) {
+            throw new \InvalidArgumentException(\sprintf('Invalid NPM package name "%s".', $name));
+        }
+    }
 }

--- a/src/Toolkit/src/Command/DebugKitCommand.php
+++ b/src/Toolkit/src/Command/DebugKitCommand.php
@@ -85,8 +85,8 @@ class DebugKitCommand extends Command
                     'Dependencies',
                 ])
                 ->addRow([
-                    implode("\n", iterator_to_array($recipe->getFiles())),
-                    implode("\n", $recipe->manifest->dependencies),
+                    implode("\n", iterator_to_array($recipe->getFiles())) ?: 'N/A',
+                    implode("\n", $recipe->manifest->dependencies) ?: 'N/A',
                 ])
                 ->setColumnWidth(1, 80)
                 ->setColumnMaxWidth(1, 80)

--- a/src/Toolkit/src/Command/InstallCommand.php
+++ b/src/Toolkit/src/Command/InstallCommand.php
@@ -171,11 +171,40 @@ class InstallCommand extends Command
         }
 
         $this->io->success('The recipe has been installed.');
-        $this->io->writeln('The following file(s) have been added to your project:');
+
+        $this->io->section('Installed files');
         $this->io->listing(array_map(fn (File $file) => Path::join($destinationPath, $file->sourceRelativePathName), $installationReport->newFiles));
 
+        if ([] !== $installationReport->suggestedPhpPackages || [] !== $installationReport->suggestedNpmPackages || [] !== $installationReport->suggestedImportmapPackages) {
+            $this->io->section('Next steps');
+        }
+
+        $stepIndex = 0;
         if ([] !== $installationReport->suggestedPhpPackages) {
-            $this->io->writeln(\sprintf('Run <info>composer require %s</> to install the required PHP dependencies.', implode(' ', $installationReport->suggestedPhpPackages)));
+            $this->io->writeln(++$stepIndex.'. Install suggested PHP package(s) with the command:');
+            $this->io->newLine();
+            $this->io->writeln(\sprintf(' $ <info>composer require %s</>', implode(' ', $installationReport->suggestedPhpPackages)));
+            $this->io->newLine();
+        }
+
+        if ([] !== $installationReport->suggestedNpmPackages && [] !== $installationReport->suggestedImportmapPackages) {
+            $this->io->writeln(++$stepIndex.'. Install suggested front-end packages with one of the following commands:');
+            $this->io->newLine();
+            $this->io->writeln(' # with npm/pnpm/yarn');
+            $this->io->writeln(\sprintf(' $ <info>npm install --save %s</>', implode(' ', $installationReport->suggestedNpmPackages)));
+            $this->io->newLine();
+            $this->io->writeln(' # or with Importmap');
+            $this->io->writeln(\sprintf(' $ <info>php bin/console importmap:install %s</>', implode(' ', $installationReport->suggestedImportmapPackages)));
+            $this->io->newLine();
+        } elseif ([] !== $installationReport->suggestedNpmPackages) {
+            $this->io->writeln(++$stepIndex.'. Install suggested front-end package(s) with the command:');
+            $this->io->newLine();
+            $this->io->writeln(\sprintf(' $ <info>npm install --save %s</>', implode(' ', $installationReport->suggestedNpmPackages)));
+            $this->io->newLine();
+        } elseif ([] !== $installationReport->suggestedImportmapPackages) {
+            $this->io->writeln(++$stepIndex.'. Install suggested front-end package(s) with the command:');
+            $this->io->newLine();
+            $this->io->writeln(\sprintf(' $ <info>php bin/console importmap:install %s</>', implode(' ', $installationReport->suggestedImportmapPackages)));
             $this->io->newLine();
         }
 

--- a/src/Toolkit/src/Dependency/ImportmapPackageDependency.php
+++ b/src/Toolkit/src/Dependency/ImportmapPackageDependency.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Dependency;
+
+/**
+ * Represents a dependency on an Importmap package.
+ *
+ * @internal
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class ImportmapPackageDependency implements DependencyInterface
+{
+    /**
+     * @param non-empty-string $package
+     */
+    public function __construct(
+        public readonly string $package,
+    ) {
+    }
+
+    public function isEquivalentTo(DependencyInterface $dependency): bool
+    {
+        if (!$dependency instanceof self) {
+            return false;
+        }
+
+        return $this->package === $dependency->package;
+    }
+
+    public function toDebug(): string
+    {
+        return \sprintf('Importmap package "%s"', $this->package);
+    }
+
+    public function __toString(): string
+    {
+        return $this->package;
+    }
+}

--- a/src/Toolkit/src/Dependency/NpmPackageDependency.php
+++ b/src/Toolkit/src/Dependency/NpmPackageDependency.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Dependency;
+
+use Symfony\UX\Toolkit\Assert;
+
+/**
+ * Represents a dependency on an NPM package.
+ *
+ * @internal
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class NpmPackageDependency implements DependencyInterface
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly ?Version $constraintVersion = null,
+    ) {
+        Assert::npmPackageName($name);
+    }
+
+    public function isEquivalentTo(DependencyInterface $dependency): bool
+    {
+        if (!$dependency instanceof self) {
+            return false;
+        }
+
+        return $this->name === $dependency->name;
+    }
+
+    public function isHigherThan(self $dependency): bool
+    {
+        if (null === $this->constraintVersion || null === $dependency->constraintVersion) {
+            return false;
+        }
+
+        return $this->constraintVersion->isHigherThan($dependency->constraintVersion);
+    }
+
+    public function toDebug(): string
+    {
+        return \sprintf('NPM package "%s"', $this->__toString());
+    }
+
+    public function __toString(): string
+    {
+        return $this->name.(null !== $this->constraintVersion ? ':'.$this->constraintVersion : '');
+    }
+}

--- a/src/Toolkit/src/Installer/InstallationReport.php
+++ b/src/Toolkit/src/Installer/InstallationReport.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\UX\Toolkit\Installer;
 
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\File;
 
@@ -26,12 +28,16 @@ use Symfony\UX\Toolkit\File;
 final class InstallationReport
 {
     /**
-     * @param array<File>                 $newFiles
-     * @param array<PhpPackageDependency> $suggestedPhpPackages
+     * @param array<File>                       $newFiles
+     * @param array<PhpPackageDependency>       $suggestedPhpPackages
+     * @param array<NpmPackageDependency>       $suggestedNpmPackages
+     * @param array<ImportmapPackageDependency> $suggestedImportmapPackages
      */
     public function __construct(
         public readonly array $newFiles,
         public readonly array $suggestedPhpPackages,
+        public readonly array $suggestedNpmPackages,
+        public readonly array $suggestedImportmapPackages,
     ) {
     }
 }

--- a/src/Toolkit/src/Installer/Installer.php
+++ b/src/Toolkit/src/Installer/Installer.php
@@ -58,7 +58,7 @@ final class Installer
             }
         }
 
-        return new InstallationReport(newFiles: $installedFiles, suggestedPhpPackages: $pool->getPhpPackageDependencies());
+        return new InstallationReport(newFiles: $installedFiles, suggestedPhpPackages: $pool->getPhpPackageDependencies(), suggestedNpmPackages: $pool->getNpmPackageDependencies(), suggestedImportmapPackages: $pool->getImportmapPackageDependencies());
     }
 
     private function copyFile(Kit $kit, string $sourceAbsolutePathName, string $destinationAbsolutePathName, bool $force): bool

--- a/src/Toolkit/src/Installer/Pool.php
+++ b/src/Toolkit/src/Installer/Pool.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\UX\Toolkit\Installer;
 
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\File;
 use Symfony\UX\Toolkit\Recipe\Recipe;
@@ -32,9 +34,19 @@ final class Pool
     private array $files = [];
 
     /**
-     * @param array<non-empty-string, PhpPackageDependency> $files
+     * @var array<non-empty-string, PhpPackageDependency>
      */
     private array $phpPackageDependencies = [];
+
+    /**
+     * @var array<non-empty-string, NpmPackageDependency>
+     */
+    private array $npmPackageDependencies = [];
+
+    /**
+     * @var array<non-empty-string, ImportmapPackageDependency>
+     */
+    private array $importmapPackageDependencies = [];
 
     public function addFile(Recipe $recipe, File $file): void
     {
@@ -51,9 +63,7 @@ final class Pool
 
     public function addPhpPackageDependency(PhpPackageDependency $dependency): void
     {
-        if (isset($this->phpPackageDependencies[$dependency->name]) && $dependency->isHigherThan($this->phpPackageDependencies[$dependency->name])) {
-            $this->phpPackageDependencies[$dependency->name] = $dependency;
-
+        if (isset($this->phpPackageDependencies[$dependency->name]) && !$dependency->isHigherThan($this->phpPackageDependencies[$dependency->name])) {
             return;
         }
 
@@ -66,5 +76,35 @@ final class Pool
     public function getPhpPackageDependencies(): array
     {
         return $this->phpPackageDependencies;
+    }
+
+    public function addNpmPackageDependency(NpmPackageDependency $dependency): void
+    {
+        if (isset($this->npmPackageDependencies[$dependency->name]) && !$dependency->isHigherThan($this->npmPackageDependencies[$dependency->name])) {
+            return;
+        }
+
+        $this->npmPackageDependencies[$dependency->name] = $dependency;
+    }
+
+    /**
+     * @return array<non-empty-string, NpmPackageDependency>
+     */
+    public function getNpmPackageDependencies(): array
+    {
+        return $this->npmPackageDependencies;
+    }
+
+    public function addImportmapPackageDependency(ImportmapPackageDependency $dependency): void
+    {
+        $this->importmapPackageDependencies[$dependency->package] = $dependency;
+    }
+
+    /**
+     * @return array<non-empty-string, ImportmapPackageDependency>
+     */
+    public function getImportmapPackageDependencies(): array
+    {
+        return $this->importmapPackageDependencies;
     }
 }

--- a/src/Toolkit/src/Installer/PoolResolver.php
+++ b/src/Toolkit/src/Installer/PoolResolver.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\UX\Toolkit\Installer;
 
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\RecipeDependency;
 use Symfony\UX\Toolkit\Kit\Kit;
@@ -50,6 +52,10 @@ final class PoolResolver
             foreach ($currentRecipe->manifest->dependencies as $dependency) {
                 if ($dependency instanceof PhpPackageDependency) {
                     $pool->addPhpPackageDependency($dependency);
+                } elseif ($dependency instanceof NpmPackageDependency) {
+                    $pool->addNpmPackageDependency($dependency);
+                } elseif ($dependency instanceof ImportmapPackageDependency) {
+                    $pool->addImportmapPackageDependency($dependency);
                 } elseif ($dependency instanceof RecipeDependency) {
                     if (null === $recipeDependency = $kit->getRecipe($dependency->name)) {
                         throw new \LogicException(\sprintf('The recipe "%s" has a dependency on unregistered recipe "%s".', $currentRecipe->manifest->name, $dependency->name));

--- a/src/Toolkit/src/Recipe/RecipeManifest.php
+++ b/src/Toolkit/src/Recipe/RecipeManifest.php
@@ -13,6 +13,8 @@ namespace Symfony\UX\Toolkit\Recipe;
 
 use Symfony\Component\Filesystem\Path;
 use Symfony\UX\Toolkit\Dependency\DependencyInterface;
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\RecipeDependency;
 use Symfony\UX\Toolkit\Dependency\Version;
@@ -55,41 +57,44 @@ final class RecipeManifest
     {
         $data = json_decode($json, true, flags: \JSON_THROW_ON_ERROR);
 
+        $type = $data['type'] ?? throw new \InvalidArgumentException('Property "type" is required.');
+        if (null === $type = RecipeType::tryFrom($type)) {
+            throw new \InvalidArgumentException(\sprintf('The recipe type "%s" is not supported.', $data['type']));
+        }
+
         $dependencies = [];
         foreach ($data['dependencies'] ?? [] as $i => $dependency) {
             if (!\is_array($dependency)) {
                 throw new \InvalidArgumentException('Each dependency must be an associative array.');
             }
             if (!isset($dependency['type'])) {
-                throw new \InvalidArgumentException(\sprintf('The dependency type is missing for dependency #%d, add "type" key.', $i));
+                throw new \InvalidArgumentException(\sprintf('The dependency #%d is missing "type" field.', $i));
             }
 
             if ('php' === $dependency['type']) {
-                $package = $dependency['package'] ?? throw new \InvalidArgumentException(\sprintf('The package name is missing for dependency #%d, add "package" key.', $i));
-                if (str_contains($package, ':')) {
-                    [$name, $version] = explode(':', $package, 2);
-                    $dependencies[] = new PhpPackageDependency($name, new Version($version));
-                } else {
-                    $dependencies[] = new PhpPackageDependency($package);
-                }
+                $name = $dependency['name'] ?? throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "php" is missing "name" field.', $i));
+                $version = $dependency['version'] ?? null;
+                $dependencies[] = new PhpPackageDependency($name, null === $version ? null : new Version($version));
             } elseif ('recipe' === $dependency['type']) {
-                $name = $dependency['name'] ?? throw new \InvalidArgumentException(\sprintf('The recipe name is missing for dependency #%d, add "name" key.', $i));
+                $name = $dependency['name'] ?? throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "recipe" is missing "name" field.', $i));
                 $dependencies[] = new RecipeDependency($name);
+            } elseif ('npm' === $dependency['type']) {
+                $name = $dependency['name'] ?? throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "npm" is missing "name" field.', $i));
+                $version = $dependency['version'] ?? null;
+                $dependencies[] = new NpmPackageDependency($name, null === $version ? null : new Version($version));
+            } elseif ('importmap' === $dependency['type']) {
+                $package = $dependency['package'] ?? throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "importmap" is missing "package" field.', $i));
+                $dependencies[] = new ImportmapPackageDependency($package);
             } else {
                 throw new \InvalidArgumentException(\sprintf('The dependency type "%s" is not supported.', $dependency['type']));
             }
-        }
-
-        $type = $data['type'] ?? throw new \InvalidArgumentException('Property "type" is required.');
-        if (null === $type = RecipeType::tryFrom($type)) {
-            throw new \InvalidArgumentException(\sprintf('The recipe type "%s" is not supported.', $data['type']));
         }
 
         return new self(
             type: $type,
             name: $data['name'] ?? throw new \InvalidArgumentException('Property "name" is required.'),
             description: $data['description'] ?? throw new \InvalidArgumentException('Property "description" is required.'),
-            copyFiles: $data['copy-files'] ?? throw new \InvalidArgumentException('Property "copy-files" is required.'),
+            copyFiles: $data['copy-files'] ?? [],
             dependencies: $dependencies,
         );
     }

--- a/src/Toolkit/tests/AssertTest.php
+++ b/src/Toolkit/tests/AssertTest.php
@@ -177,4 +177,51 @@ class AssertTest extends TestCase
         yield ['twig/html-extra/'];
         yield ['twig/html-extra/twig'];
     }
+
+    /**
+     * @dataProvider provideValidNpmPackageNames
+     */
+    public function testValidNpmPackageName(string $name)
+    {
+        $this->expectNotToPerformAssertions();
+
+        Assert::npmPackageName($name);
+    }
+
+    public static function provideValidNpmPackageNames(): iterable
+    {
+        yield ['react'];
+        yield ['@babel/core'];
+        yield ['lodash'];
+        yield ['@types/node'];
+        yield ['my-package'];
+        yield ['my_package'];
+        yield ['my.package'];
+        yield ['my-package123'];
+        yield ['@scope/my-package'];
+        yield ['~foo'];
+    }
+
+    /**
+     * @dataProvider provideInvalidNpmPackageNames
+     */
+    public function testInvalidNpmPackageName(string $name)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('Invalid NPM package name "%s".', $name));
+
+        Assert::npmPackageName($name);
+    }
+
+    public static function provideInvalidNpmPackageNames(): iterable
+    {
+        yield [''];
+        yield ['@'];
+        yield ['@scope/'];
+        yield ['my package'];
+        yield ['my/package'];
+        yield ['my@package'];
+        yield ['my/package/name'];
+        yield ['@scope//my-package'];
+    }
 }

--- a/src/Toolkit/tests/Command/DebugKitCommandTest.php
+++ b/src/Toolkit/tests/Command/DebugKitCommandTest.php
@@ -12,17 +12,18 @@
 namespace Symfony\UX\Toolkit\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Filesystem\Path;
+use Symfony\UX\Toolkit\Tests\TestHelperTrait;
 use Zenstruck\Console\Test\InteractsWithConsole;
 
 class DebugKitCommandTest extends KernelTestCase
 {
     use InteractsWithConsole;
+    use TestHelperTrait;
 
-    public function testShouldBeAbleToDebug()
+    public function testShouldBeAbleToDebugShadcnKit()
     {
         $this->bootKernel();
-        $this->consoleCommand(\sprintf('ux:toolkit:debug-kit %s', Path::join(__DIR__, '/../../kits/shadcn')))
+        $this->consoleCommand(\sprintf('ux:toolkit:debug-kit %s', self::getLocalKitPath('shadcn')))
             ->execute()
             ->assertSuccessful()
             // Kit details
@@ -49,6 +50,38 @@ class DebugKitCommandTest extends KernelTestCase
                 '|              | templates/components/Table/Header.html.twig                                      |',
                 '|              | templates/components/Table/Row.html.twig                                         |',
                 '| Dependencies | tales-from-a-dev/twig-tailwind-extra                                             |',
+                '+--------------+----------------------------------------------------------------------------------+',
+            ]));
+    }
+
+    public function testShouldBeAbleToDebugFixtureKitWithManyDependencies()
+    {
+        $this->bootKernel();
+        $this->consoleCommand(\sprintf('ux:toolkit:debug-kit %s', self::getFixtureKitPath('with-many-dependencies')))
+            ->execute()
+            ->assertSuccessful()
+            // Kit details
+            ->assertOutputContains('Name       With many dependencies')
+            ->assertOutputContains('Homepage   https://ux.symfony.com')
+            ->assertOutputContains('License    MIT')
+            // Components details
+            ->assertOutputContains(implode(\PHP_EOL, [
+                '+--------------+------------------------- Recipe: "Alert" ----------------------------------------+',
+                '| File(s)      | N/A                                                                              |',
+                '| Dependencies | twig/html-extra:^3.12.0                                                          |',
+                '|              | tales-from-a-dev/twig-tailwind-extra                                             |',
+                '|              | tailwindcss:^4.0.0                                                               |',
+                '|              | @hotwired/stimulus                                                               |',
+                '|              | Button                                                                           |',
+                '+--------------+----------------------------------------------------------------------------------+',
+            ]))
+            ->assertOutputContains(implode(\PHP_EOL, [
+                '+--------------+------------------------ Recipe: "Button" ----------------------------------------+',
+                '| File(s)      | N/A                                                                              |',
+                '| Dependencies | twig/html-extra:^3.12.0                                                          |',
+                '|              | another/php-package:^2.0                                                         |',
+                '|              | another-npm-package:^1.0.0                                                       |',
+                '|              | another-importmap-package                                                        |',
                 '+--------------+----------------------------------------------------------------------------------+',
             ]));
     }

--- a/src/Toolkit/tests/Dependency/ImportmapPackageDependencyTest.php
+++ b/src/Toolkit/tests/Dependency/ImportmapPackageDependencyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Dependency;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+
+class ImportmapPackageDependencyTest extends TestCase
+{
+    public function testShouldBeInstantiable()
+    {
+        $dependency = new ImportmapPackageDependency('react');
+        $this->assertSame('react', $dependency->package);
+        $this->assertSame('Importmap package "react"', $dependency->toDebug());
+        $this->assertSame('react', (string) $dependency);
+
+        $dependency = new ImportmapPackageDependency('bootstrap/dist/css/bootstrap.min.css');
+        $this->assertSame('bootstrap/dist/css/bootstrap.min.css', $dependency->package);
+        $this->assertSame('Importmap package "bootstrap/dist/css/bootstrap.min.css"', $dependency->toDebug());
+        $this->assertSame('bootstrap/dist/css/bootstrap.min.css', (string) $dependency);
+    }
+}

--- a/src/Toolkit/tests/Dependency/NpmPackageDependencyTest.php
+++ b/src/Toolkit/tests/Dependency/NpmPackageDependencyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Dependency;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
+use Symfony\UX\Toolkit\Dependency\Version;
+
+class NpmPackageDependencyTest extends TestCase
+{
+    public function testShouldBeInstantiable()
+    {
+        $dependency = new NpmPackageDependency('react');
+        $this->assertSame('react', $dependency->name);
+        $this->assertNull($dependency->constraintVersion);
+        $this->assertSame('NPM package "react"', $dependency->toDebug());
+        $this->assertSame('react', (string) $dependency);
+
+        $dependency = new NpmPackageDependency('react', new Version('^18.0.0'));
+        $this->assertSame('react', $dependency->name);
+        $this->assertSame('NPM package "react:^18.0.0"', $dependency->toDebug());
+        $this->assertSame('react:^18.0.0', (string) $dependency);
+    }
+
+    public function testShouldFailIfPackageNameIsInvalid()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid NPM package name "/foo".');
+
+        new NpmPackageDependency('/foo');
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/with-many-dependencies/Alert/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/with-many-dependencies/Alert/manifest.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Alert",
+    "description": "Component Alert",
+    "dependencies": [
+        {
+            "type": "php",
+            "name": "twig/html-extra",
+            "version": "^3.12.0"
+        },
+        {
+            "type": "php",
+            "name": "tales-from-a-dev/twig-tailwind-extra"
+        },
+        {
+            "type": "npm",
+            "name": "tailwindcss",
+            "version": "^4.0.0"
+        },
+        {
+            "type": "importmap",
+            "package": "@hotwired/stimulus"
+        },
+        {
+            "type": "recipe",
+            "name": "Button"
+        }
+    ]
+}

--- a/src/Toolkit/tests/Fixtures/kits/with-many-dependencies/Button/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/with-many-dependencies/Button/manifest.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Button",
+    "description": "Component Button",
+    "dependencies": [
+        {
+            "type": "php",
+            "name": "twig/html-extra",
+            "version": "^3.12.0"
+        },
+        {
+            "type": "php",
+            "name": "another/php-package",
+            "version": "^2.0"
+        },
+        {
+            "type": "npm",
+            "name": "another-npm-package",
+            "version": "^1.0.0"
+        },
+        {
+            "type": "importmap",
+            "package": "another-importmap-package"
+        }
+    ]
+}

--- a/src/Toolkit/tests/Fixtures/kits/with-many-dependencies/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/with-many-dependencies/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "With many dependencies",
+    "description": "Kit used as a test fixture.",
+    "license": "MIT",
+    "homepage": "https://ux.symfony.com/"
+}

--- a/src/Toolkit/tests/Installer/PoolResolverTest.php
+++ b/src/Toolkit/tests/Installer/PoolResolverTest.php
@@ -15,7 +15,11 @@ namespace Symfony\UX\Toolkit\Tests\Installer;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
+use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\RecipeDependency;
+use Symfony\UX\Toolkit\Dependency\Version;
 use Symfony\UX\Toolkit\Installer\PoolResolver;
 use Symfony\UX\Toolkit\Kit\KitSynchronizer;
 use Symfony\UX\Toolkit\Recipe\RecipeSynchronizer;
@@ -78,5 +82,52 @@ final class PoolResolverTest extends TestCase
         $this->assertEquals(['templates/components/B.html.twig'], array_keys($pool->getFiles()[$recipeB->absolutePath]));
         $this->assertEquals(['templates/components/C.html.twig'], array_keys($pool->getFiles()[$recipeC->absolutePath]));
         $this->assertCount(0, $pool->getPhpPackageDependencies());
+    }
+
+    public function testCanHandleAllPossibleDependencies()
+    {
+        $kitSynchronizer = new KitSynchronizer(new Filesystem(), new RecipeSynchronizer());
+        $kit = self::createFixtureKit('with-many-dependencies');
+        $kitSynchronizer->synchronize($kit);
+
+        $poolResolver = new PoolResolver();
+
+        $recipeAlert = $kit->getRecipe('Alert');
+        $recipeButton = $kit->getRecipe('Button');
+
+        $this->assertEquals([
+            new PhpPackageDependency('twig/html-extra', new Version('^3.12.0')),
+            new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra'),
+            new NpmPackageDependency('tailwindcss', new Version('^4.0.0')),
+            new ImportmapPackageDependency('@hotwired/stimulus'),
+            new RecipeDependency('Button'),
+        ], $recipeAlert->manifest->dependencies);
+
+        $this->assertEquals([
+            new PhpPackageDependency('twig/html-extra', new Version('^3.12.0')),
+            new PhpPackageDependency('another/php-package', new Version('^2.0')),
+            new NpmPackageDependency('another-npm-package', new Version('^1.0.0')),
+            new ImportmapPackageDependency('another-importmap-package'),
+        ], $recipeButton->manifest->dependencies);
+
+        $pool = $poolResolver->resolveForRecipe($kit, $recipeAlert);
+
+        $this->assertCount(0, $pool->getFiles());
+
+        $this->assertEquals([
+            'twig/html-extra' => new PhpPackageDependency('twig/html-extra', new Version('^3.12.0')),
+            'tales-from-a-dev/twig-tailwind-extra' => new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra'),
+            'another/php-package' => new PhpPackageDependency('another/php-package', new Version('^2.0')),
+        ], $pool->getPhpPackageDependencies());
+
+        $this->assertEquals([
+            'tailwindcss' => new NpmPackageDependency('tailwindcss', new Version('^4.0.0')),
+            'another-npm-package' => new NpmPackageDependency('another-npm-package', new Version('^1.0.0')),
+        ], $pool->getNpmPackageDependencies());
+
+        $this->assertEquals([
+            '@hotwired/stimulus' => new ImportmapPackageDependency('@hotwired/stimulus'),
+            'another-importmap-package' => new ImportmapPackageDependency('another-importmap-package'),
+        ], $pool->getImportmapPackageDependencies());
     }
 }

--- a/src/Toolkit/tests/Installer/PoolTest.php
+++ b/src/Toolkit/tests/Installer/PoolTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Symfony\UX\Toolkit\Tests\Installer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\Version;
 use Symfony\UX\Toolkit\File;
@@ -91,5 +93,68 @@ final class PoolTest extends TestCase
 
         $this->assertCount(1, $pool->getPhpPackageDependencies());
         $this->assertEquals('twig/html-extra:^3.12.0', (string) $pool->getPhpPackageDependencies()['twig/html-extra']);
+
+        $pool->addPhpPackageDependency(new PhpPackageDependency('twig/html-extra', new Version('^3.11.0')));
+
+        $this->assertCount(1, $pool->getPhpPackageDependencies());
+        $this->assertEquals('twig/html-extra:^3.12.0', (string) $pool->getPhpPackageDependencies()['twig/html-extra']);
+    }
+
+    public function testCanAddNpmPackageDependencies()
+    {
+        $pool = new Pool();
+
+        $pool->addNpmPackageDependency(new NpmPackageDependency('tailwindcss'));
+
+        $this->assertCount(1, $pool->getNpmPackageDependencies());
+    }
+
+    public function testCantAddSameNpmPackageDependencyTwice()
+    {
+        $pool = new Pool();
+
+        $pool->addNpmPackageDependency(new NpmPackageDependency('tailwindcss'));
+        $pool->addNpmPackageDependency(new NpmPackageDependency('tailwindcss'));
+
+        $this->assertCount(1, $pool->getNpmPackageDependencies());
+    }
+
+    public function testCanAddNpmPackageDependencyWithHigherVersion()
+    {
+        $pool = new Pool();
+
+        $pool->addNpmPackageDependency(new NpmPackageDependency('tailwindcss', new Version('^3.0.0')));
+
+        $this->assertCount(1, $pool->getNpmPackageDependencies());
+        $this->assertEquals('tailwindcss:^3.0.0', (string) $pool->getNpmPackageDependencies()['tailwindcss']);
+
+        $pool->addNpmPackageDependency(new NpmPackageDependency('tailwindcss', new Version('^4.0.0')));
+
+        $this->assertCount(1, $pool->getNpmPackageDependencies());
+        $this->assertEquals('tailwindcss:^4.0.0', (string) $pool->getNpmPackageDependencies()['tailwindcss']);
+
+        $pool->addNpmPackageDependency(new NpmPackageDependency('tailwindcss', new Version('^3.0.0')));
+
+        $this->assertCount(1, $pool->getNpmPackageDependencies());
+        $this->assertEquals('tailwindcss:^4.0.0', (string) $pool->getNpmPackageDependencies()['tailwindcss']);
+    }
+
+    public function testCanAddImportmapPackageDependencies()
+    {
+        $pool = new Pool();
+
+        $pool->addImportmapPackageDependency(new ImportmapPackageDependency('@hotwired/stimulus'));
+
+        $this->assertCount(1, $pool->getImportmapPackageDependencies());
+    }
+
+    public function testCantAddSameImportmapPackageDependencyTwice()
+    {
+        $pool = new Pool();
+
+        $pool->addImportmapPackageDependency(new ImportmapPackageDependency('@hotwired/stimulus'));
+        $pool->addImportmapPackageDependency(new ImportmapPackageDependency('@hotwired/stimulus'));
+
+        $this->assertCount(1, $pool->getImportmapPackageDependencies());
     }
 }

--- a/src/Toolkit/tests/Recipe/RecipeManifestTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeManifestTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Symfony\UX\Toolkit\Tests\Recipe;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
 use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Dependency\RecipeDependency;
 use Symfony\UX\Toolkit\Dependency\Version;
@@ -75,20 +77,6 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithMissingLicense()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Property "copy-files" is required.');
-
-        RecipeManifest::fromJson(<<<JSON
-                {
-                    "type": "component",
-                    "name": "MyComponent",
-                    "description": "An incredible component"
-                }
-            JSON);
-    }
-
     public function testFromJsonWithInvalidDependencies()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -110,7 +98,7 @@ final class RecipeManifestTest extends TestCase
     public function testFromJsonWithInvalidDependenciesType()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The dependency type is missing for dependency #0, add "type" key.');
+        $this->expectExceptionMessage('The dependency #0 is missing "type" field.');
 
         RecipeManifest::fromJson(<<<JSON
                 {
@@ -130,7 +118,7 @@ final class RecipeManifestTest extends TestCase
     public function testFromJsonWithInvalidPhpDependency()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The package name is missing for dependency #0, add "package" key.');
+        $this->expectExceptionMessage('The dependency #0 of type "php" is missing "name" field.');
 
         RecipeManifest::fromJson(<<<JSON
                 {
@@ -147,10 +135,10 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithInvalidRecipeDependency()
+    public function testFromJsonWithInvalidNpmDependency()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The recipe name is missing for dependency #0, add "name" key.');
+        $this->expectExceptionMessage('The dependency #1 of type "npm" is missing "name" field.');
 
         RecipeManifest::fromJson(<<<JSON
                 {
@@ -161,6 +149,52 @@ final class RecipeManifestTest extends TestCase
                         "templates/": "templates/"
                     },
                     "dependencies": [
+                        {"type": "php", "name": "symfony/string"},
+                        {"type": "npm"}
+                    ]
+                }
+            JSON);
+    }
+
+    public function testFromJsonWithInvalidImportmapDependency()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The dependency #2 of type "importmap" is missing "package" field.');
+
+        RecipeManifest::fromJson(<<<JSON
+                {
+                    "type": "component",
+                    "name": "MyComponent",
+                    "description": "An incredible component",
+                    "copy-files": {
+                        "templates/": "templates/"
+                    },
+                    "dependencies": [
+                        {"type": "php", "name": "symfony/string"},
+                        {"type": "npm", "name": "bar"},
+                        {"type": "importmap"}
+                    ]
+                }
+            JSON);
+    }
+
+    public function testFromJsonWithInvalidRecipeDependency()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The dependency #3 of type "recipe" is missing "name" field.');
+
+        RecipeManifest::fromJson(<<<JSON
+                {
+                    "type": "component",
+                    "name": "MyComponent",
+                    "description": "An incredible component",
+                    "copy-files": {
+                        "templates/": "templates/"
+                    },
+                    "dependencies": [
+                        {"type": "php", "name": "symfony/string"},
+                        {"type": "npm", "name": "bar"},
+                        {"type": "importmap", "package": "baz"},
                         {"type": "recipe"}
                     ]
                 }
@@ -200,7 +234,21 @@ final class RecipeManifestTest extends TestCase
                     "dependencies": [
                         {
                             "type": "php",
-                            "package": "symfony/ux-twig-component:^2.29"
+                            "name": "tales-from-a-dev/twig-tailwind-extra"
+                        },
+                        {
+                            "type": "php",
+                            "name": "symfony/ux-twig-component",
+                            "version": "^2.29"
+                        },
+                        {
+                            "type": "npm",
+                            "name": "tailwindcss",
+                            "version": "^4.0.0"
+                        },
+                        {
+                            "type": "importmap",
+                            "package": "@hotwired/stimulus"
                         },
                         {
                             "type": "recipe",
@@ -215,7 +263,10 @@ final class RecipeManifestTest extends TestCase
         $this->assertSame('An incredible component', $manifest->description);
         $this->assertSame(['templates/' => 'templates/'], $manifest->copyFiles);
         $this->assertEquals([
+            new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra', null),
             new PhpPackageDependency('symfony/ux-twig-component', new Version('^2.29')),
+            new NpmPackageDependency('tailwindcss', new Version('^4.0.0')),
+            new ImportmapPackageDependency('@hotwired/stimulus'),
             new RecipeDependency('OtherComponent'),
         ], $manifest->dependencies);
     }

--- a/src/Toolkit/tests/TestHelperTrait.php
+++ b/src/Toolkit/tests/TestHelperTrait.php
@@ -17,6 +17,11 @@ use Symfony\UX\Toolkit\Kit\KitManifest;
 
 trait TestHelperTrait
 {
+    private static function getLocalKitPath(string $kitName): string
+    {
+        return Path::join(__DIR__, '../kits', $kitName);
+    }
+
     private static function createLocalKit(string $kitName): Kit
     {
         $kitPath = Path::join(__DIR__, '../kits', $kitName);
@@ -24,9 +29,14 @@ trait TestHelperTrait
         return new Kit($kitPath, KitManifest::fromJson(file_get_contents(Path::join($kitPath, 'manifest.json'))));
     }
 
+    private static function getFixtureKitPath(string $kitName): string
+    {
+        return Path::join(__DIR__, 'Fixtures/kits', $kitName);
+    }
+
     private static function createFixtureKit(string $kitName): Kit
     {
-        $kitPath = Path::join(__DIR__, 'Fixtures/kits', $kitName);
+        $kitPath = self::getFixtureKitPath($kitName);
 
         return new Kit($kitPath, KitManifest::fromJson(file_get_contents(Path::join($kitPath, 'manifest.json'))));
     }

--- a/ux.symfony.com/src/Service/Toolkit/ToolkitService.php
+++ b/ux.symfony.com/src/Service/Toolkit/ToolkitService.php
@@ -105,6 +105,30 @@ class ToolkitService
             $manual .= '</li>';
         }
 
+        $npmPackageDependencies = $pool->getNpmPackageDependencies();
+        $importmapPackageDependencies = $pool->getImportmapPackageDependencies();
+
+        if ($npmPackageDependencies && $importmapPackageDependencies) {
+            $manual .= '<li><strong>If necessary, install the following front dependencies:</strong>';
+            $manual .= CodeBlockRenderer::highlightCode(
+                'shell',
+                '# With npm/yarn/pnpm'.\PHP_EOL
+                    .'$ npm install --save '.implode(' ', $npmPackageDependencies).\PHP_EOL
+                    .'# With importmap (Symfony 6.3+)'.\PHP_EOL
+                    .'$ php bin/console importmap:install '.implode(' ', $importmapPackageDependencies),
+                'margin-bottom: 0'
+            );
+            $manual .= '</li>';
+        } elseif ($npmPackageDependencies) {
+            $manual .= '<li><strong>If necessary, install the following npm dependencies:</strong>';
+            $manual .= CodeBlockRenderer::highlightCode('shell', '$ npm install --save '.implode(' ', $npmPackageDependencies), 'margin-bottom: 0');
+            $manual .= '</li>';
+        } elseif ($importmapPackageDependencies) {
+            $manual .= '<li><strong>If necessary, install the following importmap dependencies:</strong>';
+            $manual .= CodeBlockRenderer::highlightCode('shell', '$ php bin/console importmap:install '.implode(' ', $importmapPackageDependencies), 'margin-bottom: 0');
+            $manual .= '</li>';
+        }
+
         $manual .= '<li><strong>And the most important, enjoy!</strong></li>';
         $manual .= '</ol>';
 

--- a/ux.symfony.com/src/Twig/Components/Toolkit/ComponentDoc.php
+++ b/ux.symfony.com/src/Twig/Components/Toolkit/ComponentDoc.php
@@ -59,7 +59,7 @@ class ComponentDoc
             $this->component->manifest->description,
             current($examples),
             $this->toolkitService->renderInstallationSteps($this->kitId, $this->component),
-            dump(preg_replace('/^```twig.*\n/', '```twig'.\PHP_EOL, current($examples))),
+            preg_replace('/^```twig.*\n/', '```twig'.\PHP_EOL, current($examples)),
             array_reduce(array_keys($examples), function (string $acc, string $exampleTitle) use ($examples) {
                 $acc .= '### '.$exampleTitle.\PHP_EOL.$examples[$exampleTitle].\PHP_EOL;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

I needed to reference a npm dependency while writing on new recipes for the Shadcn kit:

<img width="1105" height="606" alt="Capture d’écran 2025-09-09 à 22 00 36" src="https://github.com/user-attachments/assets/0eddc386-cc01-4e0c-a32d-49b205034044" />


--- 

This pull request standardizes the way dependencies are defined across multiple `manifest.json` files for shadcn UI kits and updates the schema to support more flexible dependency definitions. It also introduces validation for NPM package names in the codebase.

**Manifest and Schema Standardization:**

* Updated all shadcn kit `manifest.json` files to use a `name` and optional `version` field for PHP dependencies instead of a single `package` field. This change improves consistency and clarity in dependency definitions. [[1]](diffhunk://#diff-24cc9d048e1ea32ab7acf1fb7b8efc19f740892833fa58111f4ebd5681fb85a0L12-R21) [[2]](diffhunk://#diff-b88f95cca40ccb21517ed364d1ae64aeb88625bda8ee3da66111c2977bb52803L12-R12) [[3]](diffhunk://#diff-22812152398ca59e604a70fa497e5dd421c73d4f857cf9606f3d027629b1e646L12-R12) [[4]](diffhunk://#diff-23649306253ca91b727e2ba788da884362b816613e06e421c63ed6ff3e9376e7L12-R21) [[5]](diffhunk://#diff-ff8180c4acd43b8012cf5790f0319ea396f585cd44c2a0f9a12ce7a48b2e26ecL12-R21) [[6]](diffhunk://#diff-58e4e9e27cd161c6c739e6266b1d8ed70d392dcb94735fe8ada7ef1bfb3cf153L12-R12) [[7]](diffhunk://#diff-eebe4e88402ef66554bcf3cf7f4493f792cb0b256260244f45c06f4f66324676L12-R12) [[8]](diffhunk://#diff-dc966598cc48b9fafca139520d6c4c8bcb01e15f9dcd1b21eeab3e44480f6953L12-R12) [[9]](diffhunk://#diff-b28127a845fc2217410a6f1102e2f3b16e2e9fb7b28feadf2900bcd006f8186bL12-R12) [[10]](diffhunk://#diff-f400467d5964388d2cbffbd607263fb117cefb551274af8d88fb6e7633458570L12-R12) [[11]](diffhunk://#diff-ab4aa0c78bcfd808215b9af335558a2722e7041b5be90e8c727ea1608382dbe2L12-R12) [[12]](diffhunk://#diff-8374d2d2da8dd79902987f5913ec25d1589e32ba375c1190b14636075bae911fL12-R12) [[13]](diffhunk://#diff-93608b7d5d7d64f6828df2efea3c92051aba82d16d5f9dcd56e77a51200918c7L12-R12) [[14]](diffhunk://#diff-a69e9e15bbfdafddae62b804ce99f760a6d10eef61089edd8b2f0acab801e8f5L12-R21) [[15]](diffhunk://#diff-40e38b9daaeb10efbd842b74917b8f40ad64e912e575608ac226a4851fb37a33L12-R12) [[16]](diffhunk://#diff-8b5e2a122852d850f2fb8e600e44359b85463e3e1b846a56c09c61b3dfaa27f6L12-R12) [[17]](diffhunk://#diff-594246d37d7eb85f199937add11bc90acb9afaa22ba2024ed890fab8dc826e49L12-R12) [[18]](diffhunk://#diff-e4302dc4e8a19f84ad686273ec8ba2d13bbf9861a92dbfa79d92b7f46c8d712bL12-R12)
* Enhanced the `schema-kit-recipe-v1.json` schema to:
  - Require `name` instead of `package` for PHP dependencies.
  - Add support for NPM and Importmap dependencies, each with their own required fields and validation.

**Validation Improvements:**

* Added a new `Assert::npmPackageName` method to validate NPM package names, ensuring only valid names are accepted when defining NPM dependencies.