### PR TITLE
[Toolkit][Shadcn] Add Tooltip component

### DIFF
--- a/src/Toolkit/kits/shadcn/tooltip/EXAMPLES.md
+++ b/src/Toolkit/kits/shadcn/tooltip/EXAMPLES.md
@@ -1,0 +1,105 @@
+# Examples
+
+## Default
+
+```twig {"preview":true,"height":"200px"}
+<twig:Tooltip>
+    <twig:Tooltip:Trigger as="span">
+        <twig:Button variant="outline">Hover me</twig:Button>
+    </twig:Tooltip:Trigger>
+    <twig:Tooltip:Content>
+        <p>Add to library</p>
+    </twig:Tooltip:Content>
+</twig:Tooltip>
+```
+
+## Sides
+
+```twig {"preview":true,"height":"300px"}
+<div class="flex flex-col gap-4 items-center justify-center">
+    <twig:Tooltip>
+        <twig:Tooltip:Trigger as="span">
+            <twig:Button variant="outline">Top (default)</twig:Button>
+        </twig:Tooltip:Trigger>
+        <twig:Tooltip:Content side="top">
+            Tooltip on top
+        </twig:Tooltip:Content>
+    </twig:Tooltip>
+
+    <div class="flex gap-4">
+        <twig:Tooltip>
+            <twig:Tooltip:Trigger as="span">
+                <twig:Button variant="outline">Left</twig:Button>
+            </twig:Tooltip:Trigger>
+            <twig:Tooltip:Content side="left">
+                Tooltip on left
+            </twig:Tooltip:Content>
+        </twig:Tooltip>
+
+        <twig:Tooltip>
+            <twig:Tooltip:Trigger as="span">
+                <twig:Button variant="outline">Right</twig:Button>
+            </twig:Tooltip:Trigger>
+            <twig:Tooltip:Content side="right">
+                Tooltip on right
+            </twig:Tooltip:Content>
+        </twig:Tooltip>
+    </div>
+
+    <twig:Tooltip>
+        <twig:Tooltip:Trigger as="span">
+            <twig:Button variant="outline">Bottom</twig:Button>
+        </twig:Tooltip:Trigger>
+        <twig:Tooltip:Content side="bottom">
+            Tooltip on bottom
+        </twig:Tooltip:Content>
+    </twig:Tooltip>
+</div>
+```
+
+## With Icon
+
+```twig {"preview":true,"height":"200px"}
+<twig:Tooltip>
+    <twig:Tooltip:Trigger as="span">
+        <twig:Button variant="ghost" size="icon">
+            <twig:ux:icon name="lucide:info" class="size-4" />
+        </twig:Button>
+    </twig:Tooltip:Trigger>
+    <twig:Tooltip:Content>
+        <p>This is helpful information</p>
+    </twig:Tooltip:Content>
+</twig:Tooltip>
+```
+
+## Custom Delay
+
+```twig {"preview":true,"height":"200px"}
+<twig:Tooltip delayDuration="200">
+    <twig:Tooltip:Trigger as="span">
+        <twig:Button variant="outline">Quick tooltip (200ms)</twig:Button>
+    </twig:Tooltip:Trigger>
+    <twig:Tooltip:Content>
+        This appears quickly!
+    </twig:Tooltip:Content>
+</twig:Tooltip>
+```
+
+## On Text
+
+```twig {"preview":true,"height":"200px"}
+<div class="text-sm text-muted-foreground">
+    You can use tooltips on
+    <twig:Tooltip>
+        <twig:Tooltip:Trigger as="span" class="underline decoration-dotted">
+            inline text
+        </twig:Tooltip:Trigger>
+        <twig:Tooltip:Content>
+            Like this!
+        </twig:Tooltip:Content>
+    </twig:Tooltip>
+    to provide additional context.
+</div>
+
+
+```

