### PR TITLE
[Autocomplete] Add option `clear_on_focus`

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.35
+
+- Add `reset_on_focus` option to clear and reload options when the autocomplete field regains focus
+
 ## 2.30
 
 - Ensure compatibility with PHP 8.5

--- a/src/Autocomplete/assets/dist/controller.d.ts
+++ b/src/Autocomplete/assets/dist/controller.d.ts
@@ -19,6 +19,7 @@ declare class export_default extends Controller {
     minCharacters: NumberConstructor;
     tomSelectOptions: ObjectConstructor;
     preload: StringConstructor;
+    resetOnFocus: BooleanConstructor;
   };
   readonly urlValue: string;
   readonly optionsAsHtmlValue: boolean;
@@ -31,6 +32,7 @@ declare class export_default extends Controller {
   readonly tomSelectOptionsValue: object;
   readonly hasPreloadValue: boolean;
   readonly preloadValue: string;
+  readonly resetOnFocusValue: boolean;
   tomSelect: TomSelect | undefined;
   private mutationObserver;
   private isObserving;

--- a/src/Autocomplete/assets/dist/controller.js
+++ b/src/Autocomplete/assets/dist/controller.js
@@ -290,6 +290,16 @@ function _createAutocompleteWithRemoteData(autocompleteEndpointUrl, minCharacter
 				return `<div class="create">${this.createOptionTextValue.replace("%placeholder%", `<strong>${escapeData(data.input)}</strong>`)}</div>`;
 			}
 		},
+		onFocus: () => {
+			if (this.resetOnFocusValue && this.tomSelect) {
+				if (this.tomSelect.control_input.value.trim() === "") {
+					this.tomSelect.clearOptions();
+					this.tomSelect.loadedSearches = {};
+					if (typeof this.tomSelect["clearPagination"] === "function") this.tomSelect["clearPagination"]();
+					this.tomSelect.load("");
+				}
+			}
+		},
 		preload: this.preload
 	});
 	return _assertClassBrand(_Class_brand, this, _createTomSelect).call(this, config);
@@ -333,6 +343,7 @@ _Class.values = {
 	createOptionText: String,
 	minCharacters: Number,
 	tomSelectOptions: Object,
-	preload: String
+	preload: String,
+	resetOnFocus: Boolean
 };
 export { _Class as default };

--- a/src/Autocomplete/assets/src/controller.ts
+++ b/src/Autocomplete/assets/src/controller.ts
@@ -33,6 +33,7 @@ export default class extends Controller {
         minCharacters: Number,
         tomSelectOptions: Object,
         preload: String,
+        resetOnFocus: Boolean,
     };
 
     declare readonly urlValue: string;
@@ -46,6 +47,7 @@ export default class extends Controller {
     declare readonly tomSelectOptionsValue: object;
     declare readonly hasPreloadValue: boolean;
     declare readonly preloadValue: string;
+    declare readonly resetOnFocusValue: boolean;
     tomSelect: TomSelect | undefined;
 
     private mutationObserver: MutationObserver;
@@ -320,6 +322,20 @@ export default class extends Controller {
                 option_create: (data: TomOption, escapeData: typeof escape_html): string => {
                     return `<div class="create">${this.createOptionTextValue.replace('%placeholder%', `<strong>${escapeData(data.input)}</strong>`)}</div>`;
                 },
+            },
+            onFocus: () => {
+                if (this.resetOnFocusValue && this.tomSelect) {
+                    const query = this.tomSelect.control_input.value.trim();
+                    if (query === '') {
+                        this.tomSelect.clearOptions();
+                        this.tomSelect.loadedSearches = {};
+                        // Defined by the virtual_scroll plugin
+                        if (typeof this.tomSelect['clearPagination'] === 'function') {
+                            this.tomSelect['clearPagination']();
+                        }
+                        this.tomSelect.load('');
+                    }
+                }
             },
             preload: this.preload,
         });

--- a/src/Autocomplete/assets/test/unit/controller.test.ts
+++ b/src/Autocomplete/assets/test/unit/controller.test.ts
@@ -1206,4 +1206,103 @@ describe('AutocompleteController', () => {
         // but the absence of "already initialized" error is the key indicator)
         expect(newSelect).toBeInTheDocument();
     });
