### PR TITLE
[LiveComponent][TwigComponent] Add support for dynamic template resolution

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.33
 
 - Add `fetch_credentials` option to configure the fetch API credentials mode for cross-origin requests.
-  This is useful when embedding a Live Component from a different domain that requires cookie-based authentication (e.g., JWT stored in cookies).
+  This is useful when embedding a Live Component from a different domain that requires cookie-based authentication (e.g., JWT stored in cookies)
 
     Global configuration in `config/packages/live_component.yaml`:
 
@@ -21,6 +21,8 @@
         // ...
     }
     ```
+
+- Add support for dynamic template resolution with `AsLiveComponent(template: FromMethod('customFunction'))`
 
 ## 2.31
 

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -31,7 +31,7 @@
         "symfony/property-access": "^5.4.5|^6.0|^7.0|^8.0",
         "symfony/property-info": "^5.4|^6.0|^7.0|^8.0",
         "symfony/stimulus-bundle": "^2.9",
-        "symfony/ux-twig-component": "^2.25.1",
+        "symfony/ux-twig-component": "^2.33.0",
         "twig/twig": "^3.10.3"
     },
     "require-dev": {

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -75,6 +75,28 @@ Want some demos? Check out https://ux.symfony.com/live-component#demo
         {
             // ...
 
+Dynamic Templates
+-----------------
+
+.. versionadded:: 2.33
+
+    Live components support dynamic template resolution using the ``FromMethod`` attribute, just like standard Twig components.
+
+This is particularly useful for complex live components that need to switch views based on user interaction::
+
+    #[AsLiveComponent(template: new FromMethod('getTemplate'))]
+    class SearchResults
+    {
+        #[LiveProp(writable: true)]
+        public string $layout = 'rows';
+
+        public function getTemplate(): string
+        {
+            return 'rows' === $this->layout
+                ? 'components/SearchResults/rows.html.twig'
+                : 'components/SearchResults/grid.html.twig';
+        }
+    }
 
 Installation
 ------------

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\LiveComponent\Attribute;
 
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\FromMethod;
 
 /**
  * An attribute to register a LiveComponent.
@@ -33,7 +34,7 @@ final class AsLiveComponent extends AsTwigComponent
 
     /**
      * @param string|null              $name              The component name (ie: TodoList)
-     * @param string|null              $template          The template path of the component (ie: components/TodoList.html.twig).
+     * @param string|FromMethod|null   $template          The template path of the component (ie: components/TodoList.html.twig), or a reference to a component's method (ie: FromMethod('getTemplate')
      * @param string|null              $defaultAction     The default action to call when the component is mounted (ie: __invoke)
      * @param bool                     $exposePublicProps Whether to expose every public property as a Twig variable
      * @param string                   $attributesVar     The name of the special "attributes" variable in the template
@@ -44,7 +45,7 @@ final class AsLiveComponent extends AsTwigComponent
      */
     public function __construct(
         ?string $name = null,
-        ?string $template = null,
+        string|FromMethod|null $template = null,
         ?string $defaultAction = null,
         bool $exposePublicProps = true,
         string $attributesVar = 'attributes',

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.33
 
-- Extended support for the `index.html.twig` template fallback when resolving namespaced anonymous components.
+- Extended support for the `index.html.twig` template fallback when resolving namespaced anonymous components
+- Add support for dynamic template resolution with `AsTwigComponent(template: FromMethod('getCustomFuntion'))`
 
 ## 2.32
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -382,6 +382,35 @@ use the full path of the template where the macro is defined:
         {{ message_formatter('...') }}
     </twig:Alert>
 
+Dynamic Templates
+-----------------
+
+.. versionadded:: 2.33
+
+    The ability to dynamically resolve templates via the ``FromMethod`` attribute was added.
+
+Sometimes, you need to render a different template based on the component state.
+
+It is possible to reference a component method by passing ``FromMethod`` to the ``template`` option of ``AsTwigComponent``, which will be used to compute the template to use before rendering the component::
+
+    namespace App\Twig\Components;
+
+    use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+    use Symfony\UX\TwigComponent\Attribute\FromMethod;
+
+    #[AsTwigComponent(template: new FromMethod('getTemplate'))]
+    class SearchResults
+    {
+        public string $layout = 'rows';
+
+        public function getTemplate(): string
+        {
+            return 'rows' === $this->layout
+                ? 'components/SearchResults/rows.html.twig'
+                : 'components/SearchResults/grid.html.twig';
+        }
+    }
+
 Fetching Services
 -----------------
 

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -36,7 +36,9 @@ class AsTwigComponent
         private ?string $name = null,
 
         /**
-         * The template path of the component (ie: components/Button.html.twig).
+         * The template path of the component (ie: components/Button.html.twig)
+         * or a reference to a component method to resolve the template dynamically
+         * (ie: FromMethod('customFunction')).
          *
          * With the default configuration, the template path is resolved using
          * the component's name.
@@ -46,7 +48,7 @@ class AsTwigComponent
          *
          * @see https://symfony.com/bundles/ux-twig-component#component-template-path
          */
-        private ?string $template = null,
+        private string|FromMethod|null $template = null,
 
         /**
          * Whether to expose every public property as a Twig variable.
@@ -67,12 +69,19 @@ class AsTwigComponent
      */
     public function serviceConfig(): array
     {
-        return [
+        $config = [
             'key' => $this->name,
-            'template' => $this->template,
             'expose_public_props' => $this->exposePublicProps,
             'attributes_var' => $this->attributesVar,
         ];
+
+        if ($this->template instanceof FromMethod) {
+            $config['template_from_method'] = $this->template->method;
+        } else {
+            $config['template'] = $this->template;
+        }
+
+        return $config;
     }
 
     /**

--- a/src/TwigComponent/src/Attribute/FromMethod.php
+++ b/src/TwigComponent/src/Attribute/FromMethod.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Attribute;
+
+class FromMethod
+{
+    public function __construct(
+        public readonly string $method,
+    ) {
+    }
+}

--- a/src/TwigComponent/src/ComponentMetadata.php
+++ b/src/TwigComponent/src/ComponentMetadata.php
@@ -37,6 +37,14 @@ final class ComponentMetadata
     }
 
     /**
+     * @return string|null The method name to fetch the template dynamically
+     */
+    public function getTemplateFromMethod(): ?string
+    {
+        return $this->config['template_from_method'] ?? null;
+    }
+
+    /**
      * @return class-string The Component's FQCN
      */
     public function getClass(): string

--- a/src/TwigComponent/src/Event/PreRenderEvent.php
+++ b/src/TwigComponent/src/Event/PreRenderEvent.php
@@ -41,6 +41,21 @@ final class PreRenderEvent extends Event
         private array $variables,
     ) {
         $this->template = $this->metadata->getTemplate();
+
+        if ($method = $this->metadata->getTemplateFromMethod()) {
+            $component = $this->mounted->getComponent();
+
+            if (!\is_callable($callback = [$component, $method])) {
+                throw new \LogicException(\sprintf('The template method "%s" does not exist or is not callable on component "%s".', $method, get_debug_type($component)));
+            }
+
+            $this->template = $callback();
+
+            if (!\is_string($this->template)) {
+                throw new \LogicException(\sprintf('The template method "%s" must return a string on component "%s".', $method, get_debug_type($component)));
+            }
+        }
+
         $this->parentTemplateForEmbedded = $this->template;
     }
 

--- a/src/TwigComponent/tests/Fixtures/Component/DefaultTemplateComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DefaultTemplateComponent.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent('default_template_component')]
+class DefaultTemplateComponent
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/MethodTemplateComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/MethodTemplateComponent.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\FromMethod;
+
+#[AsTwigComponent('method_template_component', template: new FromMethod('getDynamicTemplate'))]
+class MethodTemplateComponent
+{
+    public string $type = 'default';
+    
+    public function getDynamicTemplate(): string
+    {
+        return sprintf('components/dynamic_%s.html.twig', $this->type);
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/Component/MissingMethodComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/MissingMethodComponent.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\FromMethod;
+
+#[AsTwigComponent('missing_method_component', template: new FromMethod('thisMethodDoesNotExist'))]
+class MissingMethodComponent
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/StringTemplateComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/StringTemplateComponent.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent('string_template_component', template: 'components/custom_string_template.html.twig')]
+class StringTemplateComponent
+{
+}

--- a/src/TwigComponent/tests/Fixtures/templates/components/custom_method_template.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/custom_method_template.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>Method Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/custom_string_template.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/custom_string_template.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>String Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/default_template_component.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/default_template_component.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>Default Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/dynamic_custom.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/dynamic_custom.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>Dynamic Custom Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/dynamic_default.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/dynamic_default.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>Dynamic Default Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Integration/DynamicTemplateTest.php
+++ b/src/TwigComponent/tests/Integration/DynamicTemplateTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\TwigComponent\Test\InteractsWithTwigComponents;
+
+class DynamicTemplateTest extends KernelTestCase
+{
+    use InteractsWithTwigComponents;
+
+    public function testTemplateResolvedAutomaticallyWhenNotProvided()
+    {
+        // When no template is explicitly configured, the default resolution mechanism should be applied.
+        $rendered = (string) $this->renderTwigComponent('default_template_component');
+
+        $this->assertStringContainsString('Default Template Works!', $rendered);
+    }
+
+    public function testTemplateResolvedFromString()
+    {
+        // Ensures that a template defined as a string is properly resolved.
+        $rendered = (string) $this->renderTwigComponent('string_template_component');
+
+        $this->assertStringContainsString('String Template Works!', $rendered);
+    }
+
+    public function testTemplateChangesBasedOnComponentProps()
+    {
+        // 1. Default Type props
+        $html = $this->renderTwigComponent('method_template_component', ['type' => 'default']);
+        $this->assertStringContainsString('Default', $html);
+
+        // 2. Custom Type props
+        $html = $this->renderTwigComponent('method_template_component', ['type' => 'custom']);
+        $this->assertStringContainsString('Custom', $html);
+    }
+
+    public function testTemplateFromMethodThrowsExceptionWhenMethodIsMissing()
+    {
+        // Using FromMethod with a non-existing or non-callable method must throw a LogicException.
+        $this->expectException(\Twig\Error\RuntimeError::class);
+        $this->expectExceptionMessage('does not exist or is not callable');
+
+        $this->renderTwigComponent('missing_method_component');
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?      | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | -
| License        | MIT

### Description

This PR introduces the ability to dynamically resolve component templates via a dedicated method in the component class. This is particularly useful for building responsive components or multi-theme applications where the same logic (PHP class) needs to render different templates based on its internal state or props.

Instead of relying on a "magic" method, this implementation uses a new `FromMethod` attribute passed to the `template` parameter. This approach ensures explicit intent and maintains compatibility with Symfony's service tag requirements.

**How it works**

- Define a public method in your component that returns the template path as a string.
- `Pass a new FromMethod('yourMethodName')` to the `#[AsTwigComponent]` or `#[AsLiveComponent]` attribute.