--- a/src/Toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js
+++ b/src/Toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['trigger', 'content'];
+    static values = {
+        delayDuration: { type: Number, default: 700 },
+        skipDelayDuration: { type: Number, default: 300 }
+    };
+
+    static lastShownTime = 0;
+
+    connect() {
+        this.timeout = null;
+    }
+
+    disconnect() {
+        this.clearTimeout();
+    }
+
+    show() {
+        this.clearTimeout();
+
+        const now = Date.now();
+        const constructor = this.constructor;
+
+        const timeSinceLastShown = now - constructor.lastShownTime;
+        const delay = timeSinceLastShown < this.delayDurationValue
+            ? this.skipDelayDurationValue
+            : this.delayDurationValue;
+
+        this.timeout = setTimeout(() => {
+            this.contentTarget.classList.remove('opacity-0');
+            this.contentTarget.classList.add('opacity-100');
+            this.contentTarget.setAttribute('data-state', 'open');
+            constructor.lastShownTime = now;
+        }, delay);
+    }
+
+    hide() {
+        this.clearTimeout();
+
+        if (this.hasContentTarget) {
+            this.contentTarget.classList.remove('opacity-100');
+            this.contentTarget.classList.add('opacity-0');
+            this.contentTarget.setAttribute('data-state', 'closed');
+        }
+    }
+
+    clearTimeout() {
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+            this.timeout = null;
+        }
+    }
+}

--- a/src/Toolkit/kits/shadcn/tooltip/manifest.json
+++ b/src/Toolkit/kits/shadcn/tooltip/manifest.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Tooltip",
+    "description": "A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.",
+    "copy-files": {
+        "assets/": "assets/",
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["twig/extra-bundle", "twig/html-extra:^3.12.0", "tales-from-a-dev/twig-tailwind-extra:^1.0.0"]
+    }
+}

