### PR TITLE
[TwigComponent] Fix profiling loaded in production

### DIFF
--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -150,7 +150,7 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
         $container->setAlias('console.command.stimulus_component_debug', 'ux.twig_component.command.debug')
             ->setDeprecated('symfony/ux-twig-component', '2.13', '%alias_id%');
 
-        if ($config['profiler']['enabled']) {
+        if ($this->isConfigEnabled($container, $config['profiler'])) {
             $loader->load('debug.php');
 
             $container->getDefinition('ux.twig_component.data_collector')

--- a/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
@@ -58,6 +58,20 @@ class TwigComponentExtensionTest extends TestCase
         $this->assertFalse($container->getDefinition('ux.twig_component.data_collector')->getArgument(2));
     }
 
+    public function testDataCollectorNotLoadedInProductionByDefault()
+    {
+        $container = $this->createContainer();
+        $container->setParameter('kernel.debug', false);
+        $container->registerExtension(new TwigComponentExtension());
+        $container->loadFromExtension('twig_component', [
+            'defaults' => [],
+            'anonymous_template_directory' => 'components/',
+        ]);
+        $this->compileContainer($container);
+
+        $this->assertFalse($container->hasDefinition('ux.twig_component.data_collector'));
+    }
+
     public function testDataCollectorWithDebugModeCanBeDisabled()
     {
         $container = $this->createContainer();


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3380
| License        | MIT

### Summary

Fix profiler debug services being always loaded in production when no explicit `profiler` config is provided.

The `%kernel.debug%` TreeBuilder default was never resolved (TreeBuilder defaults bypass parameter resolution), resulting in a truthy string that always enabled the profiler.

Replace `booleanNode` + `defaultValue('%kernel.debug%')` with a tri-state `scalarNode` (`null`/`true`/`false`) and resolve `kernel.debug` at runtime in the extension.

### Test 

- Add `testDataCollectorNotLoadedInProductionByDefault`, verifies profiler is NOT loaded in production with default config