### PR TITLE
[Toolkit][Shadcn] Add AlertDialog recipe

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -57,6 +57,8 @@ jobs:
 
         env:
             SYMFONY_REQUIRE: ${{ matrix.symfony-version || '>=5.4' }} # TODO: To change to '>=6.4' in 3.x
+            # https://github.com/spatie/phpunit-snapshot-assertions#usage-in-ci
+            CREATE_SNAPSHOTS: false
         steps:
             - uses: actions/checkout@v4
 

--- a/src/Toolkit/kits/shadcn/AlertDialog/EXAMPLES.md
+++ b/src/Toolkit/kits/shadcn/AlertDialog/EXAMPLES.md
@@ -1,0 +1,47 @@
+# Examples
+
+## Default
+
+```twig {"preview":true,"height":"500px"}
+<twig:AlertDialog id="delete_account">
+    <twig:AlertDialog:Trigger>
+        <twig:Button {{ ...trigger_attrs }}>Open</twig:Button>
+    </twig:AlertDialog:Trigger>
+    <twig:AlertDialog:Content>
+        <twig:AlertDialog:Header>
+            <twig:AlertDialog:Title>Are you absolutely sure?</twig:AlertDialog:Title>
+            <twig:AlertDialog:Description>
+                This action cannot be undone. This will permanently delete your account
+                and remove your data from our servers.
+            </twig:AlertDialog:Description>
+        </twig:AlertDialog:Header>
+        <twig:AlertDialog:Footer>
+            <twig:AlertDialog:Cancel>Cancel</twig:AlertDialog:Cancel>
+            <twig:AlertDialog:Action>Continue</twig:AlertDialog:Action>
+        </twig:AlertDialog:Footer>
+    </twig:AlertDialog:Content>
+</twig:AlertDialog>
+```
+
+## Opened by default
+
+```twig {"preview":true,"height":"500px"}
+<twig:AlertDialog id="delete_account" open>
+    <twig:AlertDialog:Trigger>
+        <twig:Button {{ ...trigger_attrs }}>Open</twig:Button>
+    </twig:AlertDialog:Trigger>
+    <twig:AlertDialog:Content>
+        <twig:AlertDialog:Header>
+            <twig:AlertDialog:Title>Are you absolutely sure?</twig:AlertDialog:Title>
+            <twig:AlertDialog:Description>
+                This action cannot be undone. This will permanently delete your account
+                and remove your data from our servers.
+            </twig:AlertDialog:Description>
+        </twig:AlertDialog:Header>
+        <twig:AlertDialog:Footer>
+            <twig:AlertDialog:Cancel>Cancel</twig:AlertDialog:Cancel>
+            <twig:AlertDialog:Action>Continue</twig:AlertDialog:Action>
+        </twig:AlertDialog:Footer>
+    </twig:AlertDialog:Content>
+</twig:AlertDialog>
+```

--- a/src/Toolkit/kits/shadcn/AlertDialog/assets/controllers/alert_dialog_controller.js
+++ b/src/Toolkit/kits/shadcn/AlertDialog/assets/controllers/alert_dialog_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from '@hotwired/stimulus';
+import { enter, leave } from 'el-transition';
+
+export default class extends Controller {
+
+    static targets = ['trigger', 'overlay', 'dialog', 'content'];
+
+    async open() {
+        this.dialogTarget.showModal();
+
+        await Promise.all([enter(this.overlayTarget), enter(this.contentTarget)]);
+
+        if (this.hasTriggerTarget) {
+            this.triggerTarget.setAttribute('aria-expanded', 'true');
+        }
+    }
+
+    async close() {
+        await Promise.all([leave(this.overlayTarget), leave(this.contentTarget)]);
+
+        this.dialogTarget.close();
+
+        if (this.hasTriggerTarget) {
+            this.triggerTarget.setAttribute('aria-expanded', 'false');
+        }
+    }
+}

