### PR TITLE
[Turbo] Add TurboFrame service to detect Turbo Frame requests

### DIFF
--- a/src/Turbo/CHANGELOG.md
+++ b/src/Turbo/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0
 
 - Add a minimal layout for Turbo Frame responses, allowing `head` content like meta tags to work properly
+- Add `TurboFrame` service methods and Twig functions `turbo_is_frame_request()`/`turbo_frame_request_id()` to detect Turbo Frame requests
 
 ## 3.0.0
 

--- a/src/Turbo/config/services.php
+++ b/src/Turbo/config/services.php
@@ -18,6 +18,7 @@ use Symfony\UX\Turbo\Broadcaster\ImuxBroadcaster;
 use Symfony\UX\Turbo\Broadcaster\TwigBroadcaster;
 use Symfony\UX\Turbo\Doctrine\BroadcastListener;
 use Symfony\UX\Turbo\Request\RequestListener;
+use Symfony\UX\Turbo\TurboFrame;
 use Symfony\UX\Turbo\Twig\TurboRuntime;
 use Symfony\UX\Turbo\Twig\TwigExtension;
 
@@ -26,6 +27,13 @@ use Symfony\UX\Turbo\Twig\TwigExtension;
  */
 return static function (ContainerConfigurator $container): void {
     $container->services()
+
+        ->set('turbo.frame', TurboFrame::class)
+            ->args([service('request_stack')])
+            ->public()
+
+        ->alias(TurboFrame::class, 'turbo.frame')
+            ->public()
 
         ->set('turbo.broadcaster.imux', ImuxBroadcaster::class)
             ->args([tagged_iterator('turbo.broadcaster')])
@@ -54,6 +62,7 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 tagged_locator('turbo.renderer.stream_listen', 'transport'),
                 abstract_arg('default_transport'),
+                service('turbo.frame'),
             ])
             ->tag('twig.runtime')
 

--- a/src/Turbo/doc/index.rst
+++ b/src/Turbo/doc/index.rst
@@ -232,27 +232,45 @@ The content of a frame can be lazy loaded:
         </turbo-frame>
     {% endblock %}
 
-In your controller, you can detect if the request has been triggered by
-a Turbo Frame, and retrieve the ID of this frame::
+Detecting Turbo Frame Requests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Inject the ``TurboFrame`` service to detect whether the current request
+was triggered by a Turbo Frame and retrieve the frame's ID::
 
     // src/Controller/MyController.php
     namespace App\Controller;
 
-    use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing\Annotation\Route;
+    use Symfony\UX\Turbo\TurboFrame;
 
     class MyController
     {
         #[Route('/')]
-        public function home(Request $request): Response
+        public function home(TurboFrame $turboFrame): Response
         {
-            // Get the frame ID (will be null if the request hasn't been triggered by a Turbo Frame)
-            $frameId = $request->headers->get('Turbo-Frame');
+            if ($turboFrame->isFrameRequest()) {
+                // The request was triggered by a Turbo Frame.
+                // Render a partial response for the frame only.
+                $frameId = $turboFrame->getRequestId(); // e.g. "product_details"
+            }
 
             // ...
         }
     }
