### PR TITLE
[LiveComponent] Prevent automatic model binding for elements with data-live-ignore

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -326,6 +326,7 @@ function getModelDirectiveFromElement(element, throwOnMissing = true) {
 	const dataModelDirectives = getAllModelDirectiveFromElements(element);
 	if (dataModelDirectives.length > 0) return dataModelDirectives[0];
 	if (element.getAttribute("name")) {
+		if (element.hasAttribute("data-live-ignore")) return null;
 		const formElement = element.closest("form");
 		if (formElement && "model" in formElement.dataset) {
 			const directive = parseDirectives(formElement.dataset.model || "*")[0];

--- a/src/LiveComponent/assets/src/dom_utils.ts
+++ b/src/LiveComponent/assets/src/dom_utils.ts
@@ -152,6 +152,9 @@ export function getModelDirectiveFromElement(element: HTMLElement, throwOnMissin
     }
 
     if (element.getAttribute('name')) {
+        if (element.hasAttribute('data-live-ignore')) {
+            return null;
+        }
         const formElement = element.closest('form');
         // require a <form data-model="*"> around elements in order to
         // activate automatic "data binding" via the "name" attribute

--- a/src/LiveComponent/assets/test/unit/dom_utils.test.ts
+++ b/src/LiveComponent/assets/test/unit/dom_utils.test.ts
@@ -277,6 +277,15 @@ describe('getModelDirectiveFromInput', () => {
         expect(directive).toBeNull();
     });
 
+    it('returns null if data-live-ignore is present on element with name', () => {
+        const formElement = htmlToElement('<form data-model="*"></form>');
+        const element = htmlToElement('<input name="user[firstName]" data-live-ignore>');
+        formElement.appendChild(element);
+
+        const directive = getModelDirectiveFromElement(element);
+        expect(directive).toBeNull();
+    });
+
     it('throws error if no data-model found', () => {
         const element = htmlToElement('<input>');
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no 
| Documentation? | no
| Issues         | #2943
| License        | MIT

This PR fixes an issue where elements with a `name` attribute were being automatically bound as models even if they had the `data-live-ignore` attribute, specifically when using form-wide binding like `<form data-model="*">`
The Problem: When a form uses `data-model="*"`, every input with a `name` attribute is automatically treated as a live model. If a UI-only input (e.g., a radio button used for tab switching or a temporary filter) has a name that doesn't exist as a property on the PHP component, it throws an `Invalid model` name error.

This change makes `data-live-ignore` behave more intuitively as a "hands-off" flag for LiveComponent, especially in aggressive binding scenarios like `<form data-model="on(change)|*">`.