### PR TITLE
[StimulusBundle] Change AssetMapper `excluded_patterns` from `**/controllers.json` to `*/controllers.json`

### DIFF
--- a/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
+++ b/src/StimulusBundle/src/DependencyInjection/StimulusExtension.php
@@ -56,7 +56,7 @@ final class StimulusExtension extends Extension implements PrependExtensionInter
                 ],
                 'excluded_patterns' => [
                     '*.d.ts',
-                    '**/controllers.json',
+                    '*/controllers.json',
                 ],
             ],
         ]);


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Related to https://github.com/symfony/symfony/issues/61771


I wasn't able to run `perf` either (I'm on Mac), but I was still able to see performance improvements. 

Here is a list of assets from the Symfony Demo, that the AssetMapper should exclude (or not) depending on `exclude_patterns`:  
```
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/controllers.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/controllers.d.ts
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/loader.d.ts
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/loader.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live.min.css
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live_controller.d.ts
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live_controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/highlight.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/jquery_global.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/flatpicker.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/doclinks.js
/Users/kocal/workspace/symfony/symfony-demo/assets/stimulus_bootstrap.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers.json
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootstrap-tagsinput.css
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/_variables.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/admin.css
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootswatch/_variables.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootswatch/_bootswatch.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootswatch/README.md
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/_rtl.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/app.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/search.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/device-floppy.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/list.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/user.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/home.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/logout.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/tag.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/lock.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/ban.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/calendar-month.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/key.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/arrow-right.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/settings.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/login.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/code.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/rss.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/world.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/message.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/messages.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/send.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/trash.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/users-group.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/pencil.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/eye.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/tags.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/id-badge-2.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/arrow-left.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/brand-x.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/admin.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/login-controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/.gitignore
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/csrf_protection_controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/app.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@hotwired/stimulus/stimulus.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@popperjs/core/core.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap/bootstrap.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/typeahead.js/typeahead.js.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/css/lato-font.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold-italic/lato-semibold-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold-italic/lato-semibold-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline/lato-hairline.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline/lato-hairline.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light-italic/lato-light-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light-italic/lato-light-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline-italic/lato-hairline-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline-italic/lato-hairline-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold/lato-bold.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold/lato-bold.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin/lato-thin.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin/lato-thin.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium-italic/lato-medium-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium-italic/lato-medium-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium/lato-medium.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium/lato-medium.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy-italic/lato-heavy-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy-italic/lato-heavy-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal/lato-normal.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal/lato-normal.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black/lato-black.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black/lato-black.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy/lato-heavy.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy/lato-heavy.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light/lato-light.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light/lato-light.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold/lato-semibold.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold/lato-semibold.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold-italic/lato-bold-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold-italic/lato-bold-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin-italic/lato-thin-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin-italic/lato-thin-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal-italic/lato-normal-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal-italic/lato-normal-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black-italic/lato-black-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black-italic/lato-black-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/jquery/jquery.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/dist/l10n.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/dist/flatpickr.min.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/flatpickr.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/superagent/superagent.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bloodhound-js/bloodhound-js.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/storage2/storage2.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/styles/github-dark-dimmed.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/core.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/languages/php.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/languages/twig.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap-tagsinput/bootstrap-tagsinput.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/object-assign/object-assign.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/installed.php
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/es6-promise/es6-promise.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/component-emitter/component-emitter.index.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/controllers.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live_controller.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live_controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@hotwired/stimulus/stimulus.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@hotwired/stimulus/stimulus.index.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live.min.css
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live.min.css
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/login-controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/login-controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@hotwired/stimulus/stimulus.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@hotwired/stimulus/stimulus.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/csrf_protection_controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/csrf_protection_controller.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live_controller.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live_controller.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live.min.css
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live.min.css
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/login-controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/login-controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/csrf_protection_controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/csrf_protection_controller.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/loader.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@hotwired/stimulus/stimulus.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@hotwired/stimulus/stimulus.index.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/controllers.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/controllers.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live.min.css
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/ux-live-component/assets/dist/live_controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/highlight.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/core.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/core.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/languages/php.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/languages/php.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/languages/twig.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/languages/twig.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/jquery_global.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/flatpicker.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/flatpickr.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/flatpickr.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/dist/flatpickr.min.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/dist/flatpickr.min.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/dist/l10n.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/dist/l10n.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/doclinks.js
/Users/kocal/workspace/symfony/symfony-demo/assets/stimulus_bootstrap.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/loader.js
/Users/kocal/workspace/symfony/symfony-demo/vendor/symfony/stimulus-bundle/assets/dist/loader.js
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootstrap-tagsinput.css
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/_variables.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/admin.css
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootswatch/_variables.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootswatch/_bootswatch.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootswatch/README.md
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/_rtl.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/app.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/search.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/device-floppy.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/list.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/user.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/home.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/logout.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/tag.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/lock.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/ban.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/calendar-month.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/key.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/arrow-right.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/settings.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/login.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/code.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/rss.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/world.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/message.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/messages.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/send.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/trash.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/users-group.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/pencil.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/eye.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/tags.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/id-badge-2.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/arrow-left.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/icons/tabler/brand-x.svg
/Users/kocal/workspace/symfony/symfony-demo/assets/admin.js
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/admin.css
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/admin.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap/bootstrap.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap/bootstrap.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@popperjs/core/core.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@popperjs/core/core.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/typeahead.js/typeahead.js.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/typeahead.js/typeahead.js.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/jquery/jquery.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/jquery/jquery.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bloodhound-js/bloodhound-js.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bloodhound-js/bloodhound-js.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/object-assign/object-assign.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/object-assign/object-assign.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/es6-promise/es6-promise.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/es6-promise/es6-promise.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/storage2/storage2.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/storage2/storage2.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/superagent/superagent.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/superagent/superagent.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/component-emitter/component-emitter.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/component-emitter/component-emitter.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/jquery_global.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/jquery_global.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap-tagsinput/bootstrap-tagsinput.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap-tagsinput/bootstrap-tagsinput.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootstrap-tagsinput.css
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/bootstrap-tagsinput.css
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/login-controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/controllers/csrf_protection_controller.js
/Users/kocal/workspace/symfony/symfony-demo/assets/app.js
/Users/kocal/workspace/symfony/symfony-demo/assets/stimulus_bootstrap.js
/Users/kocal/workspace/symfony/symfony-demo/assets/stimulus_bootstrap.js
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/app.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/styles/app.scss
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/styles/github-dark-dimmed.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/styles/github-dark-dimmed.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/css/lato-font.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/css/lato-font.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline/lato-hairline.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline/lato-hairline.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline/lato-hairline.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline/lato-hairline.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline-italic/lato-hairline-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline-italic/lato-hairline-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline-italic/lato-hairline-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline-italic/lato-hairline-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin/lato-thin.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin/lato-thin.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin/lato-thin.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin/lato-thin.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin-italic/lato-thin-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin-italic/lato-thin-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin-italic/lato-thin-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin-italic/lato-thin-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light/lato-light.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light/lato-light.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light/lato-light.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light/lato-light.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light-italic/lato-light-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light-italic/lato-light-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light-italic/lato-light-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light-italic/lato-light-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal/lato-normal.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal/lato-normal.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal/lato-normal.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal/lato-normal.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal-italic/lato-normal-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal-italic/lato-normal-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal-italic/lato-normal-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal-italic/lato-normal-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium/lato-medium.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium/lato-medium.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium/lato-medium.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium/lato-medium.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium-italic/lato-medium-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium-italic/lato-medium-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium-italic/lato-medium-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium-italic/lato-medium-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold/lato-semibold.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold/lato-semibold.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold/lato-semibold.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold/lato-semibold.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold-italic/lato-semibold-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold-italic/lato-semibold-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold-italic/lato-semibold-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold-italic/lato-semibold-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold/lato-bold.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold/lato-bold.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold/lato-bold.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold/lato-bold.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold-italic/lato-bold-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold-italic/lato-bold-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold-italic/lato-bold-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold-italic/lato-bold-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy/lato-heavy.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy/lato-heavy.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy/lato-heavy.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy/lato-heavy.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy-italic/lato-heavy-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy-italic/lato-heavy-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy-italic/lato-heavy-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy-italic/lato-heavy-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black/lato-black.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black/lato-black.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black/lato-black.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black/lato-black.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black-italic/lato-black-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black-italic/lato-black-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black-italic/lato-black-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black-italic/lato-black-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap/bootstrap.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap/bootstrap.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/highlight.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/highlight.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/doclinks.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/doclinks.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/flatpicker.js
/Users/kocal/workspace/symfony/symfony-demo/assets/js/flatpicker.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@hotwired/stimulus/stimulus.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/@popperjs/core/core.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap/bootstrap.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/typeahead.js/typeahead.js.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/css/lato-font.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold-italic/lato-semibold-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold-italic/lato-semibold-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline/lato-hairline.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline/lato-hairline.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light-italic/lato-light-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light-italic/lato-light-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline-italic/lato-hairline-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-hairline-italic/lato-hairline-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold/lato-bold.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold/lato-bold.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin/lato-thin.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin/lato-thin.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium-italic/lato-medium-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium-italic/lato-medium-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium/lato-medium.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-medium/lato-medium.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy-italic/lato-heavy-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy-italic/lato-heavy-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal/lato-normal.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal/lato-normal.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black/lato-black.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black/lato-black.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy/lato-heavy.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-heavy/lato-heavy.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light/lato-light.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-light/lato-light.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold/lato-semibold.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-semibold/lato-semibold.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold-italic/lato-bold-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-bold-italic/lato-bold-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin-italic/lato-thin-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-thin-italic/lato-thin-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal-italic/lato-normal-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-normal-italic/lato-normal-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black-italic/lato-black-italic.woff2
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/lato-font/fonts/lato-black-italic/lato-black-italic.woff
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/jquery/jquery.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/dist/l10n.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/dist/flatpickr.min.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/flatpickr/flatpickr.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/superagent/superagent.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bloodhound-js/bloodhound-js.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/storage2/storage2.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/styles/github-dark-dimmed.css
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/core.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/languages/php.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/highlight.js/lib/languages/twig.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/bootstrap-tagsinput/bootstrap-tagsinput.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/object-assign/object-assign.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/es6-promise/es6-promise.index.js
/Users/kocal/workspace/symfony/symfony-demo/assets/vendor/component-emitter/component-emitter.index.js
 // Compiled 105 assets
```

Given the following patterns:
1. `controllers.json` → `#^(?=[^\.])controllers\.json$#`, the regex does not match directories, let's ignore it, 
2. `**/controllers.json` → `^(?=[^\.])/?(?=[^\.]).*.*/(?=[^\.])controllers\.json$`: running it on [regex101](https://regex101.com/r/eVCKkI/1) (with `mg` flags) costs **~75ms** 
3. `*/controllers.json` → `#^(?=[^\.]).*/(?=[^\.])controllers\.json$`: running it on [regex101](https://regex101.com/r/E0lD4Q/1) (with `mg` flags) costs **~2ms**, **~37.5x less! 🚀**

And of course, pattern `*/controllers.json` has no issue for matching the following path:
- `/Users/kocal/workspace/symfony/symfony-demo/assets/controllers.json`
- `/Users/kocal/workspace/symfony/symfony-demo/assets/foo/controllers.json`
- `/Users/kocal/workspace/symfony/symfony-demo/assets/foo/bar/controllers.json`

There is no BC.