### PR TITLE
[Autocomplete][Chartjs][Cropperjs][Dropzone][LazyImage][LiveComponent][Map][Notify][React][StimulusBundle][Svelte][Swup][TogglePassword][Turbo][Typed][Vue][Translator] Update package.json to `2.33.0`

### DIFF
--- a/src/Autocomplete/assets/package.json
+++ b/src/Autocomplete/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-autocomplete",
     "description": "JavaScript Autocomplete functionality for Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/Chartjs/assets/package.json
+++ b/src/Chartjs/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-chartjs",
     "description": "Chart.js integration for Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/Cropperjs/assets/package.json
+++ b/src/Cropperjs/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-cropperjs",
     "description": "Cropper.js integration for Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/Dropzone/assets/package.json
+++ b/src/Dropzone/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-dropzone",
     "description": "File input dropzones for Symfony Forms",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/LazyImage/assets/package.json
+++ b/src/LazyImage/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-lazy-image",
     "description": "Lazy image loader and utilities for Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/LiveComponent/assets/package.json
+++ b/src/LiveComponent/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-live-component",
     "description": "Live Component: bring server-side re-rendering & model binding to any element.",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux",
         "twig",

--- a/src/Map/assets/package.json
+++ b/src/Map/assets/package.json
@@ -3,7 +3,7 @@
     "description": "Easily embed interactive maps in your Symfony application.",
     "private": true,
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux",
         "map",

--- a/src/Map/src/Bridge/Google/assets/package.json
+++ b/src/Map/src/Bridge/Google/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-google-map",
     "description": "GoogleMaps bridge for Symfony UX Map, integrate interactive maps in your Symfony applications",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux",
         "google-maps",

--- a/src/Map/src/Bridge/Leaflet/assets/package.json
+++ b/src/Map/src/Bridge/Leaflet/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-leaflet-map",
     "description": "Leaflet bridge for Symfony UX Map, integrate interactive maps in your Symfony applications",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux",
         "leaflet",

--- a/src/Notify/assets/package.json
+++ b/src/Notify/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-notify",
     "description": "Native notification integration for Symfony using Mercure",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/React/assets/package.json
+++ b/src/React/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-react",
     "description": "Integration of React in Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/StimulusBundle/assets/package.json
+++ b/src/StimulusBundle/assets/package.json
@@ -3,7 +3,7 @@
     "description": "Integration of @hotwired/stimulus into Symfony",
     "private": true,
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/Svelte/assets/package.json
+++ b/src/Svelte/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-svelte",
     "description": "Integration of Svelte in Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/Swup/assets/package.json
+++ b/src/Swup/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-swup",
     "description": "Swup integration for Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/TogglePassword/assets/package.json
+++ b/src/TogglePassword/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-toggle-password",
     "description": "Toggle visibility of password inputs for Symfony Forms",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/Translator/assets/package.json
+++ b/src/Translator/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-translator",
     "description": "Symfony Translator for JavaScript",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/Turbo/assets/package.json
+++ b/src/Turbo/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-turbo",
     "description": "Hotwire Turbo integration for Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux",
         "turbo",

--- a/src/Typed/assets/package.json
+++ b/src/Typed/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-typed",
     "description": "Typed integration for Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],

--- a/src/Vue/assets/package.json
+++ b/src/Vue/assets/package.json
@@ -2,7 +2,7 @@
     "name": "@symfony/ux-vue",
     "description": "Integration of Vue.js in Symfony",
     "license": "MIT",
-    "version": "2.32.0",
+    "version": "2.33.0",
     "keywords": [
         "symfony-ux"
     ],


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

The job that release npm packages failed https://github.com/symfony/ux/actions/runs/23216748609/job/67479440402

it should be fixed by https://github.com/symfony/ux/pull/3400

note that the packages were nicely published with 2.33.0 version, it's only the `git push` on UX that failed