### PR TITLE
[Native] Introduce `assets/` to ease installation of `@hotwired/hotwire-native-bridge` JS dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,15 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
+  src/Native/assets:
+    devDependencies:
+      '@hotwired/hotwire-native-bridge':
+        specifier: 1.2.2
+        version: 1.2.2(@hotwired/stimulus@3.2.2)
+      '@hotwired/stimulus':
+        specifier: ^3.0.0
+        version: 3.2.2
+
   src/Notify/assets:
     devDependencies:
       '@hotwired/stimulus':
@@ -1179,6 +1188,11 @@ packages:
 
   '@googlemaps/js-api-loader@1.16.10':
     resolution: {integrity: sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==}
+
+  '@hotwired/hotwire-native-bridge@1.2.2':
+    resolution: {integrity: sha512-P74kFtXjpY1wV/YneZBOrWJmddLGiKBRj73JB1UgUEOfsM69xpGJbwY0sotFyJgevs2YrBgP9yDNw/uEica2VQ==}
+    peerDependencies:
+      '@hotwired/stimulus': ^3.2.2
 
   '@hotwired/stimulus-webpack-helpers@1.0.1':
     resolution: {integrity: sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==}
@@ -3793,6 +3807,10 @@ snapshots:
       tslib: 2.8.1
 
   '@googlemaps/js-api-loader@1.16.10': {}
+
+  '@hotwired/hotwire-native-bridge@1.2.2(@hotwired/stimulus@3.2.2)':
+    dependencies:
+      '@hotwired/stimulus': 3.2.2
 
   '@hotwired/stimulus-webpack-helpers@1.0.1(@hotwired/stimulus@3.2.2)':
     dependencies:

--- a/src/Native/CHANGELOG.md
+++ b/src/Native/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.35
+
+- Add `assets/` to ease the installation of `@hotwired/stimulus` and `@hotwired/hotwire-native-bridge` JavaScript dependencies.
+  Thanks to Symfony Flex, they should be automatically added to your `package.json` (when using Webpack Encore), or `importmap.php` (when using AssetMapper)
+
 ## 2.33
 
 - Create the component

--- a/src/Native/assets/LICENSE
+++ b/src/Native/assets/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2025-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Native/assets/README.md
+++ b/src/Native/assets/README.md
@@ -1,0 +1,25 @@
+# @symfony/ux-native
+
+JavaScript assets of the [symfony/ux-native](https://packagist.org/packages/symfony/ux-native) PHP package.
+
+## Installation
+
+This npm package is **reserved for advanced users** who want to decouple their JavaScript dependencies from their PHP dependencies (e.g., when building Docker images, running JavaScript-only pipelines, etc.).
+
+We **strongly recommend not installing this package directly**, but instead install the PHP package [symfony/ux-native](https://packagist.org/packages/symfony/ux-native) in your Symfony application with [Flex](https://github.com/symfony/flex) enabled.
+
+If you still want to install this package directly, please make sure its version exactly matches [symfony/ux-native](https://packagist.org/packages/symfony/ux-native) PHP package version:
+
+```shell
+composer require symfony/ux-native:2.33.0
+npm add @symfony/ux-native@2.33.0
+```
+
+**Tip:** Your `package.json` file will be automatically modified by [Flex](https://github.com/symfony/flex) when installing or upgrading a PHP package. To prevent this behavior, ensure to **use at least Flex 1.22.0 or 2.5.0**, and run `composer config --json "extra.symfony/flex.synchronize_package_json" false`.
+
+## Resources
+
+- [Documentation](https://symfony.com/bundles/ux-native/current/index.html)
+- [Report issues](https://github.com/symfony/ux/issues) and
+  [send Pull Requests](https://github.com/symfony/ux/pulls)
+  in the [main Symfony UX repository](https://github.com/symfony/ux)

--- a/src/Native/assets/package.json
+++ b/src/Native/assets/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "@symfony/ux-native",
+    "version": "2.34.0",
+    "description": "Hotwire Native integration for Symfony",
+    "keywords": [
+        "symfony-ux"
+    ],
+    "homepage": "https://ux.symfony.com/native",
+    "license": "MIT",
+    "repository": "https://github.com/symfony/ux",
+    "type": "module",
+    "files": [
+        "dist"
+    ],
+    "devDependencies": {
+        "@hotwired/hotwire-native-bridge": "1.2.2",
+        "@hotwired/stimulus": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@hotwired/hotwire-native-bridge": "1.2.2",
+        "@hotwired/stimulus": "^3.0.0"
+    },
+    "symfony": {
+        "needsPackageAsADependency": false,
+        "importmap": {
+            "@hotwired/hotwire-native-bridge": "1.2.2",
+            "@hotwired/stimulus": "^3.0.0"
+        }
+    }
+}

--- a/src/Native/src/Maker/MakeNativeBridgeController.php
+++ b/src/Native/src/Maker/MakeNativeBridgeController.php
@@ -27,11 +27,6 @@ use Symfony\Component\Console\Input\InputInterface;
  */
 final class MakeNativeBridgeController extends AbstractMaker
 {
-    private const REQUIRED_PACKAGES = [
-        '@symfony/stimulus-bundle',
-        '@hotwired/hotwire-native-bridge',
-    ];
-
     public function __construct(
         private string $projectDir,
     ) {
@@ -66,8 +61,6 @@ final class MakeNativeBridgeController extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
-        $this->ensurePackagesExist($io);
-
         $controllerName = $input->getArgument('name');
         if (!$controllerName) {
             $controllerName = $io->ask('What name do you want for your Hotwire Native Bridge controller?', 'bridge', static function ($name) {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Noticed just after @zairigimad 's conference at SymfonyLive 2026 (🎉).

We didn't see the issue before merging https://github.com/symfony/ux/pull/3338, but the `MakeNativeBridgeController` could not work because:
- `REQUIRE_PACKAGES` constant was unused
- `ensurePackagesExist()` does not exist

By creating a `assets/package.json` in UX Native, we can tell to Symfony Flex to add the JS dependencies `@hotwired/stimulus` and `@hotwired/hotwire-native-bridge` to the `package.json` and `importmap.php`.
No need anymore to check if some dependencies exist or not :D