### PR TITLE
[Translator] Improve performance of dumper under certain condition

### DIFF
--- a/src/Translator/src/TranslationsDumper.php
+++ b/src/Translator/src/TranslationsDumper.php
@@ -99,29 +99,31 @@ class TranslationsDumper
             );
         }
 
+        $additions = [];
+        $typescriptAdditions = [];
         foreach ($this->getTranslations($catalogues, $excludedDomains, $includedDomains, $includeKeysRegex, $excludeKeysRegex) as $translationId => $translationsByDomainAndLocale) {
             $translationId = str_replace('"', '\\"', $translationId);
-            $this->filesystem->appendToFile($fileIndexJs, \sprintf(
+
+            $additions[] = \sprintf(
                 '    "%s": %s,%s',
                 $translationId,
                 json_encode(['translations' => $translationsByDomainAndLocale], \JSON_THROW_ON_ERROR),
                 "\n"
-            ));
+            );
 
             if ($dumpTypeScript) {
-                $this->filesystem->appendToFile($fileIndexDts, \sprintf(
+                $typescriptAdditions[] = \sprintf(
                     '    "%s": %s;%s',
                     $translationId,
                     $this->getTranslationsTypeScriptTypeDefinition($translationsByDomainAndLocale),
                     "\n"
-                ));
+                );
             }
         }
 
-        $this->filesystem->appendToFile($fileIndexJs, '};'."\n");
-
+        $this->filesystem->appendToFile($fileIndexJs, implode('', $additions).'};'."\n");
         if ($dumpTypeScript) {
-            $this->filesystem->appendToFile($fileIndexDts, '};'."\n");
+            $this->filesystem->appendToFile($fileIndexDts, implode('', $typescriptAdditions).'};'."\n");
         }
     }
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | no
| License        | MIT

This PR moves the fileAppend-Calls out of the foreach to drastically improve performance, close to 500x on my Machine and in my project (with lots of translations). 

```
# current time in my project:
 [INFO] "Symfony\UX\Translator\CacheWarmer\TranslationsCacheWarmer" completed in 296866.54ms.  
 
# with the patch:
 [INFO] "Symfony\UX\Translator\CacheWarmer\TranslationsCacheWarmer" completed in 624.45ms.   
 ```
 
 