### PR TITLE
[LiveComponent] Fix data model radio checkbox

### DIFF
--- a/src/LiveComponent/src/EventListener/DataModelPropsSubscriber.php
+++ b/src/LiveComponent/src/EventListener/DataModelPropsSubscriber.php
@@ -64,8 +64,21 @@ final class DataModelPropsSubscriber implements EventSubscriberInterface
         foreach ($bindings as $binding) {
             $childModel = $binding['child'];
             $parentModel = $binding['parent'];
+            $propValue = $this->propertyAccessor->getValue($parentMountedComponent->getComponent(), $parentModel);
 
-            $data[$childModel] = $this->propertyAccessor->getValue($parentMountedComponent->getComponent(), $parentModel);
+            if ('value' === $childModel && \array_key_exists('value', $data)) {
+                // Radio or checkbox group: an explicit option value was passed (e.g. value="a").
+                // Preserve it and derive the checked state from the parent prop instead.
+                $data['checked'] = \is_array($propValue)
+                    ? \in_array($data['value'], $propValue, false)
+                    : ($data['value'] == $propValue);
+            } elseif ('value' === $childModel && isset($data['type']) && 'checkbox' === $data['type']) {
+                // Boolean checkbox: type="checkbox" declared at call site but no explicit value.
+                // Set checked directly from the boolean prop; do not write a value attribute.
+                $data['checked'] = (bool) $propValue;
+            } else {
+                $data[$childModel] = $propValue;
+            }
         }
 
         $event->setData($data);

--- a/src/LiveComponent/tests/Fixtures/Component/CheckboxInputComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/CheckboxInputComponent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent('checkbox_input')]
+final class CheckboxInputComponent
+{
+}

--- a/src/LiveComponent/tests/Fixtures/Component/ParentWithBoolCheckboxComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ParentWithBoolCheckboxComponent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('parent_with_bool_checkbox')]
+final class ParentWithBoolCheckboxComponent
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)]
+    public bool $isActive = true;
+}

--- a/src/LiveComponent/tests/Fixtures/Component/ParentWithCheckboxGroupComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ParentWithCheckboxGroupComponent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('parent_with_checkbox_group')]
+final class ParentWithCheckboxGroupComponent
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)]
+    public array $selected = ['a', 'c'];
+}

--- a/src/LiveComponent/tests/Fixtures/Component/ParentWithRadioGroupComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ParentWithRadioGroupComponent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('parent_with_radio_group')]
+final class ParentWithRadioGroupComponent
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)]
+    public string $selected = 'b';
+}

--- a/src/LiveComponent/tests/Fixtures/Component/RadioInputComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/RadioInputComponent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent('radio_input')]
+final class RadioInputComponent
+{
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/checkbox_input.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/checkbox_input.html.twig
@@ -1,0 +1,1 @@
+<input{{ attributes }} />

--- a/src/LiveComponent/tests/Fixtures/templates/components/parent_with_bool_checkbox.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/parent_with_bool_checkbox.html.twig
@@ -1,0 +1,1 @@
+{% component checkbox_input with { 'data-model': 'isActive', type: 'checkbox' } %}{% endcomponent %}

--- a/src/LiveComponent/tests/Fixtures/templates/components/parent_with_checkbox_group.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/parent_with_checkbox_group.html.twig
@@ -1,0 +1,3 @@
+{% component checkbox_input with { 'data-model': 'selected', value: 'a', type: 'checkbox' } %}{% endcomponent %}
+{% component checkbox_input with { 'data-model': 'selected', value: 'b', type: 'checkbox' } %}{% endcomponent %}
+{% component checkbox_input with { 'data-model': 'selected', value: 'c', type: 'checkbox' } %}{% endcomponent %}

--- a/src/LiveComponent/tests/Fixtures/templates/components/parent_with_radio_group.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/parent_with_radio_group.html.twig
@@ -1,0 +1,3 @@
+{% component radio_input with { 'data-model': 'selected', value: 'a', type: 'radio' } %}{% endcomponent %}
+{% component radio_input with { 'data-model': 'selected', value: 'b', type: 'radio' } %}{% endcomponent %}
+{% component radio_input with { 'data-model': 'selected', value: 'c', type: 'radio' } %}{% endcomponent %}

--- a/src/LiveComponent/tests/Fixtures/templates/components/radio_input.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/radio_input.html.twig
@@ -1,0 +1,1 @@
+<input{{ attributes }} />

--- a/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
+++ b/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
@@ -55,7 +55,7 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
         $this->assertStringContainsString('<input data-model="content" value="default content on mount" />', $html);
     }
 
-    public function testRadioGroupPreservesValueAndSetsChecked(): void
+    public function testRadioGroupPreservesValueAndSetsChecked()
     {
         /** @var ComponentRenderer $renderer */
         $renderer = self::getContainer()->get('ux.twig_component.component_renderer');
@@ -78,7 +78,7 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
         $this->assertStringNotContainsString('value="c" type="radio" checked', $html);
     }
 
