### PR TITLE
 [StimulusBundle] Add missing closing brace in AssetMapper 6.3 example

### DIFF
--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -418,7 +418,7 @@ is running in debug mode.
 
 .. tip::
 
-    For AssetMapper 6.3 only, you also need a ``{{ ux_controller_link_tags() }``
+    For AssetMapper 6.3 only, you also need a ``{{ ux_controller_link_tags() }}``
     in ``base.html.twig``. This is not needed in AssetMapper 6.4+.
 
 With WebpackEncoreBundle


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | <!-- none -->
| License        | MIT

---

This PR fixes a typo in the documentation.

Changed:

```twig
For AssetMapper 6.3 only, you also need a ``{{ ux_controller_link_tags() }`
``` 
to 

```twig
For AssetMapper 6.3 only, you also need a ``{{ ux_controller_link_tags() }}``
``` 

