### PR TITLE
[LiveComponent] Better file handling for forms 

### DIFF
--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -13,8 +13,12 @@ namespace Symfony\UX\LiveComponent;
 
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ClearableErrorsInterface;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Util\FormUtil;
+use Symfony\Component\Form\Util\ServerParams;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -147,7 +151,7 @@ trait ComponentWithFormTrait
         }
     }
 
-    private function submitForm(bool $validateAll = true): void
+    private function submitForm(bool $validateAll = true, ?Request $request = null): void
     {
         if (null !== $this->formView) {
             // Two scenarios can cause this:
@@ -160,7 +164,50 @@ trait ComponentWithFormTrait
         }
 
         $form = $this->getForm();
-        $form->submit($this->formValues);
+        $method = $form->getConfig()->getMethod();
+
+        // For request methods that must not have a request body we fetch data
+        // from the query string. Otherwise we look for data in the request body.
+        if ('POST' === $method && $request instanceof Request) {
+            // Mark the form with an error if the uploaded size was too large
+            // This is done here and not in FormValidator because $_POST is
+            // empty when that error occurs. Hence the form is never submitted.
+            $serverParams = new ServerParams();
+            if ($serverParams->hasPostMaxSizeBeenExceeded()) {
+                // Submit the form, but don't clear the default values
+                $form->submit(null, false);
+
+                $form->addError(new FormError(
+                    $form->getConfig()->getOption('upload_max_size_message')(),
+                    null,
+                    ['{{ max }}' => $serverParams->getNormalizedIniPostMaxSize()]
+                ));
+
+                return;
+            }
+
+            $name = $form->getName();
+
+            if ('' === $name) {
+                $params = $request->request->all();
+                $files = $request->files->all();
+            } elseif ($request->request->has($name) || $request->files->has($name)) {
+                $default = $form->getConfig()->getCompound() ? [] : null;
+                $params = $request->request->all()[$name] ?? $default;
+                $files = $request->files->get($name, $default);
+            } else {
+                // Don't submit the form if it is not present in the request
+                return;
+            }
+
+            if (\is_array($params) && \is_array($files)) {
+                $data = FormUtil::mergeParamsAndFiles($params, $files);
+            } else {
+                $data = $params ?: $files;
+            }
+        }
+
+        $form->submit($data ?? $this->formValues);
         $this->shouldAutoSubmitForm = false;
 
         if ($validateAll) {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no, but this feels like a bugfix to me
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | needed <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT


These changes allow a better file handling for live component forms with files. Currently, the docs require you to handle files directly from the $request object: "The files will be available in a regular `$request->files` files bag". Si if you have a Dto such as :

```php
class Dto {
  public string $name;
  public ?UploadedFile $file;
}
```
with a corresponding form (text + file inputs), after using $this->submitForm($form) in your live component you would have an empty Dto::file field, and you would be forced to look up inside the $request object. Here I copied and adapted the $form->handleRequest($request) logic you get in a classic controller workflow, wich picks up the files in the request and injects them as data, so now you would do

```php
#[LiveAction]
public function save(Request $request) {
  $this->submitForm(request: $request);
  $dto = $this->getForm()->getData();

  $dto->file->move('public/uploads');   // yay $dto->file is an UploadedFile now !
}
```
And at this point you _will_ have $dto::file as an UploadedFile instance you can freely manipulate.

Because `submitForm` has an existing optional parameter the usage feels weird, but to avoid BC break the Request object is to be injected second like `$this->submitForm(true, $request)` or as a named parameter `$this->submitForm(request: $request)` for proper usage. IMO the two parameters should be swapped in a future major version, I don't think the usage priority of $validateAll precedes the $request handling.

This can maybe break the data workflow if you have touched `$this->formValues` somehow because it takes its data from the request directly. I'm not familiar with _why_ this wasn't done this way in the first place so happy to discuss it!