### PR TITLE
[LiveComponent] Support DataModel bindings with LiveComponent modifiers

### DIFF
--- a/src/LiveComponent/src/EventListener/DataModelPropsSubscriber.php
+++ b/src/LiveComponent/src/EventListener/DataModelPropsSubscriber.php
@@ -65,6 +65,12 @@ final class DataModelPropsSubscriber implements EventSubscriberInterface
             $childModel = $binding['child'];
             $parentModel = $binding['parent'];
 
+            // If the data-model attribute contains LiveComponent-specific modifiers, extract the actual property name
+            if (str_contains($parentModel, '|')) {
+                $parentModelParts = explode('|', $parentModel);
+                $parentModel = end($parentModelParts);
+            }
+
             $data[$childModel] = $this->propertyAccessor->getValue($parentMountedComponent->getComponent(), $parentModel);
         }
 

--- a/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModelWithModifiers.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModelWithModifiers.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('parent_component_data_model_with_modifiers')]
+final class ParentComponentDataModelWithModifiers
+{
+    use DefaultActionTrait;
+}

--- a/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModelWithModifiers2.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModelWithModifiers2.php
@@ -20,5 +20,6 @@ final class ParentComponentDataModelWithModifiers2
 {
     use DefaultActionTrait;
 
-    #[LiveProp(writable: true)] public string $content;
+    #[LiveProp(writable: true)]
+    public string $content;
 }

--- a/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModelWithModifiers2.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ParentComponentDataModelWithModifiers2.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('parent_component_data_model_with_modifiers_2')]
+final class ParentComponentDataModelWithModifiers2
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)] public string $content;
+}

--- a/src/LiveComponent/tests/Fixtures/Component/ParentFormComponentWithModifiers.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ParentFormComponentWithModifiers.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('parent_form_component_with_modifiers')]
+final class ParentFormComponentWithModifiers
+{
+    use DefaultActionTrait;
+
+    public ?string $content = null;
+
+    public ?string $content2 = null;
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/parent_component_data_model_with_modifiers.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/parent_component_data_model_with_modifiers.html.twig
@@ -1,0 +1,2 @@
+{% component parent_component_data_model_with_modifiers_2 with { content: 'default content on mount' } %}
+{% endcomponent %}

--- a/src/LiveComponent/tests/Fixtures/templates/components/parent_component_data_model_with_modifiers_2.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/parent_component_data_model_with_modifiers_2.html.twig
@@ -1,0 +1,2 @@
+{{ component('textarea_component', { dataModel: 'norender|content' }) }}
+{% component input_component with { dataModel: 'norender|content' } %}{% endcomponent %}

--- a/src/LiveComponent/tests/Fixtures/templates/components/parent_form_component_with_modifiers.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/parent_form_component_with_modifiers.html.twig
@@ -1,0 +1,11 @@
+<div>
+    {{ component('textarea_component', {
+        'data-model': 'norender|content:value'
+    }) }}
+</div>
+
+<div>
+    {{ component('textarea_component', {
+        'dataModel': 'norender|content2:value'
+    }) }}
+</div>

--- a/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
+++ b/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
@@ -54,4 +54,39 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
         $this->assertStringContainsString('<textarea data-model="content">default content on mount</textarea>', $html);
         $this->assertStringContainsString('<input data-model="content" value="default content on mount" />', $html);
     }
+
+    public function testDataModelPropsWithModifiersAreSharedToChild()
+    {
+        /** @var ComponentRenderer $renderer */
+        $renderer = self::getContainer()->get('ux.twig_component.component_renderer');
+
+        $html = $renderer->createAndRender('parent_form_component_with_modifiers', [
+            'content' => 'Hello data-model!',
+            'content2' => 'Value for second child',
+            'attributes' => ['id' => 'dummy-live-id'],
+        ]);
+
+        // Verify that the data-model attributes include the "norender" modifier and that values are passed correctly
+        $this->assertStringContainsString('<textarea data-model="norender|content:value">Hello data-model!</textarea>', $html);
+        $this->assertStringContainsString('<textarea data-model="norender|content2:value">Value for second child</textarea>', $html);
+    }
+
+    public function testDataModelPropsWithModifiersAreAvailableInEmbeddedComponents()
+    {
+        $templateName = 'components/parent_component_data_model_with_modifiers.html.twig';
+        $obscuredName = '684c45bf85d3461dbe587407892e59d9';
+        $this->addTemplateMap($obscuredName, $templateName);
+
+        /** @var ComponentRenderer $renderer */
+        $renderer = self::getContainer()->get('ux.twig_component.component_renderer');
+
+        $html = $renderer->createAndRender('parent_component_data_model_with_modifiers', [
+            'attributes' => ['id' => 'dummy-live-id'],
+        ]);
+
+        // Verify that the data-model attributes include the "norender" modifier and that values are passed correctly
+        $this->assertStringContainsString('<textarea data-model="norender|content">default content on mount</textarea>', $html);
+        $this->assertStringContainsString('<input data-model="norender|content" value="default content on mount" />', $html);
+    }
+
 }

--- a/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
+++ b/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
@@ -88,5 +88,4 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
         $this->assertStringContainsString('<textarea data-model="norender|content">default content on mount</textarea>', $html);
         $this->assertStringContainsString('<input data-model="norender|content" value="default content on mount" />', $html);
     }
-
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3152, Fix #555
| License        | MIT

[LiveComponent] 
### Support DataModel bindings with LiveComponent modifiers

The data-model attribute is used by both the Data Binding (for parent-child prop binding) and LiveComponent (for form input binding with modifiers). This was causing LiveComponent modifiers like 'norender|field' or 'debounce(100)|field' to fail because the property was not extracted from the LiveComponent data-model attribute, but was used directly as a property

This fix adds modifier detection to DataModelPropsSubscriber that checks if data-model contains LiveComponent modifier syntax (pipe '|') and extracts the value from the modifier syntax

Co-developed with @mrbase