### PR TITLE
 Fix minimum requested 6.x version of FrameworkBundle for LiveComponent

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -44,7 +44,7 @@
         "symfony/dependency-injection": "^5.4|^6.0|^7.0|^8.0",
         "symfony/expression-language": "^5.4|^6.0|^7.0|^8.0",
         "symfony/form": "^5.4|^6.0|^7.0|^8.0",
-        "symfony/framework-bundle": "^5.4|^6.0|^7.0|^8.0",
+        "symfony/framework-bundle": "^5.4|^6.1|^7.0|^8.0",
         "symfony/options-resolver": "^5.4|^6.0|^7.0|^8.0",
         "symfony/phpunit-bridge": "^6.1|^7.0|^8.0",
         "symfony/security-bundle": "^5.4|^6.0|^7.0|^8.0",


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Related to https://github.com/symfony/ux/actions/runs/21540501201/job/62074166912?pr=3318#step:9:1262
AbstractBundle has been introduced in 6.1: https://github.com/symfony/symfony/commit/7e8cf5df105ab0bbe0112222fa5498af486d929c
