### PR TITLE
 Fix InteractsWithTwigComponents not being able to render blocks when variable scope is limited (cache friendlier solution with limitations)

### DIFF
--- a/src/TwigComponent/src/Test/InteractsWithTwigComponents.php
+++ b/src/TwigComponent/src/Test/InteractsWithTwigComponents.php
@@ -52,7 +52,7 @@ trait InteractsWithTwigComponents
         $template = \sprintf('{%% component "%s" with data %%}', addslashes($name));
 
         foreach (array_keys($blocks) as $blockName) {
-            $template .= \sprintf('{%% block %1$s %%}{{ blocks.%1$s|raw }}{%% endblock %%}', $blockName);
+            $template .= \sprintf('{%% block %1$s %%}{{ outerScope.blocks.%1$s|raw }}{%% endblock %%}', $blockName);
         }
 
         $template .= '{% endcomponent %}';

--- a/src/TwigComponent/tests/Fixtures/Component/WithSlotsAndLimitedScope.php
+++ b/src/TwigComponent/tests/Fixtures/Component/WithSlotsAndLimitedScope.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsTwigComponent]
+final class WithSlotsAndLimitedScope
+{
+}

--- a/src/TwigComponent/tests/Fixtures/templates/components/WithSlotsAndLimitedScope.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/WithSlotsAndLimitedScope.html.twig
@@ -1,0 +1,7 @@
+<div>
+    {% with { outerScope } only %}
+        {% block content %}{% endblock %}
+        {% block slot1 %}{% endblock %}
+        {% block slot2 %}{% endblock %}
+    {% endwith %}
+</div>

--- a/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
@@ -261,7 +261,7 @@ final class ComponentFactoryTest extends KernelTestCase
      * @testWith ["tabl", "Unknown component \"tabl\". Did you mean this: \"table\"?"]
      *           ["Basic", "Unknown component \"Basic\". Did you mean this: \"BasicComponent\"?"]
      *           ["basic", "Unknown component \"basic\". Did you mean this: \"BasicComponent\"?"]
-     *           ["with", "Unknown component \"with\". Did you mean one of these: \"with_attributes\", \"with_exposed_variables\", \"WithSlots\"?"]
+     *           ["with", "Unknown component \"with\". Did you mean one of these: \"with_attributes\", \"with_exposed_variables\", \"WithSlots\", \"WithSlotsAndLimitedScope\"?"]
      *           ["anonAnon", "Unknown component \"anonAnon\". And no matching anonymous component template was found."]
      */
     public function testCannotGetInvalidComponent(string $name, string $expectedExceptionMessage)

--- a/src/TwigComponent/tests/Integration/Test/InteractsWithTwigComponentsTest.php
+++ b/src/TwigComponent/tests/Integration/Test/InteractsWithTwigComponentsTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\TwigComponent\Test\InteractsWithTwigComponents;
 use Symfony\UX\TwigComponent\Tests\Fixtures\Component\ComponentA;
 use Symfony\UX\TwigComponent\Tests\Fixtures\Component\WithSlots;
+use Symfony\UX\TwigComponent\Tests\Fixtures\Component\WithSlotsAndLimitedScope;
 use Symfony\UX\TwigComponent\Tests\Fixtures\Service\ServiceA;
 
 final class InteractsWithTwigComponentsTest extends KernelTestCase
@@ -87,5 +88,7 @@ final class InteractsWithTwigComponentsTest extends KernelTestCase
     {
         yield ['WithSlots'];
         yield [WithSlots::class];
+        yield ['WithSlotsAndLimitedScope'];
+        yield [WithSlotsAndLimitedScope::class];
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3210
| License        | MIT

Alternative to https://github.com/symfony/ux/pull/3211 which should be more cache-friendly. Has the limitation that it requires components to allow the `outerScope` variable in blocks they define.
