### PR TITLE
[Toolkit][Shadcn] Add input-otp, resizable and navigation-menu recipes

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -6,11 +6,12 @@
 - Minimum required PHP version is now 8.4
 - [Shadcn] Add `input-otp` recipe
 - [Shadcn] Add `resizable` recipe
+- [Shadcn] Add `navigation-menu` recipe
 
 ## 2.35
 
 - [Flowbite] Add Flowbite v4 kit
- - [Shadcn] Add `toggle` recipe
+- [Shadcn] Add `toggle` recipe
 - [Shadcn] Use `html_attr_type` filter from `twig/html-extra:^3.24` for composable trigger attributes
 - [Shadcn] Rename `trigger_attrs` to `alert_dialog_trigger_attrs` in `AlertDialog:Trigger`
 - [Shadcn] Rename `trigger_attrs` to `dialog_trigger_attrs` in `Dialog:Trigger`

--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minimum required Symfony version is now 7.4
 - Minimum required PHP version is now 8.4
+- [Shadcn] Add `input-otp` recipe
 
 ## 2.35
 

--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -5,11 +5,12 @@
 - Minimum required Symfony version is now 7.4
 - Minimum required PHP version is now 8.4
 - [Shadcn] Add `input-otp` recipe
+- [Shadcn] Add `resizable` recipe
 
 ## 2.35
 
 - [Flowbite] Add Flowbite v4 kit
-- [Shadcn] Add `toggle` recipe
+ - [Shadcn] Add `toggle` recipe
 - [Shadcn] Use `html_attr_type` filter from `twig/html-extra:^3.24` for composable trigger attributes
 - [Shadcn] Rename `trigger_attrs` to `alert_dialog_trigger_attrs` in `AlertDialog:Trigger`
 - [Shadcn] Rename `trigger_attrs` to `dialog_trigger_attrs` in `Dialog:Trigger`

--- a/src/Toolkit/kits/shadcn/input-otp/examples/Demo.html.twig
+++ b/src/Toolkit/kits/shadcn/input-otp/examples/Demo.html.twig
@@ -1,0 +1,9 @@
+<twig:InputOtp>
+    <twig:InputOtp:Slot name="otp[0]" />
+    <twig:InputOtp:Slot name="otp[1]" />
+    <twig:InputOtp:Slot name="otp[2]" />
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Slot name="otp[3]" />
+    <twig:InputOtp:Slot name="otp[4]" />
+    <twig:InputOtp:Slot name="otp[5]" />
+</twig:InputOtp>

--- a/src/Toolkit/kits/shadcn/input-otp/examples/Usage.html.twig
+++ b/src/Toolkit/kits/shadcn/input-otp/examples/Usage.html.twig
@@ -1,0 +1,8 @@
+<twig:InputOtp>
+    <twig:InputOtp:Slot name="otp[0]" />
+    <twig:InputOtp:Slot name="otp[1]" />
+    <twig:InputOtp:Slot name="otp[2]" />
+    <twig:InputOtp:Slot name="otp[3]" />
+    <twig:InputOtp:Slot name="otp[4]" />
+    <twig:InputOtp:Slot name="otp[5]" />
+</twig:InputOtp>

--- a/src/Toolkit/kits/shadcn/input-otp/manifest.json
+++ b/src/Toolkit/kits/shadcn/input-otp/manifest.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Input OTP",
+    "description": "A group of single-character inputs for one-time passwords and verification codes.",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["tales-from-a-dev/twig-tailwind-extra:^1.0.0"]
+    }
+}

--- a/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp.html.twig
+++ b/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp.html.twig
@@ -1,0 +1,9 @@
+{# @block content The OTP slot inputs, typically multiple `InputOtp:Slot` components #}
+<div
+    class="{{ ('flex items-center gap-2 has-[:disabled]:opacity-50 ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'input-otp',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Separator.html.twig
+++ b/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Separator.html.twig
@@ -1,0 +1,8 @@
+<span
+    role="separator"
+    class="{{ ('text-muted-foreground ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'input-otp-separator',
+    }) }}
+    aria-hidden="true"
+>-</span>

