### PR TITLE
[PhpUnit] Drop PHPUnit 9.5 in favor of ^10.5|^11.5

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -74,6 +74,7 @@ jobs:
                   echo COMPOSER_UP='composer update ${{ matrix.dependency-version == 'lowest' && '--prefer-lowest' || '' }} --no-progress --no-interaction --ansi' >> $GITHUB_ENV
                   echo PHPUNIT='vendor/bin/simple-phpunit ${{ matrix.dependency-version == 'lowest' && '--exclude-group skip-on-lowest' || '' }} ${{ matrix.os == 'windows-latest' && '--exclude-group transient-on-windows' || '' }}' >> $GITHUB_ENV
                   [ 'lowest' = '${{ matrix.dependency-version }}' ] && export SYMFONY_DEPRECATIONS_HELPER=weak
+                  [ '8.1' = '${{ matrix.php-version }}' ] && export SYMFONY_PHPUNIT_VERSION=10.5 || export SYMFONY_PHPUNIT_VERSION=11.5
 
                   # Swup and Typed have no tests, Turbo has its own workflow file
                   EXCLUDED_PACKAGES="Typed|Swup|Turbo"

--- a/src/Autocomplete/phpunit.xml.dist
+++ b/src/Autocomplete/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
         <env name="KERNEL_CLASS" value="Symfony\UX\Autocomplete\Tests\Fixtures\Kernel"/>
         <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data.db"/>
     </php>

--- a/src/Chartjs/phpunit.xml.dist
+++ b/src/Chartjs/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/Cropperjs/phpunit.xml.dist
+++ b/src/Cropperjs/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/Dropzone/phpunit.xml.dist
+++ b/src/Dropzone/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/Icons/phpunit.xml.dist
+++ b/src/Icons/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
         <env name="KERNEL_CLASS" value="Symfony\UX\Icons\Tests\Fixtures\TestKernel" />
     </php>
 

--- a/src/LazyImage/phpunit.xml.dist
+++ b/src/LazyImage/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=./tests/baseline-ignore&amp;max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/LiveComponent/phpunit.xml.dist
+++ b/src/LiveComponent/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
         <env name="KERNEL_CLASS" value="Symfony\UX\LiveComponent\Tests\Fixtures\Kernel"/>
         <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data.db"/>
     </php>

--- a/src/Map/composer.json
+++ b/src/Map/composer.json
@@ -43,7 +43,7 @@
         "symfony/ux-twig-component": "^2.18|^8.0",
         "symfony/ux-icons": "^2.18",
         "spatie/phpunit-snapshot-assertions": "^4.2.17|^5.2.3",
-        "phpunit/phpunit": "^9.6.22"
+        "phpunit/phpunit": "^10.5|^11.5"
     },
     "conflict": {
         "symfony/ux-twig-component": "<2.21"

--- a/src/Map/src/Bridge/Google/composer.json
+++ b/src/Map/src/Bridge/Google/composer.json
@@ -24,7 +24,7 @@
         "symfony/phpunit-bridge": "^7.2|^8.0",
         "symfony/ux-icons": "^2.18",
         "spatie/phpunit-snapshot-assertions": "^4.2.17|^5.2.3",
-        "phpunit/phpunit": "^9.6.22"
+        "phpunit/phpunit": "^10.5|^11.5"
     },
     "autoload": {
         "psr-4": { "Symfony\\UX\\Map\\Bridge\\Google\\": "src/" },

--- a/src/Map/src/Bridge/Google/phpunit.xml.dist
+++ b/src/Map/src/Bridge/Google/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/Map/src/Bridge/Leaflet/composer.json
+++ b/src/Map/src/Bridge/Leaflet/composer.json
@@ -24,7 +24,7 @@
         "symfony/phpunit-bridge": "^7.2|^8.0",
         "symfony/ux-icons": "^2.18",
         "spatie/phpunit-snapshot-assertions": "^4.2.17|^5.2.3",
-        "phpunit/phpunit": "^9.6.22"
+        "phpunit/phpunit": "^10.5|^11.5"
     },
     "autoload": {
         "psr-4": { "Symfony\\UX\\Map\\Bridge\\Leaflet\\": "src/" },

--- a/src/Map/src/Bridge/Leaflet/phpunit.xml.dist
+++ b/src/Map/src/Bridge/Leaflet/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/Notify/phpunit.xml.dist
+++ b/src/Notify/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/React/phpunit.xml.dist
+++ b/src/React/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/StimulusBundle/phpunit.xml.dist
+++ b/src/StimulusBundle/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
         <env name="KERNEL_CLASS" value="Symfony\UX\Autocomplete\Tests\Fixtures\Kernel"/>
         <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data.db"/>
     </php>

--- a/src/Svelte/phpunit.xml.dist
+++ b/src/Svelte/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/TogglePassword/phpunit.xml.dist
+++ b/src/TogglePassword/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="ignoreFile=./tests/baseline-ignore&amp;max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/Toolkit/composer.json
+++ b/src/Toolkit/composer.json
@@ -49,7 +49,7 @@
         "symfony/phpunit-bridge": "^7.2|^8.0",
         "vincentlanglet/twig-cs-fixer": "^3.9",
         "spatie/phpunit-snapshot-assertions": "^4.2.17|^5.2.3",
-        "phpunit/phpunit": "^9.6.22",
+        "phpunit/phpunit": "^10.5|^11.5",
         "symfony/ux-icons": "^2.18",
         "tales-from-a-dev/twig-tailwind-extra": "^1.0.0"
     },

--- a/src/Toolkit/phpunit.xml.dist
+++ b/src/Toolkit/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
         <env name="KERNEL_CLASS" value="Symfony\UX\Toolkit\Tests\Fixtures\Kernel"/>
     </php>
 

--- a/src/Translator/phpunit.xml.dist
+++ b/src/Translator/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>

--- a/src/Turbo/phpunit.xml.dist
+++ b/src/Turbo/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
         <env name="APP_ENV" value="test" force="true" />
         <env name="APP_DEBUG" value="true" force="true" />
         <env name="KERNEL_CLASS" value="App\Kernel"/>

--- a/src/TwigComponent/phpunit.xml.dist
+++ b/src/TwigComponent/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
         <env name="KERNEL_CLASS" value="Symfony\UX\TwigComponent\Tests\Fixtures\Kernel"/>
     </php>
 

--- a/src/Vue/phpunit.xml.dist
+++ b/src/Vue/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="10.5"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

My goal here is to make our CI for Symfony 8.* the greenish as possible. 

For the moment, `spatie/phpunit-snapshot-assertions` and `zenstruck/browser` packages block the Symfony 8.0 CI (https://github.com/symfony/ux/actions/runs/20502817491/job/58912755003?pr=3251). But `spatie/phpunit-snapshot-assertions` installation can be fixed when allowing PHPUnit >=10.

The ^10.5|^11.5 constraint is still compatible with PHP 8.1 (our lowest PHP supported version in 2.x).

