### PR TITLE
[TwigComponent] Fix loading Twig Components by FQCN

### DIFF
--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -46,6 +46,8 @@ final class ComponentFactory implements ResetInterface
 
     public function metadataFor(string $name): ComponentMetadata
     {
+        $name = $this->classMap[$name] ?? $name;
+
         if ($config = $this->config[$name] ?? null) {
             return new ComponentMetadata($config);
         }
@@ -57,14 +59,6 @@ final class ComponentFactory implements ResetInterface
             ];
 
             return new ComponentMetadata($this->config[$name]);
-        }
-
-        if ($mappedName = $this->classMap[$name] ?? null) {
-            if ($config = $this->config[$mappedName] ?? null) {
-                return new ComponentMetadata($config);
-            }
-
-            throw new \InvalidArgumentException(\sprintf('Unknown component "%s".', $name));
         }
 
         $this->throwUnknownComponentException($name);

--- a/src/TwigComponent/tests/Unit/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentFactoryTest.php
@@ -93,4 +93,32 @@ class ComponentFactoryTest extends TestCase
         $this->assertSame('foo', $metadata->getName());
         $this->assertSame('foo.html.twig', $metadata->getTemplate());
     }
+
+    /**
+     * @testWith ["bar"]
+     *           ["Foo\\Bar"]
+     */
+    public function testPrefersClassComponentOverAnonymous(string $name)
+    {
+        $templateFinder = $this->createMock(ComponentTemplateFinderInterface::class);
+        $templateFinder->expects($this->never())
+            ->method('findAnonymousComponentTemplate');
+
+        $factory = new ComponentFactory(
+            $templateFinder,
+            $this->createMock(ServiceLocator::class),
+            $this->createMock(PropertyAccessorInterface::class),
+            $this->createMock(EventDispatcherInterface::class),
+            [
+                'bar' => ['key' => 'bar', 'template' => 'bar.html.twig'],
+            ],
+            ['Foo\\Bar' => 'bar'],
+            $this->createMock(Environment::class),
+        );
+
+        $metadata = $factory->metadataFor($name);
+
+        $this->assertSame('bar', $metadata->getName());
+        $this->assertSame('bar.html.twig', $metadata->getTemplate());
+    }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3195 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

When loading Twig Components, code needs a way to identify the component. You can use the identifiers that `ComponentFactory` internally uses (this will usually be an identifier consisting of the namespaces separated by `:`). But as the docs still state, past versions of ux-twig-component could also load them by the fully-qualified PHP class name of the component class.

da0537d96182b40f60ac9d1dd4b961fa3c605011 broke this: From this commit on, `ComponentFactory`, which is responsible for resolving the identifier the user provided to a Twig template and a class, would only attempt to resolve an FQCN if it couldn't provide metadata for loading the component anonymously (which means without a class, just the Twig template). ~~Because loading the component anonymously always works as long as there is a Twig template,~~ In case the FQCN could also be resolved as a Twig template, `ComponentFactory` would not resolve FQCNs to a class component, and instead load only the corresponding Twig template as an anonymous component.

The issue affects all versions from  `2.20.0` to `2.31.0`.

This PR fixes this by trying to resolve the FQCN right at the beginning, makig sure the first attempt to load the component with the class already happens using the right identifier.