### PR TITLE
 Add clarification of component re-rendering vs. loading content

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -998,6 +998,9 @@ Or, to *hide* an element while the component is loading:
     <!-- hide when the component is loading -->
     <span data-loading="hide">Saved!</span>
 
+Note that this is a different concept than showing a placeholder when initially loading the component itself.
+See :ref:`loading content <loading-content>` for more info.
+
 Adding and Removing Classes or Attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Add a note that explains that the re-rendering loading states is a different concept from the components initial loading state regarding placeholders, with a link to the related "loading content" section in this doc

Add a note that explains that the re-rendering loading states is a different concept from the components initial loading state regarding placeholders, with a link to the related "loading content" section in this doc.
This helps avoid confusion when a reader initially looks up the "loading state" section without knowing of the two concepts.
