### PR TITLE
[Cropper] Always apply rotation in `Crop::getCroppedImage()` and `Crop::getCroppedThumbnail()`

### DIFF
--- a/src/Cropperjs/CHANGELOG.md
+++ b/src/Cropperjs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minimum required Symfony version is now 6.4
 - Minimum required PHP version is now 8.2
+- Always apply rotation in `Crop::getCroppedImage()` and `Crop::getCroppedThumbnail()`
 
 ## 2.34
 

--- a/src/Cropperjs/src/Model/Crop.php
+++ b/src/Cropperjs/src/Model/Crop.php
@@ -55,11 +55,8 @@ class Crop
         $this->filename = $filename;
     }
 
-    public function getCroppedThumbnail(int $maxWidth, int $maxHeight, string $format = 'jpg', int $quality = 80, bool $applyRotation = false): string
+    public function getCroppedThumbnail(int $maxWidth, int $maxHeight, string $format = 'jpg', int $quality = 80): string
     {
-        if (\func_num_args() < 5 || false === $applyRotation) {
-            trigger_deprecation('symfony/ux-cropperjs', '2.34', 'Not passing "true" to the "$applyRotation" argument of "%s()" is deprecated. Rotation will be applied by default in Symfony UX 3.0.', __METHOD__);
-        }
         $image = $this->createCroppedImage();
 
         $image->resize($maxWidth, $maxHeight, static function ($constraint) {
@@ -67,7 +64,7 @@ class Crop
             $constraint->upsize();
         });
 
-        if ($applyRotation && !empty($this->options['rotate'])) {
+        if (!empty($this->options['rotate'])) {
             $image->rotate(-1 * $this->options['rotate']);
         }
 
@@ -76,11 +73,8 @@ class Crop
         return $image->getEncoded();
     }
 
-    public function getCroppedImage(string $format = 'jpg', int $quality = 80, bool $applyRotation = false): string
+    public function getCroppedImage(string $format = 'jpg', int $quality = 80): string
     {
-        if (\func_num_args() < 3 || false === $applyRotation) {
-            trigger_deprecation('symfony/ux-cropperjs', '2.34', 'Not passing "true" to the "$applyRotation" argument of "%s()" is deprecated. Rotation will be applied by default in Symfony UX 3.0.', __METHOD__);
-        }
         $image = $this->createCroppedImage();
 
         // Max size
@@ -91,7 +85,7 @@ class Crop
             });
         }
 
-        if ($applyRotation && !empty($this->options['rotate'])) {
+        if (!empty($this->options['rotate'])) {
             $image->rotate(-1 * $this->options['rotate']);
         }
 

--- a/src/Cropperjs/tests/Model/CropTest.php
+++ b/src/Cropperjs/tests/Model/CropTest.php
@@ -55,7 +55,7 @@ class CropTest extends TestCase
     {
         $crop = $this->createCrop(rotate: 90);
 
-        $result = $crop->getCroppedImage(applyRotation: true);
+        $result = $crop->getCroppedImage();
 
         $image = imagecreatefromstring($result);
         $this->assertSame(100, imagesx($image));
@@ -66,7 +66,7 @@ class CropTest extends TestCase
     {
         $crop = $this->createCrop(rotate: 0);
 
-        $result = $crop->getCroppedImage(applyRotation: true);
+        $result = $crop->getCroppedImage();
 
         $image = imagecreatefromstring($result);
         $this->assertSame(200, imagesx($image));
@@ -77,7 +77,7 @@ class CropTest extends TestCase
     {
         $crop = $this->createCrop(rotate: 90);
 
-        $result = $crop->getCroppedThumbnail(200, 200, applyRotation: true);
+        $result = $crop->getCroppedThumbnail(200, 200);
 
         $image = imagecreatefromstring($result);
         $this->assertSame(100, imagesx($image));
@@ -88,7 +88,7 @@ class CropTest extends TestCase
     {
         $crop = $this->createCrop(rotate: 0);
 
-        $result = $crop->getCroppedThumbnail(200, 200, applyRotation: true);
+        $result = $crop->getCroppedThumbnail(200, 200);
 
         $image = imagecreatefromstring($result);
         $this->assertSame(200, imagesx($image));


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no 
| Deprecations?  | no
| Documentation? | i'll check if needed
| Issues         | Next part of #2930 
| License        | MIT

I saw some PR about 3.x and tests dedicated to this change were removed, but not yet the code
