### PR TITLE
[Turbo] Fix `SplObjectStorage::attach` deprecation in Doctrine Broadcast listener

### DIFF
--- a/src/Turbo/src/Doctrine/BroadcastListener.php
+++ b/src/Turbo/src/Doctrine/BroadcastListener.php
@@ -30,20 +30,20 @@ final class BroadcastListener implements ResetInterface
     /**
      * @var array<class-string, array<mixed>>
      */
-    private $broadcastedClasses;
+    private array $broadcastedClasses = [];
 
     /**
      * @var \SplObjectStorage<object, array<mixed>>
      */
-    private $createdEntities;
+    private \SplObjectStorage $createdEntities;
     /**
      * @var \SplObjectStorage<object, array<mixed>>
      */
-    private $updatedEntities;
+    private \SplObjectStorage $updatedEntities;
     /**
      * @var \SplObjectStorage<object, array<mixed>>
      */
-    private $removedEntities;
+    private \SplObjectStorage $removedEntities;
 
     public function __construct(
         private BroadcasterInterface $broadcaster,
@@ -65,15 +65,15 @@ final class BroadcastListener implements ResetInterface
         $em = method_exists($eventArgs, 'getObjectManager') ? $eventArgs->getObjectManager() : $eventArgs->getEntityManager();
         $uow = $em->getUnitOfWork();
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
-            $this->storeEntitiesToPublish($em, $entity, 'createdEntities');
+            $this->storeEntitiesToPublish($em, $entity, $this->createdEntities);
         }
 
         foreach ($uow->getScheduledEntityUpdates() as $entity) {
-            $this->storeEntitiesToPublish($em, $entity, 'updatedEntities');
+            $this->storeEntitiesToPublish($em, $entity, $this->updatedEntities);
         }
 
         foreach ($uow->getScheduledEntityDeletions() as $entity) {
-            $this->storeEntitiesToPublish($em, $entity, 'removedEntities');
+            $this->storeEntitiesToPublish($em, $entity, $this->removedEntities);
         }
     }
 
@@ -122,7 +122,10 @@ final class BroadcastListener implements ResetInterface
         $this->removedEntities = new \SplObjectStorage();
     }
 
-    private function storeEntitiesToPublish(EntityManagerInterface $em, object $entity, string $property): void
+    /**
+     * @param \SplObjectStorage<object, array<mixed>> $objectStorage
+     */
+    private function storeEntitiesToPublish(EntityManagerInterface $em, object $entity, \SplObjectStorage $objectStorage): void
     {
         $class = ClassUtil::getEntityClass($entity);
 
@@ -144,14 +147,14 @@ final class BroadcastListener implements ResetInterface
         }
 
         if ($options = $this->broadcastedClasses[$class]) {
-            if ('createdEntities' !== $property) {
+            if ($this->createdEntities !== $objectStorage) {
                 $id = $em->getClassMetadata($class)->getIdentifierValues($entity);
                 foreach ($options as $k => $option) {
                     $options[$k]['id'] = $id;
                 }
             }
 
-            $this->{$property}->attach($entity, $options);
+            $objectStorage[$entity] = $options;
         }
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

The method [`SplObjectStorage::attach`](https://www.php.net/manual/en/splobjectstorage.attach.php) is deprecated in PHP 8.5.

I refactored the method to avoid dynamic property access, which should help the static analysis.