--- a/src/Toolkit/kits/shadcn/AlertDialog/manifest.json
+++ b/src/Toolkit/kits/shadcn/AlertDialog/manifest.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "AlertDialog",
+    "description": "A modal dialog that interrupts the user with important content and expects a response.",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": [
+        {
+            "type": "php",
+            "name": "twig/extra-bundle"
+        },
+        {
+            "type": "php",
+            "name": "twig/html-extra",
+            "version": "^3.12.0"
+        },
+        {
+            "type": "php",
+            "name": "tales-from-a-dev/twig-tailwind-extra"
+        },
+        {
+            "type": "npm",
+            "name": "el-transition"
+        },
+        {
+            "type": "importmap",
+            "package": "el-transition"
+        },
+        {
+            "type": "recipe",
+            "name": "Button"
+        }
+    ]
+}

--- a/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog.html.twig
+++ b/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog.html.twig
@@ -1,0 +1,13 @@
+{%- props open = false, id -%}
+
+{%- set _alert_dialog_open = open %}
+{%- set _alert_dialog_id = 'alert-dialog-' ~ id -%}
+{%- set _alert_dialog_title_id = _alert_dialog_id ~ '-title' -%}
+{%- set _alert_dialog_description_id = _alert_dialog_id ~ '-description' -%}
+<div {{ attributes.defaults({
+    'data-controller': 'alert-dialog',
+    'aria-labelledby': _alert_dialog_title_id,
+    'aria-describedby': _alert_dialog_description_id,
+}) }}>
+    {% block content %}{% endblock %}
+</div>

--- a/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Action.html.twig
+++ b/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Action.html.twig
@@ -1,0 +1,4 @@
+{% props variant = 'default' %}
+<twig:Button variant="{{ variant }}" {{ ...attributes }}>
+    {{ block(outerBlocks.content) }}
+</twig:Button>

--- a/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Cancel.html.twig
+++ b/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Cancel.html.twig
@@ -1,0 +1,7 @@
+<twig:Button
+    variant="outline"
+    data-action="click->alert-dialog#close"
+    {{ ...attributes }}
+>
+    {{- block(outerBlocks.content) -}}
+</twig:Button>

--- a/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Content.html.twig
@@ -1,0 +1,37 @@
+<dialog
+    id="{{ _alert_dialog_id }}"
+    {{ _alert_dialog_open ? 'open' }}
+    class="{{ 'fixed inset-0 size-auto max-h-none max-w-none overflow-y-auto bg-transparent backdrop:bg-transparent ' ~ attributes.render('class')|tailwind_merge }}"
+    data-alert-dialog-target="dialog"
+    data-action="keydown.esc->alert-dialog#close:prevent"
+    {{ attributes.without('id') }}
+>
+    <div
+        data-alert-dialog-target="overlay"
+        data-transition-enter="transition ease-out duration-100"
+        data-transition-enter-start="transform opacity-0"
+        data-transition-enter-end="transform opacity-100"
+        data-transition-leave="transition ease-in duration-75"
+        data-transition-leave-start="transform opacity-100"
+        data-transition-leave-end="transform opacity-0"
+        class="{{ _alert_dialog_open ? '' : 'hidden' }} fixed inset-0 z-50 bg-black/50"
+    ></div>
+
+    <section
+        tabindex="0"
+        class="flex min-h-full items-end justify-center p-4 text-center focus:outline-none sm:items-center sm:p-0"
+    >
+        <div
+            data-transition-enter="transition ease-out duration-200"
+            data-transition-enter-start="transform opacity-0 scale-95"
+            data-transition-enter-end="transform opacity-100 scale-100"
+            data-transition-leave="transition ease-in duration-75"
+            data-transition-leave-start="transform opacity-100 scale-100"
+            data-transition-leave-end="transform opacity-0 scale-95"
+            class="{{ _alert_dialog_open ? '' : 'hidden' }} bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg sm:max-w-lg"
+            data-alert-dialog-target="content"
+        >
+            {%- block content %}{% endblock -%}
+        </div>
+    </section>
+</dialog>

