### PR TITLE
[Map] Add fitBoundsToMarkers option to Twig extension and component

### DIFF
--- a/src/Map/CHANGELOG.md
+++ b/src/Map/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.31
+
+-  Add `fitBoundsToMarkers` parameter to `ux_map()` Twig function
+
 ## 2.30
 
 -  Ensure compatibility with PHP 8.5

--- a/src/Map/doc/index.rst
+++ b/src/Map/doc/index.rst
@@ -329,11 +329,16 @@ templates. The function accepts the same arguments as the ``Map`` class:
                 infoWindow: { content: 'Welcome to <b>New York</b>' }
             },
         ],
+        fitBoundsToMarkers: true,
         attributes: {
             class: 'foo',
             style: 'height: 800px; width: 100%; border: 4px solid red; margin-block: 10vh;',
         }
     ) }}
+
+.. versionadded:: 2.31
+
+    `fitBoundsToMarkers` option for the twig function is available since UX Map 2.31.
 
 Twig Component ``<twig:ux:map />``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -354,6 +359,7 @@ Alternatively, you can use the ``<twig:ux:map />`` component.
                 "infoWindow": {"content": "Welcome to <b>New York</b>"}
             }
         ]'
+        :fitBoundsToMarkers="true",
         class="foo"
         style="height: 800px; width: 100%; border: 4px solid red; margin-block: 10vh;"
     />
@@ -363,6 +369,10 @@ The ``<twig:ux:map />`` component requires the `Twig Component`_ package.
 .. code-block:: terminal
 
     $ composer require symfony/ux-twig-component
+
+.. versionadded:: 2.31
+
+    `fitBoundsToMarkers` option for the twig component is available since UX Map 2.31.
 
 Interact with the map
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/Map/src/Twig/MapRuntime.php
+++ b/src/Map/src/Twig/MapRuntime.php
@@ -53,9 +53,10 @@ final class MapRuntime implements RuntimeExtensionInterface
         ?array $rectangles = null,
         ?float $minZoom = null,
         ?float $maxZoom = null,
+        ?bool $fitBoundsToMarkers = null,
     ): string {
         if ($map instanceof Map) {
-            if (null !== $center || null !== $zoom || $markers || $polygons || $polylines || $circles || $rectangles || $minZoom || $maxZoom) {
+            if (null !== $center || null !== $zoom || $markers || $polygons || $polylines || $circles || $rectangles || $minZoom || $maxZoom || null !== $fitBoundsToMarkers) {
                 throw new \InvalidArgumentException('It is not allowed to pass both a Map object and other parameters (like "center", "zoom", "markers", etc...) to the "renderMap" method. Please use either a Map object or the individual parameters.');
             }
 
@@ -90,13 +91,16 @@ final class MapRuntime implements RuntimeExtensionInterface
         if (null !== $maxZoom) {
             $map->maxZoom($maxZoom);
         }
+        if (null !== $fitBoundsToMarkers) {
+            $map->fitBoundsToMarkers($fitBoundsToMarkers);
+        }
 
         return $this->renderer->renderMap($map, $attributes);
     }
 
     public function render(array $args = []): string
     {
-        $map = array_intersect_key($args, array_flip(['map', 'center', 'zoom', 'markers', 'polygons', 'polylines', 'circles', 'rectangles', 'minZoom', 'maxZoom']));
+        $map = array_intersect_key($args, array_flip(['map', 'center', 'zoom', 'markers', 'polygons', 'polylines', 'circles', 'rectangles', 'minZoom', 'maxZoom', 'fitBoundsToMarkers']));
         $attributes = array_diff_key($args, $map);
 
         return $this->renderMap(...$map, attributes: $attributes);

--- a/src/Map/src/Twig/UXMapComponent.php
+++ b/src/Map/src/Twig/UXMapComponent.php
@@ -33,6 +33,8 @@ final class UXMapComponent
 
     public ?Point $center;
 
+    public ?bool $fitBoundsToMarkers;
+
     /**
      * @var Marker[]
      */


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | -
| License        | MIT

This PR add option `fitBoundsToMarkers` to the Twig function and component because currently, when using the twig function or component by passing an array of markers without specifying the center and zoom, this throws an exception due to `fitBoundsToMarkers` set to `false` by default.