--- a/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Slot.html.twig
+++ b/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Slot.html.twig
@@ -1,0 +1,8 @@
+<input
+    type="text"
+    inputmode="numeric"
+    maxlength="1"
+    class="{{ ('relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 ' ~ attributes.render('class'))|tailwind_merge }}"
+    data-slot="input-otp-slot"
+    {{ attributes }}
+>

--- a/src/Toolkit/kits/shadcn/navigation-menu/examples/Demo.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/examples/Demo.html.twig
@@ -1,0 +1,32 @@
+<twig:NavigationMenu>
+    <twig:NavigationMenu:List>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Trigger>Getting started</twig:NavigationMenu:Trigger>
+            <twig:NavigationMenu:Content class="w-[420px]">
+                <div class="grid gap-1">
+                    <a class="rounded-md p-3 hover:bg-accent" href="/docs/install">
+                        <div class="text-sm font-medium">Installation</div>
+                        <p class="text-xs text-muted-foreground">How to install the Toolkit.</p>
+                    </a>
+                    <a class="rounded-md p-3 hover:bg-accent" href="/docs/primitives">
+                        <div class="text-sm font-medium">Primitives</div>
+                        <p class="text-xs text-muted-foreground">Building blocks of the Toolkit.</p>
+                    </a>
+                </div>
+            </twig:NavigationMenu:Content>
+        </twig:NavigationMenu:Item>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Trigger>Components</twig:NavigationMenu:Trigger>
+            <twig:NavigationMenu:Content>
+                <ul class="grid gap-1">
+                    <li><a class="block rounded-md p-2 hover:bg-accent" href="/docs/components/alert">Alert</a></li>
+                    <li><a class="block rounded-md p-2 hover:bg-accent" href="/docs/components/button">Button</a></li>
+                    <li><a class="block rounded-md p-2 hover:bg-accent" href="/docs/components/dialog">Dialog</a></li>
+                </ul>
+            </twig:NavigationMenu:Content>
+        </twig:NavigationMenu:Item>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Link href="/docs">Documentation</twig:NavigationMenu:Link>
+        </twig:NavigationMenu:Item>
+    </twig:NavigationMenu:List>
+</twig:NavigationMenu>

--- a/src/Toolkit/kits/shadcn/navigation-menu/examples/Usage.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/examples/Usage.html.twig
@@ -1,0 +1,10 @@
+<twig:NavigationMenu>
+    <twig:NavigationMenu:List>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Link href="/">Home</twig:NavigationMenu:Link>
+        </twig:NavigationMenu:Item>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+        </twig:NavigationMenu:Item>
+    </twig:NavigationMenu:List>
+</twig:NavigationMenu>

