### PR TITLE
[TwigComponent] Remove floating text in documentation

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -41,8 +41,6 @@ Enjoy your new component!
 .. image:: images/alert-example.png
     :alt: Example of the Alert Component
 
-    Example of the Alert Component
-
 This brings the familiar "component" system from client-side frameworks
 into Symfony. Combine this with `Live Components`_, to create
 an interactive frontend with automatic, Ajax-powered rendering.


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | -
| License        | MIT

This looked weird:

> <img width="784" height="223" alt="image" src="https://github.com/user-attachments/assets/d88485e3-ea01-4cc4-9286-80cfb7ded773" />
