### PR TITLE
[Chartjs] register default colors

### DIFF
--- a/src/Chartjs/assets/src/controller.ts
+++ b/src/Chartjs/assets/src/controller.ts
@@ -8,11 +8,15 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { Chart, registerables } from 'chart.js';
+import { Chart, Colors, registerables } from 'chart.js';
 
 // ChartJs 3.x
 if (registerables) {
     Chart.register(...registerables);
+}
+// ChartJs 4.x
+if (Colors) {
+    Chart.register(Colors);
 }
 
 let isChartInitialized = false;


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | none
| License        | MIT

I wanted to create chartjs v4 graph without having to define the color for each dataset
Please have in mind I didnt tested this PR yet, still trying to hook this code locally to see if it works
link https://www.chartjs.org/docs/latest/general/colors.html#default-color-palette

```
However, setting colors for each dataset might require additional work that you'd rather not do. In that case, consider using the following plugins with pre-defined or generated palettes.

If you don't have any preference for colors, you can use the built-in Colors plugin. It will cycle through a palette of seven Chart.js brand colors
```