### PR TITLE
[LiveComponent] Use `aria-busy` attribute during component re-render 

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.1
+
+- Use `aria-busy` attribute during component re-render
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1825,8 +1825,8 @@ var LoadingPlugin_default = class {
 		this.handleLoadingToggle(component, false, targetElement, null);
 	}
 	handleLoadingToggle(component, isLoading, targetElement, backendRequest) {
-		if (isLoading) this.addAttributes(targetElement, ["busy"]);
-		else this.removeAttributes(targetElement, ["busy"]);
+		if (isLoading) targetElement.setAttribute("aria-busy", "true");
+		else targetElement.removeAttribute("aria-busy");
 		this.getLoadingDirectives(component, targetElement).forEach(({ element, directives }) => {
 			if (isLoading) this.addAttributes(element, ["data-live-is-loading"]);
 			else this.removeAttributes(element, ["data-live-is-loading"]);

--- a/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
@@ -38,9 +38,9 @@ export default class implements PluginInterface {
         backendRequest: BackendRequest | null
     ) {
         if (isLoading) {
-            this.addAttributes(targetElement, ['busy']);
+            targetElement.setAttribute('aria-busy', 'true');
         } else {
-            this.removeAttributes(targetElement, ['busy']);
+            targetElement.removeAttribute('aria-busy');
         }
 
         this.getLoadingDirectives(component, targetElement).forEach(({ element, directives }) => {

--- a/src/LiveComponent/assets/test/unit/controller/child-model.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/child-model.test.ts
@@ -55,7 +55,7 @@ describe('Component parent -> child data-model binding tests', () => {
         await userEvent.type(test.queryByDataModel('value'), 'ice cream');
 
         // wait for parent to start/stop loading
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
         await waitFor(() => expect(test.element).toHaveTextContent('Food Name ice cream'));
     });
 
@@ -93,7 +93,7 @@ describe('Component parent -> child data-model binding tests', () => {
         await userEvent.type(test.queryByDataModel('value'), 'ice cream');
 
         // wait for parent to start/stop loading
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
         await waitFor(() => expect(test.element).toHaveTextContent('Food Name ice cream'));
     });
 
@@ -120,10 +120,10 @@ describe('Component parent -> child data-model binding tests', () => {
         // wait for parent model to be set
         await waitFor(() => expect(test.component.getData('foodName')).toEqual('ice cream'));
         // but it never triggers an Ajax call, because the norender modifier
-        expect(test.element).not.toHaveAttribute('busy');
+        expect(test.element).not.toHaveAttribute('aria-busy');
         // wait for a potential Ajax call to start
         await new Promise((resolve) => setTimeout(resolve, 50));
-        expect(test.element).not.toHaveAttribute('busy');
+        expect(test.element).not.toHaveAttribute('aria-busy');
     });
 
     it('start and stops model binding as child is added/removed', async () => {
@@ -161,7 +161,7 @@ describe('Component parent -> child data-model binding tests', () => {
         await userEvent.type(inputElement, 'ice cream');
 
         // wait for parent to start/stop loading
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
         await waitFor(() => expect(test.element).toHaveTextContent('Food Name ice cream'));
 
         // remove child component
@@ -172,6 +172,6 @@ describe('Component parent -> child data-model binding tests', () => {
         await userEvent.type(inputElement, ' sandwich');
         // wait for a potential Ajax call to start
         await new Promise((resolve) => setTimeout(resolve, 50));
-        expect(test.element).not.toHaveAttribute('busy');
+        expect(test.element).not.toHaveAttribute('aria-busy');
     });
 });

--- a/src/LiveComponent/assets/test/unit/controller/child.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/child.test.ts
@@ -44,7 +44,7 @@ describe('Component parent -> child initialization and rendering tests', () => {
         });
 
         test.component.render();
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
     });
 
     it('removes missing child component on re-render', async () => {
@@ -69,8 +69,8 @@ describe('Component parent -> child initialization and rendering tests', () => {
         expect(findChildren(test.component).length).toEqual(1);
         test.component.render();
         // wait for child to disappear
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
         expect(test.element).not.toHaveTextContent('Child Component');
         expect(findChildren(test.component).length).toEqual(0);
     });
@@ -97,8 +97,8 @@ describe('Component parent -> child initialization and rendering tests', () => {
         expect(findChildren(test.component).length).toEqual(0);
         test.component.render();
         // wait for child to disappear
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
         expect(test.element).toHaveTextContent('Child Component');
         expect(findChildren(test.component).length).toEqual(1);
     });
@@ -131,8 +131,8 @@ describe('Component parent -> child initialization and rendering tests', () => {
         expect(test.element).toHaveTextContent('Original Child Component');
         test.component.render();
         // wait for Ajax call
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
         // child component is STILL here: the new rendering was ignored
         expect(test.element).toHaveTextContent('Original Child Component');
         expect(test.element).toContainHTML('data-new="bar"');
@@ -280,7 +280,7 @@ describe('Component parent -> child initialization and rendering tests', () => {
         });
         test.component.render();
         // wait for parent Ajax call to start
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
 
         // E) Expect the child to re-render
         // after the parent Ajax call has finished, but shortly before it's
@@ -294,7 +294,7 @@ describe('Component parent -> child initialization and rendering tests', () => {
             .willReturn(childTemplate);
 
         // wait for parent Ajax call to finish
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
         // sanity check
         expect(test.element).toHaveTextContent('Using Original child: no');
 
@@ -302,8 +302,8 @@ describe('Component parent -> child initialization and rendering tests', () => {
         expect(childComponent.fingerprint).toEqual('updated fingerprint');
 
         // wait for child to start and stop loading
-        await waitFor(() => expect(childComponent.element).toHaveAttribute('busy'));
-        await waitFor(() => expect(childComponent.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(childComponent.element).toHaveAttribute('aria-busy', 'true'));
+        await waitFor(() => expect(childComponent.element).not.toHaveAttribute('aria-busy'));
 
         // child component re-rendered and there are a few important things here
         // 1) the toUppercase prop was changed by the parent and that change remains
@@ -345,8 +345,8 @@ describe('Component parent -> child initialization and rendering tests', () => {
         });
         test.component.render();
         // wait for parent Ajax call to start/finish
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
 
         // no child Ajax call made: we simply use the new child's content
         expect(test.element).toHaveTextContent('New Child');
@@ -429,8 +429,8 @@ describe('Component parent -> child initialization and rendering tests', () => {
         await test.component.render();
 
         // wait for child to start and stop loading
-        await waitFor(() => expect(getByTestId(test.element, 'child-component-1')).not.toHaveAttribute('busy'));
-        await waitFor(() => expect(getByTestId(test.element, 'child-component-2')).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(getByTestId(test.element, 'child-component-1')).not.toHaveAttribute('aria-busy'));
+        await waitFor(() => expect(getByTestId(test.element, 'child-component-2')).not.toHaveAttribute('aria-busy'));
 
         expect(test.element).toHaveTextContent('Child number: 1 value "New value for child 1"');
         expect(test.element).toHaveTextContent('Child number: 2 value "New value for child 2"');

--- a/src/LiveComponent/assets/test/unit/controller/loading.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/loading.test.ts
@@ -102,17 +102,17 @@ describe('LiveController data-loading Tests', () => {
         getByText(test.element, 'Re-Render').click();
         // it should not be loading yet
         expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
 
         test.expectsAjaxCall()
             .expectActionCalled('otherAction')
             // delay so we can check loading
             .delayResponse(50);
         getByText(test.element, 'Other Action').click();
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
         // it should not be loading yet
         expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
 
         test.expectsAjaxCall()
             .expectActionCalled('save')
@@ -120,10 +120,10 @@ describe('LiveController data-loading Tests', () => {
             .delayResponse(50);
         getByText(test.element, 'Save').click();
         // wait for the ajax call to start (will be 0ms, but with a timeout, so not *quite* instant)
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
         // it SHOULD be loading now
         expect(getByTestId(test.element, 'loading-element')).toBeVisible();
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
         // now it should be hidden again
         expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
     });
@@ -151,13 +151,13 @@ describe('LiveController data-loading Tests', () => {
         // it should not be loading yet due to debouncing
         expect(getByTestId(test.element, 'comments-loading')).not.toBeVisible();
         // wait for ajax call to start
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
         // NOW it should be loading
         expect(getByTestId(test.element, 'comments-loading')).toBeVisible();
         // but email-loading is not loading
         expect(getByTestId(test.element, 'email-loading')).not.toBeVisible();
         // wait for Ajax call to finish
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
         // loading is no longer visible
         expect(getByTestId(test.element, 'comments-loading')).not.toBeVisible();
 
@@ -171,13 +171,13 @@ describe('LiveController data-loading Tests', () => {
         // it should not be loading yet due to debouncing
         expect(getByTestId(test.element, 'email-loading')).not.toBeVisible();
         // wait for ajax call to start
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
         // NOW it should be loading
         expect(getByTestId(test.element, 'email-loading')).toBeVisible();
         // but comments-loading is not loading
         expect(getByTestId(test.element, 'comments-loading')).not.toBeVisible();
         // wait for Ajax call to finish
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
         // loading is no longer visible
         expect(getByTestId(test.element, 'email-loading')).not.toBeVisible();
     });
@@ -204,10 +204,10 @@ describe('LiveController data-loading Tests', () => {
 
         getByText(test.element, 'Save').click();
         getByText(test.element, 'Other Action').click();
-        await waitFor(() => expect(test.element).toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).toHaveAttribute('aria-busy', 'true'));
         // it SHOULD be loading now
         expect(getByTestId(test.element, 'loading-element')).toBeVisible();
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
         // now it should be hidden again
         expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
     });
@@ -232,7 +232,7 @@ describe('LiveController data-loading Tests', () => {
         getByText(test.element, 'Save').click();
         // it should NOT be loading: loading is delayed
         expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
-        await waitFor(() => expect(test.element).not.toHaveAttribute('busy'));
+        await waitFor(() => expect(test.element).not.toHaveAttribute('aria-busy'));
 
         // request took 30ms, action loading is delayed for 50
         // wait 30 more (30+30=60) and verify the element did not switch into loading

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1105,6 +1105,38 @@ was just changed using the ``model()`` modifier:
     <!-- multiple modifiers & child properties -->
     <span data-loading="model(user.email)|delay|addClass(opacity-50)">...</span>
 
+Styling and Accessibility with ``aria-busy``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While a component is re-rendering or an action is being processed, Live
+Components automatically set the ``aria-busy="true"`` attribute on the
+component's root element. Once the request is finished, the attribute is
+removed.
+
+This has two benefits:
+
+* **Accessibility**: assistive technologies (like screen readers) can
+  announce that the region is busy, giving users feedback that content is
+  updating.
+* **Styling**: you can target the loading state directly in CSS without
+  using ``data-loading`` directives, for example with Tailwind's
+  ``aria-busy:`` modifier:
+
+.. code-block:: html+twig
+
+    <div {{ attributes }} class="aria-busy:opacity-50">
+        ...
+    </div>
+
+Or in plain CSS:
+
+.. code-block:: css
+
+    [aria-busy="true"] {
+        opacity: 0.5;
+        pointer-events: none;
+    }
+
 .. _actions:
 
 Actions


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #1438
| License       | MIT

This replaces the non-standard `busy` attribute with the proper `aria-busy="true"` ARIA attribute for better accessibility.

Screen readers can now announce loading states, and CSS styling is possible with `[aria-busy="true"]` selectors (e.g. Tailwind's `aria-busy:` modifier).