### PR TITLE
 Add PR template and auto-close PR on Map bridges subtree split repositories

### DIFF
--- a/src/Map/src/Bridge/Google/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Map/src/Bridge/Google/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Please do not submit any Pull Requests here. They will be closed.
+
+Please submit your PR here instead:
+https://github.com/symfony/ux
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Map/src/Bridge/Google/.github/workflows/close-pull-request.yml
+++ b/src/Map/src/Bridge/Google/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+    pull_request_target:
+        types: [opened]
+
+jobs:
+    run:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: superbrothers/close-pull-request@v3
+              with:
+                  comment: |
+                      Thanks for your Pull Request! We love contributions.
+
+                      However, you should instead open your PR on the main repository:
+                      https://github.com/symfony/ux
+
+                      This repository is what we call a "subtree split": a read-only subset of that main repository.
+                      We're looking forward to your PR there!

--- a/src/Map/src/Bridge/Leaflet/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Map/src/Bridge/Leaflet/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Please do not submit any Pull Requests here. They will be closed.
+
+Please submit your PR here instead:
+https://github.com/symfony/ux
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/Map/src/Bridge/Leaflet/.github/workflows/close-pull-request.yml
+++ b/src/Map/src/Bridge/Leaflet/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+    pull_request_target:
+        types: [opened]
+
+jobs:
+    run:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: superbrothers/close-pull-request@v3
+              with:
+                  comment: |
+                      Thanks for your Pull Request! We love contributions.
+
+                      However, you should instead open your PR on the main repository:
+                      https://github.com/symfony/ux
+
+                      This repository is what we call a "subtree split": a read-only subset of that main repository.
+                      We're looking forward to your PR there!


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

As notified by @lyrixx on Symfony Slack
