### PR TITLE
[Autocomplete][Docs] Fix missing space in JSON snippet

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -724,7 +724,7 @@ a :ref:`custom autocompleter <custom-autocompleter>`:
         {
             "results": [
                 { "value": "1", "text": "Pizza" },
-                { "value": "2", "text":"Banana"}
+                { "value": "2", "text": "Banana"}
             ]
         }
 


### PR DESCRIPTION
Fixes a minor formatting issue in the JSON example shown under the “Manually using the Stimulus Controller” section, adding the missing space.