### PR TITLE
 [Toolkit][Shadcn] Fix text color of `Badge` destructive variant

### DIFF
--- a/src/Toolkit/kits/shadcn/badge/templates/components/Badge.html.twig
+++ b/src/Toolkit/kits/shadcn/badge/templates/components/Badge.html.twig
@@ -7,7 +7,7 @@
         variant: {
             default: 'border-transparent bg-primary text-primary-foreground',
             secondary: 'border-transparent bg-secondary text-secondary-foreground',
-            destructive: 'border-transparent bg-destructive text-destructive-foreground',
+            destructive: 'border-transparent bg-destructive text-white',
             outline: 'text-foreground',
         },
     },

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component badge, code 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component badge, code 4__1.html
@@ -8,5 +8,5 @@
 </twig:Badge>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-destructive text-destructive-foreground">Badge
+<div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-destructive text-white">Badge
 </div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

See https://ux.symfony.com/toolkit/kits/shadcn/components/badge

<img width="1127" height="303" alt="image" src="https://github.com/user-attachments/assets/97450c66-fbb2-4881-ba8d-bfbbf1bcb530" />

Vs shadcn website https://ui.shadcn.com/docs/components/badge
<img width="409" height="124" alt="image" src="https://github.com/user-attachments/assets/ebebd1c4-d70c-431c-92da-f07a73ebf273" />
