### PR TITLE
[Icons] Do not fail application if there is not internet connection

### DIFF
--- a/src/Icons/src/Twig/UXIconRuntime.php
+++ b/src/Icons/src/Twig/UXIconRuntime.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\Icons\Twig;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
 use Symfony\UX\Icons\IconRendererInterface;
 use Twig\Extension\RuntimeExtensionInterface;
@@ -45,6 +46,10 @@ final class UXIconRuntime implements RuntimeExtensionInterface
             }
 
             throw $e;
+        } catch (TransportException $e) {
+            $this->logger?->warning($e->getMessage());
+
+            return '';
         }
     }
 

--- a/src/Icons/tests/Unit/Twig/UXIconRuntimeTest.php
+++ b/src/Icons/tests/Unit/Twig/UXIconRuntimeTest.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\Icons\Tests\Unit\Twig;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\UX\Icons\Exception\IconNotFoundException;
 use Symfony\UX\Icons\IconRendererInterface;
 use Symfony\UX\Icons\Twig\UXIconRuntime;
@@ -39,5 +40,20 @@ class UXIconRuntimeTest extends TestCase
         $runtime = new UXIconRuntime($renderer, false);
         $this->expectException(IconNotFoundException::class);
         $runtime->renderIcon('not_found');
+    }
+
+    public function testRenderIconReturnsEmptyStringIfConnectionIsNotPossible()
+    {
+        $renderer = $this->createMock(IconRendererInterface::class);
+        $renderer->method('renderIcon')
+            ->willThrowException(new TransportException('Could not resolve host api.iconify.design'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with('Could not resolve host api.iconify.design');
+
+        $runtime = new UXIconRuntime($renderer, true, $logger);
+        $this->assertEquals('', $runtime->renderIcon('tabler:search'));
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | 
| License        | MIT

Hello 👋 First of all, thank you for amazing SymfonyUX initiative, it definitely brings a frash air in working with front-end for a total FE noobs like me 😅 

I've recently encountered a rather unusual problem while playing in icons, still a pretty annoying one. I was coding in a plane and for some reason decided clear my cache. It resulted in a situation, when I had no icons information loaded in cache and they could not be fetched from the remote server as I had no internet connection ✈️ It resulted in 500 error and not being able to use my application just because of the missing icons 😅 I believe such a situation should be handled by default and unablity to show icons should not break the application.

I propose the easiest possible solution - catching the `TransportException` on the high level in the `UXIconRuntime`. However, I suppose it could be done nicer, to not expose any registry specific information (in the end, only the `IconifyOnDemandRegistry` could result in such error) - maybe we should handle it in the registry itself, and throw some more generic exception, like `IconsNotAvailableException`? Or maybe even use the existing `IconNotFoundException`? 🤔  I didn't want to push any of these solutions, and would prefer to see the opinion of the library maintainers 🫡 