### PR TITLE
[LiveComponent] Fix Allow empty values to bypass input model validation modifiers

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -22,7 +22,7 @@
     }
     ```
 
-- Add support for dynamic template resolution with AsLiveComponent(template: FromMethod('customFunction')
+- Add support for dynamic template resolution with `AsLiveComponent(template: FromMethod('customFunction'))`
 
 ## 2.31
 

--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.33
 
 - Add `fetch_credentials` option to configure the fetch API credentials mode for cross-origin requests.
-  This is useful when embedding a Live Component from a different domain that requires cookie-based authentication (e.g., JWT stored in cookies).
+  This is useful when embedding a Live Component from a different domain that requires cookie-based authentication (e.g., JWT stored in cookies)
 
     Global configuration in `config/packages/live_component.yaml`:
 
@@ -21,6 +21,8 @@
         // ...
     }
     ```
+
+- Add support for dynamic template resolution with AsLiveComponent(template: FromMethod('customFunction')
 
 ## 2.31
 

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -3038,21 +3038,26 @@ var _LiveControllerDefault = class _LiveControllerDefault extends Controller {
       }
     }
     const finalValue = getValueFromElement(element, this.component.valueStore);
+    const isEmpty = finalValue === "" || finalValue === null || finalValue === void 0;
     if (isTextualInputElement(element) || isTextareaElement(element)) {
-      if (modelBinding.minLength !== null && typeof finalValue === "string" && finalValue.length < modelBinding.minLength) {
+      if (!isEmpty && // Only check min_length if the value is not empty
+      modelBinding.minLength !== null && typeof finalValue === "string" && finalValue.length < modelBinding.minLength) {
         return;
       }
-      if (modelBinding.maxLength !== null && typeof finalValue === "string" && finalValue.length > modelBinding.maxLength) {
+      if (!isEmpty && // Only check max_length if the value is not empty
+      modelBinding.maxLength !== null && typeof finalValue === "string" && finalValue.length > modelBinding.maxLength) {
         return;
       }
     }
     if (isNumericalInputElement(element)) {
-      const numericValue = Number(finalValue);
-      if (modelBinding.minValue !== null && numericValue < modelBinding.minValue) {
-        return;
-      }
-      if (modelBinding.maxValue !== null && numericValue > modelBinding.maxValue) {
-        return;
+      if (!isEmpty) {
+        const numericValue = Number(finalValue);
+        if (modelBinding.minValue !== null && numericValue < modelBinding.minValue) {
+          return;
+        }
+        if (modelBinding.maxValue !== null && numericValue > modelBinding.maxValue) {
+          return;
+        }
       }
     }
     this.component.set(modelBinding.modelName, finalValue, modelBinding.shouldRender, modelBinding.debounce);

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -435,8 +435,12 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
 
         const finalValue = getValueFromElement(element, this.component.valueStore);
 
+        // Check if the value has been completely cleared by the user
+        const isEmpty = finalValue === '' || finalValue === null || finalValue === undefined;
+
         if (isTextualInputElement(element) || isTextareaElement(element)) {
             if (
+                !isEmpty && // Only check min_length if the value is not empty
                 modelBinding.minLength !== null &&
                 typeof finalValue === 'string' &&
                 finalValue.length < modelBinding.minLength
@@ -445,6 +449,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
             }
 
             if (
+                !isEmpty && // Only check max_length if the value is not empty
                 modelBinding.maxLength !== null &&
                 typeof finalValue === 'string' &&
                 finalValue.length > modelBinding.maxLength
@@ -454,14 +459,18 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
         }
 
         if (isNumericalInputElement(element)) {
-            const numericValue = Number(finalValue);
+            // An empty input converts to 0 via Number(""), which could incorrectly trigger min_value rules.
+            // Therefore, we bypass validation for numeric fields if they are empty.
+            if (!isEmpty) {
+                const numericValue = Number(finalValue);
 
-            if (modelBinding.minValue !== null && numericValue < modelBinding.minValue) {
-                return;
-            }
+                if (modelBinding.minValue !== null && numericValue < modelBinding.minValue) {
+                    return;
+                }
 
-            if (modelBinding.maxValue !== null && numericValue > modelBinding.maxValue) {
-                return;
+                if (modelBinding.maxValue !== null && numericValue > modelBinding.maxValue) {
+                    return;
+                }
             }
         }
 

--- a/src/LiveComponent/assets/test/unit/controller/model.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/model.test.ts
@@ -1137,4 +1137,63 @@ describe('LiveController data-model Tests', () => {
         await userEvent.type(input, '30');
         await waitFor(() => expect(test.element).toHaveTextContent('Age: 30'));
     });
+
+    it('bypasses min_length validation and updates model when input is cleared', async () => {
+        const test = await createTest(
+            { username: 'starting_name' }, // Set an initial value
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <input data-model="min_length(3)|username" value="${data.username}" />
+                Username: ${data.username}
+            </div>
+        `
+        );
+
+        // 1. First, try entering an invalid value (2 characters)
+        const input = test.queryByDataModel('username');
+        await userEvent.clear(input);
+        await userEvent.type(input, 'ab');
+
+        // Model SHOULD NOT be updated, state should remain the same
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ username: 'starting_name' });
+
+        // 2. Now completely clear the input
+        // An empty value ('') should bypass the min_length rule and be sent to the server
+        test.expectsAjaxCall().expectUpdatedData({ username: '' });
+
+        await userEvent.clear(input);
+
+        // FIX: Ensure the old value is completely gone from the DOM to confirm re-render
+        await waitFor(() => expect(test.element).not.toHaveTextContent('starting_name'));
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ username: '' });
+    });
+
+    it('bypasses min_value validation and updates model when number input is cleared', async () => {
+        const test = await createTest(
+            { age: '30' }, // Set a valid initial value
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <input data-model="min_value(18)|age" type="number" value="${data.age}" />
+                Age: ${data.age}
+            </div>
+        `
+        );
+
+        // 1. First, enter an invalid value (<18)
+        const input = test.queryByDataModel('age');
+        await userEvent.clear(input);
+        await userEvent.type(input, '15');
+
+        // Model SHOULD NOT be updated
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ age: '30' });
+
+        // 2. Completely clear the input
+        test.expectsAjaxCall().expectUpdatedData({ age: '' });
+
+        await userEvent.clear(input);
+
+        // FIX: Ensure the old value '30' is no longer in the DOM
+        await waitFor(() => expect(test.element).not.toHaveTextContent('Age: 30'));
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ age: '' });
+    });
 });

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -31,7 +31,7 @@
         "symfony/property-access": "^5.4.5|^6.0|^7.0|^8.0",
         "symfony/property-info": "^5.4|^6.0|^7.0|^8.0",
         "symfony/stimulus-bundle": "^2.9",
