### PR TITLE
[CI] Pin explicit versions of external actions

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -27,18 +27,18 @@ jobs:
                     - name: External, from "npm add"
                       ux-packages-source: js-packages
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - run: npm i -g corepack && corepack enable
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
               with:
                   node-version-file: '.nvmrc'
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@93cb3149d228516dfca679606c5060ee44f46437
 
             - name: Install root dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@2b6adcf6fa51986b4a64e960e812c1bf5a38f237
               with:
                   working-directory: ${{ github.workspace }}
 
@@ -47,7 +47,7 @@ jobs:
 
             # We always install PHP deps because of the UX Translator, which requires `var/translations` to exists
             - name: Install PHP dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@2b6adcf6fa51986b4a64e960e812c1bf5a38f237
               with:
                   working-directory: apps/encore
                   dependency-versions: highest

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -32,10 +32,10 @@ jobs:
         env:
             SYMFONY_REQUIRE: '${{ matrix.symfony }}.*'
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
               with:
                   node-version-file: '.nvmrc'
                   cache: 'pnpm'
@@ -52,13 +52,13 @@ jobs:
             - name: Install browsers with Playwright
               run: pnpm exec playwright install firefox ffmpeg
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@93cb3149d228516dfca679606c5060ee44f46437
               with:
                   php-version: 8.2
                   tools: symfony-cli, flex
 
             - name: Install root PHP dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@2b6adcf6fa51986b4a64e960e812c1bf5a38f237
               with:
                   working-directory: ${{ github.workspace }}
 
@@ -75,7 +75,7 @@ jobs:
               working-directory: apps/e2e
 
             - name: Install E2E PHP dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@2b6adcf6fa51986b4a64e960e812c1bf5a38f237
               with:
                   working-directory: apps/e2e
                   dependency-versions: highest
@@ -99,7 +99,7 @@ jobs:
               run: pnpm run test:browser
               id: browser-tests
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
               if: ${{ always() && steps.browser-tests.conclusion == 'failure' }}
               with:
                   name: Playwright report and output (${{ matrix.symfony }})
@@ -108,7 +108,7 @@ jobs:
                       src/**/assets/.playwright-output/
                   retention-days: 7
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
               if: ${{ always() && steps.browser-tests.conclusion == 'failure' }}
               with:
                   name: Symfony logs (${{ matrix.symfony }})

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -21,7 +21,7 @@ jobs:
         name: Validate packages definition
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - name: Check all composer.json have label "symfony-ux"
               if: always()
@@ -128,10 +128,10 @@ jobs:
         name: JavaScript Formatting
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
               with:
                   node-version-file: '.nvmrc'
                   cache: 'pnpm'
@@ -145,10 +145,10 @@ jobs:
         name: JavaScript Linting
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
               with:
                   node-version-file: '.nvmrc'
                   cache: 'pnpm'
@@ -178,7 +178,7 @@ jobs:
                     - symfony-version: '6.4.*'
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - name: Configure environment
               run: |
@@ -195,7 +195,7 @@ jobs:
                   echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@93cb3149d228516dfca679606c5060ee44f46437
               with:
                   php-version: 8.1
                   tools: flex
@@ -206,7 +206,7 @@ jobs:
                   echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache packages dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-packages-${{ matrix.php-version }}-${{ matrix.dependency-version }}-${{ matrix.symfony-version }}-${{ matrix.minimum-stability }}-${{ hashFiles('src/**/composer.json') }}
@@ -214,7 +214,7 @@ jobs:
                       ${{ runner.os }}-composer-packages-${{ matrix.php-version }}-${{ matrix.dependency-version }}-${{ matrix.symfony-version }}-${{ matrix.minimum-stability }}
 
             - name: Install root dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@2b6adcf6fa51986b4a64e960e812c1bf5a38f237
               with:
                   working-directory: ${{ github.workspace }}
 

--- a/.github/workflows/dist-files-size-diff-comment.yaml
+++ b/.github/workflows/dist-files-size-diff-comment.yaml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Download artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317
               with:
                   name: dist-size-diff
                   run-id: ${{ github.event.workflow_run.id }}
@@ -23,7 +23,7 @@ jobs:
                   echo "pr-number=$(cat ./pr-number)" >> $GITHUB_OUTPUT
 
             - name: Comment on the pull request (if success)
-              uses: marocchino/sticky-pull-request-comment@v2
+              uses: marocchino/sticky-pull-request-comment@5a61de79c6a3f3f961d6e3ceea2efe7b4cd01f32
               with:
                   number: ${{ steps.read-pr-number.outputs.pr-number }}
                   path: ./diff.md