+
+You can also use the ``turbo_is_frame_request()`` and ``turbo_frame_request_id()``
+Twig functions directly in your templates:
+
+.. code-block:: html+twig
+
+    {% if turbo_is_frame_request() %}
+        {# Render a partial response for the frame #}
+        <p>Frame ID: {{ turbo_frame_request_id() }}</p>
+    {% else %}
+        {# Render the full page #}
+    {% endif %}
 
 <twig:Turbo:Frame> Twig Component
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/Turbo/src/TurboFrame.php
+++ b/src/Turbo/src/TurboFrame.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Provides helper methods to detect Turbo Frame requests.
+ *
+ * When a navigation is scoped to a Turbo Frame, Turbo sets the "Turbo-Frame"
+ * HTTP header to the frame's id attribute value.
+ *
+ * Inspired by Turbo Rails
+ * ({@see https://github.com/hotwired/turbo-rails/blob/main/app/controllers/turbo/frames/frame_request.rb}).
+ *
+ * @author Sébastien JEAN <sebastien.jean76@gmail.com>
+ *
+ * @see https://turbo.hotwired.dev/handbook/frames
+ */
+final class TurboFrame
+{
+    public function __construct(private readonly RequestStack $requestStack)
+    {
+    }
+
+    /**
+     * Returns true if the current request was triggered by a Turbo Frame.
+     *
+     * Turbo sets the "Turbo-Frame" HTTP header when navigating inside a frame.
+     *
+     * @phpstan-assert-if-true string $this->getRequestId()
+     */
+    public function isFrameRequest(): bool
+    {
+        return null !== $this->getRequestId();
+    }
+
+    /**
+     * Returns the ID of the Turbo Frame that triggered the current request,
+     * or null if the request was not triggered by a Turbo Frame.
+     */
+    public function getRequestId(): ?string
+    {
+        return $this->requestStack->getCurrentRequest()?->headers->get('Turbo-Frame');
+    }
+}

--- a/src/Turbo/src/Twig/TurboRuntime.php
+++ b/src/Turbo/src/Twig/TurboRuntime.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\Turbo\Twig;
 
 use Psr\Container\ContainerInterface;
 use Symfony\UX\Turbo\Bridge\Mercure\TopicSet;
+use Symfony\UX\Turbo\TurboFrame;
 use Twig\Environment;
 use Twig\Extension\RuntimeExtensionInterface;
 
@@ -27,6 +28,7 @@ final class TurboRuntime implements RuntimeExtensionInterface
     public function __construct(
         private ContainerInterface $turboStreamListenRenderers,
         private readonly string $defaultTransport,
+        private readonly TurboFrame $turboFrame,
     ) {
     }
 
@@ -53,5 +55,15 @@ final class TurboRuntime implements RuntimeExtensionInterface
         $renderer = $this->turboStreamListenRenderers->get($transport);
 
         return $renderer->renderTurboStreamListen($env, $topic, $options);
+    }
+
+    public function isTurboFrameRequest(): bool
+    {
+        return $this->turboFrame->isFrameRequest();
+    }
+
+    public function getTurboFrameRequestId(): ?string
+    {
+        return $this->turboFrame->getRequestId();
     }
 }

--- a/src/Turbo/src/Twig/TwigExtension.php
+++ b/src/Turbo/src/Twig/TwigExtension.php
@@ -29,6 +29,8 @@ final class TwigExtension extends AbstractExtension
     {
         return [
             new TwigFunction('turbo_stream_listen', [TurboRuntime::class, 'renderTurboStreamListen'], ['needs_environment' => true, 'is_safe' => ['html']]),
+            new TwigFunction('turbo_is_frame_request', [TurboRuntime::class, 'isTurboFrameRequest']),
+            new TwigFunction('turbo_frame_request_id', [TurboRuntime::class, 'getTurboFrameRequestId']),
             new TwigFunction('turbo_exempts_page_from_cache', $this->turboExemptsPageFromCache(...), ['is_safe' => ['html']]),
             new TwigFunction('turbo_exempts_page_from_preview', $this->turboExemptsPageFromPreview(...), ['is_safe' => ['html']]),
             new TwigFunction('turbo_page_requires_reload', $this->turboPageRequiresReload(...), ['is_safe' => ['html']]),

--- a/src/Turbo/tests/Kernel/FrameworkAppKernel.php
+++ b/src/Turbo/tests/Kernel/FrameworkAppKernel.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\UX\StimulusBundle\StimulusBundle;
 use Symfony\UX\Turbo\TurboBundle;
+use Symfony\UX\Turbo\TurboFrame;
 
 /**
  * Minimal kernel used by Turbo PHPUnit tests.
@@ -82,12 +83,21 @@ final class FrameworkAppKernel extends Kernel
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
         $routes->add('turbo_request', '/turboRequest')->controller('kernel::turboRequest');
+        $routes->add('turbo_frame_request', '/turboFrameRequest')->controller('kernel::turboFrameRequest');
     }
 
     public function turboRequest(Request $request): Response
     {
         return new JsonResponse([
             'preferred_format' => $request->getPreferredFormat(),
+        ]);
+    }
+
+    public function turboFrameRequest(TurboFrame $turboFrame): Response
+    {
+        return new JsonResponse([
+            'turbo_is_frame_request' => $turboFrame->isFrameRequest(),
+            'turbo_frame_request_id' => $turboFrame->getRequestId(),
         ]);
     }
 }

--- a/src/Turbo/tests/Request/TurboFrameRequestFunctionalTest.php
+++ b/src/Turbo/tests/Request/TurboFrameRequestFunctionalTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests\Request;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Sébastien JEAN <sebastien.jean76@gmail.com>
+ */
+class TurboFrameRequestFunctionalTest extends WebTestCase
+{
+    public function testIsNotTurboFrameRequestWithoutHeader()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/turboFrameRequest');
+
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertJsonStringEqualsJsonString(
+            (string) json_encode(['turbo_is_frame_request' => false, 'turbo_frame_request_id' => null]),
+            (string) $response->getContent()
+        );
+    }
+
+    public function testIsTurboFrameRequestWithHeader()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/turboFrameRequest', [], [], ['HTTP_Turbo-Frame' => 'my_frame']);
+
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertJsonStringEqualsJsonString(
+            (string) json_encode(['turbo_is_frame_request' => true, 'turbo_frame_request_id' => 'my_frame']),
+            (string) $response->getContent()
+        );
+    }
+}

--- a/src/Turbo/tests/TurboFrameRequestTest.php
+++ b/src/Turbo/tests/TurboFrameRequestTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Turbo\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\UX\Turbo\TurboFrame;
+
+/**
+ * @author Sébastien JEAN <sebastien.jean76@gmail.com>
+ */
+class TurboFrameRequestTest extends TestCase
+{
+    public function testIsRequestReturnsFalseWithoutHeader()
+    {
+        $turboFrame = $this->createTurboFrame(Request::create('/'));
+
+        $this->assertFalse($turboFrame->isFrameRequest());
+    }
+
+    public function testIsRequestReturnsTrueWithHeader()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Turbo-Frame', 'my_frame');
+
+        $turboFrame = $this->createTurboFrame($request);
+
+        $this->assertTrue($turboFrame->isFrameRequest());
+    }
+
+    public function testGetRequestIdReturnsNullWithoutHeader()
+    {
+        $turboFrame = $this->createTurboFrame(Request::create('/'));
+
+        $this->assertNull($turboFrame->getRequestId());
+    }
+
+    public function testGetRequestIdReturnsFrameId()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Turbo-Frame', 'my_frame');
+
+        $turboFrame = $this->createTurboFrame($request);
+
+        $this->assertSame('my_frame', $turboFrame->getRequestId());
+    }
+
+    public function testGetRequestIdReturnsNullWithNoCurrentRequest()
+    {
+        $requestStack = new RequestStack();
+        $turboFrame = new TurboFrame($requestStack);
+
+        $this->assertNull($turboFrame->getRequestId());
+        $this->assertFalse($turboFrame->isFrameRequest());
+    }
+
+    private function createTurboFrame(Request $request): TurboFrame
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return new TurboFrame($requestStack);
+    }
+}

