### PR TITLE
[Pkg] Fix pnpm build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "src/*/src/Bridge/*/assets"
     ],
     "scripts": {
-        "build": "pnpm run --filter @symfony/ux-map build && pnpm run -r --aggregate-output build",
+        "build": "pnpm run --filter @symfony/ux-map build; sync; pnpm run --filter !@symfony/ux-map --recursive --aggregate-output build",
         "test": "pnpm run -r --workspace-concurrency=1 test",
         "test:unit": "pnpm run -r --aggregate-output test:unit",
         "test:browser": "pnpm run -r --workspace-concurrency=1 test:browser",


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Following https://github.com/symfony/ux/pull/2983 and https://github.com/symfony/ux/pull/3001, I noticed sometimes we still have the `pnpm run build` command that fails.

With a `sync` call and filtering out `@symfony/ux-map` when building other packages, I think we could finally fix the issue.