### PR TITLE
[Map] Display warning when trying to define a custom icon for a `Marker` that already has an `Icon`

### DIFF
--- a/src/Map/src/Bridge/Google/CHANGELOG.md
+++ b/src/Map/src/Bridge/Google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.31
+
+-  Display a warning when trying to define `bridgeOptions.content` for a `Marker` that already has an `Icon`
+
 ## 2.30
 
 -  Ensure compatibility with PHP 8.5

--- a/src/Map/src/Bridge/Google/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Google/assets/dist/map_controller.js
@@ -248,6 +248,11 @@ var map_controller_default = class extends abstract_map_controller_default {
       this.createInfoWindow({ definition: infoWindow, element: marker });
     }
     if (icon) {
+      if (Object.prototype.hasOwnProperty.call(bridgeOptions, "content")) {
+        console.warn('[Symfony UX Map] Defining "bridgeOptions.content" for a marker with a custom icon is not supported and will be ignored.');
+      } else if (Object.prototype.hasOwnProperty.call(rawOptions, "content")) {
+        console.warn('[Symfony UX Map] Defining "rawOptions.content" for a marker with a custom icon is not supported and will be ignored.');
+      }
       this.doCreateIcon({ definition: icon, element: marker });
     }
     return marker;

--- a/src/Map/src/Bridge/Google/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Google/assets/src/map_controller.ts
@@ -188,6 +188,12 @@ export default class extends AbstractMapController<
         }
 
         if (icon) {
+            if (Object.prototype.hasOwnProperty.call(bridgeOptions, 'content')) {
+                console.warn('[Symfony UX Map] Defining "bridgeOptions.content" for a marker with a custom icon is not supported and will be ignored.');
+            } else if (Object.prototype.hasOwnProperty.call(rawOptions, 'content')) {
+                console.warn('[Symfony UX Map] Defining "rawOptions.content" for a marker with a custom icon is not supported and will be ignored.');
+            }
+
             this.doCreateIcon({ definition: icon, element: marker });
         }
 

--- a/src/Map/src/Bridge/Leaflet/CHANGELOG.md
+++ b/src/Map/src/Bridge/Leaflet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.31
+
+-  Display a warning when trying to define `bridgeOptions.icon` for a `Marker` that already has an `Icon`
+
 ## 2.30
 
 -  Ensure compatibility with PHP 8.5

--- a/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
+++ b/src/Map/src/Bridge/Leaflet/assets/dist/map_controller.js
@@ -228,6 +228,11 @@ var map_controller_default = class extends abstract_map_controller_default {
       this.createInfoWindow({ definition: infoWindow, element: marker2 });
     }
     if (icon2) {
+      if (Object.prototype.hasOwnProperty.call(bridgeOptions, "icon")) {
+        console.warn('[Symfony UX Map] Defining "bridgeOptions.icon" for a marker with a custom icon is not supported and will be ignored.');
+      } else if (Object.prototype.hasOwnProperty.call(rawOptions, "icon")) {
+        console.warn('[Symfony UX Map] Defining "rawOptions.icon" for a marker with a custom icon is not supported and will be ignored.');
+      }
       this.doCreateIcon({ definition: icon2, element: marker2 });
     }
     return marker2;

--- a/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
+++ b/src/Map/src/Bridge/Leaflet/assets/src/map_controller.ts
@@ -154,6 +154,12 @@ export default class extends AbstractMapController<
         }
 
         if (icon) {
+            if (Object.prototype.hasOwnProperty.call(bridgeOptions, 'icon')) {
+                console.warn('[Symfony UX Map] Defining "bridgeOptions.icon" for a marker with a custom icon is not supported and will be ignored.');
+            } else if (Object.prototype.hasOwnProperty.call(rawOptions, 'icon')) {
+                console.warn('[Symfony UX Map] Defining "rawOptions.icon" for a marker with a custom icon is not supported and will be ignored.');
+            }
+
             this.doCreateIcon({ definition: icon, element: marker });
         }
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | feature
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3116 
| License        | MIT

Add additional checks before creating the icon for a marker