--- a/src/Toolkit/kits/shadcn/navigation-menu/manifest.json
+++ b/src/Toolkit/kits/shadcn/navigation-menu/manifest.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Navigation Menu",
+    "description": "A collection of navigation links with optional hover-triggered submenus.",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["tales-from-a-dev/twig-tailwind-extra:^1.0.0"]
+    }
+}

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu.html.twig
@@ -1,0 +1,10 @@
+{# @block content A `NavigationMenu:List` containing `NavigationMenu:Item` children #}
+<nav
+    class="{{ ('relative flex max-w-max flex-1 items-center justify-center ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'navigation-menu',
+        'aria-label': 'Main',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</nav>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Content.html.twig
@@ -1,0 +1,9 @@
+{# @block content The submenu revealed on hover or focus #}
+<div
+    class="{{ ('invisible opacity-0 group-hover/nav-item:visible group-hover/nav-item:opacity-100 group-focus-within/nav-item:visible group-focus-within/nav-item:opacity-100 transition-opacity absolute left-0 top-full z-50 mt-1.5 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'navigation-menu-content',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Item.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Item.html.twig
@@ -1,0 +1,9 @@
+{# @block content The trigger and optional submenu content #}
+<li
+    class="{{ ('group/nav-item relative ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'navigation-menu-item',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</li>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Link.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Link.html.twig
@@ -1,0 +1,12 @@
+{# @prop href string Target URL #}
+{# @block content The link label #}
+{%- props href -%}
+<a
+    href="{{ href }}"
+    class="{{ ('inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'navigation-menu-link',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</a>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/List.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/List.html.twig
@@ -1,0 +1,9 @@
+{# @block content The `NavigationMenu:Item` children #}
+<ul
+    class="{{ ('group flex flex-1 list-none items-center justify-center gap-1 ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'navigation-menu-list',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</ul>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Trigger.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Trigger.html.twig
@@ -1,0 +1,10 @@
+{# @block content The trigger label #}
+<button
+    type="button"
+    class="{{ ('inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'navigation-menu-trigger',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</button>

--- a/src/Toolkit/kits/shadcn/resizable/examples/Demo.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/examples/Demo.html.twig
@@ -1,0 +1,11 @@
+<div class="flex flex-col gap-6">
+    <twig:Resizable direction="horizontal" class="h-32 w-64 p-4">
+        <p>Horizontal resize — drag the right edge.</p>
+    </twig:Resizable>
+    <twig:Resizable direction="vertical" class="h-32 w-64 p-4">
+        <p>Vertical resize — drag the bottom edge.</p>
+    </twig:Resizable>
+    <twig:Resizable class="h-32 w-64 p-4">
+        <p>Both axes — drag the bottom-right corner.</p>
+    </twig:Resizable>
+</div>

--- a/src/Toolkit/kits/shadcn/resizable/examples/Usage.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/examples/Usage.html.twig
@@ -1,0 +1,3 @@
+<twig:Resizable class="h-40 w-64 p-4">
+    <p>Drag the bottom-right corner to resize me in any direction.</p>
+</twig:Resizable>

--- a/src/Toolkit/kits/shadcn/resizable/manifest.json
+++ b/src/Toolkit/kits/shadcn/resizable/manifest.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Resizable",
+    "description": "A panel that can be resized horizontally or vertically using the browser native resize handle.",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["tales-from-a-dev/twig-tailwind-extra:^1.0.0"]
+    }
+}

--- a/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable.html.twig
@@ -1,0 +1,22 @@
+{# @prop direction 'both'|'horizontal'|'vertical' Which axis can be resized. Defaults to `both` #}
+{# @block content The content of the resizable panel #}
+{%- props direction = 'both' -%}
+{%- set style = html_cva(
+    base: 'overflow-auto rounded-md border bg-background',
+    variants: {
+        direction: {
+            both: 'resize min-h-24 min-w-48',
+            horizontal: 'resize-x min-w-48',
+            vertical: 'resize-y min-h-24',
+        },
+    },
+) -%}
+<div
+    class="{{ style.apply({direction: direction}, attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'resizable',
+        'data-direction': direction,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, code file Demo.html__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, code file Demo.html__1.html
@@ -1,0 +1,25 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<twig:InputOtp>
+    <twig:InputOtp:Slot name="otp[0]" />
+    <twig:InputOtp:Slot name="otp[1]" />
+    <twig:InputOtp:Slot name="otp[2]" />
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Slot name="otp[3]" />
+    <twig:InputOtp:Slot name="otp[4]" />
+    <twig:InputOtp:Slot name="otp[5]" />
+</twig:InputOtp>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex items-center gap-2 has-[:disabled]:opacity-50" data-slot="input-otp">
+<input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[0]">
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[1]">
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[2]">
+    <span role="separator" class="text-muted-foreground" data-slot="input-otp-separator" aria-hidden="true">-</span>
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[3]">
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[4]">
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[5]">
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, code file Usage.html__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, code file Usage.html__1.html
@@ -1,0 +1,23 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<twig:InputOtp>
+    <twig:InputOtp:Slot name="otp[0]" />
+    <twig:InputOtp:Slot name="otp[1]" />
+    <twig:InputOtp:Slot name="otp[2]" />
+    <twig:InputOtp:Slot name="otp[3]" />
+    <twig:InputOtp:Slot name="otp[4]" />
+    <twig:InputOtp:Slot name="otp[5]" />
+</twig:InputOtp>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex items-center gap-2 has-[:disabled]:opacity-50" data-slot="input-otp">
+<input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[0]">
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[1]">
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[2]">
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[3]">
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[4]">
+    <input type="text" inputmode="numeric" maxlength="1" class="relative flex h-10 w-10 items-center justify-center rounded-md border border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50" data-slot="input-otp-slot" name="otp[5]">
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, code file Demo.html__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, code file Demo.html__1.html
@@ -1,0 +1,61 @@
+<!--
+- Kit: Shadcn UI
+- Component: Navigation Menu
+- Code:
+```twig
+<twig:NavigationMenu>
+    <twig:NavigationMenu:List>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Trigger>Getting started</twig:NavigationMenu:Trigger>
+            <twig:NavigationMenu:Content class="w-[420px]">
+                <div class="grid gap-1">
+                    <a class="rounded-md p-3 hover:bg-accent" href="/docs/install">
+                        <div class="text-sm font-medium">Installation</div>
+                        <p class="text-xs text-muted-foreground">How to install the Toolkit.</p>
+                    </a>
+                    <a class="rounded-md p-3 hover:bg-accent" href="/docs/primitives">
+                        <div class="text-sm font-medium">Primitives</div>
+                        <p class="text-xs text-muted-foreground">Building blocks of the Toolkit.</p>
+                    </a>
+                </div>
+            </twig:NavigationMenu:Content>
+        </twig:NavigationMenu:Item>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Trigger>Components</twig:NavigationMenu:Trigger>
+            <twig:NavigationMenu:Content>
+                <ul class="grid gap-1">
+                    <li><a class="block rounded-md p-2 hover:bg-accent" href="/docs/components/alert">Alert</a></li>
+                    <li><a class="block rounded-md p-2 hover:bg-accent" href="/docs/components/button">Button</a></li>
+                    <li><a class="block rounded-md p-2 hover:bg-accent" href="/docs/components/dialog">Dialog</a></li>
+                </ul>
+            </twig:NavigationMenu:Content>
+        </twig:NavigationMenu:Item>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Link href="/docs">Documentation</twig:NavigationMenu:Link>
+        </twig:NavigationMenu:Item>
+    </twig:NavigationMenu:List>
+</twig:NavigationMenu>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<nav class="relative flex max-w-max flex-1 items-center justify-center" data-slot="navigation-menu" aria-label="Main"><ul class="group flex flex-1 list-none items-center justify-center gap-1" data-slot="navigation-menu-list">
+<li class="group/nav-item relative" data-slot="navigation-menu-item">
+<button type="button" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50" data-slot="navigation-menu-trigger">Getting started</button>            <div class="invisible opacity-0 group-hover/nav-item:visible group-hover/nav-item:opacity-100 group-focus-within/nav-item:visible group-focus-within/nav-item:opacity-100 transition-opacity absolute left-0 top-full z-50 mt-1.5 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md w-[420px]" data-slot="navigation-menu-content">
+<div class="grid gap-1">
+                    <a class="rounded-md p-3 hover:bg-accent" href="/docs/install">
+                        <div class="text-sm font-medium">Installation</div>
+                        <p class="text-xs text-muted-foreground">How to install the Toolkit.</p>
+                    </a>
+                    <a class="rounded-md p-3 hover:bg-accent" href="/docs/primitives">
+                        <div class="text-sm font-medium">Primitives</div>
+                        <p class="text-xs text-muted-foreground">Building blocks of the Toolkit.</p>
+                    </a>
+                </div>
+            </div>        </li>        <li class="group/nav-item relative" data-slot="navigation-menu-item">
+<button type="button" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50" data-slot="navigation-menu-trigger">Components</button>            <div class="invisible opacity-0 group-hover/nav-item:visible group-hover/nav-item:opacity-100 group-focus-within/nav-item:visible group-focus-within/nav-item:opacity-100 transition-opacity absolute left-0 top-full z-50 mt-1.5 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md" data-slot="navigation-menu-content">
+<ul class="grid gap-1">
+                    <li><a class="block rounded-md p-2 hover:bg-accent" href="/docs/components/alert">Alert</a></li>
+                    <li><a class="block rounded-md p-2 hover:bg-accent" href="/docs/components/button">Button</a></li>
+                    <li><a class="block rounded-md p-2 hover:bg-accent" href="/docs/components/dialog">Dialog</a></li>
+                </ul>
+            </div>        </li>        <li class="group/nav-item relative" data-slot="navigation-menu-item">
+<a href="/docs" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50" data-slot="navigation-menu-link">Documentation</a>        </li>    </ul></nav>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, code file Usage.html__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, code file Usage.html__1.html
@@ -1,0 +1,21 @@
+<!--
+- Kit: Shadcn UI
+- Component: Navigation Menu
+- Code:
+```twig
+<twig:NavigationMenu>
+    <twig:NavigationMenu:List>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Link href="/">Home</twig:NavigationMenu:Link>
+        </twig:NavigationMenu:Item>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+        </twig:NavigationMenu:Item>
+    </twig:NavigationMenu:List>
+</twig:NavigationMenu>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<nav class="relative flex max-w-max flex-1 items-center justify-center" data-slot="navigation-menu" aria-label="Main"><ul class="group flex flex-1 list-none items-center justify-center gap-1" data-slot="navigation-menu-list">
+<li class="group/nav-item relative" data-slot="navigation-menu-item">
+<a href="/" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50" data-slot="navigation-menu-link">Home</a>        </li>        <li class="group/nav-item relative" data-slot="navigation-menu-item">
+<a href="/docs" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50" data-slot="navigation-menu-link">Docs</a>        </li>    </ul></nav>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Demo.html__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Demo.html__1.html
@@ -1,0 +1,27 @@
+<!--
+- Kit: Shadcn UI
+- Component: Resizable
+- Code:
+```twig
+<div class="flex flex-col gap-6">
+    <twig:Resizable direction="horizontal" class="h-32 w-64 p-4">
+        <p>Horizontal resize — drag the right edge.</p>
+    </twig:Resizable>
+    <twig:Resizable direction="vertical" class="h-32 w-64 p-4">
+        <p>Vertical resize — drag the bottom edge.</p>
+    </twig:Resizable>
+    <twig:Resizable class="h-32 w-64 p-4">
+        <p>Both axes — drag the bottom-right corner.</p>
+    </twig:Resizable>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col gap-6">
+    <div class="overflow-auto rounded-md border bg-background resize-x min-w-48 h-32 w-64 p-4" data-slot="resizable" data-direction="horizontal">
+<p>Horizontal resize &acirc;&#128;&#148; drag the right edge.</p>
+    </div>    <div class="overflow-auto rounded-md border bg-background resize-y min-h-24 h-32 w-64 p-4" data-slot="resizable" data-direction="vertical">
+<p>Vertical resize &acirc;&#128;&#148; drag the bottom edge.</p>
+    </div>    <div class="overflow-auto rounded-md border bg-background resize min-h-24 min-w-48 h-32 w-64 p-4" data-slot="resizable" data-direction="both">
+<p>Both axes &acirc;&#128;&#148; drag the bottom-right corner.</p>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Usage.html__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Usage.html__1.html
@@ -1,0 +1,13 @@
+<!--
+- Kit: Shadcn UI
+- Component: Resizable
+- Code:
+```twig
+<twig:Resizable class="h-40 w-64 p-4">
+    <p>Drag the bottom-right corner to resize me in any direction.</p>
+</twig:Resizable>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="overflow-auto rounded-md border bg-background resize min-h-24 min-w-48 h-40 w-64 p-4" data-slot="resizable" data-direction="both">
+<p>Drag the bottom-right corner to resize me in any direction.</p>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

Hi 👋

Third batch of recipes from the unchecked list in #3233 (previous batches: #3464, #3466). Still JS-free and leaning on native HTML / CSS:

- **input-otp** — a group of single-character inputs (`inputmode=numeric`, `maxlength=1`), with `InputOtp:Slot` and an optional `InputOtp:Separator`.
- **resizable** — a panel resizable via the browser-native `resize` CSS property. Accepts a `direction` prop (`both` / `horizontal` / `vertical`). Note: shadcn's official Resizable is a panel group with draggable split bars (Radix primitive), which requires JS; this recipe ships the pragmatic CSS-only variant — happy to drop it if you'd prefer to wait for the draggable version.
- **navigation-menu** — horizontal nav with optional hover/focus submenus, using `group/nav-item` + `group-hover/nav-item` / `group-focus-within/nav-item` (same pattern as the `hover-card` recipe in #3466). Comes with `List`, `Item`, `Link`, `Trigger`, and `Content` sub-components.

Each recipe has `Usage.html.twig`, `Demo.html.twig`, and passing snapshot tests (`254 tests, 508 assertions`).

Happy to split if easier — each recipe is a single commit.

Thanks again! 🙏