### PR TITLE
 Update symfony/mercure-bundle version constraint

### DIFF
--- a/src/Notify/composer.json
+++ b/src/Notify/composer.json
@@ -32,7 +32,7 @@
         "symfony/config": "^5.4|^6.0|^7.0|^8.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0|^8.0",
         "symfony/http-kernel": "^5.4|^6.0|^7.0|^8.0",
-        "symfony/mercure-bundle": "^0.3.4",
+        "symfony/mercure-bundle": "^0.3.4|^0.4",
         "symfony/mercure-notifier": "^5.4|^6.0|^7.0|^8.0",
         "symfony/stimulus-bundle": "^2.9.1",
         "symfony/twig-bundle": "^5.4|^6.0|^7.0|^8.0"


### PR DESCRIPTION
just to check ci.
mercure-bundle 0.4.1 is not getting installed in my project. pre-release?


➜  `composer update "symfony/mercure-bundle:0.4.1" --dry-run -W`
Loading composer repositories with package information                                                                                                                            Restricting packages listed in "symfony/symfony" to "7.4.*"
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - symfony/ux-notify is locked to version v2.31.0 and an update of this package was not requested.
    - symfony/ux-notify v2.31.0 requires symfony/mercure-bundle ^0.3.4 -> found symfony/mercure-bundle[dev-main, v0.3.4, ..., 0.3.x-dev (alias of dev-main)] but it conflicts with your temporary update constraint (symfony/mercure-bundle:0.4.1).
