### PR TITLE
[LiveComponent] Replace the browser's URL before triggering `render:finished` hook

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2021,7 +2021,6 @@ var Component = class {
         thisPromiseResolve(backendResponse);
         return response;
       }
-      this.processRerender(html, backendResponse);
       const liveUrl = backendResponse.getLiveUrl();
       if (liveUrl) {
         history.replaceState(
@@ -2030,6 +2029,7 @@ var Component = class {
           new URL(liveUrl + window.location.hash, window.location.origin)
         );
       }
+      this.processRerender(html, backendResponse);
       this.backendRequest = null;
       thisPromiseResolve(backendResponse);
       if (this.isRequestPending) {

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -327,7 +327,6 @@ export default class Component {
                 return response;
             }
 
-            this.processRerender(html, backendResponse);
             const liveUrl = backendResponse.getLiveUrl();
             if (liveUrl) {
                 history.replaceState(
@@ -336,6 +335,8 @@ export default class Component {
                     new URL(liveUrl + window.location.hash, window.location.origin)
                 );
             }
+
+            this.processRerender(html, backendResponse);
 
             // finally resolve this promise
             this.backendRequest = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | >
| License       | MIT

After the URL change, performing the **``render:finished``** event will provide smoother control.