### PR TITLE
 Improve tailwind dark mode support for toolkit

### DIFF
--- a/src/Toolkit/kits/shadcn/INSTALL.md
+++ b/src/Toolkit/kits/shadcn/INSTALL.md
@@ -17,7 +17,16 @@ In your `assets/styles/app.css`, after the TailwindCSS imports, add the followin
 ```css
 @import "tailwindcss";
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark {
+  &:where(.dark, .dark *) {
+    @slot;
+  }
+  @media (prefers-color-scheme: dark) {
+    &:where(:not(.light *)) {
+      @slot;
+    }
+  }
+}
 
 :root {
     --background: oklch(1 0 0);
@@ -88,6 +97,43 @@ In your `assets/styles/app.css`, after the TailwindCSS imports, add the followin
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(0.269 0 0);
     --sidebar-ring: oklch(0.439 0 0);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not(.light *) {
+        --background: oklch(0.145 0 0);
+        --foreground: oklch(0.985 0 0);
+        --card: oklch(0.145 0 0);
+        --card-foreground: oklch(0.985 0 0);
+        --popover: oklch(0.145 0 0);
+        --popover-foreground: oklch(0.985 0 0);
+        --primary: oklch(0.985 0 0);
+        --primary-foreground: oklch(0.205 0 0);
+        --secondary: oklch(0.269 0 0);
+        --secondary-foreground: oklch(0.985 0 0);
+        --muted: oklch(0.269 0 0);
+        --muted-foreground: oklch(0.708 0 0);
+        --accent: oklch(0.269 0 0);
+        --accent-foreground: oklch(0.985 0 0);
+        --destructive: oklch(0.396 0.141 25.723);
+        --destructive-foreground: oklch(0.637 0.237 25.331);
+        --border: oklch(0.269 0 0);
+        --input: oklch(0.269 0 0);
+        --ring: oklch(0.439 0 0);
+        --chart-1: oklch(0.488 0.243 264.376);
+        --chart-2: oklch(0.696 0.17 162.48);
+        --chart-3: oklch(0.769 0.188 70.08);
+        --chart-4: oklch(0.627 0.265 303.9);
+        --chart-5: oklch(0.645 0.246 16.439);
+        --sidebar: oklch(0.205 0 0);
+        --sidebar-foreground: oklch(0.985 0 0);
+        --sidebar-primary: oklch(0.488 0.243 264.376);
+        --sidebar-primary-foreground: oklch(0.985 0 0);
+        --sidebar-accent: oklch(0.269 0 0);
+        --sidebar-accent-foreground: oklch(0.985 0 0);
+        --sidebar-border: oklch(0.269 0 0);
+        --sidebar-ring: oklch(0.439 0 0);
+    }
 }
 
 @theme inline {

--- a/src/Toolkit/kits/shadcn/INSTALL.md
+++ b/src/Toolkit/kits/shadcn/INSTALL.md
@@ -22,7 +22,7 @@ In your `assets/styles/app.css`, after the TailwindCSS imports, add the followin
     @slot;
   }
   @media (prefers-color-scheme: dark) {
-    &:where(:not(.light *)) {
+    &:where(:not(.light, .light *)) {
       @slot;
     }
   }
@@ -100,7 +100,7 @@ In your `assets/styles/app.css`, after the TailwindCSS imports, add the followin
 }
 
 @media (prefers-color-scheme: dark) {
-    :root:not(.light *) {
+    :root:not(.light, .light *) {
         --background: oklch(0.145 0 0);
         --foreground: oklch(0.985 0 0);
         --card: oklch(0.145 0 0);


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT


Improve tailwind dark mode support for toolkit. The `prefers-color-scheme` is used by default, unless you specified the .dark / .light classes

ex : if system theme is dark => use dark theme (and can use tailwind `dark:` in classes
BUT if system theme is dark and you define a `class="light"` theme remains light
AND if system them is light and you define a `class="dark"` theme will be dark and `dark:` syntax available

