### PR TITLE
[LiveComponent] Fix tests with lowest dependencies, incompatibility with `zenstruck/foundry` and Symfony 5.4

### DIFF
--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -41,6 +41,7 @@
         "doctrine/orm": "^2.9.4|^3.0",
         "doctrine/persistence": "^2.5.2|^3.0|^4.0",
         "phpdocumentor/reflection-docblock": "^5.6.2",
+        "symfony/config": "^6.3|^7.0|^8.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0|^8.0",
         "symfony/expression-language": "^5.4|^6.0|^7.0|^8.0",
         "symfony/form": "^5.4|^6.0|^7.0|^8.0",

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -45,6 +45,7 @@
         "symfony/expression-language": "^5.4|^6.0|^7.0|^8.0",
         "symfony/form": "^5.4|^6.0|^7.0|^8.0",
         "symfony/framework-bundle": "^5.4|^6.1|^7.0|^8.0",
+        "symfony/http-kernel": "^6.1|^7.0|^8.0",
         "symfony/options-resolver": "^5.4|^6.0|^7.0|^8.0",
         "symfony/phpunit-bridge": "^6.1|^7.0|^8.0",
         "symfony/security-bundle": "^5.4|^6.0|^7.0|^8.0",


### PR DESCRIPTION
| Q              | A  |
| -------------- | -- |
| Bug fix?       | no |
| New feature?   | no |
| Deprecations?  | no |
| Documentation? | no |
| Issues         | Fix [Unit Tests php (8.1, lowest)](https://github.com/symfony/ux/actions/runs/21650093202/job/62412181796) |
| License        | MIT |

### Issue 1

`zenstruck/foundry` removed the requirement for `symfony/framework-bundle` in version 5.0: https://github.com/zenstruck/foundry/commit/0b09c20e79164d2563a9d11d2146f76f65cffb00

Its bundle requires `Symfony\Component\HttpKernel\Bundle\AbstractBundle` that was introduced in `symfony/http-kernel:6.1`: https://github.com/symfony/symfony/commit/7e8cf5df105ab0bbe0112222fa5498af486d929c

This commit fixes the build to lowest dependencies:

```
Error: Class "Symfony\Component\HttpKernel\Bundle\AbstractBundle" not found

/home/runner/work/ux/ux/src/LiveComponent/vendor/zenstruck/foundry/src/ZenstruckFoundryBundle.php:40
```

### Issue 2

Support for Enum cases in the configuration was added in `symfony/config:6.3` by symfony/symfony@1655d17
```
Error: Object of class Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode could not be converted to string

/home/runner/work/ux/ux/src/LiveComponent/vendor/symfony/config/Definition/Builder/EnumNodeDefinition.php:30
/home/runner/work/ux/ux/src/LiveComponent/vendor/zenstruck/foundry/src/ZenstruckFoundryBundle.php:152
```