### PR TITLE
[Translator] Fix broken link in `Translator` doc

### DIFF
--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -12,11 +12,6 @@ The `ICU Message Format`_ is also supported.
 Installation
 ------------
 
-.. note::
-
-    This package works best with WebpackEncore. To use it with AssetMapper, see
-    :ref:`Using with AssetMapper`_.
-
 .. caution::
 
     Before you start, make sure you have `StimulusBundle configured in your app`_.


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | 
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | No issue
| License        | MIT

Currently this link is broken in [documentation](https://symfony.com/bundles/ux-translator/current/index.html#installation) 
