### PR TITLE
[Toolkit] fix getRecipes method with type

### DIFF
--- a/src/Toolkit/src/Kit/Kit.php
+++ b/src/Toolkit/src/Kit/Kit.php
@@ -57,7 +57,7 @@ final class Kit
     public function getRecipes(?RecipeType $type = null): array
     {
         if (null !== $type) {
-            $this->recipes = array_filter($this->recipes, fn (Recipe $recipe) => $recipe->manifest->type === $type);
+            return array_filter($this->recipes, fn (Recipe $recipe) => $recipe->manifest->type === $type);
         }
 
         return $this->recipes;


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | not
| Documentation? | no
| Issues         | 
| License        | MIT

When giving a type, the attribute was replaced.