--- a/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Description.html.twig
+++ b/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Description.html.twig
@@ -1,0 +1,7 @@
+<p
+    id="{{ _alert_dialog_description_id }}"
+    class="{{ 'text-muted-foreground text-sm ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes.without('id') }}
+>
+    {%- block content %}{% endblock -%}
+</p>

--- a/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Footer.html.twig
+++ b/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Footer.html.twig
@@ -1,0 +1,6 @@
+<footer
+    class="{{ 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</footer>

--- a/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Header.html.twig
+++ b/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Header.html.twig
@@ -1,0 +1,6 @@
+<header
+    class="{{ 'flex flex-col gap-2 text-center sm:text-left ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</header>

--- a/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Title.html.twig
+++ b/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Title.html.twig
@@ -1,0 +1,7 @@
+<h2
+    id="{{ _alert_dialog_title_id }}"
+    class="{{ 'text-lg font-semibold ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes.without('id') }}
+>
+    {%- block content %}{% endblock -%}
+</h2>

--- a/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Trigger.html.twig
+++ b/src/Toolkit/kits/shadcn/AlertDialog/templates/components/AlertDialog/Trigger.html.twig
@@ -1,0 +1,7 @@
+{%- set trigger_attrs = {
+    'data-action': 'click->alert-dialog#open',
+    'data-alert-dialog-target': 'trigger',
+    'aria-haspopup': 'dialog',
+    'aria-expanded': _alert_dialog_open ? 'true' : 'false',
+} -%}
+{%- block content %}{% endblock -%}

--- a/src/Toolkit/kits/shadcn/manifest.json
+++ b/src/Toolkit/kits/shadcn/manifest.json
@@ -3,5 +3,5 @@
     "name": "Shadcn UI",
     "description": "Component based on the Shadcn UI library, one of the most popular design systems in JavaScript world.",
     "license": "MIT",
-    "homepage": "https://ux.symfony.com/components"
+    "homepage": "https://ux.symfony.com/toolkit/kits/shadcn"
 }

--- a/src/Toolkit/src/Command/InstallCommand.php
+++ b/src/Toolkit/src/Command/InstallCommand.php
@@ -216,15 +216,17 @@ class InstallCommand extends Command
      */
     private function getAlternativeRecipes(Kit $kit, string $recipeName): array
     {
-        $alternative = [];
+        $alternativeRecipes = [];
 
         foreach ($kit->getRecipes() as $recipe) {
             $lev = levenshtein($recipeName, $recipe->manifest->name, 2, 5, 10);
             if ($lev <= 8 || str_contains($recipe->manifest->name, $recipeName)) {
-                $alternative[] = $recipe;
+                $alternativeRecipes[] = $recipe;
             }
         }
 
-        return $alternative;
+        usort($alternativeRecipes, fn (Recipe $recipeA, Recipe $recipeB) => strcmp($recipeA->manifest->name, $recipeB->manifest->name));
+
+        return $alternativeRecipes;
     }
 }

