### PR TITLE
[Map] Add `Map::removeAll*()` method on Elements

### DIFF
--- a/src/Map/CHANGELOG.md
+++ b/src/Map/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.32
+
+-  Add `Map::removeAllMarkers()`, `Map::removeAllPolygons()`, `Map::removeAllPolylines()`, `Map::removeAllCircles()` and `Map::removeAllRectangles()` methods
+
 ## 2.31
 
 -  Add `fitBoundsToMarkers` parameter to `ux_map()` Twig function

--- a/src/Map/doc/index.rst
+++ b/src/Map/doc/index.rst
@@ -292,6 +292,22 @@ If you haven't stored the element instance, you can still remove them by passing
     $map->removeCircle('my-circle');
     $map->removeRectangle('my-rectangle');
 
+To remove all instances of a certain element, you can use the `Map::removeAll*()` methods::
+
+    // Add elements
+    $map->addMarker($marker = new Marker(/* ... */));
+    $map->addPolygon($polygon = new Polygon(/* ... */));
+    $map->addPolyline($polyline = new Polyline(/* ... */));
+    $map->addCircle($circle = new Circle(/* ... */));
+    $map->addRectangle($rectangle = new Rectangle(/* ... */));
+
+    // And later, remove those elements
+    $map->removeAllMarkers();
+    $map->removeAllPolygons();
+    $map->removeAllPolylines();
+    $map->removeAllCircles();
+    $map->removeAllRectangles();
+
 Render a map
 ------------
 

--- a/src/Map/src/Bridge/Google/tests/GoogleRendererTest.php
+++ b/src/Map/src/Bridge/Google/tests/GoogleRendererTest.php
@@ -74,6 +74,16 @@ class GoogleRendererTest extends RendererTestCase
                 ->removeMarker('marker2'),
         ];
 
+        yield 'with all markers removed with removeAllMarkers()' => [
+            'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), apiKey: 'api_key'),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addMarker($marker1)
+                ->addMarker($marker2)
+                ->removeAllMarkers(),
+        ];
+
         yield 'with marker remove and new ones added' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), apiKey: 'api_key'),
             'map' => (new Map())
@@ -94,6 +104,16 @@ class GoogleRendererTest extends RendererTestCase
                 ->addPolygon(new Polygon(points: [new Point(1.1, 2.2), new Point(3.3, 4.4), new Point(5.5, 6.6)], infoWindow: new InfoWindow(content: 'Polygon'))),
         ];
 
+        yield 'with all polygons removed with removeAllPolygons()' => [
+            'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), apiKey: 'api_key'),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addPolygon(new Polygon(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
+                ->addPolygon(new Polygon(points: [new Point(1.1, 2.2), new Point(3.3, 4.4), new Point(5.5, 6.6)], infoWindow: new InfoWindow(content: 'Polygon')))
+                ->removeAllPolygons(),
+        ];
+
         yield 'with polylines and infoWindows' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), apiKey: 'api_key'),
             'map' => (new Map())
@@ -101,6 +121,16 @@ class GoogleRendererTest extends RendererTestCase
                 ->zoom(12)
                 ->addPolyline(new Polyline(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
                 ->addPolyline(new Polyline(points: [new Point(1.1, 2.2), new Point(3.3, 4.4), new Point(5.5, 6.6)], infoWindow: new InfoWindow(content: 'Polygon'))),
+        ];
+
+        yield 'with all polylines removed with removeAllPolylines()' => [
+            'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), apiKey: 'api_key'),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addPolyline(new Polyline(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
+                ->addPolyline(new Polyline(points: [new Point(1.1, 2.2), new Point(3.3, 4.4), new Point(5.5, 6.6)], infoWindow: new InfoWindow(content: 'Polyline')))
+                ->removeAllPolylines(),
         ];
 
         yield 'with circles and infoWindows' => [
@@ -112,6 +142,16 @@ class GoogleRendererTest extends RendererTestCase
                 ->addCircle(new Circle(center: new Point(1.1, 2.2), radius: 1000, infoWindow: new InfoWindow(content: 'Circle'))),
         ];
 
+        yield 'with all circles removed with removeAllCircles()' => [
+            'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), apiKey: 'api_key'),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addCircle(new Circle(center: new Point(48.8566, 2.3522), radius: 500, infoWindow: new InfoWindow(content: 'Circle')))
+                ->addCircle(new Circle(center: new Point(1.1, 2.2), radius: 1000, infoWindow: new InfoWindow(content: 'Circle')))
+                ->removeAllCircles(),
+        ];
+
         yield 'with rectangles and infoWindows' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), apiKey: 'api_key'),
             'map' => (new Map())
