### PR TITLE
[Turbo] Add minimal frame layout template

### DIFF
--- a/src/Turbo/CHANGELOG.md
+++ b/src/Turbo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.1.0
+
+- Add a minimal layout for Turbo Frame responses, allowing `head` content like meta tags to work properly
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -332,6 +332,51 @@ You can even watch changes happening in the browser by using:
 `Read the Turbo Frames documentation`_ to learn
 everything you can do using Turbo Frames.
 
+Minimal Frame Layout
+^^^^^^^^^^^^^^^^^^^^
+
+When a Turbo Frame request is made, the response only needs to contain the
+matching ``<turbo-frame>`` element — serving the full application layout is
+wasteful. For this reason, frame responses are typically rendered without any
+layout at all. However, this optimisation has a drawback: it prevents the
+response from including ``<head>`` content such as page-specific meta tags.
+
+To solve this, UX Turbo provides a minimal layout template that keeps the
+response lightweight while still allowing you to populate the ``<head>``
+block. Use it by extending ``@Turbo/layouts/frame.html.twig`` in templates
+that are rendered in response to Turbo Frame requests:
+
+.. code-block:: html+twig
+
+    {# templates/blog/child.html.twig #}
+    {% extends '@Turbo/layouts/frame.html.twig' %}
+
+    {% block head %}
+        {{ turbo_exempts_page_from_cache() }}
+    {% endblock %}
+
+    {% block body %}
+        <twig:Turbo:Frame id="the_frame_id">
+            A placeholder.
+        </twig:Turbo:Frame>
+    {% endblock %}
+
+This renders a minimal HTML document:
+
+.. code-block:: html
+
+    <!DOCTYPE html>
+    <html>
+        <head>
+            <meta name="turbo-cache-control" content="no-cache">
+        </head>
+        <body>
+            <turbo-frame id="the_frame_id">
+                A placeholder.
+            </turbo-frame>
+        </body>
+    </html>
+
 Coming Alive with Turbo Streams
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Turbo/templates/layouts/frame.html.twig
+++ b/src/Turbo/templates/layouts/frame.html.twig
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        {% block head %}
+        {% endblock %}
+    </head>
+    <body>
+        {% block body %}{% endblock %}
+    </body>
+</html>

--- a/src/Turbo/tests/Twig/FrameLayoutTest.php
+++ b/src/Turbo/tests/Twig/FrameLayoutTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\FilesystemLoader;
+
+class FrameLayoutTest extends TestCase
+{
+    private Environment $twig;
+    private ChainLoader $loader;
+
+    protected function setUp(): void
+    {
+        $filesystemLoader = new FilesystemLoader(__DIR__.'/../../templates');
+        $filesystemLoader->addPath(__DIR__.'/../../templates', 'Turbo');
+
+        $this->loader = new ChainLoader([new ArrayLoader(), $filesystemLoader]);
+        $this->twig = new Environment($this->loader);
+    }
+
+    public function testRendersMinimalHtmlStructure()
+    {
+        $result = $this->twig->render('@Turbo/layouts/frame.html.twig');
+
+        $this->assertStringContainsString('<!DOCTYPE html>', $result);
+        $this->assertStringContainsString('<html>', $result);
+        $this->assertStringContainsString('<head>', $result);
+        $this->assertStringContainsString('<body>', $result);
+    }
+
+    public function testHeadBlockIsOverridable()
+    {
+        $this->loader->addLoader(new ArrayLoader([
+            'child.html.twig' => '{% extends "@Turbo/layouts/frame.html.twig" %}{% block head %}<meta name="test" content="present">{% endblock %}',
+        ]));
+
+        $result = $this->twig->render('child.html.twig');
+
+        $this->assertStringContainsString('<meta name="test" content="present">', $result);
+        $this->assertStringNotContainsString('<nav', $result);
+    }
+
+    public function testBodyBlockIsOverridable()
+    {
+        $this->loader->addLoader(new ArrayLoader([
+            'child.html.twig' => '{% extends "@Turbo/layouts/frame.html.twig" %}{% block body %}<turbo-frame id="test">content</turbo-frame>{% endblock %}',
+        ]));
+
+        $result = $this->twig->render('child.html.twig');
+
+        $this->assertStringContainsString('<turbo-frame id="test">content</turbo-frame>', $result);
+    }
+
+    public function testHeadAndBodyBlocksAreIndependent()
+    {
+        $this->loader->addLoader(new ArrayLoader([
+            'child.html.twig' => '{% extends "@Turbo/layouts/frame.html.twig" %}{% block head %}<meta name="test" content="present">{% endblock %}{% block body %}<turbo-frame id="test">content</turbo-frame>{% endblock %}',
+        ]));
+
+        $result = $this->twig->render('child.html.twig');
+
+        $this->assertStringContainsString('<meta name="test" content="present">', $result);
+        $this->assertStringContainsString('<turbo-frame id="test">content</turbo-frame>', $result);
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

  Add a minimal Twig layout template (`@Turbo/layouts/frame.html.twig`) for Turbo Frame responses.

  When a Turbo Frame request is made, the full application layout is wasteful since only the matching `<turbo-frame>` element is needed. Rendering with no layout at all works, but prevents templates from populating the `<head>` (e.g. meta tags, cache control directives). This template solves the problem by providing a lightweight HTML skeleton with overridable `head` and `body` blocks:

  ```twig
  {# templates/blog/child.html.twig #}
  {% extends '@Turbo/layouts/frame.html.twig' %}

  {% block head %}
      {{ turbo_exempts_page_from_cache() }}
  {% endblock %}

  {% block body %}
      <twig:Turbo:Frame id="the_frame_id">
          A placeholder.
      </twig:Turbo:Frame>
  {% endblock %}
