### PR TITLE
[LiveComponent] Allow BackedEnum as event name

### DIFF
--- a/src/LiveComponent/src/Attribute/LiveListener.php
+++ b/src/LiveComponent/src/Attribute/LiveListener.php
@@ -22,11 +22,14 @@ namespace Symfony\UX\LiveComponent\Attribute;
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class LiveListener extends LiveAction
 {
+    private string $eventName;
+
     /**
-     * @param string $eventName The name of the event to listen to (e.g. "itemUpdated")
+     * @param string|\BackedEnum $eventName The name of the event to listen to (e.g. "itemUpdated")
      */
-    public function __construct(private string $eventName)
+    public function __construct(string|\BackedEnum $eventName)
     {
+        $this->eventName = $eventName instanceof \BackedEnum ? $eventName->value : $eventName;
     }
 
     public function getEventName(): string

--- a/src/LiveComponent/src/ComponentToolsTrait.php
+++ b/src/LiveComponent/src/ComponentToolsTrait.php
@@ -31,22 +31,22 @@ trait ComponentToolsTrait
         $this->liveResponder = $liveResponder;
     }
 
-    public function emit(string $eventName, array $data = [], ?string $componentName = null): void
+    public function emit(string|\BackedEnum $eventName, array $data = [], ?string $componentName = null): void
     {
         $this->liveResponder->emit($eventName, $data, $componentName);
     }
 
-    public function emitUp(string $eventName, array $data = [], ?string $componentName = null): void
+    public function emitUp(string|\BackedEnum $eventName, array $data = [], ?string $componentName = null): void
     {
         $this->liveResponder->emitUp($eventName, $data, $componentName);
     }
 
-    public function emitSelf(string $eventName, array $data = []): void
+    public function emitSelf(string|\BackedEnum $eventName, array $data = []): void
     {
         $this->liveResponder->emitSelf($eventName, $data);
     }
 
-    public function dispatchBrowserEvent(string $eventName, array $payload = []): void
+    public function dispatchBrowserEvent(string|\BackedEnum $eventName, array $payload = []): void
     {
         $this->liveResponder->dispatchBrowserEvent($eventName, $payload);
     }

--- a/src/LiveComponent/src/LiveResponder.php
+++ b/src/LiveComponent/src/LiveResponder.php
@@ -26,40 +26,40 @@ final class LiveResponder
      */
     private array $browserEventsToDispatch = [];
 
-    public function emit(string $eventName, array $data = [], ?string $componentName = null): void
+    public function emit(string|\BackedEnum $eventName, array $data = [], ?string $componentName = null): void
     {
         $this->eventsToEmit[] = [
-            'event' => $eventName,
+            'event' => $eventName instanceof \BackedEnum ? $eventName->value : $eventName,
             'data' => $data,
             'target' => null,
             'componentName' => $componentName,
         ];
     }
 
-    public function emitUp(string $eventName, array $data = [], ?string $componentName = null): void
+    public function emitUp(string|\BackedEnum $eventName, array $data = [], ?string $componentName = null): void
     {
         $this->eventsToEmit[] = [
-            'event' => $eventName,
+            'event' => $eventName instanceof \BackedEnum ? $eventName->value : $eventName,
             'data' => $data,
             'target' => 'up',
             'componentName' => $componentName,
         ];
     }
 
-    public function emitSelf(string $eventName, array $data = []): void
+    public function emitSelf(string|\BackedEnum $eventName, array $data = []): void
     {
         $this->eventsToEmit[] = [
-            'event' => $eventName,
+            'event' => $eventName instanceof \BackedEnum ? $eventName->value : $eventName,
             'data' => $data,
             'target' => 'self',
             'componentName' => null,
         ];
     }
 
-    public function dispatchBrowserEvent(string $event, array $payload = []): void
+    public function dispatchBrowserEvent(string|\BackedEnum $event, array $payload = []): void
     {
         $this->browserEventsToDispatch[] = [
-            'event' => $event,
+            'event' => $event instanceof \BackedEnum ? $event->value : $event,
             'payload' => $payload,
         ];
     }

--- a/src/LiveComponent/tests/Unit/Attribute/LiveListenerTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/LiveListenerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Unit\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\LiveComponent\Attribute\LiveListener;
+
+class LiveListenerTest extends TestCase
+{
+    public function testGetEventNameWithString()
+    {
+        $listener = new LiveListener('item_updated');
+
+        $this->assertSame('item_updated', $listener->getEventName());
+    }
+
+    public function testGetEventNameWithBackedEnum()
+    {
+        $listener = new LiveListener(TestEvent::ItemUpdated);
+
+        $this->assertSame('item_updated', $listener->getEventName());
+    }
+}
+
+enum TestEvent: string
+{
+    case ItemUpdated = 'item_updated';
+    case ItemDeleted = 'item_deleted';
+}

--- a/src/LiveComponent/tests/Unit/LiveResponderTest.php
+++ b/src/LiveComponent/tests/Unit/LiveResponderTest.php
@@ -100,4 +100,68 @@ class LiveResponderTest extends TestCase
         $responder->reset();
         $this->assertSame([], $responder->getBrowserEventsToDispatch());
     }
+
+    public function testEmitWithBackedEnum()
+    {
+        $responder = new LiveResponder();
+        $responder->emit(TestEvent::ItemUpdated, ['id' => 1]);
+
+        $this->assertSame([
+            [
+                'event' => 'item_updated',
+                'data' => ['id' => 1],
+                'target' => null,
+                'componentName' => null,
+            ],
+        ], $responder->getEventsToEmit());
+    }
+
+    public function testEmitUpWithBackedEnum()
+    {
+        $responder = new LiveResponder();
+        $responder->emitUp(TestEvent::ItemDeleted, ['id' => 1]);
+
+        $this->assertSame([
+            [
+                'event' => 'item_deleted',
+                'data' => ['id' => 1],
+                'target' => 'up',
+                'componentName' => null,
+            ],
+        ], $responder->getEventsToEmit());
+    }
+
+    public function testEmitSelfWithBackedEnum()
+    {
+        $responder = new LiveResponder();
+        $responder->emitSelf(TestEvent::ItemUpdated, ['id' => 1]);
+
+        $this->assertSame([
+            [
+                'event' => 'item_updated',
+                'data' => ['id' => 1],
+                'target' => 'self',
+                'componentName' => null,
+            ],
+        ], $responder->getEventsToEmit());
+    }
+
+    public function testDispatchBrowserEventWithBackedEnum()
+    {
+        $responder = new LiveResponder();
+        $responder->dispatchBrowserEvent(TestEvent::ItemUpdated, ['id' => 1]);
+
+        $this->assertSame([
+            [
+                'event' => 'item_updated',
+                'payload' => ['id' => 1],
+            ],
+        ], $responder->getBrowserEventsToDispatch());
+    }
+}
+
+enum TestEvent: string
+{
+    case ItemUpdated = 'item_updated';
+    case ItemDeleted = 'item_deleted';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #3274
| License       | MIT

This allows passing a `BackedEnum` as the `$eventName` parameter to `ComponentToolsTrait` methods (`emit`, `emitUp`, `emitSelf`, `dispatchBrowserEvent`), `LiveResponder`, and the `LiveListener` attribute.

The enum value is converted to string internally, so event matching still works on strings as before.