-        "symfony/ux-twig-component": "^2.25.1",
+        "symfony/ux-twig-component": "^2.33.0",
         "twig/twig": "^3.10.3"
     },
     "require-dev": {

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -75,6 +75,36 @@ Want some demos? Check out https://ux.symfony.com/live-component#demo
         {
             // ...
 
+Dynamic Templates
+-----------------
+
+.. versionadded:: 2.33
+
+    Live components support dynamic template resolution using the ``FromMethod`` attribute, just like standard Twig components.
+
+This is particularly useful for complex live components that need to switch views based on user interaction::
+
+    // src/Twig/Components/ChatWindow.php
+    namespace App\Twig\Components;
+
+    use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+    use Symfony\UX\LiveComponent\DefaultActionTrait;
+    use Symfony\UX\TwigComponent\Attribute\FromMethod;
+
+    #[AsLiveComponent(template: new FromMethod('resolveTemplate'))]
+    class ChatWindow
+    {
+        use DefaultActionTrait;
+
+        public bool $isMinimized = false;
+
+        public function resolveTemplate(): string
+        {
+            return $this->isMinimized 
+                ? 'components/chat/minimized.html.twig' 
+                : 'components/chat/expanded.html.twig';
+        }
+    }
 
 Installation
 ------------

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -84,33 +84,17 @@ Dynamic Templates
 
 This is particularly useful for complex live components that need to switch views based on user interaction::
 
-    // src/Twig/Components/CheckoutWizard.php
-    namespace App\Twig\Components;
-
-    use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
-    use Symfony\UX\LiveComponent\DefaultActionTrait;
-    use Symfony\UX\TwigComponent\Attribute\FromMethod;
-
-    #[AsLiveComponent('checkout_wizard', template: new FromMethod('getStepTemplate'))]
-    class CheckoutWizard
+    #[AsLiveComponent(template: new FromMethod('getTemplate'))]
+    class SearchResults
     {
-        #[LiveProp]
-        public int $currentStep = 1;
+        #[LiveProp(writable: true)]
+        public string $layout = 'rows';
 
-        #[LiveAction]
-        public function nextStep(): void
+        public function getTemplate(): string
         {
-            $this->currentStep++;
-        }
-
-        public function getStepTemplate(): string
-        {
-            return match ($this->currentStep) {
-                1 => 'components/checkout/step_1_address.html.twig',
-                2 => 'components/checkout/step_2_shipping.html.twig',
-                3 => 'components/checkout/step_3_payment.html.twig',
-                default => 'components/checkout/summary.html.twig',
-            };
+            return 'rows' === $this->layout
+                ? 'components/SearchResults/rows.html.twig'
+                : 'components/SearchResults/grid.html.twig';
         }
     }
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -84,25 +84,33 @@ Dynamic Templates
 
 This is particularly useful for complex live components that need to switch views based on user interaction::
 
-    // src/Twig/Components/ChatWindow.php
+    // src/Twig/Components/CheckoutWizard.php
     namespace App\Twig\Components;
 
     use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
     use Symfony\UX\LiveComponent\DefaultActionTrait;
     use Symfony\UX\TwigComponent\Attribute\FromMethod;
 
-    #[AsLiveComponent(template: new FromMethod('resolveTemplate'))]
-    class ChatWindow
+    #[AsLiveComponent('checkout_wizard', template: new FromMethod('getStepTemplate'))]
+    class CheckoutWizard
     {
-        use DefaultActionTrait;
+        #[LiveProp]
+        public int $currentStep = 1;
 
-        public bool $isMinimized = false;
-
-        public function resolveTemplate(): string
+        #[LiveAction]
+        public function nextStep(): void
         {
-            return $this->isMinimized 
-                ? 'components/chat/minimized.html.twig' 
-                : 'components/chat/expanded.html.twig';
+            $this->currentStep++;
+        }
+
+        public function getStepTemplate(): string
+        {
+            return match ($this->currentStep) {
+                1 => 'components/checkout/step_1_address.html.twig',
+                2 => 'components/checkout/step_2_shipping.html.twig',
+                3 => 'components/checkout/step_3_payment.html.twig',
+                default => 'components/checkout/summary.html.twig',
+            };
         }
     }
 

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\LiveComponent\Attribute;
 
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\FromMethod;
 
 /**
  * An attribute to register a LiveComponent.
@@ -33,7 +34,7 @@ final class AsLiveComponent extends AsTwigComponent
 
     /**
      * @param string|null              $name              The component name (ie: TodoList)
-     * @param string|null              $template          The template path of the component (ie: components/TodoList.html.twig).
+     * @param string|FromMethod|null   $template          The template path of the component (ie: components/TodoList.html.twig), or a reference to a component's method (ie: FromMethod('getTemplate')
      * @param string|null              $defaultAction     The default action to call when the component is mounted (ie: __invoke)
      * @param bool                     $exposePublicProps Whether to expose every public property as a Twig variable
      * @param string                   $attributesVar     The name of the special "attributes" variable in the template
@@ -44,7 +45,7 @@ final class AsLiveComponent extends AsTwigComponent
      */
     public function __construct(
         ?string $name = null,
-        ?string $template = null,
+        string|FromMethod|null $template = null,
         ?string $defaultAction = null,
         bool $exposePublicProps = true,
         string $attributesVar = 'attributes',

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.33
 
-- Extended support for the `index.html.twig` template fallback when resolving namespaced anonymous components.
+- Extended support for the `index.html.twig` template fallback when resolving namespaced anonymous components
+- Add support for dynamic template resolution with `AsTwigComponent(template: FromMethod('getTemplate'))`
 
 ## 2.32
 

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.33
 
 - Extended support for the `index.html.twig` template fallback when resolving namespaced anonymous components
-- Add support for dynamic template resolution with `AsTwigComponent(template: FromMethod('getTemplate'))`
+- Add support for dynamic template resolution with `AsTwigComponent(template: FromMethod('getCustomFuntion'))`
 
 ## 2.32
 

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -34,6 +34,7 @@
         "twig/twig": "^3.10.3"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "dev-master",
         "symfony/console": "^5.4|^6.0|^7.0|^8.0",
         "symfony/css-selector": "^5.4|^6.0|^7.0|^8.0",
         "symfony/dom-crawler": "^5.4|^6.0|^7.0|^8.0",

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -34,7 +34,6 @@
         "twig/twig": "^3.10.3"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "dev-master",
         "symfony/console": "^5.4|^6.0|^7.0|^8.0",
         "symfony/css-selector": "^5.4|^6.0|^7.0|^8.0",
         "symfony/dom-crawler": "^5.4|^6.0|^7.0|^8.0",

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -389,26 +389,25 @@ Dynamic Templates
 
     The ability to dynamically resolve templates via the ``FromMethod`` attribute was added.
 
-Sometimes, you need to render a different template based on the component's state or props.
+Sometimes, you need to render a different template based on the component state.
 
-Instead of a static string, you can pass a ``FromMethod`` instance to the ``template`` option of the ``AsTwigComponent`` attribute. This tells Symfony to call the specified method to determine the template path at runtime::
+It is possible to reference a component method by passing ``FromMethod`` to the ``template`` option of ``AsTwigComponent``, which will be used to compute the template to use before rendering the component::
 
-    // src/Twig/Components/UserProfile.php
     namespace App\Twig\Components;
 
     use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
     use Symfony\UX\TwigComponent\Attribute\FromMethod;
 
-    #[AsTwigComponent('user_profile', template: new FromMethod('getTemplateForRole'))]
-    class UserProfile
+    #[AsTwigComponent(template: new FromMethod('getTemplate'))]
+    class SearchResults
     {
-        public function getTemplateForRole(): string
-        {
-            if ($this->isGranted('ROLE_ADMIN')) {
-                return 'components/user_profile/admin_dashboard.html.twig';
-            }
+        public string $layout = 'rows';
 
-            return 'components/user_profile/public_card.html.twig';
+        public function getTemplate(): string
+        {
+            return 'rows' === $this->layout
+                ? 'components/SearchResults/rows.html.twig'
+                : 'components/SearchResults/grid.html.twig';
         }
     }
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -382,6 +382,46 @@ use the full path of the template where the macro is defined:
         {{ message_formatter('...') }}
     </twig:Alert>
 
+Dynamic Templates
+-----------------
+
+.. versionadded:: 2.33
+
+    The ability to dynamically resolve templates via the ``FromMethod`` attribute was added.
+
+Sometimes, you need to render a different template based on the component's state or props (e.g., a desktop vs. mobile version of a search dropdown).
+
+Instead of a static string, you can pass a ``FromMethod`` instance to the ``template`` option of the ``AsTwigComponent`` attribute. This tells Symfony to call the specified method to determine the template path at runtime::
+
+    // src/Twig/Components/SearchForm.php
+    namespace App\Twig\Components;
+
+    use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+    use Symfony\UX\TwigComponent\Attribute\FromMethod;
+
+    #[AsTwigComponent(template: new FromMethod('getDynamicTemplate'))]
+    class SearchForm
+    {
+        public string $theme = 'desktop';
+
+        public function getDynamicTemplate(): string
+        {
+            return 'mobile' === $this->theme
+                ? 'components/SearchForm/mobile.html.twig'
+                : 'components/SearchForm/desktop.html.twig';
+        }
+    }
+
+Now, you can switch the template by passing the ``theme`` prop:
+
+.. code-block:: html+twig
+
+    {# Renders components/SearchForm/mobile.html.twig #}
+    <twig:SearchForm theme="mobile" />
+
+    {# Renders components/SearchForm/desktop.html.twig #}
+    <twig:SearchForm theme="desktop" />
+
 Fetching Services
 -----------------
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -389,38 +389,28 @@ Dynamic Templates
 
     The ability to dynamically resolve templates via the ``FromMethod`` attribute was added.
 
-Sometimes, you need to render a different template based on the component's state or props (e.g., a desktop vs. mobile version of a search dropdown).
+Sometimes, you need to render a different template based on the component's state or props.
 
 Instead of a static string, you can pass a ``FromMethod`` instance to the ``template`` option of the ``AsTwigComponent`` attribute. This tells Symfony to call the specified method to determine the template path at runtime::
 
-    // src/Twig/Components/SearchForm.php
+    // src/Twig/Components/UserProfile.php
     namespace App\Twig\Components;
 
     use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
     use Symfony\UX\TwigComponent\Attribute\FromMethod;
 
-    #[AsTwigComponent(template: new FromMethod('getDynamicTemplate'))]
-    class SearchForm
+    #[AsTwigComponent('user_profile', template: new FromMethod('getTemplateForRole'))]
+    class UserProfile
     {
-        public string $theme = 'desktop';
-
-        public function getDynamicTemplate(): string
+        public function getTemplateForRole(): string
         {
-            return 'mobile' === $this->theme
-                ? 'components/SearchForm/mobile.html.twig'
-                : 'components/SearchForm/desktop.html.twig';
+            if ($this->isGranted('ROLE_ADMIN')) {
+                return 'components/user_profile/admin_dashboard.html.twig';
+            }
+
+            return 'components/user_profile/public_card.html.twig';
         }
     }
-
-Now, you can switch the template by passing the ``theme`` prop:
-
-.. code-block:: html+twig
-
-    {# Renders components/SearchForm/mobile.html.twig #}
-    <twig:SearchForm theme="mobile" />
-
-    {# Renders components/SearchForm/desktop.html.twig #}
-    <twig:SearchForm theme="desktop" />
 
 Fetching Services
 -----------------

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -76,7 +76,6 @@ class AsTwigComponent
         ];
 
         if ($this->template instanceof FromMethod) {
-            $config['template'] = '';
             $config['template_from_method'] = $this->template->method;
         } else {
             $config['template'] = $this->template;

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -36,7 +36,9 @@ class AsTwigComponent
         private ?string $name = null,
 
         /**
-         * The template path of the component (ie: components/Button.html.twig).
+         * The template path of the component (ie: components/Button.html.twig)
+         * or a reference to a component method to resolve the template dynamically
+         * (ie: FromMethod('customFunction')).
          *
          * With the default configuration, the template path is resolved using
          * the component's name.
@@ -46,7 +48,7 @@ class AsTwigComponent
          *
          * @see https://symfony.com/bundles/ux-twig-component#component-template-path
          */
-        private ?string $template = null,
+        private string|FromMethod|null $template = null,
 
         /**
          * Whether to expose every public property as a Twig variable.
@@ -67,12 +69,20 @@ class AsTwigComponent
      */
     public function serviceConfig(): array
     {
-        return [
+        $config = [
             'key' => $this->name,
-            'template' => $this->template,
             'expose_public_props' => $this->exposePublicProps,
             'attributes_var' => $this->attributesVar,
         ];
+
+        if ($this->template instanceof FromMethod) {
+            $config['template'] = '';
+            $config['template_from_method'] = $this->template->method;
+        } else {
+            $config['template'] = $this->template;
+        }
+
+        return $config;
     }
 
     /**

--- a/src/TwigComponent/src/Attribute/FromMethod.php
+++ b/src/TwigComponent/src/Attribute/FromMethod.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Attribute;
+
+class FromMethod
+{
+    public function __construct(
+        public readonly string $method,
+    ) {
+    }
+}

--- a/src/TwigComponent/src/ComponentMetadata.php
+++ b/src/TwigComponent/src/ComponentMetadata.php
@@ -37,6 +37,14 @@ final class ComponentMetadata
     }
 
     /**
+     * @return string|null The method name to fetch the template dynamically
+     */
+    public function getTemplateFromMethod(): ?string
+    {
+        return $this->config['template_from_method'] ?? null;
+    }
+
+    /**
      * @return class-string The Component's FQCN
      */
     public function getClass(): string

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -122,25 +122,6 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
             $metadata->getAttributesVar() => $mounted->getAttributes(),
         ]);
 
-        $template = $metadata->getTemplate();
-
-        // FIRST: method template check
-        if ($method = $metadata->getTemplateFromMethod()) {
-            if (!method_exists($component, $method) || !\is_callable([$component, $method])) {
-                throw new \LogicException(\sprintf('The template method "%s" does not exist or is not callable on component "%s".', $method, get_debug_type($component)));
-            }
-
-            $template = $component->$method();
-
-            if (!\is_string($template)) {
-                throw new \LogicException(\sprintf('The template method "%s" must return a string.', $method));
-            }
-        }
-
-        if ($template) {
-            $event->setTemplate($template);
-        }
-
         $this->dispatcher->dispatch($event);
 
         $event->setVariables([

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -122,6 +122,25 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
             $metadata->getAttributesVar() => $mounted->getAttributes(),
         ]);
 
+        $template = $metadata->getTemplate();
+
+        // FIRST: method template check
+        if ($method = $metadata->getTemplateFromMethod()) {
+            if (!method_exists($component, $method) || !\is_callable([$component, $method])) {
+                throw new \LogicException(\sprintf('The template method "%s" does not exist or is not callable on component "%s".', $method, get_debug_type($component)));
+            }
+
+            $template = $component->$method();
+
+            if (!\is_string($template)) {
+                throw new \LogicException(\sprintf('The template method "%s" must return a string.', $method));
+            }
+        }
+
+        if ($template) {
+            $event->setTemplate($template);
+        }
+
         $this->dispatcher->dispatch($event);
 
         $event->setVariables([

--- a/src/TwigComponent/src/Event/PreRenderEvent.php
+++ b/src/TwigComponent/src/Event/PreRenderEvent.php
@@ -41,6 +41,21 @@ final class PreRenderEvent extends Event
         private array $variables,
     ) {
         $this->template = $this->metadata->getTemplate();
+
+        if ($method = $this->metadata->getTemplateFromMethod()) {
+            $component = $this->mounted->getComponent();
+
+            if (!\is_callable($callback = [$component, $method])) {
+                throw new \LogicException(\sprintf('The template method "%s" does not exist or is not callable on component "%s".', $method, get_debug_type($component)));
+            }
+
+            $this->template = $callback();
+
+            if (!\is_string($this->template)) {
+                throw new \LogicException(\sprintf('The template method "%s" must return a string on component "%s".', $method, get_debug_type($component)));
+            }
+        }
+
         $this->parentTemplateForEmbedded = $this->template;
     }
 

--- a/src/TwigComponent/tests/Fixtures/Component/DefaultTemplateComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/DefaultTemplateComponent.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent('default_template_component')]
+class DefaultTemplateComponent
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/MethodTemplateComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/MethodTemplateComponent.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\FromMethod;
+
+#[AsTwigComponent('method_template_component', template: new FromMethod('getDynamicTemplate'))]
+class MethodTemplateComponent
+{
+    public string $type = 'default';
+    
+    public function getDynamicTemplate(): string
+    {
+        return sprintf('components/dynamic_%s.html.twig', $this->type);
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/Component/MissingMethodComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/MissingMethodComponent.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\FromMethod;
+
+#[AsTwigComponent('missing_method_component', template: new FromMethod('thisMethodDoesNotExist'))]
+class MissingMethodComponent
+{
+}

--- a/src/TwigComponent/tests/Fixtures/Component/StringTemplateComponent.php
+++ b/src/TwigComponent/tests/Fixtures/Component/StringTemplateComponent.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent('string_template_component', template: 'components/custom_string_template.html.twig')]
+class StringTemplateComponent
+{
+}

--- a/src/TwigComponent/tests/Fixtures/templates/components/custom_method_template.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/custom_method_template.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>Method Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/custom_string_template.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/custom_string_template.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>String Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/default_template_component.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/default_template_component.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>Default Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/dynamic_custom.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/dynamic_custom.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>Dynamic Custom Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Fixtures/templates/components/dynamic_default.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/dynamic_default.html.twig
@@ -1,0 +1,3 @@
+<div>
+    <h1>Dynamic Default Template Works!</h1>
+</div>

--- a/src/TwigComponent/tests/Integration/DynamicTemplateTest.php
+++ b/src/TwigComponent/tests/Integration/DynamicTemplateTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\TwigComponent\Test\InteractsWithTwigComponents;
+
+class DynamicTemplateTest extends KernelTestCase
+{
+    use InteractsWithTwigComponents;
+
+    public function testTemplateResolvedAutomaticallyWhenNotProvided()
+    {
+        // When no template is explicitly configured, the default resolution mechanism should be applied.
+        $rendered = (string) $this->renderTwigComponent('default_template_component');
+
+        $this->assertStringContainsString('Default Template Works!', $rendered);
+    }
+
+    public function testTemplateResolvedFromString()
+    {
+        // Ensures that a template defined as a string is properly resolved.
+        $rendered = (string) $this->renderTwigComponent('string_template_component');
+
+        $this->assertStringContainsString('String Template Works!', $rendered);
+    }
+
+    public function testTemplateChangesBasedOnComponentProps()
+    {
+        // 1. Default Type props
+        $html = $this->renderTwigComponent('method_template_component', ['type' => 'default']);
+        $this->assertStringContainsString('Default', $html);
+
+        // 2. Custom Type props
+        $html = $this->renderTwigComponent('method_template_component', ['type' => 'custom']);
+        $this->assertStringContainsString('Custom', $html);
+    }
+
+    public function testTemplateFromMethodThrowsExceptionWhenMethodIsMissing()
+    {
+        // Using FromMethod with a non-existing or non-callable method must throw a LogicException.
+        $this->expectException(\Twig\Error\RuntimeError::class);
+        $this->expectExceptionMessage('does not exist or is not callable');
+
+        $this->renderTwigComponent('missing_method_component');
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   |no 
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix 
| License        | MIT

**The Problem:**
Currently, when using input validation modifiers like `min_length(3)` on a LiveComponent model (e.g., `<input type="search" data-model="min_length(3)|query" />`), the modifier acts as a strict gatekeeper. If a user types "abc", the model updates correctly. However, if the user clears the input (e.g., by clicking the native "X" clear button on a search input or deleting the text), the update is blocked because the length is `0`. 

This creates a frustrating UX: the input appears empty on the screen, but the component fails to re-render or notify the server, leaving the page (and backend state) stuck with the previous search results.

**The Solution:**
This PR updates `LiveController` to bypass `min_length`, `max_length`, `min_value`, and `max_value` checks if the input value is completely empty (`''`, `null`, or `undefined`). 

**Why this is the correct approach (The HTML5 Standard):**
This change aligns LiveComponent's frontend validation strictly with standard HTML5 form validation behavior. In HTML5, attributes like `minlength` and `min` do **not** apply to empty values. If a field is allowed to be empty, it passes validation. If a field *must not* be empty, developers are expected to use the `required` attribute.

By allowing empty strings to pass through these modifiers:
1. It restores the expected behavior for search/filter inputs, allowing the component to naturally reset to its initial/unfiltered state when cleared.
2. It solves complex state synchronization issues between parent/child components when passing models via `props:props`.
3. It prevents numeric inputs (`min_value`) from casting an empty string to `0` and incorrectly failing validation.
