### PR TITLE
[TwigComponent] Minor performance improvement by caching `PropertyAccessor::isWritable()` calls

### DIFF
--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -28,6 +28,7 @@ use Twig\Runtime\EscaperRuntime;
 final class ComponentFactory implements ResetInterface
 {
     private array $mountMethods = [];
+    private array $writableProperties = [];
 
     /**
      * @param array<string, array>        $config
@@ -98,7 +99,7 @@ final class ComponentFactory implements ResetInterface
         if (!$componentMetadata->isAnonymous()) {
             // set data that wasn't set in mount on the component directly
             foreach ($data as $property => $value) {
-                if ($this->propertyAccessor->isWritable($component, $property)) {
+                if ($this->writableProperties[$componentMetadata->getName()][$property] ??= $this->propertyAccessor->isWritable($component, $property)) {
                     $this->propertyAccessor->setValue($component, $property, $value);
                     unset($data[$property]);
                 }
@@ -241,5 +242,6 @@ final class ComponentFactory implements ResetInterface
     public function reset(): void
     {
         $this->mountMethods = [];
+        $this->writableProperties = [];
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Still on https://github.com/Kocal/Gotta-Catch-Em-All/pull/11, my `Pokemon` component has three properties and is rendered 386 times in the page.
We can remove 1155 calls to `PropertyAccessor::isWritable()` by caching the result of the first call for each property of the component instance. This number can increase of each attributes passed to the component.

AFAIK `PropertyAccessor::isWritable($componentInstance, $propertyName)` can not return two different values for the same `$componentInstance` (an object) and `$propertyName` (a property of the object, or an HTML attr key) arguments.

<img width="1202" height="808" alt="image" src="https://github.com/user-attachments/assets/e32f7ae6-d43c-492a-bb4e-1cbec1d0cc10" />
