### PR TITLE
 Fix PHPDoc types of `TestLiveComponent::call()`

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3872,6 +3872,13 @@ uses Symfony's test client to render and make requests to your components::
             $testComponent
                 ->call('processUpload', files: ['file' => new UploadedFile(...)]);
 
+            // call live action with multiple files uploads
+            $testComponent
+                ->call('processUpload', files: ['multiple' => [
+                    new UploadedFile(...),
+                    new UploadedFile(...),
+                ]]);
+
             // emit live events
             $testComponent
                 ->emit('increaseEvent')

--- a/src/LiveComponent/src/Test/TestLiveComponent.php
+++ b/src/LiveComponent/src/Test/TestLiveComponent.php
@@ -80,8 +80,8 @@ final class TestLiveComponent
     }
 
     /**
-     * @param array<string,mixed>         $arguments
-     * @param array<string, UploadedFile> $files
+     * @param array<string,mixed>                        $arguments
+     * @param array<string, UploadedFile|UploadedFile[]> $files
      */
     public function call(string $action, array $arguments = [], array $files = []): self
     {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no 
| Deprecations?  | no
| Documentation? | yes
| License        | MIT

I followed the instructions to upload a file.
https://symfony.com/bundles/ux-live-component/current/index.html#uploading-files

```twig
<div {{ attributes }}>
    <input
        data-action="change->live#action"
        data-live-action-param="files|uploadFiles"
        class="fr-upload"
        aria-describedby="upload-file-messages"
        type="file"
        id="upload-file"
        name="multiple_files[]"
        multiple
    >
</div>
```

```php
    #[LiveAction]
    public function uploadFiles(
        Request $request,
    ): void {
        /** @var UploadedFile[] $allUploadedFiles */
        $allUploadedFiles = $request->files->all('multiple_files');
        if ($allUploadedFiles === []) {
            return;
        }
        
        // rest of my code
    }
```

And when I tried to test it, I ended up with a typing error on the files parameter.

```php
        $component = $this->createLiveComponent(FileUpload::class, [], $this->kernelBrowser)
            ->actingAs($user)
            ->call('uploadFiles', [], ['multiple_files' => [
                new UploadedFile(...),
                new UploadedFile(...),
            ]])
            ->component()
        ;
```