@@ -119,6 +159,16 @@ class GoogleRendererTest extends RendererTestCase
                 ->zoom(12)
                 ->addRectangle(new Rectangle(southWest: new Point(48.8566, 2.3522), northEast: new Point(48.8566, 2.3522), infoWindow: new InfoWindow(content: 'Rectangle')))
                 ->addRectangle(new Rectangle(southWest: new Point(1.1, 2.2), northEast: new Point(3.3, 4.4), infoWindow: new InfoWindow(content: 'Rectangle'))),
+        ];
+
+        yield 'with all rectangles removed with removeAllRectangles()' => [
+            'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), apiKey: 'api_key'),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addRectangle(new Rectangle(southWest: new Point(48.8566, 2.3522), northEast: new Point(48.8566, 2.3522), infoWindow: new InfoWindow(content: 'Rectangle')))
+                ->addRectangle(new Rectangle(southWest: new Point(1.1, 2.2), northEast: new Point(3.3, 4.4), infoWindow: new InfoWindow(content: 'Rectangle')))
+                ->removeAllRectangles(),
         ];
 
         yield 'with controls enabled' => [

--- a/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all circles removed with removeAllCircles()__1.txt
+++ b/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all circles removed with removeAllCircles()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-google-map--map"
+  data-symfony--ux-google-map--map-provider-options-value="{&quot;apiKey&quot;:&quot;api_key&quot;}"
+  data-symfony--ux-google-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-google-map--map-zoom-value="12"
+  data-symfony--ux-google-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-google-map--map-options-value="{&quot;mapId&quot;:null,&quot;gestureHandling&quot;:&quot;auto&quot;,&quot;backgroundColor&quot;:null,&quot;disableDoubleClickZoom&quot;:false,&quot;zoomControlOptions&quot;:{&quot;position&quot;:22},&quot;mapTypeControlOptions&quot;:{&quot;mapTypeIds&quot;:[],&quot;position&quot;:14,&quot;style&quot;:0},&quot;streetViewControlOptions&quot;:{&quot;position&quot;:22},&quot;fullscreenControlOptions&quot;:{&quot;position&quot;:20},&quot;@provider&quot;:&quot;google&quot;}"
+  data-symfony--ux-google-map--map-markers-value="[]"
+  data-symfony--ux-google-map--map-polygons-value="[]"
+  data-symfony--ux-google-map--map-polylines-value="[]"
+  data-symfony--ux-google-map--map-circles-value="[]"
+  data-symfony--ux-google-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all markers removed with removeAllMarkers()__1.txt
+++ b/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all markers removed with removeAllMarkers()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-google-map--map"
+  data-symfony--ux-google-map--map-provider-options-value="{&quot;apiKey&quot;:&quot;api_key&quot;}"
+  data-symfony--ux-google-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-google-map--map-zoom-value="12"
+  data-symfony--ux-google-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-google-map--map-options-value="{&quot;mapId&quot;:null,&quot;gestureHandling&quot;:&quot;auto&quot;,&quot;backgroundColor&quot;:null,&quot;disableDoubleClickZoom&quot;:false,&quot;zoomControlOptions&quot;:{&quot;position&quot;:22},&quot;mapTypeControlOptions&quot;:{&quot;mapTypeIds&quot;:[],&quot;position&quot;:14,&quot;style&quot;:0},&quot;streetViewControlOptions&quot;:{&quot;position&quot;:22},&quot;fullscreenControlOptions&quot;:{&quot;position&quot;:20},&quot;@provider&quot;:&quot;google&quot;}"
+  data-symfony--ux-google-map--map-markers-value="[]"
+  data-symfony--ux-google-map--map-polygons-value="[]"
+  data-symfony--ux-google-map--map-polylines-value="[]"
+  data-symfony--ux-google-map--map-circles-value="[]"
+  data-symfony--ux-google-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all polygons removed with removeAllPolygons()__1.txt
+++ b/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all polygons removed with removeAllPolygons()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-google-map--map"
+  data-symfony--ux-google-map--map-provider-options-value="{&quot;apiKey&quot;:&quot;api_key&quot;}"
+  data-symfony--ux-google-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-google-map--map-zoom-value="12"
+  data-symfony--ux-google-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-google-map--map-options-value="{&quot;mapId&quot;:null,&quot;gestureHandling&quot;:&quot;auto&quot;,&quot;backgroundColor&quot;:null,&quot;disableDoubleClickZoom&quot;:false,&quot;zoomControlOptions&quot;:{&quot;position&quot;:22},&quot;mapTypeControlOptions&quot;:{&quot;mapTypeIds&quot;:[],&quot;position&quot;:14,&quot;style&quot;:0},&quot;streetViewControlOptions&quot;:{&quot;position&quot;:22},&quot;fullscreenControlOptions&quot;:{&quot;position&quot;:20},&quot;@provider&quot;:&quot;google&quot;}"
+  data-symfony--ux-google-map--map-markers-value="[]"
+  data-symfony--ux-google-map--map-polygons-value="[]"
+  data-symfony--ux-google-map--map-polylines-value="[]"
+  data-symfony--ux-google-map--map-circles-value="[]"
+  data-symfony--ux-google-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all polylines removed with removeAllPolylines()__1.txt
+++ b/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all polylines removed with removeAllPolylines()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-google-map--map"
+  data-symfony--ux-google-map--map-provider-options-value="{&quot;apiKey&quot;:&quot;api_key&quot;}"
+  data-symfony--ux-google-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-google-map--map-zoom-value="12"
+  data-symfony--ux-google-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-google-map--map-options-value="{&quot;mapId&quot;:null,&quot;gestureHandling&quot;:&quot;auto&quot;,&quot;backgroundColor&quot;:null,&quot;disableDoubleClickZoom&quot;:false,&quot;zoomControlOptions&quot;:{&quot;position&quot;:22},&quot;mapTypeControlOptions&quot;:{&quot;mapTypeIds&quot;:[],&quot;position&quot;:14,&quot;style&quot;:0},&quot;streetViewControlOptions&quot;:{&quot;position&quot;:22},&quot;fullscreenControlOptions&quot;:{&quot;position&quot;:20},&quot;@provider&quot;:&quot;google&quot;}"
+  data-symfony--ux-google-map--map-markers-value="[]"
+  data-symfony--ux-google-map--map-polygons-value="[]"
+  data-symfony--ux-google-map--map-polylines-value="[]"
+  data-symfony--ux-google-map--map-circles-value="[]"
+  data-symfony--ux-google-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all rectangles removed with removeAllRectangles()__1.txt
+++ b/src/Map/src/Bridge/Google/tests/__snapshots__/GoogleRendererTest__testRenderMap with data set with all rectangles removed with removeAllRectangles()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-google-map--map"
+  data-symfony--ux-google-map--map-provider-options-value="{&quot;apiKey&quot;:&quot;api_key&quot;}"
+  data-symfony--ux-google-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-google-map--map-zoom-value="12"
+  data-symfony--ux-google-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-google-map--map-options-value="{&quot;mapId&quot;:null,&quot;gestureHandling&quot;:&quot;auto&quot;,&quot;backgroundColor&quot;:null,&quot;disableDoubleClickZoom&quot;:false,&quot;zoomControlOptions&quot;:{&quot;position&quot;:22},&quot;mapTypeControlOptions&quot;:{&quot;mapTypeIds&quot;:[],&quot;position&quot;:14,&quot;style&quot;:0},&quot;streetViewControlOptions&quot;:{&quot;position&quot;:22},&quot;fullscreenControlOptions&quot;:{&quot;position&quot;:20},&quot;@provider&quot;:&quot;google&quot;}"
+  data-symfony--ux-google-map--map-markers-value="[]"
+  data-symfony--ux-google-map--map-polygons-value="[]"
+  data-symfony--ux-google-map--map-polylines-value="[]"
+  data-symfony--ux-google-map--map-circles-value="[]"
+  data-symfony--ux-google-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Bridge/Leaflet/tests/LeafletRendererTest.php
+++ b/src/Map/src/Bridge/Leaflet/tests/LeafletRendererTest.php
@@ -69,6 +69,16 @@ class LeafletRendererTest extends RendererTestCase
                 ->removeMarker('marker2'),
         ];
 