**TwigComponent Example**
```php
#[AsTwigComponent('user_profile', template: new FromMethod('getTemplateForRole'))]
class UserProfile
{
    public function getTemplateForRole(): string
    {
        if ($this->isGranted('ROLE_ADMIN')) {
            return 'components/user_profile/admin_dashboard.html.twig';
        }

        return 'components/user_profile/public_card.html.twig';
    }
}
```

**LiveComponent Example**
```php
#[AsLiveComponent('checkout_wizard', template: new FromMethod('getStepTemplate'))]
class CheckoutWizard
{
    #[LiveProp]
    public int $currentStep = 1;

    #[LiveAction]
    public function nextStep(): void
    {
        $this->currentStep++;
    }

    public function getStepTemplate(): string
    {
        return match ($this->currentStep) {
            1 => 'components/checkout/step_1_address.html.twig',
            2 => 'components/checkout/step_2_shipping.html.twig',
            3 => 'components/checkout/step_3_payment.html.twig',
            default => 'components/checkout/summary.html.twig',
        };
    }
}
```

<details>
<summary>First PR</summary>
### Description

When building responsive or multi-theme applications, developers frequently need to reuse the exact same component logic (PHP class) with entirely different Twig templates depending on the context (e.g., a Desktop Search Dropdown vs. a Mobile Search Offcanvas).

