### PR TITLE
[Toolkit][Shadcn] add Field component

### DIFF
--- a/src/Toolkit/kits/shadcn/field/EXAMPLES.md
+++ b/src/Toolkit/kits/shadcn/field/EXAMPLES.md
@@ -1,0 +1,228 @@
+# Examples
+
+## Input
+
+```twig {"preview":true,"height":"500px"}
+<div class="w-full max-w-md">
+    <twig:Field:Set>
+        <twig:Field:Group>
+            <twig:Field>
+                <twig:Field:Label for="username">Username</twig:Field:Label>
+                <twig:Input id="username" type="text" placeholder="Max Leiter" />
+                <twig:Field:Description>
+                    Choose a unique username for your account.
+                </twig:Field:Description>
+            </twig:Field>
+            <twig:Field>
+                <twig:Field:Label for="password">Password</twig:Field:Label>
+                <twig:Field:Description>
+                    Must be at least 8 characters long.
+                </twig:Field:Description>
+                <twig:Input id="password" type="password" placeholder="********" />
+            </twig:Field>
+        </twig:Field:Group>
+    </twig:Field:Set>
+</div>
+```
+
+## Textarea
+
+```twig {"preview":true,"height":"400px"}
+<div class="w-full max-w-md">
+    <twig:Field:Set>
+        <twig:Field:Group>
+            <twig:Field>
+                <twig:Field:Label for="feedback">Feedback</twig:Field:Label>
+                <twig:Textarea
+                    id="feedback"
+                    placeholder="Your feedback helps us improve..."
+                    rows="4"
+                />
+                <twig:Field:Description>
+                    Share your thoughts about our service.
+                </twig:Field:Description>
+            </twig:Field>
+        </twig:Field:Group>
+    </twig:Field:Set>
+</div>
+```
+
+## Select
+
+```twig {"preview":true,"height":"360px"}
+<div class="w-full max-w-md">
+    <twig:Field>
+        <twig:Field:Label for="department">Department</twig:Field:Label>
+        <twig:Select id="department">
+            <option value="engineering">Engineering</option>
+            <option value="design">Design</option>
+            <option value="marketing">Marketing</option>
+            <option value="sales">Sales</option>
+            <option value="support">Customer Support</option>
+            <option value="hr">Human Resources</option>
+            <option value="finance">Finance</option>
+            <option value="operations">Operations</option>
+        </twig:Select>
+        <twig:Field:Description>
+            Select your department or area of work.
+        </twig:Field:Description>
+    </twig:Field>
+</div>
+```
+
+## Field set
+
+```twig {"preview":true,"height":"400px"}
+<div class="w-full max-w-md space-y-6">
+    <twig:Field:Set>
+        <twig:Field:Legend>Address information</twig:Field:Legend>
+        <twig:Field:Description>
+            We need your address to deliver your order.
+        </twig:Field:Description>
+        <twig:Field:Group>
+            <twig:Field>
+                <twig:Field:Label for="street">Street address</twig:Field:Label>
+                <twig:Input id="street" type="text" placeholder="123 Main St" />
+            </twig:Field>
+            <div class="grid grid-cols-2 gap-4">
+                <twig:Field>
+                    <twig:Field:Label for="city">City</twig:Field:Label>
+                    <twig:Input id="city" type="text" placeholder="New York" />
+                </twig:Field>
+                <twig:Field>
+                    <twig:Field:Label for="zip">Postal code</twig:Field:Label>
+                    <twig:Input id="zip" type="text" placeholder="90502" />
+                </twig:Field>
+            </div>
+        </twig:Field:Group>
+    </twig:Field:Set>
+</div>
+```
+
+## Checkbox
+
+```twig {"preview":true,"height":"520px"}
+<div class="w-full max-w-md">
+    <twig:Field:Group>
+        <twig:Field:Set>
+            <twig:Field:Legend variant="label">
+                Show these items on the desktop
+            </twig:Field:Legend>
+            <twig:Field:Description>
+                Select the items you want to show on the desktop.
+            </twig:Field:Description>
+            <twig:Field:Group class="gap-3">
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="finder-pref-9k2-hard-disks-ljj" />
+                    <twig:Field:Label
+                        for="finder-pref-9k2-hard-disks-ljj"
+                        class="font-normal"
+                        checked
+                    >
+                        Hard disks
+                    </twig:Field:Label>
+                </twig:Field>
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="finder-pref-9k2-external-disks-1yg" />
+                    <twig:Field:Label
+                        for="finder-pref-9k2-external-disks-1yg"
+                        class="font-normal"
+                    >
+                        External disks
+                    </twig:Field:Label>
+                </twig:Field>
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="finder-pref-9k2-cds-dvds-fzt" />
+                    <twig:Field:Label
+                        for="finder-pref-9k2-cds-dvds-fzt"
+                        class="font-normal"
+                    >
+                        CDs, DVDs, and iPods
+                    </twig:Field:Label>
+                </twig:Field>
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="finder-pref-9k2-connected-servers-6l2" />
+                    <twig:Field:Label
+                        for="finder-pref-9k2-connected-servers-6l2"
+                        class="font-normal"
+                    >
+                        Connected servers
+                    </twig:Field:Label>
+                </twig:Field>
+            </twig:Field:Group>
+        </twig:Field:Set>
+        <twig:Field:Separator />
+        <twig:Field orientation="horizontal">
+            <twig:Checkbox id="finder-pref-9k2-sync-folders-nep" checked />
+            <twig:Field:Content>
+                <twig:Field:Label for="finder-pref-9k2-sync-folders-nep">
+                    Sync Desktop & Documents folders
+                </twig:Field:Label>
+                <twig:Field:Description>
+                    Your Desktop & Documents folders are being synced with iCloud Drive. You can access them from other devices.
+                </twig:Field:Description>
+            </twig:Field:Content>
+        </twig:Field>
+    </twig:Field:Group>
+</div>
+```
+
+## Switch
+
+```twig {"preview":true,"height":"240px"}
+<div class="w-full max-w-md">
+    <twig:Field orientation="horizontal">
+        <twig:Field:Content>
+            <twig:Field:Label for="2fa">Multi-factor authentication</twig:Field:Label>
+            <twig:Field:Description>
+                Enable multi-factor authentication. If you do not have a two-factor device, you can use a one-time code sent to your email.
+            </twig:Field:Description>
+        </twig:Field:Content>
+        <twig:Switch id="2fa" />
+    </twig:Field>
+</div>
+```
+
+## Field group
+
+```twig {"preview":true,"height":"520px"}
+<div class="w-full max-w-md">
+    <twig:Field:Group>
+        <twig:Field:Set>
+            <twig:Field:Label>Responses</twig:Field:Label>
+            <twig:Field:Description>
+                Get notified when ChatGPT responds to requests that take time, like research or image generation.
+            </twig:Field:Description>
+            <twig:Field:Group data-slot="checkbox-group">
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="push" checked disabled />
+                    <twig:Field:Label for="push" class="font-normal">
+                        Push notifications
+                    </twig:Field:Label>
+                </twig:Field>
+            </twig:Field:Group>
+        </twig:Field:Set>
+        <twig:Field:Separator />
+        <twig:Field:Set>
+            <twig:Field:Label>Tasks</twig:Field:Label>
+            <twig:Field:Description>
+                Get notified when tasks you've created have updates. <a href="#">Manage tasks</a>
+            </twig:Field:Description>
+            <twig:Field:Group data-slot="checkbox-group">
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="push-tasks" />
+                    <twig:Field:Label for="push-tasks" class="font-normal">
+                        Push notifications
+                    </twig:Field:Label>
+                </twig:Field>
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="email-tasks" />
+                    <twig:Field:Label for="email-tasks" class="font-normal">
+                        Email notifications
+                    </twig:Field:Label>
+                </twig:Field>
+            </twig:Field:Group>
+        </twig:Field:Set>
+    </twig:Field:Group>
+</div>
+```