+        yield 'with all markers removed with removeAllMarkers()' => [
+            'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addMarker($marker1)
+                ->addMarker($marker2)
+                ->removeAllMarkers(),
+        ];
+
         yield 'with marker remove and new ones added' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
             'map' => (new Map())
@@ -89,6 +99,16 @@ class LeafletRendererTest extends RendererTestCase
                 ->addPolygon(new Polygon(points: [new Point(1.1, 2.2), new Point(3.3, 4.4), new Point(5.5, 6.6)], infoWindow: new InfoWindow(content: 'Polygon'), id: 'polygon2')),
         ];
 
+        yield 'with all polygons removed with removeAllPolygons()' => [
+            'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addPolygon(new Polygon(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
+                ->addPolygon(new Polygon(points: [new Point(1.1, 2.2), new Point(3.3, 4.4), new Point(5.5, 6.6)], infoWindow: new InfoWindow(content: 'Polygon')))
+                ->removeAllPolygons(),
+        ];
+
         yield 'with polylines and infoWindows' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
             'map' => (new Map())
@@ -98,6 +118,16 @@ class LeafletRendererTest extends RendererTestCase
                 ->addPolyline(new Polyline(points: [new Point(1.1, 2.2), new Point(3.3, 4.4), new Point(5.5, 6.6)], infoWindow: new InfoWindow(content: 'Polyline'), id: 'polyline2')),
         ];
 
