### PR TITLE
[Vue] Remove deprecations for 3.0

### DIFF
--- a/src/Vue/CHANGELOG.md
+++ b/src/Vue/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Minimum required Symfony version is now 6.4
 -   Minimum required PHP version is now 8.2
+-   Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 
 ## 2.30
 

--- a/src/Vue/src/Twig/VueComponentExtension.php
+++ b/src/Vue/src/Twig/VueComponentExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\UX\Vue\Twig;
 
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
-use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -24,19 +23,8 @@ use Twig\TwigFunction;
  */
 class VueComponentExtension extends AbstractExtension
 {
-    private $stimulusHelper;
-
-    /**
-     * @param $stimulus StimulusHelper
-     */
-    public function __construct(StimulusHelper|StimulusTwigExtension $stimulus)
+    public function __construct(private StimulusHelper $stimulusHelper)
     {
-        if ($stimulus instanceof StimulusTwigExtension) {
-            trigger_deprecation('symfony/ux-vue', '2.9', 'Passing an instance of "%s" to "%s" is deprecated, pass an instance of "%s" instead.', StimulusTwigExtension::class, __CLASS__, StimulusHelper::class);
-            $stimulus = new StimulusHelper(null);
-        }
-
-        $this->stimulusHelper = $stimulus;
     }
 
     public function getFunctions(): array


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

src/Vue/src/Twig/VueComponentExtension.php:35

```php
trigger_deprecation('symfony/ux-vue', '2.9', 'Passing an instance of "%s" to "%s" is deprecated, pass an instance of "%s" instead.', StimulusTwigExtension::class, __CLASS__, StimulusHelper::class);
```

