### PR TITLE
[Apps] Use Composer local repositories for UX packages

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -39,15 +39,7 @@ jobs:
 
         - uses: shivammathur/setup-php@v2
 
-        - name: Install root dependencies
-          uses: ramsey/composer-install@v3
-          with:
-            working-directory: ${{ github.workspace }}
-
-        - name: Build root packages
-          run: php .github/build-packages.php
-
-        # We always install PHP deps because of the UX Translator, which requires `var/translations` to exists
+        # We always install PHP deps because of the UX Translator, which requires `var/translations` directory to exists
         - name: Install PHP dependencies
           uses: ramsey/composer-install@v3
           with:

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -59,14 +59,6 @@ jobs:
                   php-version: 8.2
                   tools: symfony-cli, flex
 
-            - name: Install root PHP dependencies
-              uses: ramsey/composer-install@v3
-              with:
-                  working-directory: ${{ github.workspace }}
-
-            - name: Build root packages
-              run: php .github/build-packages.php
-
             - name: Start Docker containers
               run: docker compose up -d --build
               working-directory: apps/e2e

--- a/apps/e2e/composer.json
+++ b/apps/e2e/composer.json
@@ -1,7 +1,7 @@
 {
     "type": "project",
     "license": "proprietary",
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
         "auto-scripts": {
@@ -38,28 +38,28 @@
         "symfony/intl": "6.4.*|7.3.*",
         "symfony/monolog-bundle": "^3.10",
         "symfony/runtime": "6.4.*|7.3.*",
-        "symfony/stimulus-bundle": "^2.29.1",
         "symfony/twig-bundle": "6.4.*|7.3.*",
-        "symfony/ux-autocomplete": "^2.29.1",
-        "symfony/ux-chartjs": "^2.29.1",
-        "symfony/ux-cropperjs": "^2.29.1",
-        "symfony/ux-dropzone": "^2.29.1",
-        "symfony/ux-google-map": "^2.29.1",
-        "symfony/ux-icons": "^2.29",
-        "symfony/ux-lazy-image": "^2.29.1",
-        "symfony/ux-leaflet-map": "^2.29.1",
-        "symfony/ux-live-component": "^2.29.1",
-        "symfony/ux-map": "^2.29.1",
-        "symfony/ux-notify": "^2.29.1",
-        "symfony/ux-react": "^2.29.1",
-        "symfony/ux-svelte": "^2.29.1",
-        "symfony/ux-swup": "^2.29.1",
-        "symfony/ux-toggle-password": "^2.29.1",
-        "symfony/ux-translator": "^2.29.1",
-        "symfony/ux-turbo": "^2.29.1",
-        "symfony/ux-twig-component": "^2.29",
-        "symfony/ux-typed": "^2.29.1",
-        "symfony/ux-vue": "^2.29.1",
+        "symfony/stimulus-bundle": "*@dev",
+        "symfony/ux-autocomplete": "*@dev",
+        "symfony/ux-chartjs": "*@dev",
+        "symfony/ux-cropperjs": "*@dev",
+        "symfony/ux-dropzone": "*@dev",
+        "symfony/ux-google-map": "*@dev",
+        "symfony/ux-icons": "*@dev",
+        "symfony/ux-lazy-image": "*@dev",
+        "symfony/ux-leaflet-map": "*@dev",
+        "symfony/ux-live-component": "*@dev",
+        "symfony/ux-map": "*@dev",
+        "symfony/ux-notify": "*@dev",
+        "symfony/ux-react": "*@dev",
+        "symfony/ux-svelte": "*@dev",
+        "symfony/ux-swup": "*@dev",
+        "symfony/ux-toggle-password": "*@dev",
+        "symfony/ux-translator": "*@dev",
+        "symfony/ux-turbo": "*@dev",
+        "symfony/ux-twig-component": "*@dev",
+        "symfony/ux-typed": "*@dev",
+        "symfony/ux-vue": "*@dev",
         "symfony/yaml": "6.4.*|7.3.*",
         "symfonycasts/dynamic-forms": "^0.2",
         "twig/extra-bundle": "^3.21",
@@ -96,6 +96,17 @@
     "autoload-dev": {
         "psr-4": {
             "App\\Tests\\": "tests/"
+        }
+    },
+    "repositories": {
+        "ux":         {
+            "type": "path",
+            "url": "../../src/*",
+            "only": ["symfony/stimulus-bundle", "symfony/ux-*"],
+            "canonical": true,
+            "options": {
+                "symlink": true
+            }
         }
     },
     "replace": {

--- a/apps/encore/composer.json
+++ b/apps/encore/composer.json
@@ -1,7 +1,7 @@
 {
     "type": "project",
     "license": "proprietary",
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
@@ -12,27 +12,27 @@
         "symfony/flex": "^2",
         "symfony/framework-bundle": "7.2.*",
         "symfony/runtime": "7.2.*",
-        "symfony/stimulus-bundle": "^2.23",
-        "symfony/ux-autocomplete": "^2.23",
-        "symfony/ux-chartjs": "^2.23",
-        "symfony/ux-cropperjs": "^2.23",
-        "symfony/ux-dropzone": "^2.23",
-        "symfony/ux-google-map": "^2.23",
-        "symfony/ux-icons": "^2.23",
-        "symfony/ux-lazy-image": "^2.23",
-        "symfony/ux-leaflet-map": "^2.23",
-        "symfony/ux-live-component": "^2.23",
-        "symfony/ux-map": "^2.23",
-        "symfony/ux-notify": "^2.23",
-        "symfony/ux-react": "^2.23",
-        "symfony/ux-svelte": "^2.23",
-        "symfony/ux-swup": "^2.23",
-        "symfony/ux-toggle-password": "^2.23",
-        "symfony/ux-translator": "^2.23",
-        "symfony/ux-turbo": "^2.23",
-        "symfony/ux-twig-component": "^2.23",
-        "symfony/ux-typed": "^2.23",
-        "symfony/ux-vue": "^2.23",
+        "symfony/stimulus-bundle": "*@dev",
+        "symfony/ux-autocomplete": "*@dev",
+        "symfony/ux-chartjs": "*@dev",
+        "symfony/ux-cropperjs": "*@dev",
+        "symfony/ux-dropzone": "*@dev",
+        "symfony/ux-google-map": "*@dev",
+        "symfony/ux-icons": "*@dev",
+        "symfony/ux-lazy-image": "*@dev",
+        "symfony/ux-leaflet-map": "*@dev",
+        "symfony/ux-live-component": "*@dev",
+        "symfony/ux-map": "*@dev",
+        "symfony/ux-notify": "*@dev",
+        "symfony/ux-react": "*@dev",
+        "symfony/ux-svelte": "*@dev",
+        "symfony/ux-swup": "*@dev",
+        "symfony/ux-toggle-password": "*@dev",
+        "symfony/ux-translator": "*@dev",
+        "symfony/ux-turbo": "*@dev",
+        "symfony/ux-twig-component": "*@dev",
+        "symfony/ux-typed": "*@dev",
+        "symfony/ux-vue": "*@dev",
         "symfony/webpack-encore-bundle": "^2.2",
         "symfony/yaml": "7.2.*"
     },
@@ -58,6 +58,17 @@
     "autoload-dev": {
         "psr-4": {
             "App\\Tests\\": "tests/"
+        }
+    },
+    "repositories": {
+        "ux":         {
+            "type": "path",
+            "url": "../../src/*",
+            "only": ["symfony/stimulus-bundle", "symfony/ux-*"],
+            "canonical": true,
+            "options": {
+                "symlink": true
+            }
         }
     },
     "replace": {

--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -57,6 +57,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Chartjs/composer.json
+++ b/src/Chartjs/composer.json
@@ -44,6 +44,9 @@
         "symfony/flex": "<1.13"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -49,6 +49,9 @@
         "symfony/flex": "<1.13"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Dropzone/composer.json
+++ b/src/Dropzone/composer.json
@@ -43,6 +43,9 @@
         "twig/twig": "^2.14.7|^3.0.4"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Icons/composer.json
+++ b/src/Icons/composer.json
@@ -56,6 +56,9 @@
         "symfony/ux-twig-component": "<2.21"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/LazyImage/composer.json
+++ b/src/LazyImage/composer.json
@@ -44,6 +44,9 @@
         "symfony/var-dumper": "^5.4|^6.0|^7.0|^8.0"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -64,6 +64,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Map/composer.json
+++ b/src/Map/composer.json
@@ -49,6 +49,9 @@
         "symfony/ux-twig-component": "<2.21"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Map/src/Bridge/Google/composer.json
+++ b/src/Map/src/Bridge/Google/composer.json
@@ -33,5 +33,14 @@
     "autoload-dev": {
         "psr-4": { "Symfony\\UX\\Map\\Bridge\\Google\\Tests\\": "tests/" }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Map/src/Bridge/Leaflet/composer.json
+++ b/src/Map/src/Bridge/Leaflet/composer.json
@@ -33,5 +33,14 @@
     "autoload-dev": {
         "psr-4": { "Symfony\\UX\\Map\\Bridge\\Leaflet\\Tests\\": "tests/" }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Notify/composer.json
+++ b/src/Notify/composer.json
@@ -46,6 +46,9 @@
         "symfony/config": "<5.4.0"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/React/composer.json
+++ b/src/React/composer.json
@@ -40,6 +40,9 @@
         "symfony/var-dumper": "^5.4|^6.0|^7.0|^8.0"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/StimulusBundle/composer.json
+++ b/src/StimulusBundle/composer.json
@@ -28,7 +28,6 @@
         "symfony/twig-bundle": "^5.4|^6.0|^7.0|^8.0",
         "zenstruck/browser": "^1.4"
     },
-    "minimum-stability": "dev",
     "autoload": {
         "psr-4": {
             "Symfony\\UX\\StimulusBundle\\": "src"
@@ -38,5 +37,15 @@
         "psr-4": {
             "Symfony\\UX\\StimulusBundle\\Tests\\": "tests/"
         }
-    }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/Svelte/composer.json
+++ b/src/Svelte/composer.json
@@ -44,6 +44,9 @@
         "symfony/var-dumper": "^5.4|^6.2|^7.0|^8.0"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Swup/composer.json
+++ b/src/Swup/composer.json
@@ -29,6 +29,9 @@
         "symfony/flex": "<1.13"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/TogglePassword/composer.json
+++ b/src/TogglePassword/composer.json
@@ -44,6 +44,9 @@
         "twig/twig": "^2.14.7|^3.0.4"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Toolkit/composer.json
+++ b/src/Toolkit/composer.json
@@ -69,6 +69,9 @@
         }
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Translator/composer.json
+++ b/src/Translator/composer.json
@@ -41,6 +41,9 @@
         "symfony/yaml": "^5.4|^6.0|^7.0|^8.0"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -64,6 +64,9 @@
         "symfony/flex": "<1.13"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -50,6 +50,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Typed/composer.json
+++ b/src/Typed/composer.json
@@ -30,6 +30,9 @@
         "symfony/flex": "<1.13"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"

--- a/src/Vue/composer.json
+++ b/src/Vue/composer.json
@@ -44,6 +44,9 @@
         "symfony/var-dumper": "^5.4|^6.0|^7.0|^8.0"
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "2.x-dev"
+        },
         "thanks": {
             "name": "symfony/ux",
             "url": "https://github.com/symfony/ux"


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Minor modifications where I think we can avoid installing root deps & running `build-packages.php` script in order to setup E2E apps (in the CI or locally).