-    public function testCheckboxGroupPreservesValueAndSetsChecked(): void
+    public function testCheckboxGroupPreservesValueAndSetsChecked()
     {
         /** @var ComponentRenderer $renderer */
         $renderer = self::getContainer()->get('ux.twig_component.component_renderer');
@@ -99,7 +99,7 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
         $this->assertStringContainsString('value="c" type="checkbox" checked', $html);
     }
 
-    public function testBooleanCheckboxSetsCheckedWithoutValueOverwrite(): void
+    public function testBooleanCheckboxSetsCheckedWithoutValueOverwrite()
     {
         /** @var ComponentRenderer $renderer */
         $renderer = self::getContainer()->get('ux.twig_component.component_renderer');

--- a/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
+++ b/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
@@ -54,4 +54,66 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
         $this->assertStringContainsString('<textarea data-model="content">default content on mount</textarea>', $html);
         $this->assertStringContainsString('<input data-model="content" value="default content on mount" />', $html);
     }
+
+    public function testRadioGroupPreservesValueAndSetsChecked(): void
+    {
+        /** @var ComponentRenderer $renderer */
+        $renderer = self::getContainer()->get('ux.twig_component.component_renderer');
+
+        $html = $renderer->createAndRender('parent_with_radio_group', [
+            'selected' => 'b',
+            'attributes' => ['id' => 'dummy-live-id'],
+        ]);
+
+        // value attributes must be preserved as-is
+        $this->assertStringContainsString('value="a"', $html);
+        $this->assertStringContainsString('value="b"', $html);
+        $this->assertStringContainsString('value="c"', $html);
+
+        // only the matching radio gets checked
+        $this->assertStringContainsString('value="b" type="radio" checked', $html);
+
+        // non-matching radios must not get checked
+        $this->assertStringNotContainsString('value="a" type="radio" checked', $html);
+        $this->assertStringNotContainsString('value="c" type="radio" checked', $html);
+    }
+
+    public function testCheckboxGroupPreservesValueAndSetsChecked(): void
+    {
+        /** @var ComponentRenderer $renderer */
+        $renderer = self::getContainer()->get('ux.twig_component.component_renderer');
+
+        $html = $renderer->createAndRender('parent_with_checkbox_group', [
+            'selected' => ['a', 'c'],
+            'attributes' => ['id' => 'dummy-live-id'],
+        ]);
+
+        // value attributes must be preserved as-is
+        $this->assertStringContainsString('value="a"', $html);
+        $this->assertStringContainsString('value="b"', $html);
+        $this->assertStringContainsString('value="c"', $html);
+
+        // selected checkboxes ('a' and 'c') get checked; unselected ('b') does not
+        $this->assertStringContainsString('value="a" type="checkbox" checked', $html);
+        $this->assertStringNotContainsString('value="b" type="checkbox" checked', $html);
+        $this->assertStringContainsString('value="c" type="checkbox" checked', $html);
+    }
+
+    public function testBooleanCheckboxSetsCheckedWithoutValueOverwrite(): void
+    {
+        /** @var ComponentRenderer $renderer */
+        $renderer = self::getContainer()->get('ux.twig_component.component_renderer');
+
+        $html = $renderer->createAndRender('parent_with_bool_checkbox', [
+            'isActive' => true,
+            'attributes' => ['id' => 'dummy-live-id'],
+        ]);
+
+        // checked attribute must be present (positive assertion — the fix works)
+        $this->assertStringContainsString(' checked', $html);
+
+        // pre-fix symptoms: subscriber must NOT have written value="1" (true cast) or value="" (false cast)
+        $this->assertStringNotContainsString('value="1"', $html);
+        $this->assertStringNotContainsString('value=""', $html);
+    }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3412
| License        | MIT

## Bug Fix: `data-model` overwrites `value` on radio/checkbox Twig Components

**Issue:** When using `data-model` on a child `<TwigComponent>` that renders a `<input type="radio">` or `<input type="checkbox">`, the subscriber was unconditionally writing the parent prop's value into `$data['value']`. This clobbered the explicit `value="a"` / `value="b"` option values set by the template author, breaking radio groups, checkbox groups, and boolean checkboxes.

**Root cause:** `DataModelPropsSubscriber::onPreMount()` always did `$data[$childModel] = $propValue`. For `data-model="selected"`, the parser resolves `child = 'value'`, so the prop value blindly overwrote whatever `value` the template had already set.

**Fix:** Added three-branch logic in the `foreach` body:

1. **Radio / checkbox group** — when `value` already exists in `$data` (template author passed an explicit option value like `value="b"`), preserve it and instead set `$data['checked']` by comparing the option value against the parent prop. Supports both scalar (radio) and array (multi-checkbox) props.

2. **Boolean checkbox** — when `type="checkbox"` is present in `$data` but no explicit `value` was passed, set `$data['checked']` directly from the boolean prop. Avoids writing a spurious `value` attribute entirely.

3. **All other inputs** — unchanged original behavior (`$data[$childModel] = $propValue`).

**Tests added:** Three integration tests covering radio group, checkbox group, and boolean checkbox scenarios, verifying that `value` attributes are preserved and `checked` is set correctly.