### PR TITLE
 Upgrade minimum required PHP version to 8.4

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -56,7 +56,7 @@ jobs:
 
             - uses: shivammathur/setup-php@690cb7c9d81dbfe51eba732cfca0a00ca42db777
               with:
-                  php-version: ${{ matrix.symfony >= '8.0' && '8.4' || '8.2' }}
+                  php-version: ${{ matrix.symfony >= '8.0' && '8.5' || '8.4' }}
                   tools: symfony-cli, flex
 
             - name: Install root PHP dependencies

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -55,12 +55,12 @@ jobs:
                       fi
                   done
 
-            - name: Check all composer.json have dependency to "php" >=8.2
+            - name: Check all composer.json have dependency to "php" >=8.4
               if: always()
               run: |
                   for file in $(find src/ -mindepth 2 -type f -name composer.json); do
-                      if ! jq -e '.require.php | test(">=8.2")' "$file" > /dev/null; then
-                          echo "File $file does not have the dependency 'php' >=8.2 in its composer.json";
+                      if ! jq -e '.require.php | test(">=8.4")' "$file" > /dev/null; then
+                          echo "File $file does not have the dependency 'php' >=8.4 in its composer.json";
                           exit 1;
                       fi
                   done
@@ -166,7 +166,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: ['8.2']
+                php-version: ['8.4']
                 dependency-version: ['']
                 symfony-version: ['']
                 minimum-stability: ['stable']
@@ -198,7 +198,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@690cb7c9d81dbfe51eba732cfca0a00ca42db777
               with:
-                  php-version: '8.2'
+                  php-version: '8.4'
                   tools: flex
 
             - name: Get composer cache directory

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -23,7 +23,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: ['8.2', '8.3', '8.4', '8.5']
+                php-version: ['8.4', '8.5']
                 dependency-version: ['']
                 symfony-version: ['']
                 minimum-stability: ['stable']
@@ -33,10 +33,10 @@ jobs:
                     - minimum-stability: 'dev'
                       php-version: '8.5'
                     # lowest deps
-                    - php-version: '8.2'
+                    - php-version: '8.4'
                       dependency-version: 'lowest'
                     # LTS version of Symfony