--- a/.github/workflows/dist-files-size-diff.yaml
+++ b/.github/workflows/dist-files-size-diff.yaml
@@ -16,7 +16,7 @@ jobs:
                   git config --global user.email ""
                   git config --global user.name "github-action[bot]"
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
               with:
                   ref: ${{ github.base_ref }}
 
@@ -31,7 +31,7 @@ jobs:
 
                   echo "files=$FILES" >> $GITHUB_OUTPUT
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - name: Get dist files size (from pull request)
               id: pr-dist-files
@@ -46,7 +46,7 @@ jobs:
 
             - name: Generate the diff
               id: diff
-              uses: actions/github-script@v7
+              uses: actions/github-script@450193c5abd4cdb17ba9f3ffcfe8f635c4bb6c2a
               env:
                   BASE_DIST_FILES: ${{ steps.base-dist-files.outputs.files }}
                   HEAD_DIST_FILES: ${{ steps.pr-dist-files.outputs.files }}
@@ -68,7 +68,7 @@ jobs:
                   echo "${{ github.event.number }}" > pr-number
 
             - name: Upload artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
               with:
                   name: dist-size-diff
                   path: |

--- a/.github/workflows/dist-files-unbuilt.yaml
+++ b/.github/workflows/dist-files-unbuilt.yaml
@@ -18,10 +18,10 @@ jobs:
     check:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
               with:
                   node-version-file: '.nvmrc'
                   cache: 'pnpm'

--- a/.github/workflows/doctor-rst.yaml
+++ b/.github/workflows/doctor-rst.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - name: Create cache dir
               run: mkdir .cache
@@ -26,7 +26,7 @@ jobs:
               id: extract_base_branch
 
             - name: Cache DOCtor-RST
-              uses: actions/cache@v4
+              uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
               with:
                   path: .cache
                   key: doctor-rst-${{ steps.extract_base_branch.outputs.branch }}

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -53,16 +53,16 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@93cb3149d228516dfca679606c5060ee44f46437
               with:
                   php-version: ${{ matrix.php-version }}
                   tools: flex
 
             - name: Install root dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@2b6adcf6fa51986b4a64e960e812c1bf5a38f237
               with:
                   working-directory: ${{ github.workspace }}
 
@@ -74,7 +74,7 @@ jobs:
               working-directory: src/Turbo
 
             - name: Install dependencies with composer
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@2b6adcf6fa51986b4a64e960e812c1bf5a38f237
               with:
                   working-directory: src/Turbo
                   dependency-versions: ${{ matrix.dependency-version }}

--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -13,7 +13,7 @@ jobs:
     release:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
               with:
                   ref: 2.x
 
@@ -26,7 +26,7 @@ jobs:
               run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
             - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
               with:
                   registry-url: 'https://registry.npmjs.org'
                   node-version-file: '.nvmrc'

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -63,7 +63,7 @@ jobs:
             # https://github.com/spatie/phpunit-snapshot-assertions#usage-in-ci
             CREATE_SNAPSHOTS: false
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - name: Configure environment
               run: |
@@ -86,7 +86,7 @@ jobs:
                   echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@93cb3149d228516dfca679606c5060ee44f46437
               with:
                   php-version: ${{ matrix.php-version }}
                   extensions: ${{ matrix.os == 'windows-latest' && 'pdo_sqlite,sqlite3,fileinfo,gd,zip' || '' }}
@@ -98,7 +98,7 @@ jobs:
                   echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache packages dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-packages-${{ matrix.php-version }}-${{ matrix.dependency-version }}-${{ matrix.symfony-version }}-${{ matrix.minimum-stability }}-${{ hashFiles('src/**/composer.json') }}
@@ -106,7 +106,7 @@ jobs:
                       ${{ runner.os }}-composer-packages-${{ matrix.php-version }}-${{ matrix.dependency-version }}-${{ matrix.symfony-version }}-${{ matrix.minimum-stability }}
 
             - name: Install root dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@2b6adcf6fa51986b4a64e960e812c1bf5a38f237
               with:
                   working-directory: ${{ github.workspace }}
 
@@ -151,10 +151,10 @@ jobs:
     js:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
             - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
               with:
                   node-version-file: '.nvmrc'
                   cache: 'pnpm'


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Even though it makes maintenance a bit more complicated, pinning external action versions to commit hashes improves security by reducing the risk of supply-chain attacks.

**EDIT:** well, 2 days later https://x.com/sitnikcode/status/2036125773686292709 😅 

I'll look into enabling Dependabot to open PRs that update (only) GitHub actions.