--- a/src/Toolkit/kits/shadcn/tooltip/templates/components/Tooltip.html.twig
+++ b/src/Toolkit/kits/shadcn/tooltip/templates/components/Tooltip.html.twig
@@ -1,0 +1,15 @@
+{# @prop delayDuration number Délai en ms avant d'afficher le tooltip (défaut: 500) #}
+{# @prop skipDelayDuration number Délai en ms pour afficher rapidement les tooltips suivants (défaut: 300) #}
+{# @block content Le contenu du tooltip (Trigger + Content) #}
+{%- props delayDuration = 700, skipDelayDuration = 300 -%}
+
+<div
+    data-controller="tooltip"
+    data-tooltip-delay-duration-value="{{ delayDuration }}"
+    data-tooltip-skip-delay-duration-value="{{ skipDelayDuration }}"
+    data-slot="tooltip"
+    class="relative inline-block {{ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/tooltip/templates/components/Tooltip/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/tooltip/templates/components/Tooltip/Content.html.twig
@@ -1,0 +1,60 @@
+{# @prop side 'top'|'right'|'bottom'|'left' Position du tooltip (défaut: 'top') #}
+{# @prop sideOffset number Distance en pixels par rapport au trigger (défaut: 10) #}
+{# @block content Le contenu du tooltip #}
+{%- props side = 'top', sideOffset = 10 -%}
+
+{%- set margin_attribute = '' -%}
+{%- if side == 'top' -%}
+    {%- set margin_attribute = 'margin-bottom: ' ~ sideOffset ~ 'px' -%}
+{%- elseif side == 'right' -%}
+    {%- set margin_attribute = 'margin-left: ' ~ sideOffset ~ 'px' -%}
+{%- elseif side == 'bottom' -%}
+    {%- set margin_attribute = 'margin-top: ' ~ sideOffset ~ 'px' -%}
+{%- elseif side == 'left' -%}
+    {%- set margin_attribute = 'margin-right: ' ~ sideOffset ~ 'px' -%}
+{%- endif -%}
+
+{%- set style = html_cva(
+    base: 'absolute z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground pointer-events-none opacity-0 transition-opacity duration-200',
+    variants: {
+        side: {
+            top: 'bottom-full left-1/2 -translate-x-1/2',
+            right: 'left-full top-1/2 -translate-y-1/2',
+            bottom: 'top-full left-1/2 -translate-x-1/2',
+            left: 'right-full top-1/2 -translate-y-1/2',
+        },
+    },
+    default_variant: {
+        side: 'top',
+    },
+) -%}
+
+{# Arrow styles #}
+{%- set arrow_style = html_cva(
+    base: 'absolute h-2 w-2 bg-primary rotate-45',
+    variants: {
+        side: {
+            top: 'bottom-[-4px] left-1/2 -translate-x-1/2',
+            right: 'left-[-4px] top-1/2 -translate-y-1/2',
+            bottom: 'top-[-4px] left-1/2 -translate-x-1/2',
+            left: 'right-[-4px] top-1/2 -translate-y-1/2',
+        },
+    },
+    default_variant: {
+        side: 'top',
+    },
+) -%}
+
+<div
+    data-tooltip-target="content"
+    data-slot="tooltip-content"
+    data-side="{{ side }}"
+    id="tooltip-content"
+    role="tooltip"
+    class="{{ style.apply({side: side}, attributes.render('class'))|tailwind_merge }}"
+    style="{{ margin_attribute }}; {{ attributes.render('style') }}"
+    {{ attributes.without('class', 'style') }}
+>
+    {%- block content %}{% endblock -%}
+    <span class="{{ arrow_style.apply({side: side}) }}"></span>
+</div>

--- a/src/Toolkit/kits/shadcn/tooltip/templates/components/Tooltip/Trigger.html.twig
+++ b/src/Toolkit/kits/shadcn/tooltip/templates/components/Tooltip/Trigger.html.twig
@@ -1,0 +1,13 @@
+{# @prop as string Type d'élément HTML (défaut: 'button') #}
+{# @block content Le contenu du trigger #}
+{%- props as = 'button' -%}
+
+<{{ as }}
+    data-tooltip-target="trigger"
+    data-action="mouseenter->tooltip#show mouseleave->tooltip#hide focusin->tooltip#show focusout->tooltip#hide"
+    aria-describedby="tooltip-content"
+    class="{{ attributes.render('class')|tailwind_merge }}"
+    {{ attributes }}
+>
+    {%- block content %}{% endblock -%}
+</{{ as }}>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 1__1.html
@@ -1,0 +1,23 @@
+<!--
+- Kit: Shadcn UI
+- Component: Tooltip
+- Code:
+```twig
+<twig:Tooltip>
+    <twig:Tooltip:Trigger as="span">
+        <twig:Button variant="outline">Hover me</twig:Button>
+    </twig:Tooltip:Trigger>
+    <twig:Tooltip:Content>
+        <p>Add to library</p>
+    </twig:Tooltip:Content>
+</twig:Tooltip>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="tooltip" data-tooltip-delay-duration-value="700" data-tooltip-skip-delay-duration-value="300" data-slot="tooltip" class="relative inline-block ">
+<span data-tooltip-target="trigger" data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide" aria-describedby="tooltip-content" class=""><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 h-9 px-4 py-2 has-[&gt;svg]:px-3">Hover me</button>
+    </span>
+    <div data-tooltip-target="content" data-slot="tooltip-content" data-side="top" id="tooltip-content" role="tooltip" class="absolute z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground pointer-events-none opacity-0 transition-opacity duration-200 bottom-full left-1/2 -translate-x-1/2" style="margin-bottom: 10px; ">
+<p>Add to library</p>
+    <span class="absolute h-2 w-2 bg-primary rotate-45 bottom-[-4px] left-1/2 -translate-x-1/2"></span>
+</div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 2__1.html
@@ -1,0 +1,81 @@
+<!--
+- Kit: Shadcn UI
+- Component: Tooltip
+- Code:
+```twig
+<div class="flex flex-col gap-4 items-center justify-center">
+    <twig:Tooltip>
+        <twig:Tooltip:Trigger as="span">
+            <twig:Button variant="outline">Top (default)</twig:Button>
+        </twig:Tooltip:Trigger>
+        <twig:Tooltip:Content side="top">
+            Tooltip on top
+        </twig:Tooltip:Content>
+    </twig:Tooltip>
+
+    <div class="flex gap-4">
+        <twig:Tooltip>
+            <twig:Tooltip:Trigger as="span">
+                <twig:Button variant="outline">Left</twig:Button>
+            </twig:Tooltip:Trigger>
+            <twig:Tooltip:Content side="left">
+                Tooltip on left
+            </twig:Tooltip:Content>
+        </twig:Tooltip>
+
+        <twig:Tooltip>
+            <twig:Tooltip:Trigger as="span">
+                <twig:Button variant="outline">Right</twig:Button>
+            </twig:Tooltip:Trigger>
+            <twig:Tooltip:Content side="right">
+                Tooltip on right
+            </twig:Tooltip:Content>
+        </twig:Tooltip>
+    </div>
+
+    <twig:Tooltip>
+        <twig:Tooltip:Trigger as="span">
+            <twig:Button variant="outline">Bottom</twig:Button>
+        </twig:Tooltip:Trigger>
+        <twig:Tooltip:Content side="bottom">
+            Tooltip on bottom
+        </twig:Tooltip:Content>
+    </twig:Tooltip>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col gap-4 items-center justify-center">
+    <div data-controller="tooltip" data-tooltip-delay-duration-value="700" data-tooltip-skip-delay-duration-value="300" data-slot="tooltip" class="relative inline-block ">
+<span data-tooltip-target="trigger" data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide" aria-describedby="tooltip-content" class=""><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 h-9 px-4 py-2 has-[&gt;svg]:px-3">Top (default)</button>
+        </span>
+        <div data-tooltip-target="content" data-slot="tooltip-content" data-side="top" id="tooltip-content" role="tooltip" class="absolute z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground pointer-events-none opacity-0 transition-opacity duration-200 bottom-full left-1/2 -translate-x-1/2" style="margin-bottom: 10px; ">Tooltip on top
+        <span class="absolute h-2 w-2 bg-primary rotate-45 bottom-[-4px] left-1/2 -translate-x-1/2"></span>
+</div>
+    </div>
+
+    <div class="flex gap-4">
+        <div data-controller="tooltip" data-tooltip-delay-duration-value="700" data-tooltip-skip-delay-duration-value="300" data-slot="tooltip" class="relative inline-block ">
+<span data-tooltip-target="trigger" data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide" aria-describedby="tooltip-content" class=""><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 h-9 px-4 py-2 has-[&gt;svg]:px-3">Left</button>
+            </span>
+            <div data-tooltip-target="content" data-slot="tooltip-content" data-side="left" id="tooltip-content" role="tooltip" class="absolute z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground pointer-events-none opacity-0 transition-opacity duration-200 right-full top-1/2 -translate-y-1/2" style="margin-right: 10px; ">Tooltip on left
+            <span class="absolute h-2 w-2 bg-primary rotate-45 right-[-4px] top-1/2 -translate-y-1/2"></span>
+</div>
+        </div>
+
+        <div data-controller="tooltip" data-tooltip-delay-duration-value="700" data-tooltip-skip-delay-duration-value="300" data-slot="tooltip" class="relative inline-block ">
+<span data-tooltip-target="trigger" data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide" aria-describedby="tooltip-content" class=""><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 h-9 px-4 py-2 has-[&gt;svg]:px-3">Right</button>
+            </span>
+            <div data-tooltip-target="content" data-slot="tooltip-content" data-side="right" id="tooltip-content" role="tooltip" class="absolute z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground pointer-events-none opacity-0 transition-opacity duration-200 left-full top-1/2 -translate-y-1/2" style="margin-left: 10px; ">Tooltip on right
+            <span class="absolute h-2 w-2 bg-primary rotate-45 left-[-4px] top-1/2 -translate-y-1/2"></span>
+</div>
+        </div>
+    </div>
+
+    <div data-controller="tooltip" data-tooltip-delay-duration-value="700" data-tooltip-skip-delay-duration-value="300" data-slot="tooltip" class="relative inline-block ">
+<span data-tooltip-target="trigger" data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide" aria-describedby="tooltip-content" class=""><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 h-9 px-4 py-2 has-[&gt;svg]:px-3">Bottom</button>
+        </span>
+        <div data-tooltip-target="content" data-slot="tooltip-content" data-side="bottom" id="tooltip-content" role="tooltip" class="absolute z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground pointer-events-none opacity-0 transition-opacity duration-200 top-full left-1/2 -translate-x-1/2" style="margin-top: 10px; ">Tooltip on bottom
+        <span class="absolute h-2 w-2 bg-primary rotate-45 top-[-4px] left-1/2 -translate-x-1/2"></span>
+</div>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 3__1.html
@@ -1,0 +1,26 @@
+<!--
+- Kit: Shadcn UI
+- Component: Tooltip
+- Code:
+```twig
+<twig:Tooltip>
+    <twig:Tooltip:Trigger as="span">
+        <twig:Button variant="ghost" size="icon">
+            <twig:ux:icon name="lucide:info" class="size-4" />
+        </twig:Button>
+    </twig:Tooltip:Trigger>
+    <twig:Tooltip:Content>
+        <p>This is helpful information</p>
+    </twig:Tooltip:Content>
+</twig:Tooltip>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="tooltip" data-tooltip-delay-duration-value="700" data-tooltip-skip-delay-duration-value="300" data-slot="tooltip" class="relative inline-block ">
+<span data-tooltip-target="trigger" data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide" aria-describedby="tooltip-content" class=""><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 size-9"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><path d="M12 16v-4m0-4h.01"></path></g></svg>
+        </button>
+    </span>
+    <div data-tooltip-target="content" data-slot="tooltip-content" data-side="top" id="tooltip-content" role="tooltip" class="absolute z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground pointer-events-none opacity-0 transition-opacity duration-200 bottom-full left-1/2 -translate-x-1/2" style="margin-bottom: 10px; ">
+<p>This is helpful information</p>
+    <span class="absolute h-2 w-2 bg-primary rotate-45 bottom-[-4px] left-1/2 -translate-x-1/2"></span>
+</div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 4__1.html
@@ -1,0 +1,22 @@
+<!--
+- Kit: Shadcn UI
+- Component: Tooltip
+- Code:
+```twig
+<twig:Tooltip delayDuration="200">
+    <twig:Tooltip:Trigger as="span">
+        <twig:Button variant="outline">Quick tooltip (200ms)</twig:Button>
+    </twig:Tooltip:Trigger>
+    <twig:Tooltip:Content>
+        This appears quickly!
+    </twig:Tooltip:Content>
+</twig:Tooltip>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="tooltip" data-tooltip-delay-duration-value="200" data-tooltip-skip-delay-duration-value="300" data-slot="tooltip" class="relative inline-block ">
+<span data-tooltip-target="trigger" data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide" aria-describedby="tooltip-content" class=""><button data-slot="button" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 h-9 px-4 py-2 has-[&gt;svg]:px-3">Quick tooltip (200ms)</button>
+    </span>
+    <div data-tooltip-target="content" data-slot="tooltip-content" data-side="top" id="tooltip-content" role="tooltip" class="absolute z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground pointer-events-none opacity-0 transition-opacity duration-200 bottom-full left-1/2 -translate-x-1/2" style="margin-bottom: 10px; ">This appears quickly!
+    <span class="absolute h-2 w-2 bg-primary rotate-45 bottom-[-4px] left-1/2 -translate-x-1/2"></span>
+</div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 5__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component tooltip, code 5__1.html
@@ -1,0 +1,30 @@
+<!--
+- Kit: Shadcn UI
+- Component: Tooltip
+- Code:
+```twig
+<div class="text-sm text-muted-foreground">
+    You can use tooltips on
+    <twig:Tooltip>
+        <twig:Tooltip:Trigger as="span" class="underline decoration-dotted">
+            inline text
+        </twig:Tooltip:Trigger>
+        <twig:Tooltip:Content>
+            Like this!
+        </twig:Tooltip:Content>
+    </twig:Tooltip>
+    to provide additional context.
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="text-sm text-muted-foreground">
+    You can use tooltips on
+    <div data-controller="tooltip" data-tooltip-delay-duration-value="700" data-tooltip-skip-delay-duration-value="300" data-slot="tooltip" class="relative inline-block ">
+<span data-tooltip-target="trigger" data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide" aria-describedby="tooltip-content" class="underline decoration-dotted">inline text
+        </span>
+        <div data-tooltip-target="content" data-slot="tooltip-content" data-side="top" id="tooltip-content" role="tooltip" class="absolute z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground pointer-events-none opacity-0 transition-opacity duration-200 bottom-full left-1/2 -translate-x-1/2" style="margin-bottom: 10px; ">Like this!
+        <span class="absolute h-2 w-2 bg-primary rotate-45 bottom-[-4px] left-1/2 -translate-x-1/2"></span>
+</div>
+    </div>
+    to provide additional context.
+</div>

--- a/ux.symfony.com/assets/toolkit-shadcn.js
+++ b/ux.symfony.com/assets/toolkit-shadcn.js
@@ -2,7 +2,9 @@ import './styles/toolkit-shadcn.css';
 import { startStimulusApp } from '@symfony/stimulus-bundle';
 import AlertDialog from '@symfony/ux-toolkit/kits/shadcn/alert-dialog/assets/controllers/alert_dialog_controller.js';
 import Dialog from '@symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js';
+import Tooltip from '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js';
 
 const app = startStimulusApp();
 app.register('alert-dialog', AlertDialog);
 app.register('dialog', Dialog);
+app.register('tooltip', Tooltip);

--- a/ux.symfony.com/importmap.php
+++ b/ux.symfony.com/importmap.php
@@ -204,6 +204,9 @@ return [
     '@symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js',
+    ],
     'el-transition' => [
         'version' => '0.0.7',
     ],


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes 
| Deprecations?  | no 
| Documentation? | yes
| Issues         |  Tracked in https://github.com/symfony/ux/issues/3233
| License        | MIT

This PR introduces a new Tooltip component for Symfony UX based on shadcn.

