### PR TITLE
[Toolkit] Add support for documenting props/blocks API

### DIFF
--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog.html.twig
@@ -1,3 +1,5 @@
+{# @prop open boolean Open (or not) the AlertDialog at initial rendering, default to `false` #}
+{# @block content The default block #}
 {%- props open = false, id -%}
 
 {%- set _alert_dialog_open = open %}

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Action.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Action.html.twig
@@ -1,4 +1,6 @@
-{% props variant = 'default' %}
+{# @prop variant 'default'|'secondary'|'destructive'|'outline'|'ghost'|'link' The variant, default to `default` #}
+{# @block content The default block #}
+{%- props variant = 'default' -%}
 <twig:Button variant="{{ variant }}" {{ ...attributes }}>
     {{- block(outerBlocks.content) -}}
 </twig:Button>

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Cancel.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Cancel.html.twig
@@ -1,7 +1,4 @@
-<twig:Button
-    variant="outline"
-    data-action="click->alert-dialog#close"
-    {{ ...attributes }}
->
+{# @block content The default block #}
+<twig:Button variant="outline" data-action="click->alert-dialog#close" {{ ...attributes }}>
     {{- block(outerBlocks.content) -}}
 </twig:Button>

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Content.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <dialog
     id="{{ _alert_dialog_id }}"
     {{ _alert_dialog_open ? 'open' }}

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Description.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Description.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <p
     id="{{ _alert_dialog_description_id }}"
     class="{{ 'text-muted-foreground text-sm ' ~ attributes.render('class')|tailwind_merge }}"

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Footer.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Footer.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <footer
     class="{{ 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Header.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Header.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <header
     class="{{ 'flex flex-col gap-2 text-center sm:text-left ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Title.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Title.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <h2
     id="{{ _alert_dialog_title_id }}"
     class="{{ 'text-lg font-semibold ' ~ attributes.render('class')|tailwind_merge }}"

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Trigger.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Trigger.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 {%- set trigger_attrs = {
     'data-action': 'click->alert-dialog#open',
     'data-alert-dialog-target': 'trigger',

--- a/src/Toolkit/kits/shadcn/alert/templates/components/Alert.html.twig
+++ b/src/Toolkit/kits/shadcn/alert/templates/components/Alert.html.twig
@@ -1,3 +1,5 @@
+{# @prop variant 'default'|'destructive' The variant, default to `default` #}
+{# @block content The default block #}
 {%- props variant = 'default' -%}
 {%- set style = html_cva(
     base: 'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',

--- a/src/Toolkit/kits/shadcn/alert/templates/components/Alert/Description.html.twig
+++ b/src/Toolkit/kits/shadcn/alert/templates/components/Alert/Description.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <p
     class="{{ 'text-sm [&_p]:leading-relaxed ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/alert/templates/components/Alert/Title.html.twig
+++ b/src/Toolkit/kits/shadcn/alert/templates/components/Alert/Title.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <h5
     class="{{ 'mb-1 font-medium leading-none tracking-tight ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/aspect-ratio/EXAMPLES.md
+++ b/src/Toolkit/kits/shadcn/aspect-ratio/EXAMPLES.md
@@ -1,37 +1,40 @@
 # Examples
 
-## Default
+## With 1 / 1 aspect ratio
 
 ```twig {"preview":true,"height":"400px"}
-<twig:AspectRatio ratio="1 / 1" class="max-w-[300px]">
+<twig:AspectRatio ratio="1 / 1" class="max-h-90">
     <img
-        src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&amp;dpr=2&amp;q=80"
-        alt="Landscape photograph by Tobias Tullius"
+        src="https://images.unsplash.com/photo-1535189043414-47a3c49a0bed?ixlib=rb-4.1.0&q=85&fm=jpg&crop=entropy&cs=srgb&w=1000"
+        alt="Bukchon Hanok Village by Y K"
         class="h-full w-full rounded-md object-cover"
     />
+    <a href="https://unsplash.com/fr/photos/rue-vide-entre-les-maisons--e6Xu27_T50" class="hover:underline">Bukchon Hanok Village by Y K</a>
 </twig:AspectRatio>
 ```
 
-## With a 1 / 1 aspect ratio
+## With 2 / 3 aspect ratio
 
 ```twig {"preview":true,"height":"400px"}
-<twig:AspectRatio ratio="1 / 1" class="max-w-[350px]">
+<twig:AspectRatio ratio="3 / 2" class="max-h-90">
     <img
-        src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&amp;dpr=2&amp;q=80"
-        alt="Landscape photograph by Tobias Tullius"
+        src="https://images.unsplash.com/photo-1535189043414-47a3c49a0bed?ixlib=rb-4.1.0&q=85&fm=jpg&crop=entropy&cs=srgb&w=1000"
+        alt="Bukchon Hanok Village by Y K"
         class="h-full w-full rounded-md object-cover"
     />
+    <a href="https://unsplash.com/fr/photos/rue-vide-entre-les-maisons--e6Xu27_T50" class="hover:underline">Bukchon Hanok Village by Y K</a>
 </twig:AspectRatio>
 ```
 
-## With a 16 / 9 aspect ratio
+## With 16 / 9 aspect ratio
 
 ```twig {"preview":true,"height":"400px"}
-<twig:AspectRatio ratio="16 / 9" class="max-w-[350px]">
+<twig:AspectRatio ratio="16 / 9" class="max-h-90">
     <img
-        src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&amp;dpr=2&amp;q=80"
-        alt="Landscape photograph by Tobias Tullius"
+        src="https://images.unsplash.com/photo-1535189043414-47a3c49a0bed?ixlib=rb-4.1.0&q=85&fm=jpg&crop=entropy&cs=srgb&w=1000"
+        alt="Bukchon Hanok Village by Y K"
         class="h-full w-full rounded-md object-cover"
     />
+    <a href="https://unsplash.com/fr/photos/rue-vide-entre-les-maisons--e6Xu27_T50" class="hover:underline">Bukchon Hanok Village by Y K</a>
 </twig:AspectRatio>
 ```

--- a/src/Toolkit/kits/shadcn/aspect-ratio/templates/components/AspectRatio.html.twig
+++ b/src/Toolkit/kits/shadcn/aspect-ratio/templates/components/AspectRatio.html.twig
@@ -1,3 +1,6 @@
+{# @prop ratio string The ratio to use, example `3 / 4`, `16 / 9` #}
+{# @prop style string Additional CSS styles to apply #}
+{# @block content The default block #}
 {%- props ratio, style = '' -%}
 <div
     style="aspect-ratio: {{ ratio }}; {{ style }}"

--- a/src/Toolkit/kits/shadcn/badge/templates/components/Badge.html.twig
+++ b/src/Toolkit/kits/shadcn/badge/templates/components/Badge.html.twig
@@ -1,4 +1,6 @@
-{%- props variant = 'default', outline = false -%}
+{# @prop variant 'default'|'secondary'|'destructive'|'outline' The variant, default to `default` #}
+{# @block content The default block #}
+{%- props variant = 'default' -%}
 {%- set style = html_cva(
     base: 'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
     variants: {
@@ -11,7 +13,7 @@
     },
 ) -%}
 <div
-    class="{{ style.apply({variant: variant, outline: outline}, attributes.render('class'))|tailwind_merge }}"
+    class="{{ style.apply({variant: variant}, attributes.render('class'))|tailwind_merge }}"
     {{ attributes }}
 >
     {%- block content %}{% endblock -%}

--- a/src/Toolkit/kits/shadcn/breadcrumb/EXAMPLES.md
+++ b/src/Toolkit/kits/shadcn/breadcrumb/EXAMPLES.md
@@ -10,7 +10,7 @@
         </twig:Breadcrumb:Item>
         <twig:Breadcrumb:Separator />
         <twig:Breadcrumb:Item>
-            <twig:Breadcrumb:Link href=".">Docs</twig:Breadcrumb:Link>
+            <twig:Breadcrumb:Ellipsis />
         </twig:Breadcrumb:Item>
         <twig:Breadcrumb:Separator />
         <twig:Breadcrumb:Item>

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <nav{{ attributes }} aria-label="Breadcrumb">
     {%- block content %}{% endblock -%}
 </nav>

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Ellipsis.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Ellipsis.html.twig
@@ -1,13 +1,8 @@
 <span
-    class="{{ 'flex h-9 w-9 items-center justify-center ' ~ attributes.render('class')|tailwind_merge }}"
+    class="{{ '[&>svg]:w-3.5 [&>svg]:h-3.5 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}
     role="presentation"
     aria-hidden="true"
 >
-    {% set _block = block('content') %}
-    {% if content is defined and content is not empty %}
-        {%- block content %}{% endblock -%}
-    {% else %}
-        <span class="h-4 w-4">...</span>
-    {% endif %}
+    <twig:ux:icon name="lucide:ellipsis" />
 </span>

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Item.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Item.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <li
     class="{{ 'inline-flex items-center gap-1.5 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Link.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Link.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <a
     class="{{ 'transition-colors hover:text-foreground ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/List.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/List.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <ol
     class="{{ 'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Page.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Page.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <span
     class="{{ 'font-normal text-foreground ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Separator.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Separator.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <li
     class="{{ '[&>svg]:w-3.5 [&>svg]:h-3.5 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/button/EXAMPLES.md
+++ b/src/Toolkit/kits/shadcn/button/EXAMPLES.md
@@ -17,7 +17,7 @@
 ## Secondary
 
 ```twig {"preview":true}
-<twig:Button variant="outline">Outline</twig:Button>
+<twig:Button variant="secondary">Secondary</twig:Button>
 ```
 
 ## Destructive
@@ -66,4 +66,14 @@
 <twig:Button disabled>
     <twig:ux:icon name="lucide:loader-2" class="animate-spin" /> Please wait
 </twig:Button>
+```
+
+## Different sizes
+
+```twig {"preview":true}
+<div class="flex items-center gap-2">
+    <twig:Button size="sm">Small</twig:Button>
+    <twig:Button>Default</twig:Button>
+    <twig:Button size="lg">Large</twig:Button>
+</div>
 ```

--- a/src/Toolkit/kits/shadcn/button/templates/components/Button.html.twig
+++ b/src/Toolkit/kits/shadcn/button/templates/components/Button.html.twig
@@ -1,4 +1,8 @@
-{%- props variant = 'default', outline = false, size = 'default', as = 'button' -%}
+{# @prop variant 'default'|'secondary'|'destructive'|'outline'|'ghost'|'link' The variant, default to `default` #}
+{# @prop size 'default'|'sm'|'lg'|'icon' The size, default to `default` #}
+{# @prop as 'button' The HTML tag to use, default to `button` #}
+{# @block content The default block #}
+{%- props variant = 'default', size = 'default', as = 'button' -%}
 {%- set style = html_cva(
     base: 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
     variants: {
@@ -20,7 +24,7 @@
 ) -%}
 
 <{{ as }}
-    class="{{ style.apply({variant: variant, outline: outline, size: size}, attributes.render('class'))|tailwind_merge }}"
+    class="{{ style.apply({variant: variant, size: size}, attributes.render('class'))|tailwind_merge }}"
     {{ attributes }}
 >
     {%- block content %}{% endblock -%}

--- a/src/Toolkit/kits/shadcn/card/templates/components/Card.html.twig
+++ b/src/Toolkit/kits/shadcn/card/templates/components/Card.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <div
     class="{{ 'rounded-lg border bg-card text-card-foreground shadow-sm ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/card/templates/components/Card/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/card/templates/components/Card/Content.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <div
     class="{{ 'p-6 pt-0 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/card/templates/components/Card/Description.html.twig
+++ b/src/Toolkit/kits/shadcn/card/templates/components/Card/Description.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <div
     class="{{ 'text-sm text-muted-foreground ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/card/templates/components/Card/Footer.html.twig
+++ b/src/Toolkit/kits/shadcn/card/templates/components/Card/Footer.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <div
     class="{{ 'flex items-center p-6 pt-0 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/card/templates/components/Card/Header.html.twig
+++ b/src/Toolkit/kits/shadcn/card/templates/components/Card/Header.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <div
     class="{{ 'flex flex-col space-y-1.5 p-6 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/card/templates/components/Card/Title.html.twig
+++ b/src/Toolkit/kits/shadcn/card/templates/components/Card/Title.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <div
     class="{{ 'text-2xl font-semibold leading-none tracking-tight ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/input/templates/components/Input.html.twig
+++ b/src/Toolkit/kits/shadcn/input/templates/components/Input.html.twig
@@ -1,6 +1,4 @@
-{%- props type = 'text' -%}
 <input
-    type="{{ type }}"
     class="{{ 'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}
 >

--- a/src/Toolkit/kits/shadcn/label/templates/components/Label.html.twig
+++ b/src/Toolkit/kits/shadcn/label/templates/components/Label.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <label
     class="{{ ('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 ' ~ attributes.render('class'))|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/pagination/EXAMPLES.md
+++ b/src/Toolkit/kits/shadcn/pagination/EXAMPLES.md
@@ -12,7 +12,7 @@
             <twig:Pagination:Link href="#">1</twig:Pagination:Link>
         </twig:Pagination:Item>
         <twig:Pagination:Item>
-            <twig:Pagination:Link href="#" isActive>2</twig:Pagination:Link>
+            <twig:Pagination:Link href="#" active>2</twig:Pagination:Link>
         </twig:Pagination:Item>
         <twig:Pagination:Item>
             <twig:Pagination:Link href="#">3</twig:Pagination:Link>
@@ -45,7 +45,7 @@
             <twig:Pagination:Link href="#">4</twig:Pagination:Link>
         </twig:Pagination:Item>
         <twig:Pagination:Item>
-            <twig:Pagination:Link href="#" isActive>5</twig:Pagination:Link>
+            <twig:Pagination:Link href="#" active>5</twig:Pagination:Link>
         </twig:Pagination:Item>
         <twig:Pagination:Item>
             <twig:Pagination:Link href="#">6</twig:Pagination:Link>

--- a/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination.html.twig
+++ b/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <nav
     class="{{ 'mx-auto flex w-full justify-center ' ~ attributes.render('class')|tailwind_merge }}"
     role="navigation"

--- a/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination/Content.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <ul {{ attributes.without('class') }}
     class="{{ 'flex flex-row items-center gap-1 ' ~ attributes.render('class')|tailwind_merge }}"
 >

--- a/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination/Ellipsis.html.twig
+++ b/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination/Ellipsis.html.twig
@@ -1,6 +1,6 @@
 <span
     aria-hidden="true"
-    class="{{ 'flex h-9 w-9 items-center justify-center ' ~ attributes.render('class')|tailwind_merge }}"
+    class="{{ 'flex size-9 items-center justify-center ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes.without('class') }}
 >
     <twig:ux:icon name="lucide:more-horizontal" class="size-4" />

--- a/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination/Item.html.twig
+++ b/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination/Item.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <li{{ attributes }}>
     {%- block content %}{% endblock -%}
 </li>

--- a/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination/Link.html.twig
+++ b/src/Toolkit/kits/shadcn/pagination/templates/components/Pagination/Link.html.twig
@@ -1,9 +1,11 @@
-{%- props isActive = false, size = 'icon' -%}
+{# @prop active boolean Whether the link is active or not, default to `false` #}
+{# @block content The default block #}
+{%- props active = false -%}
 <twig:Button
     as="a"
-    variant="{{ isActive ? 'outline' : 'ghost' }}"
-    size="{{ size }}"
-    aria-current="{{ isActive ? 'page' : false }}"
+    variant="{{ active ? 'outline' : 'ghost' }}"
+    size="icon"
+    aria-current="{{ active ? 'page' : false }}"
     {{ ...attributes.without('class') }}
 >
     {{- block(outerBlocks.content) -}}

--- a/src/Toolkit/kits/shadcn/progress/templates/components/Progress.html.twig
+++ b/src/Toolkit/kits/shadcn/progress/templates/components/Progress.html.twig
@@ -1,5 +1,5 @@
+{# @prop value integer The progress value between 0 and 100, default to `0` #}
 {%- props value = 0 -%}
-
 <div
     class="{{ 'relative h-4 w-full overflow-hidden rounded-full bg-secondary ' ~ attributes.render('class')|tailwind_merge }}"
     role="progressbar"

--- a/src/Toolkit/kits/shadcn/select/templates/components/Select.html.twig
+++ b/src/Toolkit/kits/shadcn/select/templates/components/Select.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <select
     class="{{ 'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/separator/templates/components/Separator.html.twig
+++ b/src/Toolkit/kits/shadcn/separator/templates/components/Separator.html.twig
@@ -1,3 +1,5 @@
+{# @prop orientation 'horizontal'|'vertical' The orientation of the separator, default to `horizontal` #}
+{# @prop decorative boolean Whether the separator is decorative or not, default to `true` #}
 {%- props orientation = 'horizontal', decorative = true -%}
 {%- set style = html_cva(
     base: 'shrink-0 bg-border',
@@ -14,5 +16,4 @@
         role: decorative ? 'none' : 'separator',
         'aria-orientation': decorative ? false : orientation,
     }) }}
->
-</div>
+></div>

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <div class="relative w-full overflow-auto">
     <table
         class="{{ 'w-full caption-bottom text-sm ' ~ attributes.render('class')|tailwind_merge }}"

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Body.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Body.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <tbody
     class="{{ '[&_tr:last-child]:border-0 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Caption.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Caption.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <caption
     class="{{ 'mt-4 text-sm text-muted-foreground ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Cell.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Cell.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <td
     class="{{ 'p-4 align-middle [&:has([role=checkbox])]:pr-0 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Footer.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Footer.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <tfoot
     class="{{ 'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Head.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Head.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <th
     class="{{ 'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Header.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Header.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <thead
     class="{{ '[&_tr]:border-b ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Row.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Row.html.twig
@@ -1,3 +1,4 @@
+{# @block content The default block #}
 <tr
     class="{{ 'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}

--- a/src/Toolkit/kits/shadcn/textarea/EXAMPLES.md
+++ b/src/Toolkit/kits/shadcn/textarea/EXAMPLES.md
@@ -6,11 +6,17 @@
 <twig:Textarea placeholder="Type your message here." class="max-w-sm" />
 ```
 
+## With default content
+
+```twig {"preview":true}
+<twig:Textarea class="max-w-sm">This is the default content of the textarea.</twig:Textarea>
+```
+
 ## With Label
 
 ```twig {"preview":true}
 <div class="grid w-sm gap-1.5">
-    <label for="message">Your message</label>
+    <twig:Label for="message">Your message</twig:Label>
     <twig:Textarea id="message" placeholder="Type your message here." />
 </div>
 ```

--- a/src/Toolkit/kits/shadcn/textarea/templates/components/Textarea.html.twig
+++ b/src/Toolkit/kits/shadcn/textarea/templates/components/Textarea.html.twig
@@ -1,4 +1,7 @@
+{# @block content The default block #}
 <textarea
     class="{{ 'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm ' ~ attributes.render('class')|tailwind_merge }}"
     {{ attributes }}
-></textarea>
+>
+    {%- block content %}{% endblock -%}
+</textarea>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component aspect-ratio, code 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component aspect-ratio, code 1__1.html
@@ -3,15 +3,17 @@
 - Component: Aspect Ratio
 - Code:
 ```twig
-<twig:AspectRatio ratio="1 / 1" class="max-w-[300px]">
+<twig:AspectRatio ratio="1 / 1" class="max-h-90">
     <img
-        src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&amp;dpr=2&amp;q=80"
-        alt="Landscape photograph by Tobias Tullius"
+        src="https://images.unsplash.com/photo-1535189043414-47a3c49a0bed?ixlib=rb-4.1.0&q=85&fm=jpg&crop=entropy&cs=srgb&w=1000"
+        alt="Bukchon Hanok Village by Y K"
         class="h-full w-full rounded-md object-cover"
     />
+    <a href="https://unsplash.com/fr/photos/rue-vide-entre-les-maisons--e6Xu27_T50" class="hover:underline">Bukchon Hanok Village by Y K</a>
 </twig:AspectRatio>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<div style="aspect-ratio: 1 / 1; " class="max-w-[300px]">
-<img src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&amp;dpr=2&amp;q=80" alt="Landscape photograph by Tobias Tullius" class="h-full w-full rounded-md object-cover">
+<div style="aspect-ratio: 1 / 1; " class="max-h-90">
+<img src="https://images.unsplash.com/photo-1535189043414-47a3c49a0bed?ixlib=rb-4.1.0&amp;q=85&amp;fm=jpg&amp;crop=entropy&amp;cs=srgb&amp;w=1000" alt="Bukchon Hanok Village by Y K" class="h-full w-full rounded-md object-cover">
+    <a href="https://unsplash.com/fr/photos/rue-vide-entre-les-maisons--e6Xu27_T50" class="hover:underline">Bukchon Hanok Village by Y K</a>
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component aspect-ratio, code 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component aspect-ratio, code 2__1.html
@@ -3,15 +3,17 @@
 - Component: Aspect Ratio
 - Code:
 ```twig
-<twig:AspectRatio ratio="1 / 1" class="max-w-[350px]">
+<twig:AspectRatio ratio="3 / 2" class="max-h-90">
     <img
-        src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&amp;dpr=2&amp;q=80"
-        alt="Landscape photograph by Tobias Tullius"
+        src="https://images.unsplash.com/photo-1535189043414-47a3c49a0bed?ixlib=rb-4.1.0&q=85&fm=jpg&crop=entropy&cs=srgb&w=1000"
+        alt="Bukchon Hanok Village by Y K"
         class="h-full w-full rounded-md object-cover"
     />
+    <a href="https://unsplash.com/fr/photos/rue-vide-entre-les-maisons--e6Xu27_T50" class="hover:underline">Bukchon Hanok Village by Y K</a>
 </twig:AspectRatio>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<div style="aspect-ratio: 1 / 1; " class="max-w-[350px]">
-<img src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&amp;dpr=2&amp;q=80" alt="Landscape photograph by Tobias Tullius" class="h-full w-full rounded-md object-cover">
+<div style="aspect-ratio: 3 / 2; " class="max-h-90">
+<img src="https://images.unsplash.com/photo-1535189043414-47a3c49a0bed?ixlib=rb-4.1.0&amp;q=85&amp;fm=jpg&amp;crop=entropy&amp;cs=srgb&amp;w=1000" alt="Bukchon Hanok Village by Y K" class="h-full w-full rounded-md object-cover">
+    <a href="https://unsplash.com/fr/photos/rue-vide-entre-les-maisons--e6Xu27_T50" class="hover:underline">Bukchon Hanok Village by Y K</a>
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component aspect-ratio, code 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component aspect-ratio, code 3__1.html
@@ -3,15 +3,17 @@
 - Component: Aspect Ratio
 - Code:
 ```twig
-<twig:AspectRatio ratio="16 / 9" class="max-w-[350px]">
+<twig:AspectRatio ratio="16 / 9" class="max-h-90">
     <img
-        src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&amp;dpr=2&amp;q=80"
-        alt="Landscape photograph by Tobias Tullius"
+        src="https://images.unsplash.com/photo-1535189043414-47a3c49a0bed?ixlib=rb-4.1.0&q=85&fm=jpg&crop=entropy&cs=srgb&w=1000"
+        alt="Bukchon Hanok Village by Y K"
         class="h-full w-full rounded-md object-cover"
     />
+    <a href="https://unsplash.com/fr/photos/rue-vide-entre-les-maisons--e6Xu27_T50" class="hover:underline">Bukchon Hanok Village by Y K</a>
 </twig:AspectRatio>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<div style="aspect-ratio: 16 / 9; " class="max-w-[350px]">
-<img src="https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&amp;dpr=2&amp;q=80" alt="Landscape photograph by Tobias Tullius" class="h-full w-full rounded-md object-cover">
+<div style="aspect-ratio: 16 / 9; " class="max-h-90">
+<img src="https://images.unsplash.com/photo-1535189043414-47a3c49a0bed?ixlib=rb-4.1.0&amp;q=85&amp;fm=jpg&amp;crop=entropy&amp;cs=srgb&amp;w=1000" alt="Bukchon Hanok Village by Y K" class="h-full w-full rounded-md object-cover">
+    <a href="https://unsplash.com/fr/photos/rue-vide-entre-les-maisons--e6Xu27_T50" class="hover:underline">Bukchon Hanok Village by Y K</a>
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code 1__1.html
@@ -10,7 +10,7 @@
         </twig:Breadcrumb:Item>
         <twig:Breadcrumb:Separator />
         <twig:Breadcrumb:Item>
-            <twig:Breadcrumb:Link href=".">Docs</twig:Breadcrumb:Link>
+            <twig:Breadcrumb:Ellipsis />
         </twig:Breadcrumb:Item>
         <twig:Breadcrumb:Separator />
         <twig:Breadcrumb:Item>
@@ -31,7 +31,10 @@
         <li class="[&amp;&gt;svg]:w-3.5 [&amp;&gt;svg]:h-3.5 " role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="currentColor" d="M8.59 16.58L13.17 12L8.59 7.41L10 6l6 6l-6 6z"></path></svg></li>
 
         <li class="inline-flex items-center gap-1.5 ">
-<a class="transition-colors hover:text-foreground " href=".">Docs</a>
+<span class="[&amp;&gt;svg]:w-3.5 [&amp;&gt;svg]:h-3.5 " role="presentation" aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></g></svg>
+</span>
+
         </li>
         <li class="[&amp;&gt;svg]:w-3.5 [&amp;&gt;svg]:h-3.5 " role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="currentColor" d="M8.59 16.58L13.17 12L8.59 7.41L10 6l6 6l-6 6z"></path></svg></li>
 

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component button, code 11__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component button, code 11__1.html
@@ -1,0 +1,17 @@
+<!--
+- Kit: Shadcn UI
+- Component: Button
+- Code:
+```twig
+<div class="flex items-center gap-2">
+    <twig:Button size="sm">Small</twig:Button>
+    <twig:Button>Default</twig:Button>
+    <twig:Button size="lg">Large</twig:Button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex items-center gap-2">
+    <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-3">Small</button>
+    <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">Default</button>
+    <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-11 px-8">Large</button>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component button, code 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component button, code 3__1.html
@@ -3,7 +3,7 @@
 - Component: Button
 - Code:
 ```twig
-<twig:Button variant="outline">Outline</twig:Button>
+<twig:Button variant="secondary">Secondary</twig:Button>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Outline</button>
+<button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-secondary text-secondary-foreground hover:bg-secondary/80 h-10 px-4 py-2">Secondary</button>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 1__1.html
@@ -6,4 +6,4 @@
 <twig:Input type="email" placeholder="Email" class="max-w-sm" />
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<input type="email" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 max-w-sm" placeholder="Email">
+<input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 max-w-sm" type="email" placeholder="Email">

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 2__1.html
@@ -11,6 +11,6 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="grid w-full max-w-sm items-center gap-1.5">
     <label for="picture">Picture</label>
-    <input type="file" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="picture">
+    <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " type="file" id="picture">
 
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 3__1.html
@@ -6,4 +6,4 @@
 <twig:Input type="email" placeholder="Email" disabled class="max-w-sm" />
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<input type="email" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 max-w-sm" placeholder="Email" disabled>
+<input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 max-w-sm" type="email" placeholder="Email" disabled>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 4__1.html
@@ -11,6 +11,6 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="grid w-full max-w-sm items-center gap-1.5">
     <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="email">Email</label>
-    <input type="email" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="email">
+    <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " type="email" id="email">
 
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 5__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input, code 5__1.html
@@ -10,7 +10,7 @@
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex w-full max-w-sm items-center space-x-2">
-    <input type="email" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="email">
+    <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " type="email" id="email">
 
     <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2" type="submit">Subscribe</button>
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component label, code 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component label, code 2__1.html
@@ -11,6 +11,6 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="grid w-full max-w-sm items-center gap-1.5">
     <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="email">Email</label>
-    <input type="email" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="email" placeholder="Enter your email">
+    <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " type="email" id="email" placeholder="Enter your email">
 
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component label, code 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component label, code 3__1.html
@@ -11,6 +11,6 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="grid w-full max-w-sm items-center gap-1.5">
     <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 after:content-['*'] after:ml-0.5 after:text-red-500" for="email">Email</label>
-    <input type="email" class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="email" placeholder="Enter your email">
+    <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " type="email" id="email" placeholder="Enter your email">
 
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component pagination, code 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component pagination, code 1__1.html
@@ -12,7 +12,7 @@
             <twig:Pagination:Link href="#">1</twig:Pagination:Link>
         </twig:Pagination:Item>
         <twig:Pagination:Item>
-            <twig:Pagination:Link href="#" isActive>2</twig:Pagination:Link>
+            <twig:Pagination:Link href="#" active>2</twig:Pagination:Link>
         </twig:Pagination:Item>
         <twig:Pagination:Item>
             <twig:Pagination:Link href="#">3</twig:Pagination:Link>
@@ -44,7 +44,7 @@
 <a class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-10 w-10" href="#">3</a>
         </li>
         <li>
-<span aria-hidden="true" class="flex h-9 w-9 items-center justify-center ">
+<span aria-hidden="true" class="flex size-9 items-center justify-center ">
     <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></g></svg>
     <span class="sr-only">More pages</span>
 </span>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component pagination, code 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component pagination, code 2__1.html
@@ -18,7 +18,7 @@
             <twig:Pagination:Link href="#">4</twig:Pagination:Link>
         </twig:Pagination:Item>
         <twig:Pagination:Item>
-            <twig:Pagination:Link href="#" isActive>5</twig:Pagination:Link>
+            <twig:Pagination:Link href="#" active>5</twig:Pagination:Link>
         </twig:Pagination:Item>
         <twig:Pagination:Item>
             <twig:Pagination:Link href="#">6</twig:Pagination:Link>
@@ -47,7 +47,7 @@
 <a class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-10 w-10" href="#">1</a>
         </li>
         <li>
-<span aria-hidden="true" class="flex h-9 w-9 items-center justify-center ">
+<span aria-hidden="true" class="flex size-9 items-center justify-center ">
     <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></g></svg>
     <span class="sr-only">More pages</span>
 </span>
@@ -63,7 +63,7 @@
 <a class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-10 w-10" href="#">6</a>
         </li>
         <li>
-<span aria-hidden="true" class="flex h-9 w-9 items-center justify-center ">
+<span aria-hidden="true" class="flex size-9 items-center justify-center ">
     <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></g></svg>
     <span class="sr-only">More pages</span>
 </span>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component separator, code 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component separator, code 1__1.html
@@ -28,17 +28,14 @@
             Symfony UX initiative: a JavaScript ecosystem for Symfony
         </p>
     </div>
-    <div class="shrink-0 bg-border h-[1px] w-full my-4" role="none">
-</div>
+    <div class="shrink-0 bg-border h-[1px] w-full my-4" role="none"></div>
 
     <div class="flex h-5 items-center space-x-4 text-sm">
         <a href="https://ux.symfony.com" class="hover:underline">Website</a>
-        <div class="shrink-0 bg-border h-full w-[1px]" role="none">
-</div>
+        <div class="shrink-0 bg-border h-full w-[1px]" role="none"></div>
 
         <a href="https://ux.symfony.com/packages" class="hover:underline">Packages</a>
-        <div class="shrink-0 bg-border h-full w-[1px]" role="none">
-</div>
+        <div class="shrink-0 bg-border h-full w-[1px]" role="none"></div>
 
         <a href="https://github.com/symfony/ux" class="hover:underline">Source</a>
     </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component separator, code 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component separator, code 2__1.html
@@ -14,12 +14,10 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex h-5 items-center gap-4 text-sm">
     <div>Blog</div>
-    <div class="shrink-0 bg-border h-full w-[1px]" role="none">
-</div>
+    <div class="shrink-0 bg-border h-full w-[1px]" role="none"></div>
 
     <div>Docs</div>
-    <div class="shrink-0 bg-border h-full w-[1px]" role="none">
-</div>
+    <div class="shrink-0 bg-border h-full w-[1px]" role="none"></div>
 
     <div>Source</div>
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component textarea, code 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component textarea, code 2__1.html
@@ -3,14 +3,7 @@
 - Component: Textarea
 - Code:
 ```twig
-<div class="grid w-sm gap-1.5">
-    <label for="message">Your message</label>
-    <twig:Textarea id="message" placeholder="Type your message here." />
-</div>
+<twig:Textarea class="max-w-sm">This is the default content of the textarea.</twig:Textarea>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<div class="grid w-sm gap-1.5">
-    <label for="message">Your message</label>
-    <textarea class="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm " id="message" placeholder="Type your message here."></textarea>
-
-</div>
+<textarea class="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-sm">This is the default content of the textarea.</textarea>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component textarea, code 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component textarea, code 3__1.html
@@ -3,7 +3,14 @@
 - Component: Textarea
 - Code:
 ```twig
-<twig:Textarea placeholder="Type your message here." disabled class="max-w-sm" />
+<div class="grid w-sm gap-1.5">
+    <twig:Label for="message">Your message</twig:Label>
+    <twig:Textarea id="message" placeholder="Type your message here." />
+</div>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<textarea class="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-sm" placeholder="Type your message here." disabled></textarea>
+<div class="grid w-sm gap-1.5">
+    <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="message">Your message</label>
+    <textarea class="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm " id="message" placeholder="Type your message here."></textarea>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component textarea, code 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component textarea, code 4__1.html
@@ -1,0 +1,9 @@
+<!--
+- Kit: Shadcn UI
+- Component: Textarea
+- Code:
+```twig
+<twig:Textarea placeholder="Type your message here." disabled class="max-w-sm" />
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<textarea class="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-sm" placeholder="Type your message here." disabled></textarea>

--- a/ux.symfony.com/assets/styles/components/_Wysiwyg.scss
+++ b/ux.symfony.com/assets/styles/components/_Wysiwyg.scss
@@ -26,4 +26,14 @@
         color: var(--bs-link-color);
         text-decoration: underline;
     }
+
+    .table-responsive {
+        margin-bottom: $spacer;
+        border: 1px solid var(--bs-border-color);
+        border-radius: .75rem;
+    }
+
+    .table-responsive .table {
+        margin-bottom: 0;
+    }
 }

--- a/ux.symfony.com/composer.json
+++ b/ux.symfony.com/composer.json
@@ -29,6 +29,7 @@
         "symfony/runtime": "^7.2",
         "symfony/serializer": "7.2.*",
         "symfony/stimulus-bundle": "2.x-dev",
+        "symfony/string": "7.2.*",
         "symfony/translation": "7.2.*",
         "symfony/twig-bundle": "7.2.*",
         "symfony/uid": "7.2.*",

--- a/ux.symfony.com/composer.lock
+++ b/ux.symfony.com/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0866bbab4d07cd77c2832549a45b8d0b",
+    "content-hash": "823754b33f16ed72a8cf393aab684f2d",
     "packages": [
         {
             "name": "composer/semver",

--- a/ux.symfony.com/src/Service/CommonMark/ConverterFactory.php
+++ b/ux.symfony.com/src/Service/CommonMark/ConverterFactory.php
@@ -15,9 +15,12 @@ use App\Service\CommonMark\Extension\CodeBlockRenderer\CodeBlockRenderer;
 use App\Service\Toolkit\ToolkitService;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Extension\DefaultAttributes\DefaultAttributesExtension;
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
 use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\Mention\MentionExtension;
+use League\CommonMark\Extension\Table\Table;
+use League\CommonMark\Extension\Table\TableExtension;
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 
 /**
@@ -34,6 +37,11 @@ final class ConverterFactory
     public function __invoke(): CommonMarkConverter
     {
         $converter = new CommonMarkConverter([
+            'default_attributes' => [
+                Table::class => [
+                    'class' => 'table',
+                ],
+            ],
             'mentions' => [
                 'github_handle' => [
                     'prefix' => '@',
@@ -49,12 +57,21 @@ final class ConverterFactory
             'external_link' => [
                 'internal_hosts' => ['/(^|\.)symfony\.com$/'],
             ],
+            'table' => [
+                'wrap' => [
+                    'enabled' => true,
+                    'tag' => 'div',
+                    'attributes' => ['class' => 'table-responsive'],
+                ],
+            ],
         ]);
 
         $converter->getEnvironment()
+            ->addExtension(new DefaultAttributesExtension())
             ->addExtension(new ExternalLinkExtension())
             ->addExtension(new MentionExtension())
             ->addExtension(new FrontMatterExtension())
+            ->addExtension(new TableExtension())
             ->addRenderer(FencedCode::class, new CodeBlockRenderer($this->toolkitService))
         ;
 

--- a/ux.symfony.com/src/Twig/Components/Toolkit/ComponentDoc.php
+++ b/ux.symfony.com/src/Twig/Components/Toolkit/ComponentDoc.php
@@ -36,6 +36,8 @@ class ComponentDoc
     {
         $examples = $this->getExamples();
 
+        $apiReference = $this->toolkitService->renderApiReference($this->component);
+
         return $this->adaptPreviewableCodeBlocks(\sprintf(<<<MARKDOWN
             # %s
 
@@ -54,6 +56,7 @@ class ComponentDoc
             ## Examples
 
             %s
+            %s
             MARKDOWN,
             $this->component->manifest->name,
             $this->component->manifest->description,
@@ -64,7 +67,8 @@ class ComponentDoc
                 $acc .= '### '.$exampleTitle.\PHP_EOL.$examples[$exampleTitle].\PHP_EOL;
 
                 return $acc;
-            }, '')
+            }, ''),
+            $apiReference ? '## API Reference'.\PHP_EOL.$apiReference : '',
         ));
     }
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #2950 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Props and blocks now render like that:
<img width="1130" height="581" alt="image" src="https://github.com/user-attachments/assets/73073232-b030-40de-b332-d4515a34bb09" />

I also updated/fixed some examples or components