### PR TITLE
[LiveComponent] Improve form validation error messages in exceptions

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1
 
 - Use `aria-busy` attribute during component re-render
+- Include field paths and violation messages in `UnprocessableEntityHttpException` thrown by `submitForm()` when validation fails
 
 ## 3.0.0
 

--- a/src/LiveComponent/src/ComponentWithFormTrait.php
+++ b/src/LiveComponent/src/ComponentWithFormTrait.php
@@ -186,7 +186,7 @@ trait ComponentWithFormTrait
         );
 
         if (!$form->isValid()) {
-            throw new UnprocessableEntityHttpException('Form validation failed in component.');
+            throw new UnprocessableEntityHttpException(\sprintf("Form validation failed:\n%s", implode("\n", $this->extractErrors($form, $form->getName()))));
         }
     }
 
@@ -317,5 +317,24 @@ trait ComponentWithFormTrait
         foreach ($form as $name => $child) {
             $this->clearErrorsForNonValidatedFields($child, \sprintf('%s.%s', $currentPath, $name));
         }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractErrors(FormInterface $form, string $prefix): array
+    {
+        $errors = [];
+
+        foreach ($form->getErrors() as $error) {
+            $errors[] = $prefix.': '.$error->getMessage();
+        }
+
+        $childErrors = [];
+        foreach ($form->all() as $name => $child) {
+            $childErrors[] = $this->extractErrors($child, $prefix.'.'.$name);
+        }
+
+        return array_merge($errors, ...$childErrors);
     }
 }

--- a/src/LiveComponent/tests/Fixtures/Component/FormWithCollectionTypeComponent.php
+++ b/src/LiveComponent/tests/Fixtures/Component/FormWithCollectionTypeComponent.php
@@ -53,4 +53,10 @@ class FormWithCollectionTypeComponent extends AbstractController
     {
         unset($this->formValues['comments'][$index]);
     }
+
+    #[LiveAction]
+    public function save(): void
+    {
+        $this->submitForm();
+    }
 }

--- a/src/LiveComponent/tests/Fixtures/Form/CommentFormType.php
+++ b/src/LiveComponent/tests/Fixtures/Form/CommentFormType.php
@@ -17,12 +17,18 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Comment;
 
+use Symfony\Component\Validator\Constraints\NotBlank;
+
 class CommentFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('content', TextareaType::class)
+            ->add('content', TextareaType::class, [
+                'constraints' => [
+                    new NotBlank(message: 'The comment content field should not be blank'),
+                ],
+            ])
         ;
     }
 

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\LiveComponent\Tests\Functional\Form;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Component\FormWithCollectionTypeComponent;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Entity\User;
 use Symfony\UX\LiveComponent\Tests\Fixtures\Factory\CategoryFixtureEntityFactory;
@@ -487,5 +488,41 @@ class ComponentWithFormTest extends KernelTestCase
         refresh($user);
         self::assertEquals(1, $user->id);
         self::assertEquals('Nicolas', $user->username);
+    }
+
+    public function testSubmitFormExceptionMessageContainsFieldPathsAndMessages()
+    {
+        $mounted = $this->mountComponent('form_with_collection_type');
+        $dehydratedProps = $this->dehydrateComponent($mounted)->getProps();
+
+        $exception = null;
+
+        try {
+            $this->browser()
+                ->throwExceptions()
+                ->post('/_components/form_with_collection_type/save', [
+                    'body' => [
+                        'data' => json_encode([
+                            'props' => $dehydratedProps,
+                            'updated' => [
+                                'blog_post_form.title' => '',
+                                'blog_post_form.content' => 'too short',
+                                'blog_post_form.comments' => [['content' => '']],
+                            ],
+                        ]),
+                    ],
+                ])
+            ;
+        } catch (UnprocessableEntityHttpException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertStringContainsString('title', $exception->getMessage());
+        $this->assertStringContainsString('content', $exception->getMessage());
+        $this->assertStringContainsString('The title field should not be blank', $exception->getMessage());
+        $this->assertStringContainsString('The content field is too short', $exception->getMessage());
+        $this->assertStringContainsString('blog_post_form.comments.0.content', $exception->getMessage());
+        $this->assertStringContainsString('The comment content field should not be blank', $exception->getMessage());
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no 
| Documentation? | no 
| License        | MIT


When calling $this->submitForm() manually in a LiveAction, if validation fails, an UnprocessableEntityHttpException is thrown. Currently, this exception contains a generic message: "Form validation failed in component."

This makes it difficult to debug failures in automated tests or during development, especially with large forms or collections, as we need to manually inspect the form state to find the cause.

This PR adds the the full field path and the specific violation message in the exception.

Example output:

```
Form validation failed:
blog_post_form.title: This value should not be blank.
blog_post_form.content: This value is too short. It should have 100 characters or more.
blog_post_form.comments.0.text: This value should not be blank.
```