### PR TITLE
[LiveComponent] Support default value for new collection item

### DIFF
--- a/src/LiveComponent/src/LiveCollectionTrait.php
+++ b/src/LiveComponent/src/LiveCollectionTrait.php
@@ -34,7 +34,7 @@ trait LiveCollectionTrait
         }
 
         $index = [] !== $data ? max(array_keys($data)) + 1 : 0;
-        $propertyAccessor->setValue($this->formValues, $propertyPath."[$index]", []);
+        $propertyAccessor->setValue($this->formValues, $propertyPath."[$index]", $this->setCollectionItemDefaultValue($propertyPath, $index));
     }
 
     #[LiveAction]
@@ -59,5 +59,10 @@ trait LiveCollectionTrait
         }
 
         return $propertyPath;
+    }
+
+    protected function setCollectionItemDefaultValue(string $propertyPath, int $index): iterable
+    {
+        return [];
     }
 }

--- a/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
+++ b/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
@@ -73,6 +73,23 @@ final class LiveCollectionTraitTest extends TestCase
                 ],
             ],
         ];
+        yield 'named parent, default value' => [
+            [
+                'parentName' => [
+                    'collectionNameDefault' => null,
+                ],
+            ],
+            'parentName[collectionNameDefault]',
+            [
+                'parentName' => [
+                    'collectionNameDefault' => [
+                        0 => [
+                            'property' => 'value',
+                        ],
+                    ],
+                ],
+            ],
+        ];
         yield 'named parent, empty array value' => [
             [
                 'parentName' => [
@@ -220,6 +237,17 @@ final class LiveCollectionTraitTest extends TestCase
             protected function instantiateForm(): FormInterface
             {
                 return $this->theForm;
+            }
+
+            protected function setCollectionItemDefaultValue(string $propertyPath, int $index): iterable
+            {
+                if ('[collectionNameDefault]' === $propertyPath) {
+                    return [
+                        'property' => 'value',
+                    ];
+                }
+
+                return [];
             }
         };
         $component->formName = array_key_first($postedFormData);


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix 
| License        | MIT

when adding a new item to a collection of `LiveCollectionType`, it was always an empty value
somehow, defining `prototype_data` is not working

so this introduces a new method to set the default value of a collection item