### PR TITLE
[*CS-Fixer] Ensure "apps/" exists before adding it in Finder

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,10 +9,6 @@
  * file that was distributed with this source code.
  */
 
-if (!file_exists(__DIR__.'/src')) {
-    exit(0);
-}
-
 $fileHeaderParts = [
     <<<'EOF'
         This file is part of the Symfony package.
@@ -28,13 +24,17 @@ $fileHeaderParts = [
 ];
 
 $finder = PhpCsFixer\Finder::create()
-    ->in([__DIR__.'/src', __DIR__.'/apps'])
+    // Some directories may not exist when running Fabbot action, if no files under them were changed.
+    ->in(array_filter([__DIR__.'/src', __DIR__.'/apps'], is_dir(...)))
     ->append([__FILE__])
     ->notPath('#/Fixtures/#')
     ->notPath('#/assets/#')
     ->notPath('#/var/#')
     // does not work well with `fully_qualified_strict_types` rule
-    ->notPath('LiveComponent/tests/Integration/LiveComponentHydratorTest.php');
+    ->notPath('LiveComponent/tests/Integration/LiveComponentHydratorTest.php')
+    // apps/
+    ->notPath(['#config/#', '#public/#', 'importmap.php'])
+;
 
 return (new PhpCsFixer\Config())
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())

--- a/.twig-cs-fixer.dist.php
+++ b/.twig-cs-fixer.dist.php
@@ -13,10 +13,14 @@ $ruleset = new TwigCsFixer\Ruleset\Ruleset();
 $ruleset->addStandard(new TwigCsFixer\Standard\TwigCsFixer());
 
 $finder = new TwigCsFixer\File\Finder();
-$finder->in([__DIR__.'/src', __DIR__.'/apps']);
+
+// Some directories may not exist when running Fabbot action, if no files under them were changed.
+$finder->in(array_filter([__DIR__.'/src', __DIR__.'/apps'], is_dir(...)));
 $finder->notPath('#/Fixtures/#');
 $finder->notPath('#/assets/#');
 $finder->notPath('#/var/#');
+// apps/
+$finder->notPath(['#config/#', '#public/#', 'importmap.php'])
 
 $config = new TwigCsFixer\Config\Config();
 $config->setCacheFile('.twig-cs-fixer.cache');


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Follow https://github.com/symfony/ux/pull/3251, I noticed in https://github.com/symfony/ux/pull/3256 that Fabbot is failing because the Finder used by PHP-CS-Fixer throw an error because the directory `apps/` does not exist (https://github.com/symfony/ux/actions/runs/20607943823/job/59187283446?pr=3256#step:4:25).

Indeed, I didn't modified any files from `apps/` folder in this PR, and it looks like `Finder::in()` throws an exception when the path does not exist.