-                    - php-version: '8.2'
+                    - php-version: '8.4'
                       symfony-version: '6.4.*'
         env:
             SYMFONY_REQUIRE: ${{ matrix.symfony-version || '>=5.4' }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -34,7 +34,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: ['8.2', '8.3', '8.4', '8.5']
+                php-version: ['8.4', '8.5']
                 dependency-version: ['']
                 symfony-version: ['']
                 minimum-stability: ['stable']
@@ -44,17 +44,17 @@ jobs:
                       php-version: '8.5'
 
                     # lowest deps
-                    - php-version: '8.2'
+                    - php-version: '8.4'
                       dependency-version: 'lowest'
 
                     # 6.4 LTS
-                    - php-version: '8.2'
+                    - php-version: '8.4'
                       symfony-version: '6.4.*'
 
                     # 7.4 LTS
-                    - php-version: '8.2'
+                    - php-version: '8.4'
                       symfony-version: '7.4.*'
-                    - php-version: '8.2'
+                    - php-version: '8.4'
                       symfony-version: '7.4.*'
                       os: 'windows-latest'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ $ git remote add upstream git@github.com:symfony/ux.git
 
 To set up the development environment, you need the following tools:
 
-- **[PHP](https://www.php.net/downloads.php) 8.2 or higher** - Required for running Symfony components
+- **[PHP](https://www.php.net/downloads.php) 8.4 or higher** - Required for running Symfony components
 - **[Composer](https://getcomposer.org/download/)** - PHP dependency manager
 - **[Node.js](https://nodejs.org/en/download/package-manager) 22.18 or higher** - Required for asset compilation
 - **[Corepack](https://github.com/nodejs/corepack)** - Package manager manager (comes with Node.js 16+)

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -6,7 +6,7 @@ upgrade, make sure to resolve all deprecation notices. Read more about this in
 the [Symfony documentation](https://symfony.com/doc/6.4/setup/upgrade_major.html#upgrade-major-symfony-deprecations).
 
 > [!NOTE]
-> Requires PHP `8.2` or higher.
+> Requires PHP `8.4` or higher.
 >
 > Requires Symfony `6.4` or higher.
 

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -8,7 +8,7 @@ to ensure they work as expected for multiple Symfony versions and various browse
 ## Requirements
 
 - Symfony CLI
-- PHP 8.2 or higher
+- PHP 8.4 or higher
 - Docker and Docker Compose
 - Composer
 

--- a/apps/e2e/composer.json
+++ b/apps/e2e/composer.json
@@ -18,7 +18,7 @@
         ]
     },
     "require": {
-        "php": ">=8.2.0",
+        "php": ">=8.4.0",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "doctrine/dbal": "^3.10.1|^4.4.3",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     ],
     "minimum-stability": "dev",
     "require-dev": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/filesystem": "^6.4|^7.0",
         "symfony/finder": "^6.4|^7.0",
         "php-cs-fixer/shim": "^3.62",

--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Remove `ParentEntityAutocompleteType` in favor of `BaseEntityAutocompleteType`
 - Remove `ExtraLazyChoiceLoader` in favor of `Symfony\Component\Form\ChoiceList\Loader\LazyChoiceLoader` from Symfony Form >=7.2
 - Add parameter `$security` to `AutocompleteResultsExecutor::__construct()`

--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-foundation": "^6.4|^7.0|^8.0",

--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -82,7 +82,7 @@ final class Kernel extends BaseKernel
             {
                 $container->removeDefinition('doctrine.orm.listeners.pdo_session_handler_schema_listener');
 
-                if (\PHP_VERSION_ID >= 80400 && $container->hasParameter('doctrine.orm.proxy_dir')) {
+                if ($container->hasParameter('doctrine.orm.proxy_dir')) {
                     // Workaround for `RuntimeException: Unable to create the Doctrine Proxy directory "". in vendor/symfony/doctrine-bridge/CacheWarmer/ProxyCacheWarmer.php:49`
                     // when running PHP 8.4 and Doctrine ORM 3.5+.
                     $container->getDefinition('doctrine.orm.default_configuration')
@@ -142,7 +142,7 @@ final class Kernel extends BaseKernel
                 }
             }
 
-            if (\PHP_VERSION_ID >= 80400 && version_compare($doctrineBundleVersion, '2.15.0', '>=') && version_compare($doctrineBundleVersion, '4.0.0', '<')) {
+            if (version_compare($doctrineBundleVersion, '2.15.0', '>=') && version_compare($doctrineBundleVersion, '4.0.0', '<')) {
                 $doctrineConfig['orm']['enable_native_lazy_objects'] = true;
             }
         }

--- a/src/Chartjs/CHANGELOG.md
+++ b/src/Chartjs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 
 ## 2.35

--- a/src/Chartjs/composer.json
+++ b/src/Chartjs/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/config": "^6.4|^7.0|^8.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/http-kernel": "^6.4|^7.0|^8.0",

--- a/src/Cropperjs/CHANGELOG.md
+++ b/src/Cropperjs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Always apply rotation in `Crop::getCroppedImage()` and `Crop::getCroppedThumbnail()`
 
 ## 2.34

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "intervention/image": "^2.5",
         "symfony/config": "^6.4|^7.0|^8.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",

--- a/src/Dropzone/CHANGELOG.md
+++ b/src/Dropzone/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 
 ## 2.30
 

--- a/src/Dropzone/composer.json
+++ b/src/Dropzone/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/config": "^6.4|^7.0|^8.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/form": "^6.4|^7.0|^8.0",

--- a/src/Icons/CHANGELOG.md
+++ b/src/Icons/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 
 ## 2.35
 

--- a/src/Icons/composer.json
+++ b/src/Icons/composer.json
@@ -35,7 +35,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/twig-bundle": "^6.4|^7.0|^8.0"
     },

--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Remove `csrf` argument from `AsLiveComponent` in favor of same-origin/CORS
 
 ## 2.35

--- a/src/LiveComponent/composer.json
+++ b/src/LiveComponent/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/property-access": "^6.4|^7.0|^8.0",
         "symfony/property-info": "^6.4|^7.0|^8.0",

--- a/src/LiveComponent/tests/Fixtures/Kernel.php
+++ b/src/LiveComponent/tests/Fixtures/Kernel.php
@@ -197,7 +197,7 @@ final class Kernel extends BaseKernel
                 }
             }
 
-            if (\PHP_VERSION_ID >= 80400 && version_compare($doctrineBundleVersion, '2.15.0', '>=') && version_compare($doctrineBundleVersion, '4.0.0', '<')) {
+            if (version_compare($doctrineBundleVersion, '2.15.0', '>=') && version_compare($doctrineBundleVersion, '4.0.0', '<')) {
                 $doctrineConfig['orm']['enable_native_lazy_objects'] = true;
             }
         }

--- a/src/Map/CHANGELOG.md
+++ b/src/Map/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Remove `render_map()` Twig function, use `ux_map()` instead
 - Remove option `title` from `Polygon`, `Polyline`, `Rectangle` and `Circle`, use `infoWindow` instead
 - Remove property `rawOptions` from `ux:map:*:before-create` events, use `bridgeOptions` instead.

--- a/src/Map/composer.json
+++ b/src/Map/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/stimulus-bundle": "^2.18.1|^3.0"
     },
     "require-dev": {

--- a/src/Map/src/Bridge/Google/CHANGELOG.md
+++ b/src/Map/src/Bridge/Google/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Upgrade `@googlemaps/js-api-loader` JavaScript package from `^1.16.6` to `^2.0.0`:
     - If you use Symfony AssetMapper without Symfony Flex, run `bin/console importmap:require @googlemaps/js-api-loader@^2.0`
     - Options configurable through `UX_MAP_DSN` query params have changed:

--- a/src/Map/src/Bridge/Google/composer.json
+++ b/src/Map/src/Bridge/Google/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/stimulus-bundle": "^2.18.1|^3.0",
         "symfony/ux-map": "^2.19|^3.0"
     },

--- a/src/Map/src/Bridge/Leaflet/CHANGELOG.md
+++ b/src/Map/src/Bridge/Leaflet/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 
 ## 2.35
 

--- a/src/Map/src/Bridge/Leaflet/composer.json
+++ b/src/Map/src/Bridge/Leaflet/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/stimulus-bundle": "^2.18.1|^3.0",
         "symfony/ux-map": "^2.19|^3.0"
     },

--- a/src/Native/composer.json
+++ b/src/Native/composer.json
@@ -12,7 +12,7 @@
     ],
     "homepage": "https://symfony.com",
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/asset": "^6.4|^7.0|^8.0",
         "symfony/filesystem": "^6.4|^7.0|^8.0",
         "symfony/process": "^6.4|^7.0|^8.0",

