### PR TITLE
[CI] Remove usage of framework.annotations.enabled

### DIFF
--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -90,7 +90,7 @@ final class Kernel extends BaseKernel
 
     protected function configureContainer(ContainerConfigurator $c): void
     {
-        $frameworkConfig = [
+        $c->extension('framework', [
             'csrf_protection' => ['enabled' => false],
             'secret' => 'S3CRET',
             'test' => true,
@@ -106,22 +106,21 @@ final class Kernel extends BaseKernel
             ...(self::VERSION_ID >= 60200 ? [
                 'handle_all_throwables' => true,
             ] : []),
+            ...(self::VERSION_ID >= 60400 && self::VERSION_ID < 70400 ? [
+                'annotations' => ['enabled' => false]
+            ] : []),
+            ...(self::VERSION_ID >= 70300 ? [
+                'session' => [
+                    'storage_factory_id' => 'session.storage.factory.mock_file',
+                    'cookie_secure' => 'auto',
+                    'cookie_samesite' => 'lax',
+                    'handler_id' => null,
+                ]
+            ] : []),
             ...(self::VERSION_ID >= 70300 ? [
                 'property_info' => ['with_constructor_extractor' => false],
             ] : []),
-        ];
-
-        if (self::VERSION_ID >= 60400) {
-            $frameworkConfig['session'] = [
-                'storage_factory_id' => 'session.storage.factory.mock_file',
-                'cookie_secure' => 'auto',
-                'cookie_samesite' => 'lax',
-                'handler_id' => null,
-            ];
-            $frameworkConfig['annotations']['enabled'] = false;
-        }
-
-        $c->extension('framework', $frameworkConfig);
+        ]);
 
         $c->extension('twig', [
             'default_path' => '%kernel.project_dir%/tests/Fixtures/templates',


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Done in https://github.com/symfony/symfony/pull/61174