--- a/src/Toolkit/kits/shadcn/field/manifest.json
+++ b/src/Toolkit/kits/shadcn/field/manifest.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Field",
+    "description": "Layout helpers for form fields with labels, descriptions, errors, grouping, and separators.",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["twig/extra-bundle", "twig/html-extra:^3.12.0", "tales-from-a-dev/twig-tailwind-extra:^1.0.0"],
+        "recipe": ["label", "separator"]
+    }
+}

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field.html.twig
@@ -1,0 +1,23 @@
+{# @prop orientation 'vertical'|'horizontal'|'responsive' The orientation of the field, default to `vertical` #}
+{# @block content The default block #}
+{%- props orientation = 'vertical' -%}
+{%- set style = html_cva(
+    base: 'group/field flex w-full gap-3 data-[invalid=true]:text-destructive',
+    variants: {
+        orientation: {
+            vertical: 'flex-col [&>*]:w-full [&>.sr-only]:w-auto',
+            horizontal: 'flex-row items-center [&>[data-slot=field-label]]:flex-auto has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
+            responsive: 'flex-col [&>*]:w-full [&>.sr-only]:w-auto @md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto @md/field-group:[&>[data-slot=field-label]]:flex-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
+        },
+    },
+) -%}
+
+<div
+    role="group"
+    data-slot="field"
+    data-orientation="{{ orientation }}"
+    class="{{ style.apply({orientation: orientation}, attributes.render('class'))|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field/Content.html.twig
@@ -1,0 +1,8 @@
+{# @block content The default block #}
+<div
+    data-slot="field-content"
+    class="{{ 'group/field-content flex flex-1 flex-col gap-1.5 leading-snug ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field/Description.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field/Description.html.twig
@@ -1,0 +1,8 @@
+{# @block content The default block #}
+<p
+    data-slot="field-description"
+    class="{{ 'text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5 [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4 ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</p>

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field/Error.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field/Error.html.twig
@@ -1,0 +1,36 @@
+{# @prop errors array A list of errors (string or objects with a `message` field), defaults to `[]` #}
+{# @block content The default block #}
+{%- props errors = [] -%}
+{%- set slot_content -%}{%- block content %}{% endblock -%}{%- endset -%}
+{%- set slot_content = slot_content|trim -%}
+
+{%- if slot_content == '' -%}
+    {%- set messages = [] -%}
+    {%- for error in errors|default([]) -%}
+        {%- set message = error.message ?? error -%}
+        {%- if message is not same as(false) and message is not null and message != '' and not (message in messages) -%}
+            {%- set messages = messages|merge([message]) -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endif -%}
+
+{%- if slot_content != '' or (messages ?? [])|length > 0 -%}
+    <div
+        role="alert"
+        data-slot="field-error"
+        class="{{ 'text-destructive text-sm font-normal ' ~ attributes.render('class')|tailwind_merge }}"
+        {{ attributes }}
+    >
+        {%- if slot_content != '' -%}
+            {{ slot_content }}
+        {%- elseif (messages ?? [])|length == 1 -%}
+            {{ messages[0] }}
+        {%- else -%}
+            <ul class="ml-4 flex list-disc flex-col gap-1">
+                {%- for message in messages|default([]) -%}
+                    <li>{{ message }}</li>
+                {%- endfor -%}
+            </ul>
+        {%- endif -%}
+    </div>
+{%- endif -%}

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field/Group.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field/Group.html.twig
@@ -1,0 +1,8 @@
+{# @block content The default block #}
+<div
+    data-slot="field-group"
+    class="{{ 'group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4 ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field/Label.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field/Label.html.twig
@@ -1,0 +1,8 @@
+{# @block content The default block #}
+<twig:Label
+    data-slot="field-label"
+    class="{{ 'group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10 ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ ...attributes }}
+>
+    {{- block(outerBlocks.content) -}}
+</twig:Label>

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field/Legend.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field/Legend.html.twig
@@ -1,0 +1,20 @@
+{# @prop variant 'legend'|'label' The variant, default to `legend` #}
+{# @block content The default block #}
+{%- props variant = 'legend' -%}
+{%- set style = html_cva(
+    base: 'mb-3 font-medium',
+    variants: {
+        variant: {
+            legend: 'text-base',
+            label: 'text-sm',
+        },
+    },
+) %}
+<legend
+    data-slot="field-legend"
+    data-variant="{{ variant }}"
+    class="{{ style.apply({variant: variant}, attributes.render('class'))|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</legend>

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field/Separator.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field/Separator.html.twig
@@ -1,0 +1,19 @@
+{# @block content The default block #}
+{%- set content -%}{%- block content %}{% endblock -%}{%- endset -%}
+{%- set has_content = content|trim != '' -%}
+<div
+    data-slot="field-separator"
+    data-content="{{ has_content ? 'true' : 'false' }}"
+    class="{{ 'relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2 ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    <twig:Separator class="absolute inset-0 top-1/2" />
+    {%- if has_content -%}
+        <span
+            class="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+            data-slot="field-separator-content"
+        >
+            {{ content }}
+        </span>
+    {%- endif -%}
+</div>

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field/Set.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field/Set.html.twig
@@ -1,0 +1,8 @@
+{# @block content The default block #}
+<fieldset
+    data-slot="field-set"
+    class="{{ 'flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3 ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</fieldset>

--- a/src/Toolkit/kits/shadcn/field/templates/components/Field/Title.html.twig
+++ b/src/Toolkit/kits/shadcn/field/templates/components/Field/Title.html.twig
@@ -1,0 +1,8 @@
+{# @block content The default block #}
+<div
+    data-slot="field-label"
+    class="{{ 'flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50 ' ~ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 1__1.html
@@ -1,0 +1,47 @@
+<!--
+- Kit: Shadcn UI
+- Component: Field
+- Code:
+```twig
+<div class="w-full max-w-md">
+    <twig:Field:Set>
+        <twig:Field:Group>
+            <twig:Field>
+                <twig:Field:Label for="username">Username</twig:Field:Label>
+                <twig:Input id="username" type="text" placeholder="Max Leiter" />
+                <twig:Field:Description>
+                    Choose a unique username for your account.
+                </twig:Field:Description>
+            </twig:Field>
+            <twig:Field>
+                <twig:Field:Label for="password">Password</twig:Field:Label>
+                <twig:Field:Description>
+                    Must be at least 8 characters long.
+                </twig:Field:Description>
+                <twig:Input id="password" type="password" placeholder="********" />
+            </twig:Field>
+        </twig:Field:Group>
+    </twig:Field:Set>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="w-full max-w-md">
+    <fieldset data-slot="field-set" class="flex flex-col gap-6 has-[&gt;[data-slot=checkbox-group]]:gap-3 has-[&gt;[data-slot=radio-group]]:gap-3 ">
+<div data-slot="field-group" class="group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&amp;&gt;[data-slot=field-group]]:gap-4 ">
+<div role="group" data-slot="field" data-orientation="vertical" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-col [&amp;&gt;*]:w-full [&amp;&gt;.sr-only]:w-auto">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label" for="username">Username</label>
+                <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="username" type="text" placeholder="Max Leiter">
+
+                <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">Choose a unique username for your account.
+                </p>
+            </div>
+            <div role="group" data-slot="field" data-orientation="vertical" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-col [&amp;&gt;*]:w-full [&amp;&gt;.sr-only]:w-auto">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label" for="password">Password</label>
+                <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">Must be at least 8 characters long.
+                </p>
+                <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="password" type="password" placeholder="********">
+
+            </div>
+        </div>
+    </fieldset>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 2__1.html
@@ -1,0 +1,37 @@
+<!--
+- Kit: Shadcn UI
+- Component: Field
+- Code:
+```twig
+<div class="w-full max-w-md">
+    <twig:Field:Set>
+        <twig:Field:Group>
+            <twig:Field>
+                <twig:Field:Label for="feedback">Feedback</twig:Field:Label>
+                <twig:Textarea
+                    id="feedback"
+                    placeholder="Your feedback helps us improve..."
+                    rows="4"
+                />
+                <twig:Field:Description>
+                    Share your thoughts about our service.
+                </twig:Field:Description>
+            </twig:Field>
+        </twig:Field:Group>
+    </twig:Field:Set>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="w-full max-w-md">
+    <fieldset data-slot="field-set" class="flex flex-col gap-6 has-[&gt;[data-slot=checkbox-group]]:gap-3 has-[&gt;[data-slot=radio-group]]:gap-3 ">
+<div data-slot="field-group" class="group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&amp;&gt;[data-slot=field-group]]:gap-4 ">
+<div role="group" data-slot="field" data-orientation="vertical" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-col [&amp;&gt;*]:w-full [&amp;&gt;.sr-only]:w-auto">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label" for="feedback">Feedback</label>
+                <textarea class="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm " id="feedback" placeholder="Your feedback helps us improve..." rows="4"></textarea>
+
+                <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">Share your thoughts about our service.
+                </p>
+            </div>
+        </div>
+    </fieldset>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 3__1.html
@@ -1,0 +1,41 @@
+<!--
+- Kit: Shadcn UI
+- Component: Field
+- Code:
+```twig
+<div class="w-full max-w-md">
+    <twig:Field>
+        <twig:Field:Label for="department">Department</twig:Field:Label>
+        <twig:Select id="department">
+            <option value="engineering">Engineering</option>
+            <option value="design">Design</option>
+            <option value="marketing">Marketing</option>
+            <option value="sales">Sales</option>
+            <option value="support">Customer Support</option>
+            <option value="hr">Human Resources</option>
+            <option value="finance">Finance</option>
+            <option value="operations">Operations</option>
+        </twig:Select>
+        <twig:Field:Description>
+            Select your department or area of work.
+        </twig:Field:Description>
+    </twig:Field>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="w-full max-w-md">
+    <div role="group" data-slot="field" data-orientation="vertical" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-col [&amp;&gt;*]:w-full [&amp;&gt;.sr-only]:w-auto">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label" for="department">Department</label>
+        <select class="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&amp;&gt;span]:line-clamp-1 " id="department"><option value="engineering">Engineering</option>
+            <option value="design">Design</option>
+            <option value="marketing">Marketing</option>
+            <option value="sales">Sales</option>
+            <option value="support">Customer Support</option>
+            <option value="hr">Human Resources</option>
+            <option value="finance">Finance</option>
+            <option value="operations">Operations</option>
+        </select>
+        <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">Select your department or area of work.
+        </p>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 4__1.html
@@ -1,0 +1,57 @@
+<!--
+- Kit: Shadcn UI
+- Component: Field
+- Code:
+```twig
+<div class="w-full max-w-md space-y-6">
+    <twig:Field:Set>
+        <twig:Field:Legend>Address information</twig:Field:Legend>
+        <twig:Field:Description>
+            We need your address to deliver your order.
+        </twig:Field:Description>
+        <twig:Field:Group>
+            <twig:Field>
+                <twig:Field:Label for="street">Street address</twig:Field:Label>
+                <twig:Input id="street" type="text" placeholder="123 Main St" />
+            </twig:Field>
+            <div class="grid grid-cols-2 gap-4">
+                <twig:Field>
+                    <twig:Field:Label for="city">City</twig:Field:Label>
+                    <twig:Input id="city" type="text" placeholder="New York" />
+                </twig:Field>
+                <twig:Field>
+                    <twig:Field:Label for="zip">Postal code</twig:Field:Label>
+                    <twig:Input id="zip" type="text" placeholder="90502" />
+                </twig:Field>
+            </div>
+        </twig:Field:Group>
+    </twig:Field:Set>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="w-full max-w-md space-y-6">
+    <fieldset data-slot="field-set" class="flex flex-col gap-6 has-[&gt;[data-slot=checkbox-group]]:gap-3 has-[&gt;[data-slot=radio-group]]:gap-3 ">
+<legend data-slot="field-legend" data-variant="legend" class="mb-3 font-medium text-base">Address information</legend>
+        <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">We need your address to deliver your order.
+        </p>
+        <div data-slot="field-group" class="group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&amp;&gt;[data-slot=field-group]]:gap-4 ">
+<div role="group" data-slot="field" data-orientation="vertical" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-col [&amp;&gt;*]:w-full [&amp;&gt;.sr-only]:w-auto">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label" for="street">Street address</label>
+                <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="street" type="text" placeholder="123 Main St">
+
+            </div>
+            <div class="grid grid-cols-2 gap-4">
+                <div role="group" data-slot="field" data-orientation="vertical" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-col [&amp;&gt;*]:w-full [&amp;&gt;.sr-only]:w-auto">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label" for="city">City</label>
+                    <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="city" type="text" placeholder="New York">
+
+                </div>
+                <div role="group" data-slot="field" data-orientation="vertical" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-col [&amp;&gt;*]:w-full [&amp;&gt;.sr-only]:w-auto">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label" for="zip">Postal code</label>
+                    <input class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 " id="zip" type="text" placeholder="90502">
+
+                </div>
+            </div>
+        </div>
+    </fieldset>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 5__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 5__1.html
@@ -1,0 +1,120 @@
+<!--
+- Kit: Shadcn UI
+- Component: Field
+- Code:
+```twig
+<div class="w-full max-w-md">
+    <twig:Field:Group>
+        <twig:Field:Set>
+            <twig:Field:Legend variant="label">
+                Show these items on the desktop
+            </twig:Field:Legend>
+            <twig:Field:Description>
+                Select the items you want to show on the desktop.
+            </twig:Field:Description>
+            <twig:Field:Group class="gap-3">
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="finder-pref-9k2-hard-disks-ljj" />
+                    <twig:Field:Label
+                        for="finder-pref-9k2-hard-disks-ljj"
+                        class="font-normal"
+                        checked
+                    >
+                        Hard disks
+                    </twig:Field:Label>
+                </twig:Field>
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="finder-pref-9k2-external-disks-1yg" />
+                    <twig:Field:Label
+                        for="finder-pref-9k2-external-disks-1yg"
+                        class="font-normal"
+                    >
+                        External disks
+                    </twig:Field:Label>
+                </twig:Field>
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="finder-pref-9k2-cds-dvds-fzt" />
+                    <twig:Field:Label
+                        for="finder-pref-9k2-cds-dvds-fzt"
+                        class="font-normal"
+                    >
+                        CDs, DVDs, and iPods
+                    </twig:Field:Label>
+                </twig:Field>
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="finder-pref-9k2-connected-servers-6l2" />
+                    <twig:Field:Label
+                        for="finder-pref-9k2-connected-servers-6l2"
+                        class="font-normal"
+                    >
+                        Connected servers
+                    </twig:Field:Label>
+                </twig:Field>
+            </twig:Field:Group>
+        </twig:Field:Set>
+        <twig:Field:Separator />
+        <twig:Field orientation="horizontal">
+            <twig:Checkbox id="finder-pref-9k2-sync-folders-nep" checked />
+            <twig:Field:Content>
+                <twig:Field:Label for="finder-pref-9k2-sync-folders-nep">
+                    Sync Desktop & Documents folders
+                </twig:Field:Label>
+                <twig:Field:Description>
+                    Your Desktop & Documents folders are being synced with iCloud Drive. You can access them from other devices.
+                </twig:Field:Description>
+            </twig:Field:Content>
+        </twig:Field>
+    </twig:Field:Group>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="w-full max-w-md">
+    <div data-slot="field-group" class="group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&amp;&gt;[data-slot=field-group]]:gap-4 ">
+<fieldset data-slot="field-set" class="flex flex-col gap-6 has-[&gt;[data-slot=checkbox-group]]:gap-3 has-[&gt;[data-slot=radio-group]]:gap-3 ">
+<legend data-slot="field-legend" data-variant="label" class="mb-3 font-medium text-sm">Show these items on the desktop
+            </legend>
+            <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">Select the items you want to show on the desktop.
+            </p>
+            <div data-slot="field-group" class="group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&amp;&gt;[data-slot=field-group]]:gap-4 gap-3">
+<div role="group" data-slot="field" data-orientation="horizontal" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-row items-center [&amp;&gt;[data-slot=field-label]]:flex-auto has-[&gt;[data-slot=field-content]]:items-start has-[&gt;[data-slot=field-content]]:[&amp;&gt;[role=checkbox],[role=radio]]:mt-px">
+<input type="checkbox" class="peer size-4 inline-block align-middle accent-primary " id="finder-pref-9k2-hard-disks-ljj">
+
+                    <label class="flex items-center gap-2 text-sm leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 font-normal" data-slot="field-label" for="finder-pref-9k2-hard-disks-ljj" checked>Hard disks
+                    </label>
+                </div>
+                <div role="group" data-slot="field" data-orientation="horizontal" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-row items-center [&amp;&gt;[data-slot=field-label]]:flex-auto has-[&gt;[data-slot=field-content]]:items-start has-[&gt;[data-slot=field-content]]:[&amp;&gt;[role=checkbox],[role=radio]]:mt-px">
+<input type="checkbox" class="peer size-4 inline-block align-middle accent-primary " id="finder-pref-9k2-external-disks-1yg">
+
+                    <label class="flex items-center gap-2 text-sm leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 font-normal" data-slot="field-label" for="finder-pref-9k2-external-disks-1yg">External disks
+                    </label>
+                </div>
+                <div role="group" data-slot="field" data-orientation="horizontal" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-row items-center [&amp;&gt;[data-slot=field-label]]:flex-auto has-[&gt;[data-slot=field-content]]:items-start has-[&gt;[data-slot=field-content]]:[&amp;&gt;[role=checkbox],[role=radio]]:mt-px">
+<input type="checkbox" class="peer size-4 inline-block align-middle accent-primary " id="finder-pref-9k2-cds-dvds-fzt">
+
+                    <label class="flex items-center gap-2 text-sm leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 font-normal" data-slot="field-label" for="finder-pref-9k2-cds-dvds-fzt">CDs, DVDs, and iPods
+                    </label>
+                </div>
+                <div role="group" data-slot="field" data-orientation="horizontal" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-row items-center [&amp;&gt;[data-slot=field-label]]:flex-auto has-[&gt;[data-slot=field-content]]:items-start has-[&gt;[data-slot=field-content]]:[&amp;&gt;[role=checkbox],[role=radio]]:mt-px">
+<input type="checkbox" class="peer size-4 inline-block align-middle accent-primary " id="finder-pref-9k2-connected-servers-6l2">
+
+                    <label class="flex items-center gap-2 text-sm leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 font-normal" data-slot="field-label" for="finder-pref-9k2-connected-servers-6l2">Connected servers
+                    </label>
+                </div>
+            </div>
+        </fieldset>
+        <div data-slot="field-separator" data-content="false" class="relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2 ">
+    <div class="shrink-0 bg-border h-[1px] w-full absolute inset-0 top-1/2" role="none"></div>
+</div>
+
+        <div role="group" data-slot="field" data-orientation="horizontal" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-row items-center [&amp;&gt;[data-slot=field-label]]:flex-auto has-[&gt;[data-slot=field-content]]:items-start has-[&gt;[data-slot=field-content]]:[&amp;&gt;[role=checkbox],[role=radio]]:mt-px">
+<input type="checkbox" class="peer size-4 inline-block align-middle accent-primary " id="finder-pref-9k2-sync-folders-nep" checked>
+
+            <div data-slot="field-content" class="group/field-content flex flex-1 flex-col gap-1.5 leading-snug ">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label" for="finder-pref-9k2-sync-folders-nep">Sync Desktop &amp; Documents folders
+                </label>
+                <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">Your Desktop &amp; Documents folders are being synced with iCloud Drive. You can access them from other devices.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 6__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 6__1.html
@@ -1,0 +1,32 @@
+<!--
+- Kit: Shadcn UI
+- Component: Field
+- Code:
+```twig
+<div class="w-full max-w-md">
+    <twig:Field orientation="horizontal">
+        <twig:Field:Content>
+            <twig:Field:Label for="2fa">Multi-factor authentication</twig:Field:Label>
+            <twig:Field:Description>
+                Enable multi-factor authentication. If you do not have a two-factor device, you can use a one-time code sent to your email.
+            </twig:Field:Description>
+        </twig:Field:Content>
+        <twig:Switch id="2fa" />
+    </twig:Field>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="w-full max-w-md">
+    <div role="group" data-slot="field" data-orientation="horizontal" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-row items-center [&amp;&gt;[data-slot=field-label]]:flex-auto has-[&gt;[data-slot=field-content]]:items-start has-[&gt;[data-slot=field-content]]:[&amp;&gt;[role=checkbox],[role=radio]]:mt-px">
+<div data-slot="field-content" class="group/field-content flex flex-1 flex-col gap-1.5 leading-snug ">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label" for="2fa">Multi-factor authentication</label>
+            <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">Enable multi-factor authentication. If you do not have a two-factor device, you can use a one-time code sent to your email.
+            </p>
+        </div>
+        <label class="relative inline-flex items-center cursor-pointer ">
+    <input type="checkbox" class="sr-only peer absolute inset-0 w-full h-full cursor-pointer" id="2fa">
+    <div class="pointer-events-none w-11 h-6 bg-input rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary peer-disabled:opacity-50 peer-disabled:cursor-not-allowed"></div>
+</label>
+
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 7__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component field, code 7__1.html
@@ -1,0 +1,86 @@
+<!--
+- Kit: Shadcn UI
+- Component: Field
+- Code:
+```twig
+<div class="w-full max-w-md">
+    <twig:Field:Group>
+        <twig:Field:Set>
+            <twig:Field:Label>Responses</twig:Field:Label>
+            <twig:Field:Description>
+                Get notified when ChatGPT responds to requests that take time, like research or image generation.
+            </twig:Field:Description>
+            <twig:Field:Group data-slot="checkbox-group">
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="push" checked disabled />
+                    <twig:Field:Label for="push" class="font-normal">
+                        Push notifications
+                    </twig:Field:Label>
+                </twig:Field>
+            </twig:Field:Group>
+        </twig:Field:Set>
+        <twig:Field:Separator />
+        <twig:Field:Set>
+            <twig:Field:Label>Tasks</twig:Field:Label>
+            <twig:Field:Description>
+                Get notified when tasks you've created have updates. <a href="#">Manage tasks</a>
+            </twig:Field:Description>
+            <twig:Field:Group data-slot="checkbox-group">
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="push-tasks" />
+                    <twig:Field:Label for="push-tasks" class="font-normal">
+                        Push notifications
+                    </twig:Field:Label>
+                </twig:Field>
+                <twig:Field orientation="horizontal">
+                    <twig:Checkbox id="email-tasks" />
+                    <twig:Field:Label for="email-tasks" class="font-normal">
+                        Email notifications
+                    </twig:Field:Label>
+                </twig:Field>
+            </twig:Field:Group>
+        </twig:Field:Set>
+    </twig:Field:Group>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="w-full max-w-md">
+    <div data-slot="field-group" class="group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&amp;&gt;[data-slot=field-group]]:gap-4 ">
+<fieldset data-slot="field-set" class="flex flex-col gap-6 has-[&gt;[data-slot=checkbox-group]]:gap-3 has-[&gt;[data-slot=radio-group]]:gap-3 ">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label">Responses</label>
+            <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">Get notified when ChatGPT responds to requests that take time, like research or image generation.
+            </p>
+            <div data-slot="field-group" class="group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&amp;&gt;[data-slot=field-group]]:gap-4 ">
+<div role="group" data-slot="field" data-orientation="horizontal" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-row items-center [&amp;&gt;[data-slot=field-label]]:flex-auto has-[&gt;[data-slot=field-content]]:items-start has-[&gt;[data-slot=field-content]]:[&amp;&gt;[role=checkbox],[role=radio]]:mt-px">
+<input type="checkbox" class="peer size-4 inline-block align-middle accent-primary " id="push" checked disabled>
+
+                    <label class="flex items-center gap-2 text-sm leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 font-normal" data-slot="field-label" for="push">Push notifications
+                    </label>
+                </div>
+            </div>
+        </fieldset>
+        <div data-slot="field-separator" data-content="false" class="relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2 ">
+    <div class="shrink-0 bg-border h-[1px] w-full absolute inset-0 top-1/2" role="none"></div>
+</div>
+
+        <fieldset data-slot="field-set" class="flex flex-col gap-6 has-[&gt;[data-slot=checkbox-group]]:gap-3 has-[&gt;[data-slot=radio-group]]:gap-3 ">
+<label class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col has-[&gt;[data-slot=field]]:rounded-md has-[&gt;[data-slot=field]]:border [&amp;&gt;*]:data-[slot=field]:p-4 has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10" data-slot="field-label">Tasks</label>
+            <p data-slot="field-description" class="text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&amp;]:-mt-1.5 [&amp;&gt;a:hover]:text-primary [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 ">Get notified when tasks you've created have updates. <a href="#">Manage tasks</a>
+            </p>
+            <div data-slot="field-group" class="group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&amp;&gt;[data-slot=field-group]]:gap-4 ">
+<div role="group" data-slot="field" data-orientation="horizontal" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-row items-center [&amp;&gt;[data-slot=field-label]]:flex-auto has-[&gt;[data-slot=field-content]]:items-start has-[&gt;[data-slot=field-content]]:[&amp;&gt;[role=checkbox],[role=radio]]:mt-px">
+<input type="checkbox" class="peer size-4 inline-block align-middle accent-primary " id="push-tasks">
+
+                    <label class="flex items-center gap-2 text-sm leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 font-normal" data-slot="field-label" for="push-tasks">Push notifications
+                    </label>
+                </div>
+                <div role="group" data-slot="field" data-orientation="horizontal" class="group/field flex w-full gap-3 data-[invalid=true]:text-destructive flex-row items-center [&amp;&gt;[data-slot=field-label]]:flex-auto has-[&gt;[data-slot=field-content]]:items-start has-[&gt;[data-slot=field-content]]:[&amp;&gt;[role=checkbox],[role=radio]]:mt-px">
+<input type="checkbox" class="peer size-4 inline-block align-middle accent-primary " id="email-tasks">
+
+                    <label class="flex items-center gap-2 text-sm leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 font-normal" data-slot="field-label" for="email-tasks">Email notifications
+                    </label>
+                </div>
+            </div>
+        </fieldset>
+    </div>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| License        | MIT

Add Field, Combine labels, controls, and help text to compose accessible form fields and grouped inputs.
ref: https://ui.shadcn.com/docs/components/field

---

<img width="1122" height="609" alt="Screenshot 2025-12-05 at 02 02 22" src="https://github.com/user-attachments/assets/ed601f5d-8efd-4d04-b132-999ce3e4b791" />
<img width="1138" height="510" alt="Screenshot 2025-12-05 at 02 02 31" src="https://github.com/user-attachments/assets/e5c2e8ca-0009-48e7-bebc-4657d032c04c" />
<img width="1135" height="515" alt="Screenshot 2025-12-05 at 02 02 43" src="https://github.com/user-attachments/assets/facf275e-a651-42d2-b006-e2ca306592d6" />
<img width="1144" height="358" alt="Screenshot 2025-12-05 at 02 02 56" src="https://github.com/user-attachments/assets/8d2e96cb-7a44-458a-bc5b-a35ebf08f11a" />
