### PR TITLE
[TwigComponent] explain that default values are mandatory for props

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -702,7 +702,7 @@ You can also pass a variable (prop) into your template:
     </div>
 
 To tell the system that ``icon`` and ``type`` are props and not attributes, use the
-``{% props %}`` tag at the top of your template.
+``{% props %}`` tag at the top of your template. You must define the default value for each prop.
 
 .. code-block:: html+twig
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | -
| License        | MIT

I wanted to write `{% props icon, type %}` but it didn't work, because default values are mandatory for props.

So this PR make it explicit.