### PR TITLE
[Icons] Fix `aliases` and `default_attributes` config types for `config/reference.php`

### DIFF
--- a/src/Icons/src/DependencyInjection/UXIconsExtension.php
+++ b/src/Icons/src/DependencyInjection/UXIconsExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\Icons\DependencyInjection;
 
 use Symfony\Component\AssetMapper\Event\PreAssetsCompileEvent;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
@@ -38,10 +39,15 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
                     ->info('The local directory where icons are stored.')
                     ->defaultValue('%kernel.project_dir%/assets/icons')
                 ->end()
-                ->variableNode('default_icon_attributes')
+                ->arrayNode('default_icon_attributes')
                     ->info('Default attributes to add to all icons.')
                     ->defaultValue(['fill' => 'currentColor'])
                     ->example(['class' => 'icon'])
+                    ->normalizeKeys(false)
+                    ->useAttributeAsKey('key')
+                    ->scalarPrototype()
+                        ->cannotBeEmpty()
+                    ->end()
                 ->end()
                 ->arrayNode('icon_sets')
                     ->info('Icon sets configuration.')
@@ -63,7 +69,9 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
                                 ->info('Override default icon attributes for icons in this set.')
                                 ->example(['class' => 'icon icon-acme', 'fill' => 'none'])
                                 ->normalizeKeys(false)
-                                ->variablePrototype()
+                                ->useAttributeAsKey('key')
+                                ->scalarPrototype()
+                                    ->cannotBeEmpty()
                                 ->end()
                             ->end()
                         ->end()
@@ -80,7 +88,8 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
                         'privacy' => 'bi:cookie',
                     ])
                     ->normalizeKeys(false)
-                    ->scalarPrototype()
+                    ->useAttributeAsKey('key')
+                    ->{method_exists(ArrayNodeDefinition::class, 'stringPrototype') ? 'stringPrototype' : 'scalarPrototype'}()
                         ->cannotBeEmpty()
                     ->end()
                 ->end()

--- a/src/Icons/tests/UXIconsBundleTest.php
+++ b/src/Icons/tests/UXIconsBundleTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\UX\Icons\DependencyInjection\UXIconsExtension;
+
+class UXIconsBundleTest extends TestCase
+{
+    public static function provideTestInvalidAliasConfiguration(): iterable
+    {
+        yield ['', 'Invalid type for path "ux_icons.aliases". Expected "array", but got "string"'];
+        yield [123, 'Invalid type for path "ux_icons.aliases". Expected "array", but got "int'];
+        yield [false, 'Invalid type for path "ux_icons.aliases". Expected "array", but got "bool"'];
+
+        if (method_exists(ArrayNodeDefinition::class, 'stringPrototype')) {
+            yield [[1, 2, 3], 'Invalid type for path "ux_icons.aliases.0". Expected "string", but got "int"'];
+            yield [['foo' => 123], 'Invalid type for path "ux_icons.aliases.foo". Expected "string", but got "int"'];
+        }
+    }
+
+    /**
+     * @dataProvider provideTestInvalidAliasConfiguration
+     */
+    #[DataProvider('provideTestInvalidAliasConfiguration')]
+    public function testInvalidAliasConfiguration(mixed $value, string $expectedMessage)
+    {
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage($expectedMessage);
+
+        $processor = new Processor();
+        $configurableExtension = new UXIconsExtension();
+        $processor->processConfiguration($configurableExtension, [
+            [
+                'aliases' => $value,
+            ],
+        ]);
+    }
+
+    public static function provideTestValidAliasConfiguration(): iterable
+    {
+        yield [[]];
+        yield [['foo' => 'bar']];
+    }
+
+    /**
+     * @dataProvider provideTestValidAliasConfiguration
+     */
+    #[DataProvider('provideTestValidAliasConfiguration')]
+    public function testValidAliasConfiguration(array $value)
+    {
+        $processor = new Processor();
+        $configurableExtension = new UXIconsExtension();
+        $processedConfig = $processor->processConfiguration($configurableExtension, [
+            [
+                'aliases' => $value,
+            ],
+        ]);
+
+        $this->assertSame($value, $processedConfig['aliases']);
+    }
+
+    public static function provideTestInvalidIconAttributesConfiguration(): iterable
+    {
+        yield ['', 'Invalid type for path "ux_icons.default_icon_attributes". Expected "array", but got "string"'];
+        yield [123, 'Invalid type for path "ux_icons.default_icon_attributes". Expected "array", but got "int"'];
+        yield [false, 'Invalid type for path "ux_icons.default_icon_attributes". Expected "array", but got "bool"'];
+    }
+
+    /**
+     * @dataProvider provideTestInvalidIconAttributesConfiguration
+     */
+    #[DataProvider('provideTestInvalidIconAttributesConfiguration')]
+    public function testInvalidIconAttributeConfiguration(mixed $value, string $expectedMessage)
+    {
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage($expectedMessage);
+
+        $processor = new Processor();
+        $configurableExtension = new UXIconsExtension();
+        $processor->processConfiguration($configurableExtension, [
+            [
+                'default_icon_attributes' => $value,
+            ],
+        ]);
+    }
+
+    public static function provideTestValidIconAttributesConfiguration(): iterable
+    {
+        yield [[]];
+        yield [['class' => 'icon-large', 'aria-hidden' => 'true', 'data-test' => 123]];
+    }
+
+    /**
+     * @dataProvider provideTestValidIconAttributesConfiguration
+     */
+    #[DataProvider('provideTestValidIconAttributesConfiguration')]
+    public function testValidIconAttributeConfiguration(array $value)
+    {
+        $processor = new Processor();
+        $configurableExtension = new UXIconsExtension();
+        $processedConfig = $processor->processConfiguration($configurableExtension, [
+            [
+                'default_icon_attributes' => $value,
+            ],
+        ]);
+        $this->assertSame($value, $processedConfig['default_icon_attributes']);
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3193 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Types are now correct:
<img width="1126" height="349" alt="image" src="https://github.com/user-attachments/assets/2d776f45-8062-46dc-aa5c-3fcbd1c389ff" />
