### PR TITLE
[CI] Fix compatibility issues with Symfony 8 and spatie/phpunit-snapshot-assertions

### DIFF
--- a/.github/workflows/.utils.sh
+++ b/.github/workflows/.utils.sh
@@ -32,6 +32,7 @@ export -f _run_task
 before_composer_install() {
   local component=$1
   local php_version=$2
+  local symfony_version=$3
 
   # Install specific versions of PropertyInfo and TypeInfo based on PHP version
   # To remove in Symfony UX 4.0
@@ -57,5 +58,46 @@ before_composer_install() {
     composer require symfony/type-info --no-update
   fi
 
+  # When testing with Symfony 8 and PHP 8.4+, we have issue with spatie/phpunit-snapshot-assertions:
+  # - version ^4 is not compatible with Symfony 8
+  # - version ^5 is compatible with Symfony 8, but requires PHPUnit 10+
+  # PHPUnit 10+ is not really "usable", it's not compatible with PHPUnit Bridge, and there is no native deprecations handling.
+  # To remove in Symfony UX 3.0
+  if [[ "$symfony_version" == "8.0.*" ]]; then
+    if grep -q '"spatie/phpunit-snapshot-assertions"' composer.json; then
+      composer remove symfony/phpunit-bridge --dev --no-update
+      composer require phpunit/phpunit:^11 --dev --no-update
+      cp phpunit11.dist.xml phpunit.dist.xml
+      if [ ! -f tests/bootstrap.php ]; then
+        cat > tests/bootstrap.php <<'PHP'
+<?php
+
+use Symfony\Component\ErrorHandler\ErrorHandler;
+use Symfony\Component\Filesystem\Filesystem;
+
+require __DIR__.'/../vendor/autoload.php';
+
+// @see https://github.com/symfony/symfony/issues/53812
+ErrorHandler::register(null, false);
+PHP
+      fi
+    fi
+  fi
 }
 export -f before_composer_install
+
+after_composer_install() {
+  local component=$1
+  local php_version=$2
+  local symfony_version=$3
+
+  # To remove in Symfony UX 3.0
+  if [[ "$symfony_version" == "8.0.*" ]]; then
+    if grep -q '"spatie/phpunit-snapshot-assertions"' composer.json; then
+      # The Symfony PHPUnit bridge was previously removed to allow PHPUnit 11 installation.
+      # Creating a symlink to "phpunit" as "simple-phpunit" makes things easier for unit-tests.yaml workflow.
+      ln -s phpunit vendor/bin/simple-phpunit
+    fi
+  fi
+}
+export -f after_composer_install

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -122,8 +122,9 @@ jobs:
                 echo "$PACKAGES" | xargs -n1 | parallel -j +3 "_run_task {} \
                   '(cd src/{} \
                   && $COMPOSER_MIN_STAB \
-                  && before_composer_install \"{}\" \"${{ matrix.php-version }}\" \
+                  && before_composer_install \"{}\" \"${{ matrix.php-version }}\" \"${{ matrix.symfony-version }}\" \
                   && $COMPOSER_UP \
+                  && after_composer_install \"{}\" \"${{ matrix.php-version }}\" \"${{ matrix.symfony-version }}\" \
                   && $PHPUNIT)'"
 
             - name: Run packages tests (Windows)
@@ -137,8 +138,9 @@ jobs:
                   if ! PACKAGE="$PACKAGE" _run_task_sequential $PACKAGE \
                     '(cd src/$PACKAGE \
                     && $COMPOSER_MIN_STAB \
-                    && before_composer_install $PACKAGE ${{ matrix.php-version }} \
+                    && before_composer_install $PACKAGE ${{ matrix.php-version }} ${{ matrix.symfony-version }} \
                     && $COMPOSER_UP \
+                    && after_composer_install $PACKAGE ${{ matrix.php-version }} ${{ matrix.symfony-version }} \
                     && $PHPUNIT)'; then
                     FAILED_PACKAGES="$FAILED_PACKAGES $PACKAGE"
                   fi

--- a/src/Map/phpunit11.dist.xml
+++ b/src/Map/phpunit11.dist.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+        failOnDeprecation="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UX Map Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source
+            ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/src/Map/src/Bridge/Google/phpunit11.dist.xml
+++ b/src/Map/src/Bridge/Google/phpunit11.dist.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+        failOnDeprecation="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UX Google Map Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source
+            ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/src/Map/src/Bridge/Leaflet/phpunit11.dist.xml
+++ b/src/Map/src/Bridge/Leaflet/phpunit11.dist.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+        failOnDeprecation="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UX Leaflet Map Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source
+            ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/src/Map/tests/Renderer/NullRendererTest.php
+++ b/src/Map/tests/Renderer/NullRendererTest.php
@@ -21,21 +21,21 @@ use Symfony\UX\Map\Renderer\RendererInterface;
 
 final class NullRendererTest extends TestCase
 {
-    public function provideTestRenderMap(): iterable
+    public static function provideTestRenderMap(): iterable
     {
         yield 'no bridges' => [
-            'expected_exception_message' => 'You must install at least one bridge package to use the Symfony UX Map component.',
+            'expectedExceptionMessage' => 'You must install at least one bridge package to use the Symfony UX Map component.',
             'renderer' => new NullRenderer(),
         ];
 
         yield 'one bridge' => [
-            'expected_exception_message' => 'You must install at least one bridge package to use the Symfony UX Map component.'
+            'expectedExceptionMessage' => 'You must install at least one bridge package to use the Symfony UX Map component.'
                 .\PHP_EOL.'Try running "composer require symfony/ux-leaflet-map".',
             'renderer' => new NullRenderer(['symfony/ux-leaflet-map']),
         ];
 
         yield 'two bridges' => [
-            'expected_exception_message' => 'You must install at least one bridge package to use the Symfony UX Map component.'
+            'expectedExceptionMessage' => 'You must install at least one bridge package to use the Symfony UX Map component.'
                 .\PHP_EOL.'Try running "composer require symfony/ux-leaflet-map" or "composer require symfony/ux-google-map".',
             'renderer' => new NullRenderer(['symfony/ux-leaflet-map', 'symfony/ux-google-map']),
         ];

--- a/src/Map/tests/Twig/MapExtensionTest.php
+++ b/src/Map/tests/Twig/MapExtensionTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\UX\Map\Tests\Twig;
 
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\Map\Map;
 use Symfony\UX\Map\Point;
@@ -23,8 +22,6 @@ use Twig\Environment;
 
 class MapExtensionTest extends KernelTestCase
 {
-    use ExpectDeprecationTrait;
-
     protected static function getKernelClass(): string
     {
         return TwigAppKernel::class;

--- a/src/Toolkit/phpunit11.dist.xml
+++ b/src/Toolkit/phpunit11.dist.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+        failOnDeprecation="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+        <env name="KERNEL_CLASS" value="Symfony\UX\Toolkit\Tests\Fixtures\Kernel"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UX Toolkit Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source
+            ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

In order to make the CI full green, the last blocking step is the compatibility issue between Symfony 8 and `spatie/phpunit-snapshot-assertions`.

I re-used the PHPUnit files from 3.x