--- a/src/Turbo/tests/Twig/TurboRuntimeTest.php
+++ b/src/Turbo/tests/Twig/TurboRuntimeTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\UX\Turbo\Tests\Twig;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 use Symfony\Contracts\Service\ServiceProviderInterface;
+use Symfony\UX\Turbo\TurboFrame;
 use Symfony\UX\Turbo\Twig\TurboRuntime;
 use Symfony\UX\Turbo\Twig\TurboStreamListenRendererInterface;
 use Twig\Environment;
@@ -32,7 +34,7 @@ final class TurboRuntimeTest extends TestCase
             use ServiceLocatorTrait;
         };
 
-        $runtime = new TurboRuntime($container, 'default');
+        $runtime = new TurboRuntime($container, 'default', new TurboFrame(new RequestStack()));
         $runtime->renderTurboStreamListen($twig, 'a_topic');
     }
 
@@ -50,7 +52,7 @@ final class TurboRuntimeTest extends TestCase
             use ServiceLocatorTrait;
         };
 
-        $runtime = new TurboRuntime($container, 'hub1');
+        $runtime = new TurboRuntime($container, 'hub1', new TurboFrame(new RequestStack()));
         $runtime->renderTurboStreamListen($twig, 'a_topic', 'hub2');
     }
 
@@ -64,7 +66,7 @@ final class TurboRuntimeTest extends TestCase
             use ServiceLocatorTrait;
         };
 
-        $runtime = new TurboRuntime($container, 'default');
+        $runtime = new TurboRuntime($container, 'default', new TurboFrame(new RequestStack()));
         $runtime->renderTurboStreamListen($twig, 'a_topic', 'default', ['hub' => 'hub3']);
     }
 }


### PR DESCRIPTION

| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

**Summary**

Adds `TurboFrame` service to detect Turbo Frame requests in Symfony UX Turbo, inspired by the https://github.com/hotwired/turbo-rails/blob/main/app/controllers/turbo/frames/frame_request.rb helpers from Turbo Rails.

**New service**

Inject `TurboFrame` in your controller to detect whether the current request was triggered by a Turbo Frame:

```php
use Symfony\UX\Turbo\TurboFrame;

public function show(Post $post, TurboFrame $turboFrame): Response
{
    if ($turboFrame->isFrameRequest()) {
        return $this->render('post/_show.html.twig', ['post' => $post]);
    }

    return $this->render('post/show.html.twig', ['post' => $post]);
}
```

**New Twig functions**

```twig
  {# post/_show.html.twig #}
  <turbo-frame id="{{ turbo_frame_request_id() }}">
      {{ post.title }}
  </turbo-frame>
```