### PR TITLE
[Icons] Add support for suffixes

### DIFF
--- a/src/Icons/CHANGELOG.md
+++ b/src/Icons/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.33
+
+- Add support for suffixes
+
 ## 2.30
 
 - Ensure compatibility with PHP 8.5

--- a/src/Icons/config/services.php
+++ b/src/Icons/config/services.php
@@ -70,6 +70,8 @@ return static function (ContainerConfigurator $container): void {
                 service('.ux_icons.icon_registry'),
                 abstract_arg('default_icon_attributes'),
                 abstract_arg('icon_aliases'),
+                abstract_arg('icon_set_attributes'),
+                abstract_arg('icon_suffix_attributes'),
             ])
 
         ->alias(IconRendererInterface::class, '.ux_icons.icon_renderer')

--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -443,6 +443,60 @@ Now, you can use the ``dots`` alias in your templates:
     {# same as: #}
     <twig:ux:icon name="clarity:ellipsis-horizontal-line" />
 
+Icon Set Suffixes
+~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.33
+
+    Icon Set Suffixes feature was added in 2.33.
+
+Some icon sets like `Heroicons`_ use suffixes to denote icon variants
+(e.g. ``arrow-right-solid``, ``arrow-right-16-solid``, ``arrow-right-20-solid``).
+You can configure suffix-based attributes to automatically apply different
+attributes depending on the icon name suffix:
+
+.. code-block:: yaml
+
+    # config/packages/ux_icons.yaml
+    ux_icons:
+        icon_sets:
+            heroicons:
+                icon_attributes:
+                    data-slot: 'icon'
+                suffixes:
+                    16-solid:
+                        icon_attributes:
+                            fill: 'currentColor'
+                    20-solid:
+                        icon_attributes:
+                            fill: 'currentColor'
+                    solid:
+                        icon_attributes:
+                            fill: 'currentColor'
+                    '':
+                        icon_attributes:
+                            stroke: 'currentColor'
+                            stroke-width: 1.5
+                            fill: 'none'
+
+With this configuration, all icons in the ``heroicons`` set will have
+``data-slot="icon"`` (from ``icon_attributes``), plus the suffix-specific attributes:
+
+- ``heroicons:arrow-right-16-solid`` will have ``data-slot="icon"`` and ``fill="currentColor"`` (matches the ``16-solid`` suffix)
+- ``heroicons:arrow-right-20-solid`` will have ``data-slot="icon"`` and ``fill="currentColor"`` (matches the ``20-solid`` suffix)
+- ``heroicons:arrow-right-solid`` will have ``data-slot="icon"`` and ``fill="currentColor"`` (matches the ``solid`` suffix)
+- ``heroicons:arrow-right`` will have ``data-slot="icon"``, ``stroke="currentColor"``, ``stroke-width="1.5"`` and ``fill="none"`` (no suffix matches, falls back to ``''``)
+
+Suffixes are automatically sorted by length (longest first) to ensure that
+more specific suffixes like ``16-solid`` or ``20-solid`` take precedence over
+``solid``.
+
+.. note::
+
+    The empty string suffix (``''``) acts as a fallback for icons that don't
+    match any other suffix. This is different from ``icon_attributes``, which
+    applies to **all** icons in the set regardless of suffix matching.
+
 Errors
 ------
 
@@ -670,6 +724,23 @@ Full Configuration
                     class: 'flag'    # Replace the default class
                     stroke: 'none'      # Add a new attribute
                     fill: false         # Use "false" to remove a default attribute
+
+                # Suffix-based attributes (following Iconify naming conventions)
+                suffixes:
+                    16-solid:
+                        icon_attributes:
+                            fill: 'currentColor'
+                    20-solid:
+                        icon_attributes:
+                            fill: 'currentColor'
+                    solid:
+                        icon_attributes:
+                            fill: 'currentColor'
+                    '':
+                        icon_attributes:
+                            stroke: 'currentColor'
+                            stroke-width: 1.5
+                            fill: 'none'
 
 Learn more
 ----------

--- a/src/Icons/src/DependencyInjection/UXIconsExtension.php
+++ b/src/Icons/src/DependencyInjection/UXIconsExtension.php
@@ -74,6 +74,24 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
                                     ->cannotBeEmpty()
                                 ->end()
                             ->end()
+                            ->arrayNode('suffixes')
+                                ->info("Suffix-based attributes (following Iconify naming conventions).\nhttps://iconify.design/docs/libraries/tools/icon-set/themes.html")
+                                ->normalizeKeys(false)
+                                ->useAttributeAsKey('suffix')
+                                ->arrayPrototype()
+                                    ->info('The suffix name (e.g. "solid", "20-solid")')
+                                    ->children()
+                                        ->arrayNode('icon_attributes')
+                                            ->info('Attributes for icons matching this suffix.')
+                                            ->normalizeKeys(false)
+                                            ->useAttributeAsKey('key')
+                                            ->scalarPrototype()
+                                                ->cannotBeEmpty()
+                                            ->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                     ->validate()
@@ -139,6 +157,7 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
         $iconSetAliases = [];
         $iconSetAttributes = [];
         $iconSetPaths = [];
+        $iconSuffixAttributes = [];
         foreach ($mergedConfig['icon_sets'] as $prefix => $config) {
             if (isset($config['icon_attributes'])) {
                 $iconSetAttributes[$prefix] = $config['icon_attributes'];
@@ -148,6 +167,11 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
             }
             if (isset($config['path'])) {
                 $iconSetPaths[$prefix] = $config['path'];
+            }
+            if (isset($config['suffixes'])) {
+                $suffixes = array_map(static fn ($s) => $s['icon_attributes'] ?? [], $config['suffixes']);
+                uksort($suffixes, static fn ($a, $b) => \strlen($b) <=> \strlen($a));
+                $iconSuffixAttributes[$prefix] = $suffixes;
             }
         }
 
@@ -166,6 +190,7 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
             ->setArgument(1, $mergedConfig['default_icon_attributes'])
             ->setArgument(2, $mergedConfig['aliases'])
             ->setArgument(3, $iconSetAttributes)
+            ->setArgument(4, $iconSuffixAttributes)
         ;
 
         $container->getDefinition('.ux_icons.twig_icon_runtime')

--- a/src/Icons/src/IconRenderer.php
+++ b/src/Icons/src/IconRenderer.php
@@ -19,15 +19,17 @@ namespace Symfony\UX\Icons;
 final class IconRenderer implements IconRendererInterface
 {
     /**
-     * @param array<string, mixed>                $defaultIconAttributes
-     * @param array<string, string>               $iconAliases
-     * @param array<string, array<string, mixed>> $iconSetsAttributes
+     * @param array<string, mixed>                               $defaultIconAttributes
+     * @param array<string, string>                              $iconAliases
+     * @param array<string, array<string, mixed>>                $iconSetsAttributes
+     * @param array<string, array<string, array<string, mixed>>> $iconSuffixAttributes
      */
     public function __construct(
         private readonly IconRegistryInterface $registry,
         private readonly array $defaultIconAttributes = [],
         private readonly array $iconAliases = [],
         private readonly array $iconSetsAttributes = [],
+        private readonly array $iconSuffixAttributes = [],
     ) {
     }
 
@@ -46,18 +48,57 @@ final class IconRenderer implements IconRendererInterface
 
         $icon = $this->registry->get($iconName);
 
+        $setAttributes = $suffixAttributes = [];
         if (0 < (int) $pos = strpos($name, ':')) {
-            $setAttributes = $this->iconSetsAttributes[substr($name, 0, $pos)] ?? [];
-        } elseif ($iconName !== $name && 0 < (int) $pos = strpos($iconName, ':')) {
-            $setAttributes = $this->iconSetsAttributes[substr($iconName, 0, $pos)] ?? [];
+            [$setAttributes, $suffixAttributes] = $this->resolveAttributes($name, $pos);
+        } elseif ($iconName !== $name && $pos = strpos($iconName, ':')) {
+            [$setAttributes, $suffixAttributes] = $this->resolveAttributes($iconName, $pos);
         }
-        $icon = $icon->withAttributes([...$this->defaultIconAttributes, ...($setAttributes ?? []), ...$attributes]);
+
+        $icon = $icon->withAttributes([
+            ...$this->defaultIconAttributes,
+            ...$setAttributes,
+            ...$suffixAttributes,
+            ...$attributes,
+        ]);
 
         foreach ($this->getPreRenderers() as $preRenderer) {
             $icon = $preRenderer($icon);
         }
 
         return $icon->toHtml();
+    }
+
+    /**
+     * Resolves set and suffix attributes for a given icon name.
+     *
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>}
+     */
+    private function resolveAttributes(string $name, int $pos): array
+    {
+        $prefix = substr($name, 0, $pos);
+
+        return [
+            $this->iconSetsAttributes[$prefix] ?? [],
+            $this->findSuffixAttributes($prefix, substr($name, $pos + 1)),
+        ];
+    }
+
+    /**
+     * Finds attributes for the matching suffix.
+     * Suffixes are pre-sorted by length (longest first).
+     *
+     * @return array<string, mixed>
+     */
+    private function findSuffixAttributes(string $prefix, string $iconNamePart): array
+    {
+        foreach ($this->iconSuffixAttributes[$prefix] ?? [] as $suffix => $config) {
+            if ('' === $suffix || str_ends_with($iconNamePart, '-'.$suffix)) {
+                return $config;
+            }
+        }
+
+        return [];
     }
 
     /**

--- a/src/Icons/tests/Unit/IconRendererTest.php
+++ b/src/Icons/tests/Unit/IconRendererTest.php
@@ -407,6 +407,172 @@ class IconRendererTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider provideRenderIconWithSuffixCases
+     */
+    public function testRenderIconWithSuffixes(string $name, string $expectedSvg)
+    {
+        $registry = $this->createRegistry([
+            'heroicons:arrow-right' => '<path d="outline"/>',
+            'heroicons:arrow-right-solid' => '<path d="solid"/>',
+            'heroicons:arrow-right-20-solid' => '<path d="20-solid"/>',
+        ]);
+        $iconSuffixAttributes = [
+            'heroicons' => [
+                '20-solid' => ['class' => 'icon-20 icon-solid'],
+                'solid' => ['class' => 'icon-solid'],
+                '' => ['class' => 'icon-outline'],
+            ],
+        ];
+        $iconRenderer = new IconRenderer($registry, [], [], [], $iconSuffixAttributes);
+
+        $svg = $iconRenderer->renderIcon($name);
+        $svg = str_replace(' aria-hidden="true"', '', $svg);
+        $this->assertSame($expectedSvg, $svg);
+    }
+
+    public static function provideRenderIconWithSuffixCases(): iterable
+    {
+        yield 'no suffix matches empty string suffix' => [
+            'heroicons:arrow-right',
+            '<svg class="icon-outline"><path d="outline"/></svg>',
+        ];
+        yield 'solid suffix matches' => [
+            'heroicons:arrow-right-solid',
+            '<svg class="icon-solid"><path d="solid"/></svg>',
+        ];
+        yield 'longest suffix wins (20-solid over solid)' => [
+            'heroicons:arrow-right-20-solid',
+            '<svg class="icon-20 icon-solid"><path d="20-solid"/></svg>',
+        ];
+    }
+
+    public function testRenderIconWithSuffixAttributeCascade()
+    {
+        $registry = $this->createRegistry([
+            'heroicons:arrow-solid' => ['<path d="solid"/>', ['ico' => 'ICON']],
+        ]);
+        $defaultAttributes = ['def' => 'DEF'];
+        $iconSetsAttributes = ['heroicons' => ['set' => 'SET']];
+        $iconSuffixAttributes = [
+            'heroicons' => [
+                'solid' => ['suf' => 'SUF'],
+            ],
+        ];
+        $iconRenderer = new IconRenderer($registry, $defaultAttributes, [], $iconSetsAttributes, $iconSuffixAttributes);
+
+        $svg = $iconRenderer->renderIcon('heroicons:arrow-solid', ['ren' => 'REN']);
+        $svg = str_replace(' aria-hidden="true"', '', $svg);
+
+        $this->assertSame('<svg ico="ICON" def="DEF" set="SET" suf="SUF" ren="REN">', substr($svg, 0, strpos($svg, '>') + 1));
+    }
+
+    public function testRenderIconWithSuffixOverwritesCascade()
+    {
+        $registry = $this->createRegistry([
+            'heroicons:arrow-solid' => '<path d="solid"/>',
+        ]);
+        $defaultAttributes = ['class' => 'default'];
+        $iconSetsAttributes = ['heroicons' => ['class' => 'icon-set']];
+        $iconSuffixAttributes = [
+            'heroicons' => [
+                'solid' => ['class' => 'icon-solid'],
+            ],
+        ];
+        $iconRenderer = new IconRenderer($registry, $defaultAttributes, [], $iconSetsAttributes, $iconSuffixAttributes);
+
+        $svg = $iconRenderer->renderIcon('heroicons:arrow-solid');
+        $svg = str_replace(' aria-hidden="true"', '', $svg);
+
+        $this->assertSame('<svg class="icon-solid"><path d="solid"/></svg>', $svg);
+    }
+
+    public function testRenderIconWithSuffixAndRenderTimeOverwrite()
+    {
+        $registry = $this->createRegistry([
+            'heroicons:arrow-solid' => '<path d="solid"/>',
+        ]);
+        $iconSuffixAttributes = [
+            'heroicons' => [
+                'solid' => ['class' => 'icon-solid'],
+            ],
+        ];
+        $iconRenderer = new IconRenderer($registry, [], [], [], $iconSuffixAttributes);
+
+        $svg = $iconRenderer->renderIcon('heroicons:arrow-solid', ['class' => 'custom']);
+        $svg = str_replace(' aria-hidden="true"', '', $svg);
+
+        $this->assertSame('<svg class="custom"><path d="solid"/></svg>', $svg);
+    }
+
+    public function testRenderIconWithoutSuffixesRemainsBackwardsCompatible()
+    {
+        $registry = $this->createRegistry([
+            'heroicons:arrow' => '<path d="arrow"/>',
+        ]);
+        $iconRenderer = new IconRenderer($registry, ['class' => 'icon'], [], ['heroicons' => ['fill' => 'none']]);
+
+        $svg = $iconRenderer->renderIcon('heroicons:arrow');
+        $svg = str_replace(' aria-hidden="true"', '', $svg);
+
+        $this->assertSame('<svg class="icon" fill="none"><path d="arrow"/></svg>', $svg);
+    }
+
+    public function testRenderIconWithSuffixAndAliases()
+    {
+        $registry = $this->createRegistry([
+            'heroicons:arrow-solid' => '<path d="solid"/>',
+        ]);
+        $iconAliases = ['arrow' => 'heroicons:arrow-solid'];
+        $iconSuffixAttributes = [
+            'heroicons' => [
+                'solid' => ['class' => 'icon-solid'],
+            ],
+        ];
+        $iconRenderer = new IconRenderer($registry, [], $iconAliases, [], $iconSuffixAttributes);
+
+        $svg = $iconRenderer->renderIcon('arrow');
+        $svg = str_replace(' aria-hidden="true"', '', $svg);
+
+        $this->assertSame('<svg class="icon-solid"><path d="solid"/></svg>', $svg);
+    }
+
+    public function testRenderIconWithNoMatchingSuffix()
+    {
+        $registry = $this->createRegistry([
+            'heroicons:arrow-unknown' => '<path d="unknown"/>',
+        ]);
+        $iconSuffixAttributes = [
+            'heroicons' => [
+                'solid' => ['class' => 'icon-solid'],
+            ],
+        ];
+        $iconRenderer = new IconRenderer($registry, ['class' => 'default'], [], [], $iconSuffixAttributes);
+
+        $svg = $iconRenderer->renderIcon('heroicons:arrow-unknown');
+        $svg = str_replace(' aria-hidden="true"', '', $svg);
+
+        $this->assertSame('<svg class="default"><path d="unknown"/></svg>', $svg);
+    }
+
+    public function testRenderIconWithSuffixOnIconSetWithoutSuffixes()
+    {
+        $registry = $this->createRegistry([
+            'other:icon-solid' => '<path d="solid"/>',
+        ]);
+        $iconSuffixAttributes = [
+            'heroicons' => [
+                'solid' => ['class' => 'icon-solid'],
+            ],
+        ];
+        $iconRenderer = new IconRenderer($registry, [], [], [], $iconSuffixAttributes);
+
+        $svg = $iconRenderer->renderIcon('other:icon-solid');
+        $svg = str_replace(' aria-hidden="true"', '', $svg);
+
+        $this->assertSame('<svg><path d="solid"/></svg>', $svg);
+    }
+
     private function createRegistry(array $icons): IconRegistryInterface
     {
         $registryIcons = [];


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix https://github.com/symfony/ux/issues/3312
| License        | MIT

 This feature allows configuring icon attributes based on icon name suffixes. This is particularly useful for icon sets like Heroicons that use suffixes to distinguish icon variants (e.g., `arrow-right-solid`, `arrow-right-20-solid`, etc).

  Example configuration:

```yaml
ux_icons:
    icon_sets:
        heroicons:
            icon_attributes:
                data-slot: 'icon'
            suffixes:
                16-solid:
                    icon_attributes:
                        fill: 'currentColor'
                20-solid:
                    icon_attributes:
                        fill: 'currentColor'
                solid:
                    icon_attributes:
                        fill: 'currentColor'
                '':
                    icon_attributes:
                        stroke: 'currentColor'
                        stroke-width: 1.5
                        fill: 'none'
```

Suffixes are automatically sorted by length (longest first) to ensure more specific suffixes like `20-solid` match before `solid`.