### PR TITLE
[Site] Hide Toolkit menu

### DIFF
--- a/ux.symfony.com/composer.json
+++ b/ux.symfony.com/composer.json
@@ -140,14 +140,5 @@
             "importmap:install": "symfony-cmd",
             "tailwind:build": "symfony-cmd"
         }
-    },
-    "repositories": {
-        "symfony-ux-toolkit": {
-            "type": "path",
-            "url": "../src/Toolkit",
-            "options": {
-                "symlink": true
-            }
-        }
     }
 }

--- a/ux.symfony.com/templates/_header.html.twig
+++ b/ux.symfony.com/templates/_header.html.twig
@@ -46,10 +46,11 @@
             </div>
 
             <div class="AppNav_menu">
-                <a href="{{ path('app_toolkit') }}" class="AppNav_item AppNav_item--cs">
+                {# TODO: To uncomment when UX Toolkit is released #}
+                {# <a href="{{ path('app_toolkit') }}" class="AppNav_item AppNav_item--cs">
                     <span class="AppNav_badge" data-content="New"></span>
                     Toolkit
-                </a>
+                </a> #}
                 <a href="{{ path('app_turbo') }}" class="AppNav_item">Turbo</a>
                 <a href="{{ path('app_live_component') }}" class="AppNav_item">Live <span>Components</span></a>
                 <a href="{{ path('app_icons') }}" class="AppNav_item">Icons</a>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

So we can release the website with https://github.com/symfony/ux/pull/3220 & https://github.com/symfony/ux/issues/2848, without releasing the Toolkit page.

I didn't have 404 Not Found for `toolkit/*` URLs, I believe hiding the link from the main menu is enough. We have nothing super-important to hide, just the access