+        yield 'with all polylines removed with removeAllPolylines()' => [
+            'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addPolyline(new Polyline(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
+                ->addPolyline(new Polyline(points: [new Point(1.1, 2.2), new Point(3.3, 4.4), new Point(5.5, 6.6)], infoWindow: new InfoWindow(content: 'Polyline')))
+                ->removeAllPolylines(),
+        ];
+
         yield 'with circles and infoWindows' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
             'map' => (new Map())
@@ -105,6 +135,16 @@ class LeafletRendererTest extends RendererTestCase
                 ->zoom(12)
                 ->addCircle(new Circle(center: new Point(48.8566, 2.3522), radius: 1000000, id: 'circle1'))
                 ->addCircle(new Circle(center: new Point(1.1, 2.2), radius: 500, infoWindow: new InfoWindow(content: 'Circle'), id: 'circle2')),
+        ];
+
+        yield 'with all circles removed with removeAllCircles()' => [
+            'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addCircle(new Circle(center: new Point(48.8566, 2.3522), radius: 500, infoWindow: new InfoWindow(content: 'Circle')))
+                ->addCircle(new Circle(center: new Point(1.1, 2.2), radius: 1000, infoWindow: new InfoWindow(content: 'Circle')))
+                ->removeAllCircles(),
         ];
 
         yield 'with rectangles and infoWindows' => [
@@ -123,6 +163,16 @@ class LeafletRendererTest extends RendererTestCase
                     infoWindow: new InfoWindow(content: 'Rectangle'),
                     id: 'rectangle2'
                 )),
