### PR TITLE
[Chartjs][Notify][React][Svelte] Remove StimulusHelper deprecation for 3.0

### DIFF
--- a/src/Chartjs/CHANGELOG.md
+++ b/src/Chartjs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Minimum required Symfony version is now 6.4
 -   Minimum required PHP version is now 8.2
+-   Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 
 ## 2.30
 

--- a/src/Chartjs/src/Twig/ChartExtension.php
+++ b/src/Chartjs/src/Twig/ChartExtension.php
@@ -13,7 +13,6 @@ namespace Symfony\UX\Chartjs\Twig;
 
 use Symfony\UX\Chartjs\Model\Chart;
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
-use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -24,19 +23,8 @@ use Twig\TwigFunction;
  */
 class ChartExtension extends AbstractExtension
 {
-    private $stimulus;
-
-    /**
-     * @param $stimulus StimulusHelper
-     */
-    public function __construct(StimulusHelper|StimulusTwigExtension $stimulus)
+    public function __construct(private StimulusHelper $stimulusHelper)
     {
-        if ($stimulus instanceof StimulusTwigExtension) {
-            trigger_deprecation('symfony/ux-chartjs', '2.9', 'Passing an instance of "%s" to "%s" is deprecated, pass an instance of "%s" instead.', StimulusTwigExtension::class, __CLASS__, StimulusHelper::class);
-            $stimulus = new StimulusHelper(null);
-        }
-
-        $this->stimulus = $stimulus;
     }
 
     public function getFunctions(): array
@@ -56,7 +44,7 @@ class ChartExtension extends AbstractExtension
         }
         $controllers['@symfony/ux-chartjs/chart'] = ['view' => $chart->createView()];
 
-        $stimulusAttributes = $this->stimulus->createStimulusAttributes();
+        $stimulusAttributes = $this->stimulusHelper->createStimulusAttributes();
         foreach ($controllers as $name => $controllerValues) {
             $stimulusAttributes->addController($name, $controllerValues);
         }

--- a/src/Notify/CHANGELOG.md
+++ b/src/Notify/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Minimum required Symfony version is now 6.4
 -   Minimum required PHP version is now 8.2
+-   Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 
 ## 2.30
 

--- a/src/Notify/src/Twig/NotifyRuntime.php
+++ b/src/Notify/src/Twig/NotifyRuntime.php
@@ -13,7 +13,6 @@ namespace Symfony\UX\Notify\Twig;
 
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
-use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
 use Twig\Extension\RuntimeExtensionInterface;
 
 /**
@@ -21,21 +20,10 @@ use Twig\Extension\RuntimeExtensionInterface;
  */
 final class NotifyRuntime implements RuntimeExtensionInterface
 {
-    private StimulusHelper $stimulusHelper;
-
-    /**
-     * @param $stimulus StimulusHelper
-     */
     public function __construct(
         private HubInterface $hub,
-        StimulusHelper|StimulusTwigExtension $stimulus,
+        private StimulusHelper $stimulusHelper,
     ) {
-        if ($stimulus instanceof StimulusTwigExtension) {
-            trigger_deprecation('symfony/ux-notify', '2.9', 'Passing an instance of "%s" to "%s" is deprecated, pass an instance of "%s" instead.', StimulusTwigExtension::class, __CLASS__, StimulusHelper::class);
-            $stimulus = new StimulusHelper(null);
-        }
-
-        $this->stimulusHelper = $stimulus;
     }
 
     public function renderStreamNotifications(array|string $topics = [], array $options = []): string

--- a/src/React/CHANGELOG.md
+++ b/src/React/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Minimum required Symfony version is now 6.4
 -   Minimum required PHP version is now 8.2
+-   Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 
 ## 2.30
 

--- a/src/React/src/Twig/ReactComponentExtension.php
+++ b/src/React/src/Twig/ReactComponentExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\UX\React\Twig;
 
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
-use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,19 +22,8 @@ use Twig\TwigFunction;
  */
 class ReactComponentExtension extends AbstractExtension
 {
-    private $stimulusHelper;
-
-    /**
-     * @param $stimulus StimulusHelper
-     */
-    public function __construct(StimulusHelper|StimulusTwigExtension $stimulus)
+    public function __construct(private StimulusHelper $stimulusHelper)
     {
-        if ($stimulus instanceof StimulusTwigExtension) {
-            trigger_deprecation('symfony/ux-react', '2.9', 'Passing an instance of "%s" to "%s" is deprecated, pass an instance of "%s" instead.', StimulusTwigExtension::class, __CLASS__, StimulusHelper::class);
-            $stimulus = new StimulusHelper(null);
-        }
-
-        $this->stimulusHelper = $stimulus;
     }
 
     public function getFunctions(): array

--- a/src/Svelte/CHANGELOG.md
+++ b/src/Svelte/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Minimum required Symfony version is now 6.4
 -   Minimum required PHP version is now 8.2
+-   Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 
 ## 2.30
 

--- a/src/Svelte/src/Twig/SvelteComponentExtension.php
+++ b/src/Svelte/src/Twig/SvelteComponentExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\UX\Svelte\Twig;
 
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
-use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -24,19 +23,8 @@ use Twig\TwigFunction;
  */
 class SvelteComponentExtension extends AbstractExtension
 {
-    private $stimulusHelper;
-
-    /**
-     * @param $stimulus StimulusHelper
-     */
-    public function __construct(StimulusHelper|StimulusTwigExtension $stimulus)
+    public function __construct(private StimulusHelper $stimulusHelper)
     {
-        if ($stimulus instanceof StimulusTwigExtension) {
-            trigger_deprecation('symfony/ux-svelte', '2.9', 'Passing an instance of "%s" to "%s" is deprecated, pass an instance of "%s" instead.', StimulusTwigExtension::class, __CLASS__, StimulusHelper::class);
-            $stimulus = new StimulusHelper(null);
-        }
-
-        $this->stimulusHelper = $stimulus;
     }
 
     public function getFunctions(): array

--- a/src/Vue/src/Twig/VueComponentExtension.php
+++ b/src/Vue/src/Twig/VueComponentExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\Vue\Twig;
 
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
+use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,8 +24,19 @@ use Twig\TwigFunction;
  */
 class VueComponentExtension extends AbstractExtension
 {
-    public function __construct(private StimulusHelper $stimulusHelper)
+    private $stimulusHelper;
+
+    /**
+     * @param $stimulus StimulusHelper
+     */
+    public function __construct(StimulusHelper|StimulusTwigExtension $stimulus)
     {
+        if ($stimulus instanceof StimulusTwigExtension) {
+            trigger_deprecation('symfony/ux-vue', '2.9', 'Passing an instance of "%s" to "%s" is deprecated, pass an instance of "%s" instead.', StimulusTwigExtension::class, __CLASS__, StimulusHelper::class);
+            $stimulus = new StimulusHelper(null);
+        }
+
+        $this->stimulusHelper = $stimulus;
     }
 
     public function getFunctions(): array


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   |  yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  |  no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Remove this check (or same-ish) in these ux pacakges

```php
        if ($stimulus instanceof StimulusTwigExtension) {
            trigger_deprecation('symfony/ux-chartjs', '2.9', 'Passing an instance of "%s" to "%s" is deprecated, pass an instance of "%s" instead.', StimulusTwigExtension::class, __CLASS__, StimulusHelper::class);
            $stimulus = new StimulusHelper(null);
        }
```        
