### PR TITLE
[Toolkit] Prepare base for recipe type `Block`

### DIFF
--- a/src/Toolkit/schema-kit-recipe-v1.json
+++ b/src/Toolkit/schema-kit-recipe-v1.json
@@ -5,6 +5,11 @@
     "type": "object",
     "required": ["name", "description"],
     "properties": {
+        "type": {
+            "type": "string",
+            "description": "The type of the Recipe",
+            "enum": ["component", "block"]
+        },
         "name": {
             "type": "string",
             "description": "The name of the Recipe"

--- a/src/Toolkit/src/Recipe/RecipeManifest.php
+++ b/src/Toolkit/src/Recipe/RecipeManifest.php
@@ -59,7 +59,7 @@ final class RecipeManifest
 
         $type = $data['type'] ?? throw new \InvalidArgumentException('Property "type" is required.');
         if (null === $type = RecipeType::tryFrom($type)) {
-            throw new \InvalidArgumentException(\sprintf('The recipe type "%s" is not supported.', $data['type']));
+            throw new \InvalidArgumentException(\sprintf('The recipe type "%s" is not supported, valid types are "%s".', $data['type'], implode('", "', array_map(fn (RecipeType $type) => $type->value, RecipeType::cases()))));
         }
 
         $dependencies = [];

--- a/src/Toolkit/src/Recipe/RecipeType.php
+++ b/src/Toolkit/src/Recipe/RecipeType.php
@@ -18,5 +18,6 @@ namespace Symfony\UX\Toolkit\Recipe;
  */
 enum RecipeType: string
 {
+    case Block = 'block';
     case Component = 'component';
 }

--- a/src/Toolkit/tests/Kit/KitTest.php
+++ b/src/Toolkit/tests/Kit/KitTest.php
@@ -49,9 +49,15 @@ final class KitTest extends TestCase
             __DIR__.'/table',
             new RecipeManifest(RecipeType::Component, 'Table', 'Description', []),
         ));
+        $kit->addRecipe(new Recipe(
+            'login',
+            __DIR__.'/Login',
+            new RecipeManifest(RecipeType::Block, 'Login', 'Description', []),
+        ));
 
-        $this->assertCount(2, $kit->getRecipes());
+        $this->assertCount(3, $kit->getRecipes());
         $this->assertCount(2, $kit->getRecipes(type: RecipeType::Component));
+        $this->assertCount(1, $kit->getRecipes(type: RecipeType::Block));
     }
 
     public function testShouldFailIfComponentIsAlreadyRegisteredInTheKit()

--- a/src/Toolkit/tests/Recipe/RecipeManifestTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeManifestTest.php
@@ -43,7 +43,7 @@ final class RecipeManifestTest extends TestCase
     public function testFromJsonWithInvalidType()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The recipe type "test" is not supported.');
+        $this->expectExceptionMessage('The recipe type "test" is not supported, valid types are "block", "component".');
 
         RecipeManifest::fromJson(<<<JSON
                 {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | #3246
| License        | MIT

This introduce a new`Block` type for the Toolkit recipes as explained in the #3246 issue.