+        ];
+
+        yield 'with all rectangles removed with removeAllRectangles()' => [
+            'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
+            'map' => (new Map())
+                ->center(new Point(48.8566, 2.3522))
+                ->zoom(12)
+                ->addRectangle(new Rectangle(southWest: new Point(48.8566, 2.3522), northEast: new Point(48.8566, 2.3522), infoWindow: new InfoWindow(content: 'Rectangle')))
+                ->addRectangle(new Rectangle(southWest: new Point(1.1, 2.2), northEast: new Point(3.3, 4.4), infoWindow: new InfoWindow(content: 'Rectangle')))
+                ->removeAllRectangles(),
         ];
 
         yield 'markers with icons' => [

--- a/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all circles removed with removeAllCircles()__1.txt
+++ b/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all circles removed with removeAllCircles()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-leaflet-map--map"
+  data-symfony--ux-leaflet-map--map-provider-options-value="{}"
+  data-symfony--ux-leaflet-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-leaflet-map--map-zoom-value="12"
+  data-symfony--ux-leaflet-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-leaflet-map--map-options-value="{&quot;tileLayer&quot;:{&quot;url&quot;:&quot;https:\/\/tile.openstreetmap.org\/{z}\/{x}\/{y}.png&quot;,&quot;attribution&quot;:&quot;\u00a9 &lt;a href=\&quot;https:\/\/www.openstreetmap.org\/copyright\&quot;&gt;OpenStreetMap&lt;\/a&gt;&quot;,&quot;options&quot;:[]},&quot;attributionControlOptions&quot;:{&quot;position&quot;:&quot;bottomright&quot;,&quot;prefix&quot;:&quot;Leaflet&quot;},&quot;zoomControlOptions&quot;:{&quot;position&quot;:&quot;topleft&quot;,&quot;zoomInText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;+&lt;\/span&gt;&quot;,&quot;zoomInTitle&quot;:&quot;Zoom in&quot;,&quot;zoomOutText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;&amp;#x2212;&lt;\/span&gt;&quot;,&quot;zoomOutTitle&quot;:&quot;Zoom out&quot;},&quot;@provider&quot;:&quot;leaflet&quot;}"
+  data-symfony--ux-leaflet-map--map-markers-value="[]"
+  data-symfony--ux-leaflet-map--map-polygons-value="[]"
+  data-symfony--ux-leaflet-map--map-polylines-value="[]"
+  data-symfony--ux-leaflet-map--map-circles-value="[]"
+  data-symfony--ux-leaflet-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all markers removed with removeAllMarkers()__1.txt
+++ b/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all markers removed with removeAllMarkers()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-leaflet-map--map"
+  data-symfony--ux-leaflet-map--map-provider-options-value="{}"
+  data-symfony--ux-leaflet-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-leaflet-map--map-zoom-value="12"
+  data-symfony--ux-leaflet-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-leaflet-map--map-options-value="{&quot;tileLayer&quot;:{&quot;url&quot;:&quot;https:\/\/tile.openstreetmap.org\/{z}\/{x}\/{y}.png&quot;,&quot;attribution&quot;:&quot;\u00a9 &lt;a href=\&quot;https:\/\/www.openstreetmap.org\/copyright\&quot;&gt;OpenStreetMap&lt;\/a&gt;&quot;,&quot;options&quot;:[]},&quot;attributionControlOptions&quot;:{&quot;position&quot;:&quot;bottomright&quot;,&quot;prefix&quot;:&quot;Leaflet&quot;},&quot;zoomControlOptions&quot;:{&quot;position&quot;:&quot;topleft&quot;,&quot;zoomInText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;+&lt;\/span&gt;&quot;,&quot;zoomInTitle&quot;:&quot;Zoom in&quot;,&quot;zoomOutText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;&amp;#x2212;&lt;\/span&gt;&quot;,&quot;zoomOutTitle&quot;:&quot;Zoom out&quot;},&quot;@provider&quot;:&quot;leaflet&quot;}"
+  data-symfony--ux-leaflet-map--map-markers-value="[]"
+  data-symfony--ux-leaflet-map--map-polygons-value="[]"
+  data-symfony--ux-leaflet-map--map-polylines-value="[]"
+  data-symfony--ux-leaflet-map--map-circles-value="[]"
+  data-symfony--ux-leaflet-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all polygons removed with removeAllPolygons()__1.txt
+++ b/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all polygons removed with removeAllPolygons()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-leaflet-map--map"
+  data-symfony--ux-leaflet-map--map-provider-options-value="{}"
+  data-symfony--ux-leaflet-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-leaflet-map--map-zoom-value="12"
+  data-symfony--ux-leaflet-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-leaflet-map--map-options-value="{&quot;tileLayer&quot;:{&quot;url&quot;:&quot;https:\/\/tile.openstreetmap.org\/{z}\/{x}\/{y}.png&quot;,&quot;attribution&quot;:&quot;\u00a9 &lt;a href=\&quot;https:\/\/www.openstreetmap.org\/copyright\&quot;&gt;OpenStreetMap&lt;\/a&gt;&quot;,&quot;options&quot;:[]},&quot;attributionControlOptions&quot;:{&quot;position&quot;:&quot;bottomright&quot;,&quot;prefix&quot;:&quot;Leaflet&quot;},&quot;zoomControlOptions&quot;:{&quot;position&quot;:&quot;topleft&quot;,&quot;zoomInText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;+&lt;\/span&gt;&quot;,&quot;zoomInTitle&quot;:&quot;Zoom in&quot;,&quot;zoomOutText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;&amp;#x2212;&lt;\/span&gt;&quot;,&quot;zoomOutTitle&quot;:&quot;Zoom out&quot;},&quot;@provider&quot;:&quot;leaflet&quot;}"
+  data-symfony--ux-leaflet-map--map-markers-value="[]"
+  data-symfony--ux-leaflet-map--map-polygons-value="[]"
+  data-symfony--ux-leaflet-map--map-polylines-value="[]"
+  data-symfony--ux-leaflet-map--map-circles-value="[]"
+  data-symfony--ux-leaflet-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all polylines removed with removeAllPolylines()__1.txt
+++ b/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all polylines removed with removeAllPolylines()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-leaflet-map--map"
+  data-symfony--ux-leaflet-map--map-provider-options-value="{}"
+  data-symfony--ux-leaflet-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-leaflet-map--map-zoom-value="12"
+  data-symfony--ux-leaflet-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-leaflet-map--map-options-value="{&quot;tileLayer&quot;:{&quot;url&quot;:&quot;https:\/\/tile.openstreetmap.org\/{z}\/{x}\/{y}.png&quot;,&quot;attribution&quot;:&quot;\u00a9 &lt;a href=\&quot;https:\/\/www.openstreetmap.org\/copyright\&quot;&gt;OpenStreetMap&lt;\/a&gt;&quot;,&quot;options&quot;:[]},&quot;attributionControlOptions&quot;:{&quot;position&quot;:&quot;bottomright&quot;,&quot;prefix&quot;:&quot;Leaflet&quot;},&quot;zoomControlOptions&quot;:{&quot;position&quot;:&quot;topleft&quot;,&quot;zoomInText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;+&lt;\/span&gt;&quot;,&quot;zoomInTitle&quot;:&quot;Zoom in&quot;,&quot;zoomOutText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;&amp;#x2212;&lt;\/span&gt;&quot;,&quot;zoomOutTitle&quot;:&quot;Zoom out&quot;},&quot;@provider&quot;:&quot;leaflet&quot;}"
+  data-symfony--ux-leaflet-map--map-markers-value="[]"
+  data-symfony--ux-leaflet-map--map-polygons-value="[]"
+  data-symfony--ux-leaflet-map--map-polylines-value="[]"
+  data-symfony--ux-leaflet-map--map-circles-value="[]"
+  data-symfony--ux-leaflet-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all rectangles removed with removeAllRectangles()__1.txt
+++ b/src/Map/src/Bridge/Leaflet/tests/__snapshots__/LeafletRendererTest__testRenderMap with data set with all rectangles removed with removeAllRectangles()__1.txt
@@ -1,0 +1,15 @@
+<!-- This HTML has been prettified for testing purposes, and may not represent the actual HTML output.
+     Run "php vendor/bin/phpunit -d --update-snapshots" to update the snapshot. -->
+<div
+  data-controller="symfony--ux-leaflet-map--map"
+  data-symfony--ux-leaflet-map--map-provider-options-value="{}"
+  data-symfony--ux-leaflet-map--map-center-value="{&quot;lat&quot;:48.8566,&quot;lng&quot;:2.3522}"
+  data-symfony--ux-leaflet-map--map-zoom-value="12"
+  data-symfony--ux-leaflet-map--map-fit-bounds-to-markers-value="false"
+  data-symfony--ux-leaflet-map--map-options-value="{&quot;tileLayer&quot;:{&quot;url&quot;:&quot;https:\/\/tile.openstreetmap.org\/{z}\/{x}\/{y}.png&quot;,&quot;attribution&quot;:&quot;\u00a9 &lt;a href=\&quot;https:\/\/www.openstreetmap.org\/copyright\&quot;&gt;OpenStreetMap&lt;\/a&gt;&quot;,&quot;options&quot;:[]},&quot;attributionControlOptions&quot;:{&quot;position&quot;:&quot;bottomright&quot;,&quot;prefix&quot;:&quot;Leaflet&quot;},&quot;zoomControlOptions&quot;:{&quot;position&quot;:&quot;topleft&quot;,&quot;zoomInText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;+&lt;\/span&gt;&quot;,&quot;zoomInTitle&quot;:&quot;Zoom in&quot;,&quot;zoomOutText&quot;:&quot;&lt;span aria-hidden=\&quot;true\&quot;&gt;&amp;#x2212;&lt;\/span&gt;&quot;,&quot;zoomOutTitle&quot;:&quot;Zoom out&quot;},&quot;@provider&quot;:&quot;leaflet&quot;}"
+  data-symfony--ux-leaflet-map--map-markers-value="[]"
+  data-symfony--ux-leaflet-map--map-polygons-value="[]"
+  data-symfony--ux-leaflet-map--map-polylines-value="[]"
+  data-symfony--ux-leaflet-map--map-circles-value="[]"
+  data-symfony--ux-leaflet-map--map-rectangles-value="[]"
+></div>

--- a/src/Map/src/Elements.php
+++ b/src/Map/src/Elements.php
@@ -64,6 +64,13 @@ abstract class Elements
         return $this;
     }
 