Currently, the only ways to achieve this are:
1. **Duplicating the component class** just to change the `#[AsLiveComponent(template: '...')]` attribute.
2. **Creating a global `PreRenderEvent` listener**, which breaks component encapsulation and litters the codebase with boilerplate listeners.

This PR solves this by introducing a magic `getTemplate(): string` method. If a component defines this public method, the `ComponentRenderer` will use its return value as the template, overriding the default attribute metadata. This aligns perfectly with existing UX magic methods like `mount()` and `hydrate()`.

**Additional Note:** P.S. As this relies on the underlying ComponentRenderer, the getTemplate() method also works out-of-the-box for LiveComponents. It might be worth mentioning this in the LiveComponent documentation as well.

### Example Usage

Instead of duplicating components, developers can now encapsulate the logic gracefully:

```php
#[AsLiveComponent('SearchForm')]
class SearchForm extends AbstractController
{
    #[LiveProp]
    public string $theme = 'desktop';

    // The component dynamically decides its own template
    public function getTemplate(): string
    {
        return $this->theme === 'mobile' 
            ? 'components/MobileSearch.html.twig'
            : 'components/DesktopSearch.html.twig';
    }
}


{# Renders the mobile template #}
{{ component('SearchForm', { theme: 'mobile' }) }}
</details>