### PR TITLE
[Tookit] Fix recipe name display when asking for what alternative recipe to install

### DIFF
--- a/src/Toolkit/src/Command/InstallCommand.php
+++ b/src/Toolkit/src/Command/InstallCommand.php
@@ -144,7 +144,7 @@ class InstallCommand extends Command
 
             if (1 === $alternativeRecipesCount && $input->isInteractive()) {
                 $io->warning($message);
-                if ($io->confirm(\sprintf('Do you want to install the recipe "%s" instead?', $alternativeRecipes[0]->manifest->name))) {
+                if ($io->confirm(\sprintf('Do you want to install the recipe "%s" instead?', $alternativeRecipes[0]->name))) {
                     $recipe = $alternativeRecipes[0];
                 } else {
                     return Command::FAILURE;


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | 
| License        | MIT

The name was not ok.
 
```
symfony console ux:install Alert --kit shadcn -vvv

[WARNING] The recipe "Alert" does not exist.

Do you want to install the recipe "alert" instead? (yes/no) [yes]:
 ```