### PR TITLE
[Translator] Early exit parameters extraction from Intl messages, if no `{` is found

### DIFF
--- a/src/Translator/src/MessageParameters/Extractor/IntlMessageParametersExtractor.php
+++ b/src/Translator/src/MessageParameters/Extractor/IntlMessageParametersExtractor.php
@@ -23,6 +23,11 @@ final class IntlMessageParametersExtractor implements ExtractorInterface
 {
     public function extract(string $message): array
     {
+        // Early return if there is no parameter-like pattern in the message
+        if (!str_contains($message, '{')) {
+            return [];
+        }
+
         $parameters = [];
 
         $intlMessageParser = new IntlMessageParser($message);


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Following https://github.com/symfony/ux/pull/3218

On an app with ~3320 keys, ~2870 of them didn't use the ICU syntax. Early exiting when no `{` reduced the cache-clear time by ~60%:
[![](https://github.com/user-attachments/assets/481076d8-1d5c-4b98-b454-e936d16b3ca9)](https://blackfire.io/profiles/compare/209538ae-26bf-40bf-a3f4-5a51d91a4fe7/graph)