--- a/src/Notify/CHANGELOG.md
+++ b/src/Notify/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 
 ## 2.35

--- a/src/Notify/composer.json
+++ b/src/Notify/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/config": "^6.4|^7.0|^8.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/http-kernel": "^6.4|^7.0|^8.0",

--- a/src/React/CHANGELOG.md
+++ b/src/React/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 
 ## 2.35

--- a/src/React/composer.json
+++ b/src/React/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/stimulus-bundle": "^2.9.1|^3.0"
     },
     "require-dev": {

--- a/src/StimulusBundle/CHANGELOG.md
+++ b/src/StimulusBundle/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Remove Twig function `ux_controller_link_tags()`, which requires Symfony AssetMapper >=6.4
 
 ## 2.33

--- a/src/StimulusBundle/composer.json
+++ b/src/StimulusBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/config": "^6.4|^7.0|^8.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/finder": "^6.4|^7.0|^8.0",

--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 
 ## 2.35
 

--- a/src/Toolkit/composer.json
+++ b/src/Toolkit/composer.json
@@ -30,7 +30,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "twig/twig": "^3.0",
         "symfony/console": "^6.4|^7.0|^8.0",
         "symfony/filesystem": "^6.4|^7.0|^8.0",

--- a/src/Translator/CHANGELOG.md
+++ b/src/Translator/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 
 ## 2.32
 

--- a/src/Translator/composer.json
+++ b/src/Translator/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/console": "^6.4|^7.0|^8.0",
         "symfony/filesystem": "^6.4|^7.0|^8.0",
         "symfony/string": "^6.4|^7.0|^8.0",

--- a/src/Turbo/CHANGELOG.md
+++ b/src/Turbo/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 - Remove BC layer for `TurboStreamListenRendererInterface::renderTurboStreamListen()` `$eventSourceOptions` parameter
 

--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -34,7 +34,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/stimulus-bundle": "^2.9.1|^3.0"
     },
     "require-dev": {

--- a/src/Turbo/tests/app/Kernel.php
+++ b/src/Turbo/tests/app/Kernel.php
@@ -111,7 +111,7 @@ class Kernel extends BaseKernel
                 }
             }
 
-            if (\PHP_VERSION_ID >= 80400 && version_compare($doctrineBundleVersion, '2.15.0', '>=') && version_compare($doctrineBundleVersion, '4.0.0', '<')) {
+            if (version_compare($doctrineBundleVersion, '2.15.0', '>=') && version_compare($doctrineBundleVersion, '4.0.0', '<')) {
                 $doctrineConfig['orm']['enable_native_lazy_objects'] = true;
             }
         }
