### PR TITLE
[TwigComponent] Minor performance improvements when using `{% props %}`

### DIFF
--- a/src/TwigComponent/src/Twig/PropsNode.php
+++ b/src/TwigComponent/src/Twig/PropsNode.php
@@ -30,36 +30,40 @@ class PropsNode extends Node
 
     public function compile(Compiler $compiler): void
     {
-        $compiler
-            ->addDebugInfo($this)
-            ->write('$propsNames = [];')
-        ;
+        $compiler->addDebugInfo($this);
 
-        if (!$this->getAttribute('names')) {
+        if (!$propsNames = $this->getAttribute('names')) {
+            $compiler->write('$propsNames = [];');
+
             return;
         }
+
+        $compiler
+            ->write('$propsNames = [\''.implode("', '", $propsNames).'\'];')
+            ->raw("\n")
+            ->write('$context[\'attributes\'] = $context[\'attributes\']->without(...$propsNames);')
+            ->raw("\n")
+        ;
 
         foreach ($this->getAttribute('names') as $name) {
             $compiler
                 ->write('if (isset($context[\'__props\'][\''.$name.'\'])) {')
                 ->raw("\n")
+                ->indent()
                 ->write('$componentClass = isset($context[\'this\']) ? get_debug_type($context[\'this\']) : "";')
                 ->raw("\n")
                 ->write('throw new \Twig\Error\RuntimeError(\'Cannot define prop "'.$name.'" in template "'.$this->getTemplateName().'". Property already defined in component class "\'.$componentClass.\'".\');')
                 ->raw("\n")
+                ->outdent()
                 ->write('}')
                 ->raw("\n")
             ;
 
-            $compiler
-                ->write('$propsNames[] = \''.$name.'\';')
-                ->write("\n")
-                ->write('$context[\'attributes\'] = $context[\'attributes\']->remove(\''.$name.'\');')
-                ->write("\n")
-                ->write('if (!isset($context[\''.$name.'\'])) {');
+            $compiler->write('if (!isset($context[\''.$name.'\'])) {');
 
             if (!$this->hasNode($name)) {
                 $compiler
+                    ->write("\n")
                     ->indent()
                     ->write('throw new \Twig\Error\RuntimeError("'.$name.' should be defined for component '.$this->getTemplateName().'.");')
                     ->write("\n")
@@ -97,18 +101,10 @@ class PropsNode extends Node
         }
 
         $compiler
-            ->write('$attributesKeys = array_keys($context[\'attributes\']->all());')
-            ->raw("\n")
-            ->write('foreach ($context as $key => $value) {')
-            ->raw("\n")
-            ->indent()
-            ->write('if (in_array($key, $attributesKeys) && !in_array($key, $propsNames)) {')
+            ->write('foreach ($context[\'attributes\']->all() as $key => $value) {')
             ->raw("\n")
             ->indent()
             ->raw('unset($context[$key]);')
-            ->raw("\n")
-            ->outdent()
-            ->write('}')
             ->raw("\n")
             ->outdent()
             ->write('}')

--- a/src/TwigComponent/tests/Fixtures/templates/components/AttributesNotLeakingToContext.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/AttributesNotLeakingToContext.html.twig
@@ -1,0 +1,8 @@
+{% props name %}
+
+<div {{ attributes }}>
+    <p>name={{ name }}</p>
+    <p>class-var-defined={{ class is defined ? 'yes' : 'no' }}</p>
+    <p>style-var-defined={{ style is defined ? 'yes' : 'no' }}</p>
+    <p>data_foo-var-defined={{ data_foo is defined ? 'yes' : 'no' }}</p>
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/PropsAndAttributesSeparation.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/PropsAndAttributesSeparation.html.twig
@@ -1,0 +1,15 @@
+{% props propA, propB, propC = 'default' %}
+
+<div {{ attributes }}>
+    <p>propA={{ propA }}</p>
+    <p>propB={{ propB }}</p>
+    <p>propC={{ propC }}</p>
+    <p>has-propA-attr={{ attributes.has('propA') ? 'yes' : 'no' }}</p>
+    <p>has-propB-attr={{ attributes.has('propB') ? 'yes' : 'no' }}</p>
+    <p>has-propC-attr={{ attributes.has('propC') ? 'yes' : 'no' }}</p>
+    <p>has-class-attr={{ attributes.has('class') ? 'yes' : 'no' }}</p>
+    <p>has-extra-attr={{ attributes.has('data-extra') ? 'yes' : 'no' }}</p>
+    <p>propA-in-context={{ propA is defined ? 'yes' : 'no' }}</p>
+    <p>propB-in-context={{ propB is defined ? 'yes' : 'no' }}</p>
+    <p>propC-in-context={{ propC is defined ? 'yes' : 'no' }}</p>
+</div>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -513,6 +513,117 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('Confirm deletion?', $output);
     }
 
+    public function testPropsAreRemovedFromAttributesInSingleCall()
+    {
+        $output = $this->renderComponent('PropsAndAttributesSeparation', [
+            'propA' => 'valueA',
+            'propB' => 'valueB',
+            'propC' => 'valueC',
+            'class' => 'my-class',
+            'data-extra' => 'extra-value',
+        ]);
+
+        // Props should be available as template variables
+        $this->assertStringContainsString('propA=valueA', $output);
+        $this->assertStringContainsString('propB=valueB', $output);
+        $this->assertStringContainsString('propC=valueC', $output);
+
+        // Props should NOT be in attributes anymore
+        $this->assertStringContainsString('has-propA-attr=no', $output);
+        $this->assertStringContainsString('has-propB-attr=no', $output);
+        $this->assertStringContainsString('has-propC-attr=no', $output);
+
+        // Non-prop attributes should still be in attributes
+        $this->assertStringContainsString('has-class-attr=yes', $output);
+        $this->assertStringContainsString('has-extra-attr=yes', $output);
+
+        // Props should be defined in context
+        $this->assertStringContainsString('propA-in-context=yes', $output);
+        $this->assertStringContainsString('propB-in-context=yes', $output);
+        $this->assertStringContainsString('propC-in-context=yes', $output);
+
+        // Non-prop attributes should be rendered in the div
+        $this->assertStringContainsString('class="my-class"', $output);
+        $this->assertStringContainsString('data-extra="extra-value"', $output);
+    }
+
+    /**
+     * Test that extra attributes (non-props) are correctly cleaned from context.
+     *
+     * This is a regression test for the optimization that iterates directly over
+     * attributes->all() instead of iterating over the entire context.
+     */
+    public function testExtraAttributesAreCleanedFromContext()
+    {
+        $output = $this->renderComponent('PropsAndAttributesSeparation', [
+            'propA' => 'A',
+            'propB' => 'B',
+            'class' => 'test-class',
+            'data-extra' => 'test-extra',
+            'id' => 'test-id',
+        ]);
+
+        // Props should be available
+        $this->assertStringContainsString('propA=A', $output);
+        $this->assertStringContainsString('propB=B', $output);
+        $this->assertStringContainsString('propC=default', $output);
+
+        // All non-prop attributes should be in the attributes object
+        $this->assertStringContainsString('class="test-class"', $output);
+        $this->assertStringContainsString('data-extra="test-extra"', $output);
+        $this->assertStringContainsString('id="test-id"', $output);
+    }
+
+    /**
+     * Test that props with default values work correctly when not provided.
+     */
+    public function testPropsWithDefaultValuesWhenNotProvided()
+    {
+        $output = $this->renderComponent('PropsAndAttributesSeparation', [
+            'propA' => 'A',
+            'propB' => 'B',
+            // propC is not provided, should use default
+            'class' => 'some-class',
+        ]);
+
+        $this->assertStringContainsString('propA=A', $output);
+        $this->assertStringContainsString('propB=B', $output);
+        $this->assertStringContainsString('propC=default', $output);
+
+        // propC should not be in attributes
+        $this->assertStringContainsString('has-propC-attr=no', $output);
+    }
+
+    /**
+     * Test that attributes passed to a component do not leak into template context.
+     *
+     * This is a regression test for the optimization that directly iterates over
+     * attributes->all() to unset context variables, ensuring non-prop attributes
+     * are properly cleaned from the context.
+     */
+    public function testAttributesDoNotLeakToTemplateContext()
+    {
+        $output = $this->renderComponent('AttributesNotLeakingToContext', [
+            'name' => 'test-name',
+            'class' => 'my-class',
+            'style' => 'color: red;',
+            'data-foo' => 'bar',
+        ]);
+
+        // The prop should be available
+        $this->assertStringContainsString('name=test-name', $output);
+
+        // The attributes should be rendered in the HTML
+        $this->assertStringContainsString('class="my-class"', $output);
+        $this->assertStringContainsString('style="color: red;"', $output);
+        $this->assertStringContainsString('data-foo="bar"', $output);
+
+        // But the attribute names should NOT be defined as template variables
+        $this->assertStringContainsString('class-var-defined=no', $output);
+        $this->assertStringContainsString('style-var-defined=no', $output);
+        $this->assertStringContainsString('data_foo-var-defined=no', $output);
+    }
+
     private function renderComponent(string $name, array $data = []): string
     {
         return self::getContainer()->get(Environment::class)->render('render_component.html.twig', [

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -69,9 +69,10 @@ final class ComponentAttributesTest extends TestCase
 
     public function testCanGetWithout()
     {
-        $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;'], new EscaperRuntime());
+        $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;', 'data-foo' => 'bar'], new EscaperRuntime());
 
-        $this->assertSame(['class' => 'foo'], $attributes->without('style')->all());
+        $this->assertSame(['class' => 'foo', 'data-foo' => 'bar'], $attributes->without('style')->all());
+        $this->assertSame(['class' => 'foo'], $attributes->without('style', 'data-foo')->all());
     }
 
     /**


### PR DESCRIPTION
| Q              | A                                                                                                                        |
| -------------- | ------------------------------------------------------------------------------------------------------------------------ |
| Bug fix?       | no                                                                                                                   |
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->                                                                  |
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->                                                 |
| Documentation? | no <!-- required for new features, or documentation updates -->                                                      |
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead --> |
| License        | MIT                                                                                                                      |

When running Blackfire on https://github.com/Kocal/Gotta-Catch-Em-All (especially [this PR](https://github.com/Kocal/Gotta-Catch-Em-All/pull/11)), I noticed that the code generated by `PropsNode` could be slighty optimized.

Each (minor) performance improvement are individually commited.

**Before**:
```php
<?php
    protected function doDisplay(array $context, array $blocks = []): iterable
    {
        $macros = $this->macros;
        // line 1
        $propsNames = [];        if (isset($context['__props']['isLogged'])) {
        $componentClass = isset($context['this']) ? get_debug_type($context['this']) : "";
        throw new \Twig\Error\RuntimeError('Cannot define prop "isLogged" in template "components/Pokemon.html.twig". Property already defined in component class "'.$componentClass.'".');
        }
        $propsNames[] = 'isLogged';
        $context['attributes'] = $context['attributes']->remove('isLogged');
        if (!isset($context['isLogged'])) {            throw new \Twig\Error\RuntimeError("isLogged should be defined for component components/Pokemon.html.twig.");
        }
        if (isset($context['__props']['pokemon'])) {
        $componentClass = isset($context['this']) ? get_debug_type($context['this']) : "";
        throw new \Twig\Error\RuntimeError('Cannot define prop "pokemon" in template "components/Pokemon.html.twig". Property already defined in component class "'.$componentClass.'".');
        }
        $propsNames[] = 'pokemon';
        $context['attributes'] = $context['attributes']->remove('pokemon');
        if (!isset($context['pokemon'])) {            throw new \Twig\Error\RuntimeError("pokemon should be defined for component components/Pokemon.html.twig.");
        }
        if (isset($context['__props']['caughtPokemons'])) {
        $componentClass = isset($context['this']) ? get_debug_type($context['this']) : "";
        throw new \Twig\Error\RuntimeError('Cannot define prop "caughtPokemons" in template "components/Pokemon.html.twig". Property already defined in component class "'.$componentClass.'".');
        }
        $propsNames[] = 'caughtPokemons';
        $context['attributes'] = $context['attributes']->remove('caughtPokemons');
        if (!isset($context['caughtPokemons'])) {            throw new \Twig\Error\RuntimeError("caughtPokemons should be defined for component components/Pokemon.html.twig.");
        }
        $attributesKeys = array_keys($context['attributes']->all());
        foreach ($context as $key => $value) {
            if (in_array($key, $attributesKeys) && !in_array($key, $propsNames)) {
unset($context[$key]);
            }
        }
        // line 2
        if ((($tmp = ($context["isLogged"] ?? null)) && $tmp instanceof Markup ? (string) $tmp : $tmp)) {
            // line 3
            yield "<a
    href=\"";
            // line 4
            yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape($this->extensions['Symfony\Bridge\Twig\Extension\RoutingExtension']->getPath("app_toggle_pokemon_caught", ["pokemonId" => CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "id", [], "any", false, false, false, 4)]), "html", null, true);
            yield "\"
    onclick=\"this.querySelector('img').classList.toggle('grayscale-100');\"
>
    ";
        }
        // line 8
        yield "    <img
        src=\"";
        // line 9
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape($this->extensions['Symfony\Bridge\Twig\Extension\AssetExtension']->getAssetUrl((("images/pokemon/" . CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "id", [], "any", false, false, false, 9)) . ".png")), "html", null, true);
        yield "\"
        alt=\"";
        // line 10
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape(CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "name", [], "any", false, false, false, 10), "html", null, true);
        yield "\"
        title=\"";
        // line 11
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape(CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "name", [], "any", false, false, false, 11), "html", null, true);
        yield " #";
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape(CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "id", [], "any", false, false, false, 11), "html", null, true);
        yield " (";
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape(CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "getCatchableInGamesLabel", [], "method", false, false, false, 11), "html", null, true);
        yield ")\"
        class=\"select-none ";
        // line 12
        yield ((CoreExtension::getAttribute($this->env, $this->source, ($context["caughtPokemons"] ?? null), CoreExtension::getAttribute($this->env, $this->source, CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "id", [], "any", false, false, false, 12), "toInt", [], "any", false, false, false, 12), [], "array", true, true, false, 12)) ? ("") : ("grayscale-100"));
        yield " w-full place-self-center\"
    />
    ";
        // line 14
        if ((($tmp = ($context["isLogged"] ?? null)) && $tmp instanceof Markup ? (string) $tmp : $tmp)) {
            // line 15
            yield "</a>
";
        }
        yield from [];
    }
```

**After**:
```php    protected function doDisplay(array $context, array $blocks = []): iterable
    {
        $macros = $this->macros;
        // line 1
        $propsNames = ['isLogged', 'pokemon', 'caughtPokemons'];
        $context['attributes'] = $context['attributes']->without(...$propsNames);
        if (isset($context['__props']['isLogged'])) {
            $componentClass = isset($context['this']) ? get_debug_type($context['this']) : "";
            throw new \Twig\Error\RuntimeError('Cannot define prop "isLogged" in template "components/Pokemon.html.twig". Property already defined in component class "'.$componentClass.'".');
        }
        if (!isset($context['isLogged'])) {        
            throw new \Twig\Error\RuntimeError("isLogged should be defined for component components/Pokemon.html.twig.");            
        }        
        if (isset($context['__props']['pokemon'])) {
            $componentClass = isset($context['this']) ? get_debug_type($context['this']) : "";
            throw new \Twig\Error\RuntimeError('Cannot define prop "pokemon" in template "components/Pokemon.html.twig". Property already defined in component class "'.$componentClass.'".');
        }
        if (!isset($context['pokemon'])) {        
            throw new \Twig\Error\RuntimeError("pokemon should be defined for component components/Pokemon.html.twig.");            
        }        
        if (isset($context['__props']['caughtPokemons'])) {
            $componentClass = isset($context['this']) ? get_debug_type($context['this']) : "";
            throw new \Twig\Error\RuntimeError('Cannot define prop "caughtPokemons" in template "components/Pokemon.html.twig". Property already defined in component class "'.$componentClass.'".');
        }
        if (!isset($context['caughtPokemons'])) {        
            throw new \Twig\Error\RuntimeError("caughtPokemons should be defined for component components/Pokemon.html.twig.");            
        }        
        foreach ($context['attributes']->all() as $key => $value) {
unset($context[$key]);
        }
        // line 2
        if ((($tmp = ($context["isLogged"] ?? null)) && $tmp instanceof Markup ? (string) $tmp : $tmp)) {
            // line 3
            yield "<a
    href=\"";
            // line 4
            yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape($this->extensions['Symfony\Bridge\Twig\Extension\RoutingExtension']->getPath("app_toggle_pokemon_caught", ["pokemonId" => CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "id", [], "any", false, false, false, 4)]), "html", null, true);
            yield "\"
    onclick=\"this.querySelector('img').classList.toggle('grayscale-100');\"
>
    ";
        }
        // line 8
        yield "    <img
        src=\"";
        // line 9
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape($this->extensions['Symfony\Bridge\Twig\Extension\AssetExtension']->getAssetUrl((("images/pokemon/" . CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "id", [], "any", false, false, false, 9)) . ".png")), "html", null, true);
        yield "\"
        alt=\"";
        // line 10
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape(CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "name", [], "any", false, false, false, 10), "html", null, true);
        yield "\"
        title=\"";
        // line 11
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape(CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "name", [], "any", false, false, false, 11), "html", null, true);
        yield " #";
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape(CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "id", [], "any", false, false, false, 11), "html", null, true);
        yield " (";
        yield $this->env->getRuntime('Twig\Runtime\EscaperRuntime')->escape(CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "getCatchableInGamesLabel", [], "method", false, false, false, 11), "html", null, true);
        yield ")\"
        class=\"select-none ";
        // line 12
        yield ((CoreExtension::getAttribute($this->env, $this->source, ($context["caughtPokemons"] ?? null), CoreExtension::getAttribute($this->env, $this->source, CoreExtension::getAttribute($this->env, $this->source, ($context["pokemon"] ?? null), "id", [], "any", false, false, false, 12), "toInt", [], "any", false, false, false, 12), [], "array", true, true, false, 12)) ? ("") : ("grayscale-100"));
        yield " w-full place-self-center\"
    />
    ";
        // line 14
        if ((($tmp = ($context["isLogged"] ?? null)) && $tmp instanceof Markup ? (string) $tmp : $tmp)) {
            // line 15
            yield "</a>
";
        }
        yield from [];
    }

```