### PR TITLE
[LiveComponent] add controller tag and default metadata values for all service declaration types

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/Compiler/AddControllerTagToLiveComponentPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/AddControllerTagToLiveComponentPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AddControllerTagToLiveComponentPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('twig.component') as $id => $component) {
+            if (!($component[0]['live'] ?? false)) {
+                continue;
+            }
+
+            $definition = $container->getDefinition($id);
+
+            if (!$definition->hasTag('controller.service_arguments')) {
+                $definition->addTag('controller.service_arguments');
+            }
+        }
+    }
+}

--- a/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
+++ b/src/LiveComponent/src/DependencyInjection/LiveComponentExtension.php
@@ -93,7 +93,6 @@ final class LiveComponentExtension extends Extension implements PrependExtension
             function (ChildDefinition $definition, AsLiveComponent $attribute) {
                 $definition
                     ->addTag('twig.component', array_filter($attribute->serviceConfig(), static fn ($v) => null !== $v && '' !== $v))
-                    ->addTag('controller.service_arguments')
                 ;
             }
         );

--- a/src/LiveComponent/src/LiveComponentBundle.php
+++ b/src/LiveComponent/src/LiveComponentBundle.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\LiveComponent;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\UX\LiveComponent\DependencyInjection\Compiler\AddControllerTagToLiveComponentPass;
 use Symfony\UX\LiveComponent\DependencyInjection\Compiler\ComponentDefaultActionPass;
 use Symfony\UX\LiveComponent\DependencyInjection\Compiler\OptionalDependencyPass;
 
@@ -28,6 +29,7 @@ final class LiveComponentBundle extends Bundle
     {
         // must run before Symfony\Component\Serializer\DependencyInjection\SerializerPass
         $container->addCompilerPass(new OptionalDependencyPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 100);
+        $container->addCompilerPass(new AddControllerTagToLiveComponentPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         $container->addCompilerPass(new ComponentDefaultActionPass());
     }
 

--- a/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
+++ b/src/LiveComponent/src/Util/LiveControllerAttributesCreator.php
@@ -57,7 +57,11 @@ class LiveControllerAttributesCreator
         $attributesCollection = $this->attributeHelper->create();
         $attributesCollection->setLiveController($mounted->getName());
 
-        $url = $this->urlGenerator->generate($metadata->get('route'), ['_live_component' => $mounted->getName()], $metadata->get('url_reference_type'));
+        $url = $this->urlGenerator->generate(
+            $metadata->get('route') ?? 'ux_live_component',
+            ['_live_component' => $mounted->getName()],
+            $metadata->get('url_reference_type') ?? UrlGeneratorInterface::ABSOLUTE_PATH
+        );
         $attributesCollection->setUrl($url);
 
         $liveListeners = AsLiveComponent::liveListeners($mounted->getComponent());


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no 
| Documentation? | no
| License        | MIT

In my project I don't use attributes like `#[AsLiveComponent]` in order to declare services and live components but I use yaml files (not my choice).
It works fine for all my services but live components are not well supported because we have to add extra parameters.

With  `#[AsLiveComponent]` attribute, we have default values for : 
* the route metadata : `'ux_live_component'`
* and the url reference type metadata `UrlGeneratorInterface::ABSOLUTE_PATH`

We also add `controller.service_arguments` tag in `LiveComponentExtension` class.

But if we don't use this attribute and we want to use another type of service declaration, we have to add all these information  : 
```yaml
services:
    MyServiceClass:
        tags:
            -
                name: twig.component
                live: true
                route: ux_live_component
                url_reference_type: 1
            -
                name: controller.service_arguments
```

If we do not, we have errors likes theses : 
```
An exception has been thrown during the rendering of a template ("Symfony\Component\Routing\Router::generate(): Argument #1 ($name) must be of type string, null given, called in /app/vendor/symfony/ux-live-component/src/Util/LiveControllerAttributesCreator.php on line 63")
```
```
An exception has been thrown during the rendering of a template ("Symfony\Component\Routing\Router::generate(): Argument #3 ($referenceType) must be of type int, null given, called in /app/vendor/symfony/ux-live-component/src/Util/LiveControllerAttributesCreator.php on line 63")
```
```
The controller for URI "/_components/my_customer_live_component" is not callable: Controller "MyCustomLiveComponentClass" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?
```

These errors do not exist for php attribute declaration so I made this PR to have the same behavior regardless of how the live component is declared