+
+    it('reloads options on focus when resetOnFocus is enabled', async () => {
+        const { container, tomSelect } = await startAutocompleteTest(`
+            <label for="the-select">Items</label>
+            <select
+                id="the-select"
+                data-testid="main-element"
+                data-controller="autocomplete"
+                data-autocomplete-url-value="/path/to/autocomplete"
+                data-autocomplete-reset-on-focus-value="true"
+            ></select>
+        `);
+
+        // first focus: initial load
+        fetchMock.mockResponseOnce(
+            JSON.stringify({
+                results: [
+                    { value: 1, text: 'pizza' },
+                    { value: 2, text: 'popcorn' },
+                ],
+            })
+        );
+
+        const controlInput = tomSelect.control_input;
+
+        userEvent.click(controlInput);
+        await waitFor(() => {
+            expect(container.querySelectorAll('.option[data-selectable]')).toHaveLength(2);
+        });
+
+        expect(fetchMock.requests().length).toEqual(1);
+        expect(fetchMock.requests()[0].url).toEqual('/path/to/autocomplete?query=');
+
+        // simulate blur then re-focus: should reload
+        fetchMock.mockResponseOnce(
+            JSON.stringify({
+                results: [
+                    { value: 1, text: 'pizza' },
+                    { value: 2, text: 'popcorn' },
+                    { value: 3, text: 'salad' },
+                ],
+            })
+        );
+
+        // trigger TomSelect's focus event which calls our onFocus callback
+        tomSelect.trigger('focus');
+        await waitFor(() => {
+            expect(fetchMock.requests().length).toEqual(2);
+        });
+
+        expect(fetchMock.requests()[1].url).toEqual('/path/to/autocomplete?query=');
+
+        // open the dropdown to render the new options
+        tomSelect.open();
+        await waitFor(() => {
+            expect(container.querySelectorAll('.option[data-selectable]')).toHaveLength(3);
+        });
+    });
+
+    it('does not reload options on focus when resetOnFocus is not set', async () => {
+        const { container, tomSelect } = await startAutocompleteTest(`
+            <label for="the-select">Items</label>
+            <select
+                id="the-select"
+                data-testid="main-element"
+                data-controller="autocomplete"
+                data-autocomplete-url-value="/path/to/autocomplete"
+            ></select>
+        `);
+
+        // first focus: initial load (preload: 'focus' is the default)
+        fetchMock.mockResponseOnce(
+            JSON.stringify({
+                results: [
+                    { value: 1, text: 'pizza' },
+                    { value: 2, text: 'popcorn' },
+                ],
+            })
+        );
+
+        const controlInput = tomSelect.control_input;
+
+        userEvent.click(controlInput);
+        await waitFor(() => {
+            expect(container.querySelectorAll('.option[data-selectable]')).toHaveLength(2);
+        });
+
+        expect(fetchMock.requests().length).toEqual(1);
+
+        // blur and re-focus: should NOT make a new request
+        tomSelect.blur();
+        await shortDelay(10);
+
+        userEvent.click(controlInput);
+        await shortDelay(50);
+
+        // still only 1 request — no reload on re-focus
+        expect(fetchMock.requests().length).toEqual(1);
+    });
 });

--- a/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
+++ b/src/Autocomplete/src/Form/AutocompleteChoiceTypeExtension.php
@@ -94,6 +94,10 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
         $values['create-option-text'] = $this->trans($options['create_option_text']);
         $values['preload'] = $options['preload'];
 
+        if ($options['reset_on_focus']) {
+            $values['reset-on-focus'] = '';
+        }
+
         foreach ($values as $name => $value) {
             $attr['data-'.$controllerName.'-'.$name.'-value'] = $value;
         }
@@ -152,6 +156,7 @@ final class AutocompleteChoiceTypeExtension extends AbstractTypeExtension
             'min_characters' => null,
             'max_results' => 10,
             'preload' => 'focus',
+            'reset_on_focus' => false,
             'extra_options' => [],
         ]);
 

--- a/src/Autocomplete/tests/Fixtures/Form/ProductType.php
+++ b/src/Autocomplete/tests/Fixtures/Form/ProductType.php
@@ -54,6 +54,16 @@ class ProductType extends AbstractType
                     'createOnBlur' => true,
                 ],
             ])
+            ->add('portionSizeResetOnFocus', ChoiceType::class, [
+                'choices' => [
+                    'small' => 's',
+                    'medium' => 'm',
+                    'large' => 'l',
+                ],
+                'autocomplete' => true,
+                'reset_on_focus' => true,
+                'mapped' => false,
+            ])
         ;
     }
 

--- a/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
+++ b/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
@@ -38,6 +38,9 @@ class AutocompleteFormRenderingTest extends KernelTestCase
             ->assertElementAttributeContains('#product_portionSize', 'data-controller', 'symfony--ux-autocomplete--autocomplete')
             ->assertElementAttributeContains('#product_tags', 'data-controller', 'symfony--ux-autocomplete--autocomplete')
             ->assertElementAttributeContains('#product_tags', 'data-symfony--ux-autocomplete--autocomplete-tom-select-options-value', 'createOnBlur')
+
+            ->assertElementAttributeContains('#product_portionSizeResetOnFocus', 'data-controller', 'symfony--ux-autocomplete--autocomplete')
+            ->assertElementAttributeContains('#product_portionSizeResetOnFocus', 'data-symfony--ux-autocomplete--autocomplete-reset-on-focus-value', '')
         ;
     }
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3415 
| License        | MIT

It’s not actually a bug, but the default behavior of Tom Select.
When the preload option is set to focus (which is the default), it fetches the data once and then reuses the cache to avoid triggering a request every time the select is opened.

With this PR, a new option is introduced to let you control whether the state should be reset on focus or not.
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
