### PR TITLE
[Site] Set dark/light theme of Toolkit preview iframes, given current page theme

### DIFF
--- a/ux.symfony.com/assets/controllers/theme-switcher-controller.js
+++ b/ux.symfony.com/assets/controllers/theme-switcher-controller.js
@@ -16,12 +16,10 @@ export default class extends Controller {
         clearTimeout(this.timeout);
 
         this.element.setAttribute('data-switch', theme);
-        localStorage.setItem('user-theme', theme);
 
+        // Small delay to allow CSS transitions during theme switch.
         this.timeout = setTimeout(() => {
-            /**
-             * Small delay to allow CSS transitions during theme switch.
-             */
+            localStorage.setItem('user-theme', theme);
             document.documentElement.setAttribute('data-bs-theme', theme);
         }, 250);
     }

--- a/ux.symfony.com/src/Controller/Toolkit/ComponentsController.php
+++ b/ux.symfony.com/src/Controller/Toolkit/ComponentsController.php
@@ -80,6 +80,18 @@ class ComponentsController extends AbstractController
                     <meta charset="utf-8">
                     <title>Preview</title>
                     <meta name="viewport" content="width=device-width, initial-scale=1">
+                    <script>
+                        const theme = localStorage.getItem('user-theme');
+                        if (theme) {
+                            document.documentElement.classList.add(theme);
+                        }
+                        window.addEventListener('storage', (event) => {
+                            if (event.key === 'user-theme') {
+                                document.documentElement.classList.toggle('dark', event.newValue === 'dark');
+                                document.documentElement.classList.toggle('light', event.newValue === 'light');
+                            }
+                        });
+                    </script>
                     {{ importmap('toolkit-{$kitId->value}') }}
                 </head>
                 <body class="flex min-h-[{$height}] w-full justify-center p-5 items-center">{$code}</body>

--- a/ux.symfony.com/src/Controller/UxPackage/ToolkitController.php
+++ b/ux.symfony.com/src/Controller/UxPackage/ToolkitController.php
@@ -11,53 +11,24 @@
 
 namespace App\Controller\UxPackage;
 
-use App\Enum\ToolkitKitId;
 use App\Service\Toolkit\ToolkitService;
 use App\Service\UxPackageRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ToolkitController extends AbstractController
 {
     #[Route('/toolkit', name: 'app_toolkit')]
     public function index(
         UxPackageRepository $packageRepository,
-        UriSigner $uriSigner,
         ToolkitService $toolkitService,
     ): Response {
         $package = $packageRepository->find('toolkit');
-        $demoPreviewHeight = '400px';
-        $demoPreviewUrl = $uriSigner->sign($this->generateUrl('app_toolkit_component_preview', [
-            'kitId' => ToolkitKitId::Shadcn->value,
-            'code' => <<<'TWIG'
-                <twig:Card>
-                    <twig:Card:Header>
-                        <twig:Card:Title>Symfony is cool</twig:Card:Title>
-                        <twig:Card:Description>
-                            Symfony is a set of reusable PHP components...
-                        </twig:Card:Description>
-                    </twig:Card:Header>
-                    <twig:Card:Content>
-                        ... and a PHP framework for web projects
-                    </twig:Card:Content>
-                    <twig:Card:Footer>
-                        <twig:Button as="a" href="https://symfony.com" target="_blank">
-                            Visit symfony.com
-                        </twig:Button>
-                    </twig:Card:Footer>
-                </twig:Card>
-                TWIG,
-            'height' => $demoPreviewHeight,
-        ], UrlGeneratorInterface::ABSOLUTE_URL));
 
         return $this->render('ux_packages/toolkit.html.twig', [
             'package' => $package,
             'kits' => $toolkitService->getKits(),
-            'demoPreviewUrl' => $demoPreviewUrl,
-            'demoPreviewHeight' => $demoPreviewHeight,
         ]);
     }
 }

--- a/ux.symfony.com/src/Service/CommonMark/Extension/ToolkitPreview/Renderer/ToolkitPreviewRenderer.php
+++ b/ux.symfony.com/src/Service/CommonMark/Extension/ToolkitPreview/Renderer/ToolkitPreviewRenderer.php
@@ -50,7 +50,13 @@ final readonly class ToolkitPreviewRenderer implements NodeRendererInterface
                 <svg width="18" height="18" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
                 <span>Loading...</span>
             </div>
-            <iframe class="Toolkit_Preview loading" src="{$previewUrl}" style="height: {$height};" loading="lazy" onload="this.previousElementSibling.style.display = 'none'; this.classList.remove('loading')"></iframe>
+            <iframe
+                class="Toolkit_Preview loading"
+                src="{$previewUrl}"
+                loading="lazy"
+                style="height: {$height};"
+                onload="this.previousElementSibling.style.display = 'none'; this.classList.remove('loading')"
+            ></iframe>
             HTML;
     }
 }

--- a/ux.symfony.com/templates/ux_packages/toolkit.html.twig
+++ b/ux.symfony.com/templates/ux_packages/toolkit.html.twig
@@ -50,7 +50,11 @@ tree templates/components
 {% block demo_title %}UX Toolkit{% endblock %}
 
 {% block demo_content %}
-    <iframe src="{{ demoPreviewUrl }}" style="width:100%; height:{{ demoPreviewHeight }};"></iframe>
+    {% apply markdown_to_html %}
+    [toolkit-preview {"kit":"shadcn","height":"400px"}]
+    {{ source ('toolkit/_code_block_right.html.twig') }}
+    [/toolkit-preview]
+    {% endapply %}
 {% endblock %}
 
 {% block package_install %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT


We will see for future kits how we will handle light/dark mode, but for the moment it's fine
https://github.com/user-attachments/assets/b04201cb-b472-405f-af20-4152b84dee04

I will merge it tomorrow morning