### PR TITLE
[LiveComponent] Allow empty values to bypass model validation modifiers

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2262,14 +2262,17 @@ var LiveControllerDefault = class LiveControllerDefault extends Controller {
 		if (false === modelBinding.debounce) if (modelBinding.targetEventName === "input") modelBinding.debounce = true;
 		else modelBinding.debounce = 0;
 		const finalValue = getValueFromElement(element, this.component.valueStore);
+		const finalValueIsEmpty = finalValue === "" || finalValue === null || finalValue === void 0;
 		if (isTextualInputElement(element) || isTextareaElement(element)) {
-			if (modelBinding.minLength !== null && typeof finalValue === "string" && finalValue.length < modelBinding.minLength) return;
-			if (modelBinding.maxLength !== null && typeof finalValue === "string" && finalValue.length > modelBinding.maxLength) return;
+			if (!finalValueIsEmpty && modelBinding.minLength !== null && typeof finalValue === "string" && finalValue.length < modelBinding.minLength) return;
+			if (!finalValueIsEmpty && modelBinding.maxLength !== null && typeof finalValue === "string" && finalValue.length > modelBinding.maxLength) return;
 		}
 		if (isNumericalInputElement(element)) {
-			const numericValue = Number(finalValue);
-			if (modelBinding.minValue !== null && numericValue < modelBinding.minValue) return;
-			if (modelBinding.maxValue !== null && numericValue > modelBinding.maxValue) return;
+			if (!finalValueIsEmpty) {
+				const numericValue = Number(finalValue);
+				if (modelBinding.minValue !== null && numericValue < modelBinding.minValue) return;
+				if (modelBinding.maxValue !== null && numericValue > modelBinding.maxValue) return;
+			}
 		}
 		this.component.set(modelBinding.modelName, finalValue, modelBinding.shouldRender, modelBinding.debounce);
 	}

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -435,8 +435,11 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
 
         const finalValue = getValueFromElement(element, this.component.valueStore);
 
