### PR TITLE
[Autocomplete] Untranslated `no_results` label when `options_as_html` is set

### DIFF
--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -306,6 +306,7 @@ createAutocompleteWithHtmlContents_fn = function() {
       };
     },
     render: {
+      ...commonConfig.render,
       item: (item) => `<div>${item[labelField]}</div>`,
       option: (item) => `<div>${item[labelField]}</div>`
     }

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -239,6 +239,7 @@ export default class extends Controller {
                 };
             },
             render: {
+                ...commonConfig.render,
                 item: (item: any) => `<div>${item[labelField]}</div>`,
                 option: (item: any) => `<div>${item[labelField]}</div>`,
             },


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #2477 
| License        | MIT

during `createAutocompleteWithHtmlContents()` it seems that a `commonConfig` is overridden by a new one but some nested properties are lost during the `#mergeConfigs()` and especially `no_results` that fallbacks to the untranslated tom-select default one