--- a/src/Toolkit/src/Kit/KitContextRunner.php
+++ b/src/Toolkit/src/Kit/KitContextRunner.php
@@ -24,6 +24,11 @@ use Twig\Loader\FilesystemLoader;
  */
 final class KitContextRunner
 {
+    /**
+     * @var array<string, ComponentTemplateFinderInterface>
+     */
+    private static $componentTemplateFinders = [];
+
     public function __construct(
         private readonly \Twig\Environment $twig,
         private readonly ComponentFactory $componentFactory,
@@ -39,51 +44,59 @@ final class KitContextRunner
      */
     public function runForKit(Kit $kit, callable $callback): mixed
     {
-        $resetServices = $this->contextualizeServicesForKit($kit);
+        $resetTwig = $this->contextualizeTwig($kit);
+        $resetComponentFactory = $this->contextualizeComponentFactory($kit);
 
         try {
             return $callback($kit);
         } finally {
-            $resetServices();
+            $resetTwig();
+            $resetComponentFactory();
         }
     }
 
     /**
-     * @return callable(): void Reset the services when called
+     * @return callable(): void
      */
-    private function contextualizeServicesForKit(Kit $kit): callable
+    private function contextualizeTwig(Kit $kit): callable
     {
-        // Configure Twig
         $initialTwigLoader = $this->twig->getLoader();
+
         $loaders = [];
         foreach ($kit->getRecipes(type: RecipeType::Component) as $recipe) {
             $loaders[] = new FilesystemLoader($recipe->absolutePath);
         }
-        $this->twig->setLoader(new ChainLoader([...$loaders, $initialTwigLoader]));
+        $loaders[] = $initialTwigLoader;
 
-        // Configure Twig Components
+        $this->twig->setLoader(new ChainLoader($loaders));
+
+        return fn () => $this->twig->setLoader($initialTwigLoader);
+    }
+
+    /**
+     * @return callable(): void
+     */
+    private function contextualizeComponentFactory(Kit $kit): callable
+    {
         $reflComponentFactory = new \ReflectionClass($this->componentFactory);
 
-        $reflComponentFactoryConfig = $reflComponentFactory->getProperty('config');
-        $initialComponentFactoryConfig = $reflComponentFactoryConfig->getValue($this->componentFactory);
-        $reflComponentFactoryConfig->setValue($this->componentFactory, []);
+        $reflConfig = $reflComponentFactory->getProperty('config');
+        $initialConfig = $reflConfig->getValue($this->componentFactory);
+        $reflConfig->setValue($this->componentFactory, []);
 
-        $reflComponentFactoryComponentTemplateFinder = $reflComponentFactory->getProperty('componentTemplateFinder');
-        $initialComponentFactoryComponentTemplateFinder = $reflComponentFactoryComponentTemplateFinder->getValue($this->componentFactory);
-        $reflComponentFactoryComponentTemplateFinder->setValue($this->componentFactory, $this->createComponentTemplateFinder($kit));
+        $reflComponentTemplateFinder = $reflComponentFactory->getProperty('componentTemplateFinder');
+        $initialComponentTemplateFinder = $reflComponentTemplateFinder->getValue($this->componentFactory);
+        $reflComponentTemplateFinder->setValue($this->componentFactory, $this->createComponentTemplateFinder($kit));
 
-        return function () use ($initialTwigLoader, $reflComponentFactoryConfig, $initialComponentFactoryConfig, $reflComponentFactoryComponentTemplateFinder, $initialComponentFactoryComponentTemplateFinder) {
-            $this->twig->setLoader($initialTwigLoader);
-            $reflComponentFactoryConfig->setValue($this->componentFactory, $initialComponentFactoryConfig);
-            $reflComponentFactoryComponentTemplateFinder->setValue($this->componentFactory, $initialComponentFactoryComponentTemplateFinder);
+        return function () use ($reflConfig, $initialConfig, $reflComponentTemplateFinder, $initialComponentTemplateFinder): void {
+            $reflConfig->setValue($this->componentFactory, $initialConfig);
+            $reflComponentTemplateFinder->setValue($this->componentFactory, $initialComponentTemplateFinder);
         };
     }
 
     private function createComponentTemplateFinder(Kit $kit): ComponentTemplateFinderInterface
     {
-        static $instances = [];
-
-        return $instances[$kit->manifest->name] ?? new class($kit) implements ComponentTemplateFinderInterface {
+        return self::$componentTemplateFinders[$kit->manifest->name] ??= new class($kit) implements ComponentTemplateFinderInterface {
             public function __construct(private readonly Kit $kit)
             {
             }

--- a/src/Toolkit/tests/Command/DebugKitCommandTest.php
+++ b/src/Toolkit/tests/Command/DebugKitCommandTest.php
@@ -28,7 +28,7 @@ class DebugKitCommandTest extends KernelTestCase
             ->assertSuccessful()
             // Kit details
             ->assertOutputContains('Name       Shadcn')
-            ->assertOutputContains('Homepage   https://ux.symfony.com/components')
+            ->assertOutputContains('Homepage   https://ux.symfony.com/toolkit/kits/shadcn')
             ->assertOutputContains('License    MIT')
             // Components details
             ->assertOutputContains(implode(\PHP_EOL, [

--- a/src/Toolkit/tests/Command/InstallCommandTest.php
+++ b/src/Toolkit/tests/Command/InstallCommandTest.php
@@ -76,7 +76,7 @@ class InstallCommandTest extends KernelTestCase
             ->execute()
             ->assertFaulty()
             ->assertOutputContains('[WARNING] The recipe "A" does not exist')
-            ->assertOutputContains('Possible alternatives: "Alert", "AspectRatio", "Avatar"')
+            ->assertOutputContains('Possible alternatives: "Alert", "AlertDialog", "AspectRatio"')
         ;
     }
 

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component AlertDialog, code 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component AlertDialog, code 1__1.html
@@ -1,0 +1,45 @@
+<!--
+- Kit: Shadcn UI
+- Component: AlertDialog
+- Code:
+```twig
+<twig:AlertDialog id="delete_account">
+    <twig:AlertDialog:Trigger>
+        <twig:Button {{ ...trigger_attrs }}>Open</twig:Button>
+    </twig:AlertDialog:Trigger>
+    <twig:AlertDialog:Content>
+        <twig:AlertDialog:Header>
+            <twig:AlertDialog:Title>Are you absolutely sure?</twig:AlertDialog:Title>
+            <twig:AlertDialog:Description>
+                This action cannot be undone. This will permanently delete your account
+                and remove your data from our servers.
+            </twig:AlertDialog:Description>
+        </twig:AlertDialog:Header>
+        <twig:AlertDialog:Footer>
+            <twig:AlertDialog:Cancel>Cancel</twig:AlertDialog:Cancel>
+            <twig:AlertDialog:Action>Continue</twig:AlertDialog:Action>
+        </twig:AlertDialog:Footer>
+    </twig:AlertDialog:Content>
+</twig:AlertDialog>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="alert-dialog" aria-labelledby="alert-dialog-delete_account-title" aria-describedby="alert-dialog-delete_account-description">
+    <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2" data-action="click-&gt;alert-dialog#open" data-alert-dialog-target="trigger" aria-haspopup="dialog" aria-expanded="false">Open</button>
+        <dialog id="alert-dialog-delete_account" class="fixed inset-0 size-auto max-h-none max-w-none overflow-y-auto bg-transparent backdrop:bg-transparent " data-alert-dialog-target="dialog" data-action="keydown.esc-&gt;alert-dialog#close:prevent">
+    <div data-alert-dialog-target="overlay" data-transition-enter="transition ease-out duration-100" data-transition-enter-start="transform opacity-0" data-transition-enter-end="transform opacity-100" data-transition-leave="transition ease-in duration-75" data-transition-leave-start="transform opacity-100" data-transition-leave-end="transform opacity-0" class="hidden fixed inset-0 z-50 bg-black/50"></div>
+
+    <section tabindex="0" class="flex min-h-full items-end justify-center p-4 text-center focus:outline-none sm:items-center sm:p-0">
+        <div data-transition-enter="transition ease-out duration-200" data-transition-enter-start="transform opacity-0 scale-95" data-transition-enter-end="transform opacity-100 scale-100" data-transition-leave="transition ease-in duration-75" data-transition-leave-start="transform opacity-100 scale-100" data-transition-leave-end="transform opacity-0 scale-95" class="hidden bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg sm:max-w-lg" data-alert-dialog-target="content">
+<header class="flex flex-col gap-2 text-center sm:text-left "><h2 id="alert-dialog-delete_account-title" class="text-lg font-semibold ">Are you absolutely sure?</h2>
+            <p id="alert-dialog-delete_account-description" class="text-muted-foreground text-sm ">This action cannot be undone. This will permanently delete your account
+                and remove your data from our servers.
+            </p>
+        </header>
+        <footer class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end "><button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2" data-action="click-&gt;alert-dialog#close">Cancel</button>
+            <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">Continue
+</button>
+        </footer>
+    </div>
+    </section>
+</dialog>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component AlertDialog, code 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component AlertDialog, code 2__1.html
@@ -1,0 +1,45 @@
+<!--
+- Kit: Shadcn UI
+- Component: AlertDialog
+- Code:
+```twig
+<twig:AlertDialog id="delete_account" open>
+    <twig:AlertDialog:Trigger>
+        <twig:Button {{ ...trigger_attrs }}>Open</twig:Button>
+    </twig:AlertDialog:Trigger>
+    <twig:AlertDialog:Content>
+        <twig:AlertDialog:Header>
+            <twig:AlertDialog:Title>Are you absolutely sure?</twig:AlertDialog:Title>
+            <twig:AlertDialog:Description>
+                This action cannot be undone. This will permanently delete your account
+                and remove your data from our servers.
+            </twig:AlertDialog:Description>
+        </twig:AlertDialog:Header>
+        <twig:AlertDialog:Footer>
+            <twig:AlertDialog:Cancel>Cancel</twig:AlertDialog:Cancel>
+            <twig:AlertDialog:Action>Continue</twig:AlertDialog:Action>
+        </twig:AlertDialog:Footer>
+    </twig:AlertDialog:Content>
+</twig:AlertDialog>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="alert-dialog" aria-labelledby="alert-dialog-delete_account-title" aria-describedby="alert-dialog-delete_account-description">
+    <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2" data-action="click-&gt;alert-dialog#open" data-alert-dialog-target="trigger" aria-haspopup="dialog" aria-expanded="true">Open</button>
+        <dialog id="alert-dialog-delete_account" open class="fixed inset-0 size-auto max-h-none max-w-none overflow-y-auto bg-transparent backdrop:bg-transparent " data-alert-dialog-target="dialog" data-action="keydown.esc-&gt;alert-dialog#close:prevent">
+    <div data-alert-dialog-target="overlay" data-transition-enter="transition ease-out duration-100" data-transition-enter-start="transform opacity-0" data-transition-enter-end="transform opacity-100" data-transition-leave="transition ease-in duration-75" data-transition-leave-start="transform opacity-100" data-transition-leave-end="transform opacity-0" class=" fixed inset-0 z-50 bg-black/50"></div>
+
+    <section tabindex="0" class="flex min-h-full items-end justify-center p-4 text-center focus:outline-none sm:items-center sm:p-0">
+        <div data-transition-enter="transition ease-out duration-200" data-transition-enter-start="transform opacity-0 scale-95" data-transition-enter-end="transform opacity-100 scale-100" data-transition-leave="transition ease-in duration-75" data-transition-leave-start="transform opacity-100 scale-100" data-transition-leave-end="transform opacity-0 scale-95" class=" bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg sm:max-w-lg" data-alert-dialog-target="content">
+<header class="flex flex-col gap-2 text-center sm:text-left "><h2 id="alert-dialog-delete_account-title" class="text-lg font-semibold ">Are you absolutely sure?</h2>
+            <p id="alert-dialog-delete_account-description" class="text-muted-foreground text-sm ">This action cannot be undone. This will permanently delete your account
+                and remove your data from our servers.
+            </p>
+        </header>
+        <footer class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end "><button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2" data-action="click-&gt;alert-dialog#close">Cancel</button>
+            <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">Continue
+</button>
+        </footer>
+    </div>
+    </section>
+</dialog>
+</div>

--- a/ux.symfony.com/assets/toolkit-shadcn.js
+++ b/ux.symfony.com/assets/toolkit-shadcn.js
@@ -1,1 +1,6 @@
 import './styles/toolkit-shadcn.css';
+import { startStimulusApp } from '@symfony/stimulus-bundle';
+import AlertDialog from '@symfony/ux-toolkit/kits/shadcn/AlertDialog/assets/controllers/alert_dialog_controller.js';
+
+const app = startStimulusApp();
+app.register('alert-dialog', AlertDialog);

--- a/ux.symfony.com/config/packages/asset_mapper.yaml
+++ b/ux.symfony.com/config/packages/asset_mapper.yaml
@@ -2,7 +2,8 @@ framework:
     asset_mapper:
         # The paths to make available to the asset mapper.
         paths:
-            - assets/
+            assets/: ''
+            vendor/symfony/ux-toolkit/kits/: '@symfony/ux-toolkit/kits'
         excluded_patterns:
             - '*/assets/styles/_*.scss'
             - '*/assets/styles/**/_*.scss'
@@ -11,6 +12,9 @@ framework:
             - '*/assets/react/src**'       # React sources
             - '*/assets/svelte/build**'    # ESvelte build dir
             - '*/assets/svelte/src**'      # Svelte source files
+            - '*/kits/**/*.html.twig'      # UX Toolkit kit Twig templates
+            - '*/kits/**/*.md'             # UX Toolkit kit documentation
+            - '*/kits/**/manifest.json'    # UX Toolkit kit manifest files
         importmap_polyfill: false
 
 react:

--- a/ux.symfony.com/importmap.php
+++ b/ux.symfony.com/importmap.php
@@ -204,4 +204,10 @@ return [
     '@symfony/ux-leaflet-map' => [
         'path' => './vendor/symfony/ux-leaflet-map/assets/dist/map_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/AlertDialog/assets/controllers/alert_dialog_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/AlertDialog/assets/controllers/alert_dialog_controller.js',
+    ],
+    'el-transition' => [
+        'version' => '0.0.7',
+    ],
 ];

--- a/ux.symfony.com/src/Service/Toolkit/ToolkitService.php
+++ b/ux.symfony.com/src/Service/Toolkit/ToolkitService.php
@@ -132,7 +132,7 @@ class ToolkitService
         $manual .= '<li><strong>And the most important, enjoy!</strong></li>';
         $manual .= '</ol>';
 
-        return $this->generateTabs([
+        return self::generateTabs([
             'Automatic' => \sprintf(
                 '<p>Ensure the Symfony UX Toolkit is installed in your Symfony app:</p>%s<p>Then, run the following command to install the component and its dependencies:</p>%s',
                 CodeBlockRenderer::highlightCode('shell', '$ composer require --dev symfony/ux-toolkit'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

With this new AlertDialog recipe, the following code:
```twig
<twig:AlertDialog>
    <twig:AlertDialog:Trigger>
        <twig:Button {{ ...trigger_attrs }}>Open</twig:Button>
    </twig:AlertDialog:Trigger>
    <twig:AlertDialog:Content>
        <twig:AlertDialog:Header>
            <twig:AlertDialog:Title>Are you absolutely sure?</twig:AlertDialog:Title>
            <twig:AlertDialog:Description>
                This action cannot be undone. This will permanently delete your account
                and remove your data from our servers.
            </twig:AlertDialog:Description>
        </twig:AlertDialog:Header>
        <twig:AlertDialog:Footer>
            <twig:AlertDialog:Cancel>Cancel</twig:AlertDialog:Cancel>
            <twig:AlertDialog:Action>Continue</twig:AlertDialog:Action>
        </twig:AlertDialog:Footer>
    </twig:AlertDialog:Content>
</twig:AlertDialog>
```

renders: 

https://github.com/user-attachments/assets/4c1c836f-9051-489a-a2ec-83e09a75853f

---

This pull request introduces the new `AlertDialog` component to the Shadcn UI kit in the Symfony UX Toolkit, including its templates, JavaScript controller, documentation, and manifest. It also updates the toolkit infrastructure to support the new component, refines asset mapping, and improves component context handling. Additionally, some minor documentation and test updates are included.

**New AlertDialog Component:**

- Added the complete `AlertDialog` component, including Twig templates for all subcomponents (`Content`, `Header`, `Footer`, `Title`, `Description`, `Trigger`, `Action`, `Cancel`), a Stimulus controller for open/close behavior with transitions, and detailed usage examples in `EXAMPLES.md`. [[1]](diffhunk://#diff-1e8ce2e329975545f086aa3b8750d3b44da63cdf032646af0d99e7b9b2de4c5cR1-R47) [[2]](diffhunk://#diff-f14c3832bf831f5267b41d784094cf24a84edc5f79abc0637b1dac6920e14df1R1-R27) [[3]](diffhunk://#diff-91557baac0c727764c3898ee86de6ec62deb6b33ce82bc86d621f2c3b9ba7233R1-R13) [[4]](diffhunk://#diff-a2c365dd11321098d3f26effc35341c9279cded71da56b1797f861e1cd0c723aR1-R37) [[5]](diffhunk://#diff-2b90716a494d08147e3707a62675fcaaf6befdc041085d7d44e06cb3af32b485R1-R6) [[6]](diffhunk://#diff-40dc30f4cd5b6a18cfd9da93bb067cf7854e200c2348431e045cdcbebed4eb96R1-R6) [[7]](diffhunk://#diff-206b916d71f01ccad6e8b3950731ec0f3cd8dab058b2e038804439ba9b2d9c44R1-R7) [[8]](diffhunk://#diff-0369bb96b47c3d4c0acfe5dfdea8642690e8f8f6681bc926fae0b6264ef34219R1-R7) [[9]](diffhunk://#diff-7eda7755d4c14d6ce00a3e8199913b3b9f7a0f1e1ced0deeb8fba9a0e3379e96R1-R7) [[10]](diffhunk://#diff-05905531ae89a23629be33318174aaead05963b525710179b98e8e248c0d6ea4R1-R4) [[11]](diffhunk://#diff-bb139b689add718b84387dddd493a83d71911eb6e6faed46e41d68461b78d9b4R1-R7)

- Added a manifest for the `AlertDialog` component specifying dependencies and recipe details.

**Toolkit Infrastructure and Asset Handling:**

- Refined the `KitContextRunner` to better separate Twig and component factory contextualization, improving reliability and maintainability when running code for specific kits. [[1]](diffhunk://#diff-cfffacbba1a1731189cefcdcfbf0096947ac2b4f2d41d83656b8814f072ce535R27-R31) [[2]](diffhunk://#diff-cfffacbba1a1731189cefcdcfbf0096947ac2b4f2d41d83656b8814f072ce535L42-R99)

- Updated asset mapping to expose kit assets under a namespaced path and to exclude kit templates, documentation, and manifests from asset mapping. [[1]](diffhunk://#diff-f414b69a2be9ec873133c4230f66df08251e9efc1885d4dc9246a7d28c428472L5-R6) [[2]](diffhunk://#diff-f414b69a2be9ec873133c4230f66df08251e9efc1885d4dc9246a7d28c428472R15-R17)

- Registered the `alert-dialog` Stimulus controller in the app's JavaScript entrypoint and importmap, and added the `el-transition` dependency. [[1]](diffhunk://#diff-778967d6b92db56e30a61c00288340db8cf087bbb76626da93bdd2abd8399a18R2-R6) [[2]](diffhunk://#diff-a2b46fc4576c4f4edafcd41c9d18f6288c855a95ac32139e6e721be80d2e2052R207-R212)

**Documentation and Test Updates:**

- Updated kit and component documentation to reference the new homepage URL and include `AlertDialog` in suggestions and tests. [[1]](diffhunk://#diff-aa11a152e722d16f5bd4601cdbaa7a977b62370267ca536c1dc6677cb5d48cd3L6-R6) [[2]](diffhunk://#diff-bd0225f055b73556a1d02abc993c0cc75d00ec79077eebb0746a831d749c680cL79-R79) [[3]](diffhunk://#diff-13a35e56dbb84c2b7166f8ba00ee56fbbd9f79719a2e04f93a1171691961b22fL31-R31)

- Minor fix to use `self::generateTabs` in the toolkit service for consistency.