@@ -203,17 +203,17 @@ class Kernel extends BaseKernel
     public function books(Request $request, EntityManagerInterface $doctrine, Environment $twig): Response
     {
         if ($request->isMethod('POST')) {
-            if ($id = $request->get('id')) {
+            if ($id = $request->request->get('id')) {
                 if (!($book = $doctrine->find(Book::class, $id))) {
                     throw new NotFoundHttpException();
                 }
             } else {
                 $book = new Book();
             }
-            if ($title = $request->get('title')) {
+            if ($title = $request->request->getString('title')) {
                 $book->title = $title;
             }
-            if ($remove = $request->get('remove')) {
+            if ($request->request->getBoolean('remove')) {
                 $doctrine->remove($book);
             } else {
                 $doctrine->persist($book);
@@ -228,21 +228,21 @@ class Kernel extends BaseKernel
     public function songs(Request $request, EntityManagerInterface $doctrine, Environment $twig): Response
     {
         if ($request->isMethod('POST')) {
-            if ($id = $request->get('id')) {
+            if ($id = $request->request->get('id')) {
                 if (!($song = $doctrine->find(Song::class, $id))) {
                     throw new NotFoundHttpException();
                 }
             } else {
                 $song = new Song();
             }
-            if ($title = $request->get('title')) {
+            if ($title = $request->request->getString('title')) {
                 $song->title = $title;
-                $artistId = $request->get('artistId');
+                $artistId = $request->request->get('artistId');
                 if ($artistId > 0) {
                     $song->artist = $doctrine->find(Artist::class, $artistId);
                 }
             }
-            if ($request->get('remove')) {
+            if ($request->request->get('remove')) {
                 $doctrine->remove($song);
             } else {
                 $doctrine->persist($song);
@@ -257,17 +257,17 @@ class Kernel extends BaseKernel
     public function artists(Request $request, EntityManagerInterface $doctrine, Environment $twig): Response
     {
         if ($request->isMethod('POST')) {
-            if ($id = $request->get('id')) {
+            if ($id = $request->request->get('id')) {
                 if (!($artist = $doctrine->find(Artist::class, $id))) {
                     throw new NotFoundHttpException();
                 }
             } else {
                 $artist = new Artist();
             }
-            if ($name = $request->get('name')) {
+            if ($name = $request->request->getString('name')) {
                 $artist->name = $name;
             }
-            if ($remove = $request->get('remove')) {
+            if ($request->request->get('remove')) {
                 $doctrine->remove($artist);
             } else {
                 $doctrine->persist($artist);
@@ -281,7 +281,7 @@ class Kernel extends BaseKernel
 
     public function artist(Request $request, EntityManagerInterface $doctrine, Environment $twig): Response
     {
-        $id = $request->get('id');
+        $id = $request->request->get('id');
 
         if (!($artist = $doctrine->find(Artist::class, $id))) {
             throw new NotFoundHttpException();
@@ -296,7 +296,7 @@ class Kernel extends BaseKernel
         if ($request->isMethod('POST')) {
             // on first post, create the objects
             // on second, update the artist
-            $id = $request->get('id');
+            $id = $request->request->get('id');
             if (!$id) {
                 $artist = new Artist();
                 $artist->name = 'testing artist';

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - The configuration `twig_component.defaults` could not be nullable anymore
 - Remove method `PreCreateForRenderEvent::getProps()` in favor of `PreCreateForRenderEvent::getInputProps()`
 - Remove `cva` Twig function in favor of [`html_cva` Twig function from `twig/html-extra`](https://twig.symfony.com/html_cva)

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/event-dispatcher": "^6.4|^7.0|^8.0",

--- a/src/Vue/CHANGELOG.md
+++ b/src/Vue/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0
 
 - Minimum required Symfony version is now 6.4
-- Minimum required PHP version is now 8.2
+- Minimum required PHP version is now 8.4
 - Remove old compatibility layer with deprecated `StimulusTwigExtension` from WebpackEncoreBundle ^1.0, use StimulusBundle instead
 
 ## 2.35

--- a/src/Vue/composer.json
+++ b/src/Vue/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "symfony/stimulus-bundle": "^2.9.1|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

As discussed internally, we upgraded from PHP 8.1 to 8.2 eight months ago, but we didn't have luck to release UX 3.0 yet.
Now, it does not really make sense, Symfony 8.0 has been released for a moment, and PHP 8.4 is the lowest maintained version of PHP.