+    public function removeAll(): static
+    {
+        $this->elements->removeAll($this->elements);
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         foreach ($this->elements as $element) {

--- a/src/Map/src/Map.php
+++ b/src/Map/src/Map.php
@@ -133,6 +133,13 @@ final class Map
         return $this;
     }
 
+    public function removeAllMarkers(): self
+    {
+        $this->markers->removeAll();
+
+        return $this;
+    }
+
     public function addPolygon(Polygon $polygon): self
     {
         $this->polygons->add($polygon);
@@ -143,6 +150,13 @@ final class Map
     public function removePolygon(Polygon|string $polygonOrId): self
     {
         $this->polygons->remove($polygonOrId);
+
+        return $this;
+    }
+
+    public function removeAllPolygons(): self
+    {
+        $this->polygons->removeAll();
 
         return $this;
     }
@@ -161,6 +175,13 @@ final class Map
         return $this;
     }
 
+    public function removeAllPolylines(): self
+    {
+        $this->polylines->removeAll();
+
+        return $this;
+    }
+
     public function addCircle(Circle $circle): self
     {
         $this->circles->add($circle);
@@ -175,6 +196,13 @@ final class Map
         return $this;
     }
 
+    public function removeAllCircles(): self
+    {
+        $this->circles->removeAll();
+
+        return $this;
+    }
+
     public function addRectangle(Rectangle $rectangle): self
     {
         $this->rectangles->add($rectangle);
@@ -185,6 +213,13 @@ final class Map
     public function removeRectangle(Rectangle|string $rectangleOrId): self
     {
         $this->rectangles->remove($rectangleOrId);
+
+        return $this;
+    }
+
+    public function removeAllRectangles(): self
+    {
+        $this->rectangles->removeAll();
 
         return $this;
     }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| License        | MIT

# Description

Adds a `Map::removeAll*()` method to all map elements (such as markers, circles, polylines, etc.) in Map.php.

# Motivation

In my use case, map elements—especially markers—need to be dynamically adapted depending on the map zoom level.

For example:

At a low zoom level, markers may be clustered

At a higher zoom level, clusters are replaced by individual points

In this scenario, the simplest and most reliable approach is to remove all existing elements and rebuild them from scratch whenever the zoom changes.