+        const finalValueIsEmpty = finalValue === '' || finalValue === null || finalValue === undefined;
+
         if (isTextualInputElement(element) || isTextareaElement(element)) {
             if (
+                !finalValueIsEmpty &&
                 modelBinding.minLength !== null &&
                 typeof finalValue === 'string' &&
                 finalValue.length < modelBinding.minLength
@@ -445,6 +448,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
             }
 
             if (
+                !finalValueIsEmpty &&
                 modelBinding.maxLength !== null &&
                 typeof finalValue === 'string' &&
                 finalValue.length > modelBinding.maxLength
@@ -454,14 +458,18 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
         }
 
         if (isNumericalInputElement(element)) {
-            const numericValue = Number(finalValue);
+            // An empty input converts to 0 via Number(""), which could incorrectly trigger min_value rules.
+            // Therefore, we bypass validation for numeric fields if they are empty.
+            if (!finalValueIsEmpty) {
+                const numericValue = Number(finalValue);
 
-            if (modelBinding.minValue !== null && numericValue < modelBinding.minValue) {
-                return;
-            }
+                if (modelBinding.minValue !== null && numericValue < modelBinding.minValue) {
+                    return;
+                }
 
-            if (modelBinding.maxValue !== null && numericValue > modelBinding.maxValue) {
-                return;
+                if (modelBinding.maxValue !== null && numericValue > modelBinding.maxValue) {
+                    return;
+                }
             }
         }
 

--- a/src/LiveComponent/assets/test/unit/controller/model.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/model.test.ts
@@ -1137,4 +1137,93 @@ describe('LiveController data-model Tests', () => {
         await userEvent.type(input, '30');
         await waitFor(() => expect(test.element).toHaveTextContent('Age: 30'));
     });
+
+    it('bypasses min_length validation and updates model when input is cleared', async () => {
+        const test = await createTest(
+            { username: 'starting_name' }, // Set an initial value
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <input data-model="min_length(3)|username" value="${data.username}" />
+                Username: ${data.username}
+            </div>
+        `
+        );
+
+        // 1. First, try entering an invalid value (2 characters)
+        const input = test.queryByDataModel('username');
+        await userEvent.clear(input);
+        await userEvent.type(input, 'ab');
+
+        // Model SHOULD NOT be updated, state should remain the same
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ username: 'starting_name' });
+
+        // 2. Now completely clear the input
+        // An empty value ('') should bypass the min_length rule and be sent to the server
+        test.expectsAjaxCall().expectUpdatedData({ username: '' });
+
+        await userEvent.clear(input);
+
+        // FIX: Ensure the old value is completely gone from the DOM to confirm re-render
+        await waitFor(() => expect(test.element).not.toHaveTextContent('starting_name'));
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ username: '' });
+    });
+
+    it('bypasses min_value validation and updates model when number input is cleared', async () => {
+        const test = await createTest(
+            { age: '30' }, // Set a valid initial value
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <input data-model="min_value(18)|age" type="number" value="${data.age}" />
+                Age: ${data.age}
+            </div>
+        `
+        );
+
+        // 1. First, enter an invalid value (<18)
+        const input = test.queryByDataModel('age');
+        await userEvent.clear(input);
+        await userEvent.type(input, '15');
+
+        // Model SHOULD NOT be updated
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ age: '30' });
+
+        // 2. Completely clear the input
+        test.expectsAjaxCall().expectUpdatedData({ age: '' });
+
+        await userEvent.clear(input);
+
+        // FIX: Ensure the old value '30' is no longer in the DOM
+        await waitFor(() => expect(test.element).not.toHaveTextContent('Age: 30'));
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ age: '' });
+    });
+
+    it('bypasses max_length validation and updates model when input is cleared', async () => {
+        const test = await createTest(
+            { username: 'starting_name' }, // Set an initial value
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <input data-model="max_length(5)|username" value="${data.username}" />
+                Username: ${data.username}
+            </div>
+        `
+        );
+
+        // 1. First, try entering an invalid value (6 characters)
+        const input = test.queryByDataModel('username');
+        await userEvent.clear(input);
+        await userEvent.type(input, 'abcdef');
+
+        // Model SHOULD NOT be updated, state should remain the same
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ username: 'starting_name' });
+
+        // 2. Now completely clear the input
+        // An empty value ('') should bypass the max_length rule and be sent to the server
+        test.expectsAjaxCall().expectUpdatedData({ username: '' });
+
+        await userEvent.clear(input);
+
+        // FIX: Ensure the old value is completely gone from the DOM to confirm re-render
+        await waitFor(() => expect(test.element).not.toHaveTextContent('starting_name'));
+        expect(test.component.valueStore.getOriginalProps()).toEqual({ username: '' });
+    });
 });


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   |no 
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3153
| License        | MIT

**The Problem:**
Currently, when using input validation modifiers like `min_length(3)` on a LiveComponent model (e.g., `<input type="search" data-model="min_length(3)|query" />`), the modifier acts as a strict gatekeeper. If a user types "abc", the model updates correctly. However, if the user clears the input (e.g., by clicking the native "X" clear button on a search input or deleting the text), the update is blocked because the length is `0`. 

This creates a frustrating UX: the input appears empty on the screen, but the component fails to re-render or notify the server, leaving the page (and backend state) stuck with the previous search results.

**The Solution:**
This PR updates `LiveController` to bypass `min_length`, `max_length`, `min_value`, and `max_value` checks if the input value is completely empty (`''`, `null`, or `undefined`). 

**Why this is the correct approach (The HTML5 Standard):**
This change aligns LiveComponent's frontend validation strictly with standard HTML5 form validation behavior. In HTML5, attributes like `minlength` and `min` do **not** apply to empty values. If a field is allowed to be empty, it passes validation. If a field *must not* be empty, developers are expected to use the `required` attribute.

By allowing empty strings to pass through these modifiers:
1. It restores the expected behavior for search/filter inputs, allowing the component to naturally reset to its initial/unfiltered state when cleared.
2. It solves complex state synchronization issues between parent/child components when passing models via `props:props`.
3. It prevents numeric inputs (`min_value`) from casting an empty string to `0` and incorrectly failing validation.

### **Demo**
![firefox_uET9s3ozhL](https://github.com/user-attachments/assets/faefd7ab-5c0a-4cfa-a708-e00cf08e4792)

