### PR TITLE
[PHP-CS-Fixer] Sync and adapt configuration from symfony/symfony

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -26,8 +26,8 @@ $fileHeaderParts = [
 return (new PhpCsFixer\Config())
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
-        '@PHP8x1Migration' => true, // take lowest version from `git grep -h '"php"' **/composer.json | uniq | sort`
-        '@PHPUnit9x1Migration:risky' => true,
+        '@PHP8x4Migration' => true, // take lowest version from `git grep -h '"php"' **/composer.json | uniq | sort`
+        '@PHPUnit11x0Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'header_comment' => [
@@ -41,10 +41,38 @@ return (new PhpCsFixer\Config())
             ]),
         ],
     ])
+    ->setRuleCustomisationPolicy(new class implements PhpCsFixer\Config\RuleCustomisationPolicyInterface {
+        public function getPolicyVersionForCache(): string
+        {
+            return hash_file('xxh128', __FILE__);
+        }
+
+        public function getRuleCustomisers(): array
+        {
+            return [
+                'void_return' => static function (SplFileInfo $file) {
+                    // temporary hack due to bug: https://github.com/symfony/symfony/issues/62734
+                    if (!$file instanceof Symfony\Component\Finder\SplFileInfo) {
+                        return false;
+                    }
+
+                    $relativePathname = $file->getRelativePathname();
+
+                    if (
+                        str_contains($relativePathname, '/Tests/') // don't touch test files, as massive change with little benefit - as outside of public contract anyway
+                        || str_contains($relativePathname, '/Test/') // public namespace not following the rule, do not mistake it with `/Tests/`
+                    ) {
+                        return false;
+                    }
+
+                    return true;
+                },
+            ];
+        }
+    })
     ->setRiskyAllowed(true)
     ->setFinder((new PhpCsFixer\Finder())
         ->in(__DIR__)
-        ->append([__FILE__])
         ->notPath('#/Fixtures/#')
         ->notPath('#/assets/#')
         ->notPath('#/var/#')

--- a/apps/e2e/src/Controller/MapController.php
+++ b/apps/e2e/src/Controller/MapController.php
@@ -35,7 +35,7 @@ final class MapController extends AbstractController
     public function basic(
         #[MapQueryParameter] MapRenderer $renderer,
     ): Response {
-        $map = (new Map(rendererName: $renderer->value))
+        $map = new Map(rendererName: $renderer->value)
             ->center(new Point(48.8566, 2.3522))
             ->zoom(12)
         ;
@@ -46,7 +46,7 @@ final class MapController extends AbstractController
     #[Route('/with-markers-and-fit-bounds-to-markers', name: 'with_markers_and_fit_bounds_to_markers')]
     public function withMarkersAndFitBoundsToMarkers(#[MapQueryParameter] MapRenderer $renderer): Response
     {
-        $map = (new Map(rendererName: $renderer->value))
+        $map = new Map(rendererName: $renderer->value)
             ->fitBoundsToMarkers()
             ->addMarker(new Marker(
                 position: new Point(48.8566, 2.3522),
@@ -64,7 +64,7 @@ final class MapController extends AbstractController
     #[Route('/with-markers-and-zoomed-on-paris', name: 'with_markers_and_zoomed_on_paris')]
     public function withMarkersZoomedOnParis(#[MapQueryParameter] MapRenderer $renderer): Response
     {
-        $map = (new Map(rendererName: $renderer->value))
+        $map = new Map(rendererName: $renderer->value)
             ->center(new Point(48.8566, 2.3522))
             ->zoom(10)
             ->addMarker(new Marker(
@@ -83,7 +83,7 @@ final class MapController extends AbstractController
     #[Route('/with-markers-and-info-windows', name: 'with_markers_and_info_windows')]
     public function withMarkersAndInfoWindows(#[MapQueryParameter] MapRenderer $renderer): Response
     {
-        $map = (new Map(rendererName: $renderer->value))
+        $map = new Map(rendererName: $renderer->value)
             ->fitBoundsToMarkers()
             ->addMarker(new Marker(
                 position: new Point(48.8566, 2.3522),
@@ -105,7 +105,7 @@ final class MapController extends AbstractController
         #[MapQueryParameter] MapRenderer $renderer,
         #[Autowire(service: 'asset_mapper.asset_package')] PackageInterface $package,
     ): Response {
-        $map = (new Map(rendererName: $renderer->value))
+        $map = new Map(rendererName: $renderer->value)
             ->fitBoundsToMarkers()
             ->addMarker(new Marker(
                 position: new Point(48.8566, 2.3522),
@@ -130,7 +130,7 @@ final class MapController extends AbstractController
     #[Route('/with-polygons', name: 'with_polygons')]
     public function withPolygons(#[MapQueryParameter] MapRenderer $renderer): Response
     {
-        $map = (new Map(rendererName: $renderer->value))
+        $map = new Map(rendererName: $renderer->value)
             ->center(new Point(48.8566, 2.3522))
             ->zoom(5)
             ->addPolygon(new Polygon(
@@ -171,7 +171,7 @@ final class MapController extends AbstractController
     #[Route('/with-polylines', name: 'with_polylines')]
     public function withPolylines(#[MapQueryParameter] MapRenderer $renderer): Response
     {
-        $map = (new Map(rendererName: $renderer->value))
+        $map = new Map(rendererName: $renderer->value)
             ->center(new Point(48.8566, 2.3522))
             ->zoom(5)
             ->addPolyline(new Polyline(
@@ -203,7 +203,7 @@ final class MapController extends AbstractController
     #[Route('/with-circles', name: 'with_circles')]
     public function withCircles(#[MapQueryParameter] MapRenderer $renderer): Response
     {
-        $map = (new Map(rendererName: $renderer->value))
+        $map = new Map(rendererName: $renderer->value)
             ->center(new Point(48.8566, 2.3522))
             ->zoom(5)
             ->addCircle(new Circle(
@@ -228,7 +228,7 @@ final class MapController extends AbstractController
     #[Route('/with-rectangles', name: 'with_rectangles')]
     public function withRectangles(#[MapQueryParameter] MapRenderer $renderer): Response
     {
-        $map = (new Map(rendererName: $renderer->value))
+        $map = new Map(rendererName: $renderer->value)
             ->center(new Point(48.8566, 2.3522))
             ->zoom(5)
             ->addRectangle(new Rectangle(

--- a/apps/e2e/src/Controller/TurboController.php
+++ b/apps/e2e/src/Controller/TurboController.php
@@ -27,12 +27,12 @@ final class TurboController extends AbstractController
     ): Response {
         if (2 === $page) {
             return $this->render('ux_turbo/drive_page_2.html.twig', [
-                'current_time' => (new \DateTimeImmutable())->format(\DateTimeInterface::RFC3339_EXTENDED),
+                'current_time' => new \DateTimeImmutable()->format(\DateTimeInterface::RFC3339_EXTENDED),
             ]);
         }
 
         return $this->render('ux_turbo/drive.html.twig', [
-            'current_time' => (new \DateTimeImmutable())->format(\DateTimeInterface::RFC3339_EXTENDED),
+            'current_time' => new \DateTimeImmutable()->format(\DateTimeInterface::RFC3339_EXTENDED),
         ]);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=8.4",
         "symfony/filesystem": "^6.4|^7.0",
         "symfony/finder": "^6.4|^7.0",
-        "php-cs-fixer/shim": "^3.62",
+        "php-cs-fixer/shim": "^3.95",
         "vincentlanglet/twig-cs-fixer": "^3.11"
     }
 }

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteFormTypePass.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteFormTypePass.php
@@ -44,7 +44,7 @@ class AutocompleteFormTypePass implements CompilerPassInterface
             }
             $alias = $this->getAlias($serviceId, $serviceDefinition, $tag);
 
-            $wrappedDefinition = (new ChildDefinition('ux.autocomplete.wrapped_entity_type_autocompleter'))
+            $wrappedDefinition = new ChildDefinition('ux.autocomplete.wrapped_entity_type_autocompleter')
                 // the "formType" string
                 ->replaceArgument(0, $serviceDefinition->getClass())
                 ->addTag(self::ENTITY_AUTOCOMPLETER_TAG, ['alias' => $alias])

--- a/src/Autocomplete/tests/Integration/AutocompleteResultsExecutorTest.php
+++ b/src/Autocomplete/tests/Integration/AutocompleteResultsExecutorTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Icons/src/Registry/LocalSvgIconRegistry.php
+++ b/src/Icons/src/Registry/LocalSvgIconRegistry.php
@@ -72,6 +72,6 @@ final class LocalSvgIconRegistry implements IconRegistryInterface
     {
         $filename = \sprintf('%s/%s.svg', $this->iconDir, $name);
 
-        (new Filesystem())->dumpFile($filename, $svg);
+        new Filesystem()->dumpFile($filename, $svg);
     }
 }

--- a/src/Icons/src/Twig/IconFinder.php
+++ b/src/Icons/src/Twig/IconFinder.php
@@ -52,7 +52,7 @@ final class IconFinder
 
         // Extract prefix-less SVG files from the root of the icon directory
         if (is_dir($this->iconDirectory)) {
-            $icons = (new Finder())->files()->in($this->iconDirectory)->depth(0)->name('*.svg');
+            $icons = new Finder()->files()->in($this->iconDirectory)->depth(0)->name('*.svg');
             foreach ($icons as $icon) {
                 $found[] = $icon->getBasename('.svg');
             }
@@ -72,7 +72,7 @@ final class IconFinder
                 $paths = [...$paths, ...$loader->getPaths($namespace)];
             }
             if ($paths) {
-                foreach ((new Finder())->files()->in($paths)->name('*.twig') as $file) {
+                foreach (new Finder()->files()->in($paths)->name('*.twig') as $file) {
                     yield (string) $file;
                 }
             }

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -578,7 +578,7 @@ final class LiveComponentHydrator
         }
 
         $dehydratedObjectValues = [];
-        foreach ((new PropertyInfoExtractor([new ReflectionExtractor()]))->getProperties($classType) as $property) {
+        foreach (new PropertyInfoExtractor([new ReflectionExtractor()])->getProperties($classType) as $property) {
             $propertyValue = $this->propertyAccessor->getValue($value, $property);
             $propMetadata = $this->liveComponentMetadataFactory->createLivePropMetadata($classType, $property, new \ReflectionProperty($classType, $property), new LiveProp());
             $dehydratedObjectValues[$property] = $this->dehydrateValue($propertyValue, $propMetadata, $parentObject);

--- a/src/LiveComponent/src/Test/TestLiveComponent.php
+++ b/src/LiveComponent/src/Test/TestLiveComponent.php
@@ -65,7 +65,7 @@ final class TestLiveComponent
             $this->metadataFactory->getMetadata($this->metadata->getName()),
         );
 
-        return (new MountedComponent($this->metadata->getName(), $component, $componentAttributes))->getComponent();
+        return new MountedComponent($this->metadata->getName(), $component, $componentAttributes)->getComponent();
     }
 
     /**

--- a/src/LiveComponent/src/Util/LiveComponentStack.php
+++ b/src/LiveComponent/src/Util/LiveComponentStack.php
@@ -45,7 +45,7 @@ final class LiveComponentStack extends ComponentStack
 
     private function isLiveComponent(string $classname): bool
     {
-        return [] !== (new \ReflectionClass($classname))->getAttributes(AsLiveComponent::class);
+        return [] !== new \ReflectionClass($classname)->getAttributes(AsLiveComponent::class);
     }
 
     public function getCurrentComponent(): ?MountedComponent

--- a/src/LiveComponent/tests/Unit/Attribute/LivePropTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/LivePropTest.php
@@ -21,21 +21,21 @@ final class LivePropTest extends TestCase
 {
     public function testHydrateWithMethod()
     {
-        $this->assertSame('someMethod', (new LiveProp(false, 'someMethod'))->hydrateMethod());
-        $this->assertSame('someMethod', (new LiveProp(false, 'someMethod()'))->hydrateMethod());
+        $this->assertSame('someMethod', new LiveProp(false, 'someMethod')->hydrateMethod());
+        $this->assertSame('someMethod', new LiveProp(false, 'someMethod()')->hydrateMethod());
     }
 
     public function testDehydrateWithMethod()
     {
-        $this->assertSame('someMethod', (new LiveProp(false, null, 'someMethod'))->dehydrateMethod());
-        $this->assertSame('someMethod', (new LiveProp(false, null, 'someMethod()'))->dehydrateMethod());
+        $this->assertSame('someMethod', new LiveProp(false, null, 'someMethod')->dehydrateMethod());
+        $this->assertSame('someMethod', new LiveProp(false, null, 'someMethod()')->dehydrateMethod());
     }
 
     public function testCanCallCalculateFieldNameAsString()
     {
         $component = new class {};
 
-        $this->assertSame('field', (new LiveProp(false, null, null, false, [], 'field'))->calculateFieldName($component, 'fallback'));
+        $this->assertSame('field', new LiveProp(false, null, null, false, [], 'field')->calculateFieldName($component, 'fallback'));
     }
 
     public function testCanCallCalculateFieldNameAsMethod()
@@ -47,14 +47,14 @@ final class LivePropTest extends TestCase
             }
         };
 
-        $this->assertSame('foo', (new LiveProp(false, null, null, false, [], 'fieldName()'))->calculateFieldName($component, 'fallback'));
+        $this->assertSame('foo', new LiveProp(false, null, null, false, [], 'fieldName()')->calculateFieldName($component, 'fallback'));
     }
 
     public function testCanCallCalculateFieldNameWhenNotSet()
     {
         $component = new class {};
 
-        $this->assertSame('fallback', (new LiveProp())->calculateFieldName($component, 'fallback'));
+        $this->assertSame('fallback', new LiveProp()->calculateFieldName($component, 'fallback'));
     }
 
     public function testIsIdentityWritableAndWritablePaths()

--- a/src/Map/src/Bridge/Google/tests/GoogleRendererTest.php
+++ b/src/Map/src/Bridge/Google/tests/GoogleRendererTest.php
@@ -31,7 +31,7 @@ class GoogleRendererTest extends RendererTestCase
 {
     public static function provideTestRenderMap(): iterable
     {
-        $map = (new Map())
+        $map = new Map()
             ->center(new Point(48.8566, 2.3522))
             ->zoom(12);
         $marker1 = new Marker(position: new Point(48.8566, 2.3522), title: 'Paris', id: 'marker1');
@@ -56,7 +56,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with markers and infoWindows' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker(new Marker(position: new Point(48.8566, 2.3522), title: 'Paris', id: 'marker1'))
@@ -65,7 +65,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with all markers removed' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker($marker1)
@@ -76,7 +76,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with all markers removed with removeAllMarkers()' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker($marker1)
@@ -86,7 +86,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with marker remove and new ones added' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker($marker3)
@@ -97,7 +97,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with polygons and infoWindows' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addPolygon(new Polygon(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
@@ -106,7 +106,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with all polygons removed with removeAllPolygons()' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addPolygon(new Polygon(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
@@ -116,7 +116,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with polylines and infoWindows' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addPolyline(new Polyline(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
@@ -125,7 +125,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with all polylines removed with removeAllPolylines()' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addPolyline(new Polyline(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
@@ -135,7 +135,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with circles and infoWindows' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addCircle(new Circle(center: new Point(48.8566, 2.3522), radius: 500, infoWindow: new InfoWindow(content: 'Circle')))
@@ -144,7 +144,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with all circles removed with removeAllCircles()' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addCircle(new Circle(center: new Point(48.8566, 2.3522), radius: 500, infoWindow: new InfoWindow(content: 'Circle')))
@@ -154,7 +154,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with rectangles and infoWindows' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addRectangle(new Rectangle(southWest: new Point(48.8566, 2.3522), northEast: new Point(48.8566, 2.3522), infoWindow: new InfoWindow(content: 'Rectangle')))
@@ -163,7 +163,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with all rectangles removed with removeAllRectangles()' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addRectangle(new Rectangle(southWest: new Point(48.8566, 2.3522), northEast: new Point(48.8566, 2.3522), infoWindow: new InfoWindow(content: 'Rectangle')))
@@ -173,7 +173,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with controls enabled' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->options(new GoogleOptions(
@@ -186,7 +186,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'without controls enabled' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->options(new GoogleOptions(
@@ -199,14 +199,14 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with default map id' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), 'my_api_key', defaultMapId: 'DefaultMapId'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12),
         ];
 
         yield 'with default map id, when passing options (except the "mapId")' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), 'my_api_key', defaultMapId: 'DefaultMapId'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->options(new GoogleOptions()),
@@ -214,7 +214,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with default map id overridden by option "mapId"' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), 'my_api_key', defaultMapId: 'DefaultMapId'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->options(new GoogleOptions(mapId: 'CustomMapId')),
@@ -231,7 +231,7 @@ class GoogleRendererTest extends RendererTestCase
                 }),
                 'my_api_key'
             ),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker(new Marker(position: new Point(48.8566, 2.3522), title: 'Paris', icon: Icon::url('https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/icons/geo-alt.svg')->width(32)->height(32)))
@@ -241,7 +241,7 @@ class GoogleRendererTest extends RendererTestCase
 
         yield 'with map extra data' => [
             'renderer' => new GoogleRenderer(new StimulusHelper(null), new UxIconRenderer(null), key: 'api_key'),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->extra([

--- a/src/Map/src/Bridge/Leaflet/tests/LeafletRendererTest.php
+++ b/src/Map/src/Bridge/Leaflet/tests/LeafletRendererTest.php
@@ -30,7 +30,7 @@ class LeafletRendererTest extends RendererTestCase
 {
     public static function provideTestRenderMap(): iterable
     {
-        $map = (new Map())
+        $map = new Map()
             ->center(new Point(48.8566, 2.3522))
             ->zoom(12);
 
@@ -51,7 +51,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with markers and infoWindows' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker($marker1)
@@ -60,7 +60,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with all markers removed' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker($marker1)
@@ -71,7 +71,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with all markers removed with removeAllMarkers()' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker($marker1)
@@ -81,7 +81,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with marker remove and new ones added' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker($marker3)
@@ -92,7 +92,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with polygons and infoWindows' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addPolygon(new Polygon(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)], id: 'polygon1'))
@@ -101,7 +101,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with all polygons removed with removeAllPolygons()' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addPolygon(new Polygon(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
@@ -111,7 +111,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with polylines and infoWindows' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addPolyline(new Polyline(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)], id: 'polyline1'))
@@ -120,7 +120,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with all polylines removed with removeAllPolylines()' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addPolyline(new Polyline(points: [new Point(48.8566, 2.3522), new Point(48.8566, 2.3522), new Point(48.8566, 2.3522)]))
@@ -130,7 +130,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with circles and infoWindows' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addCircle(new Circle(center: new Point(48.8566, 2.3522), radius: 1000000, id: 'circle1'))
@@ -139,7 +139,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with all circles removed with removeAllCircles()' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addCircle(new Circle(center: new Point(48.8566, 2.3522), radius: 500, infoWindow: new InfoWindow(content: 'Circle')))
@@ -149,7 +149,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with rectangles and infoWindows' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addRectangle(new Rectangle(
@@ -167,7 +167,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with all rectangles removed with removeAllRectangles()' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addRectangle(new Rectangle(southWest: new Point(48.8566, 2.3522), northEast: new Point(48.8566, 2.3522), infoWindow: new InfoWindow(content: 'Rectangle')))
@@ -184,7 +184,7 @@ class LeafletRendererTest extends RendererTestCase
                         return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">...</svg>';
                     }
                 })),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->addMarker(new Marker(position: new Point(48.8566, 2.3522), title: 'Paris', icon: Icon::url('https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/icons/geo-alt.svg')->width(32)->height(32)))
@@ -194,7 +194,7 @@ class LeafletRendererTest extends RendererTestCase
 
         yield 'with map extra data' => [
             'renderer' => new LeafletRenderer(new StimulusHelper(null), new UxIconRenderer(null)),
-            'map' => (new Map())
+            'map' => new Map()
                 ->center(new Point(48.8566, 2.3522))
                 ->zoom(12)
                 ->extra(['key1' => 'value1', 'key2' => 'value2']),

--- a/src/Map/src/Exception/UnableToDenormalizeOptionsException.php
+++ b/src/Map/src/Exception/UnableToDenormalizeOptionsException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Map/src/Exception/UnableToNormalizeOptionsException.php
+++ b/src/Map/src/Exception/UnableToNormalizeOptionsException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Map/src/Live/ComponentWithMapTrait.php
+++ b/src/Map/src/Live/ComponentWithMapTrait.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Map/src/MapOptionsNormalizer.php
+++ b/src/Map/src/MapOptionsNormalizer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Map/tests/DummyOptions.php
+++ b/src/Map/tests/DummyOptions.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Map/tests/MapFactoryTest.php
+++ b/src/Map/tests/MapFactoryTest.php
@@ -62,7 +62,7 @@ class MapFactoryTest extends TestCase
 
     public function testToArrayFromArray()
     {
-        $map = (new Map())
+        $map = new Map()
             ->center(new Point(48.8566, 2.3522))
             ->zoom(12)
             ->addMarker(new Marker(

--- a/src/Map/tests/MapOptionsNormalizerTest.php
+++ b/src/Map/tests/MapOptionsNormalizerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Map/tests/Renderer/NullRendererFactoryTest.php
+++ b/src/Map/tests/Renderer/NullRendererFactoryTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Map/tests/Renderer/NullRendererTest.php
+++ b/src/Map/tests/Renderer/NullRendererTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Map/tests/Renderer/RenderersTest.php
+++ b/src/Map/tests/Renderer/RenderersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Map/tests/Twig/MapComponentTest.php
+++ b/src/Map/tests/Twig/MapComponentTest.php
@@ -26,7 +26,7 @@ class MapComponentTest extends KernelTestCase
 
     public function testRenderMapComponent()
     {
-        $map = (new Map())
+        $map = new Map()
             ->center(new Point(latitude: 5, longitude: 10))
             ->zoom(4);
         $attributes = ['data-foo' => 'bar'];

--- a/src/Map/tests/Twig/MapExtensionTest.php
+++ b/src/Map/tests/Twig/MapExtensionTest.php
@@ -46,7 +46,7 @@ class MapExtensionTest extends KernelTestCase
 
     public function testMapFunctionWithArray()
     {
-        $map = (new Map())
+        $map = new Map()
             ->center(new Point(latitude: 5, longitude: 10))
             ->zoom(4);
         $attributes = ['data-foo' => 'bar'];

--- a/src/Native/tests/AndroidConfigurationFactory.php
+++ b/src/Native/tests/AndroidConfigurationFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/AppKernel.php
+++ b/src/Native/tests/AppKernel.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/Command/ConfigurationDumperTest.php
+++ b/src/Native/tests/Command/ConfigurationDumperTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *
@@ -32,7 +30,7 @@ final class ConfigurationDumperTest extends TestCase
 
     protected function tearDown(): void
     {
-        (new Filesystem())->remove($this->outputDir);
+        new Filesystem()->remove($this->outputDir);
     }
 
     public function testExecuteCallsBuildAndReturnsSuccess()

--- a/src/Native/tests/Configuration/ConfigurationTest.php
+++ b/src/Native/tests/Configuration/ConfigurationTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/Configuration/RuleTest.php
+++ b/src/Native/tests/Configuration/RuleTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/ConfigurationBuilderTest.php
+++ b/src/Native/tests/ConfigurationBuilderTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *
@@ -31,7 +29,7 @@ final class ConfigurationBuilderTest extends TestCase
 
     protected function tearDown(): void
     {
-        (new Filesystem())->remove($this->outputDir);
+        new Filesystem()->remove($this->outputDir);
     }
 
     public function testAddAndHas()

--- a/src/Native/tests/ConfigurationCompilerPassTest.php
+++ b/src/Native/tests/ConfigurationCompilerPassTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/EventListener/DevServerEventListenerTest.php
+++ b/src/Native/tests/EventListener/DevServerEventListenerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/EventListener/NativeListenerTest.php
+++ b/src/Native/tests/EventListener/NativeListenerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/Functional/CompileCommandTest.php
+++ b/src/Native/tests/Functional/CompileCommandTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/IosConfigurationFactory.php
+++ b/src/Native/tests/IosConfigurationFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/Twig/NativeExtensionTest.php
+++ b/src/Native/tests/Twig/NativeExtensionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/autoload.php
+++ b/src/Native/tests/autoload.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/config.php
+++ b/src/Native/tests/config.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Native/tests/routes.php
+++ b/src/Native/tests/routes.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/src/Command/DebugKitCommand.php
+++ b/src/Toolkit/src/Command/DebugKitCommand.php
@@ -77,7 +77,7 @@ class DebugKitCommand extends Command
 
         $io->section('Recipes');
         foreach ($kit->getRecipes() as $recipe) {
-            (new Table($io))
+            new Table($io)
                 ->setHeaderTitle(\sprintf('Recipe: "%s"', $recipe->name))
                 ->setHorizontal()
                 ->setHeaders([

--- a/src/Toolkit/src/Installer/InstallationReport.php
+++ b/src/Toolkit/src/Installer/InstallationReport.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/src/Installer/Installer.php
+++ b/src/Toolkit/src/Installer/Installer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/src/Installer/Pool.php
+++ b/src/Toolkit/src/Installer/Pool.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/src/Installer/PoolResolver.php
+++ b/src/Toolkit/src/Installer/PoolResolver.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/src/Kit/KitSynchronizer.php
+++ b/src/Toolkit/src/Kit/KitSynchronizer.php
@@ -40,7 +40,7 @@ final class KitSynchronizer
 
     private function synchronizeRecipes(Kit $kit): void
     {
-        $finder = (new Finder())
+        $finder = new Finder()
             ->in($kit->absolutePath)
             ->files()
             ->depth('== 1')

--- a/src/Toolkit/src/Recipe/Recipe.php
+++ b/src/Toolkit/src/Recipe/Recipe.php
@@ -42,7 +42,7 @@ final class Recipe
     public function getFiles(): iterable
     {
         foreach ($this->manifest->copyFiles as $source => $destination) {
-            $finder = (new Finder())->in(Path::join($this->absolutePath, $source))->sortByName()->files();
+            $finder = new Finder()->in(Path::join($this->absolutePath, $source))->sortByName()->files();
 
             foreach ($finder as $file) {
                 yield new File(Path::join($source, $file->getRelativePathname()), Path::join($destination, $file->getRelativePathname()));

--- a/src/Toolkit/src/Registry/LocalRegistry.php
+++ b/src/Toolkit/src/Registry/LocalRegistry.php
@@ -54,7 +54,7 @@ final class LocalRegistry implements RegistryInterface
     public static function getAvailableKitsName(): array
     {
         $availableKitsName = [];
-        $finder = (new Finder())->directories()->in(self::$kitsDir)->sortByName()->depth(0);
+        $finder = new Finder()->directories()->in(self::$kitsDir)->sortByName()->depth(0);
 
         foreach ($finder as $directory) {
             $kitName = $directory->getRelativePathname();

--- a/src/Toolkit/tests/Dependency/ConstraintVersionTest.php
+++ b/src/Toolkit/tests/Dependency/ConstraintVersionTest.php
@@ -25,11 +25,11 @@ final class ConstraintVersionTest extends TestCase
 
     public function testCanBeCompared()
     {
-        $this->assertTrue((new ConstraintVersion('1.2.3'))->isHigherThan(new ConstraintVersion('1.2.2')));
-        $this->assertFalse((new ConstraintVersion('1.2.3'))->isHigherThan(new ConstraintVersion('1.2.4')));
-        $this->assertTrue((new ConstraintVersion('1.2.3'))->isHigherThan(new ConstraintVersion('1.1.99')));
-        $this->assertFalse((new ConstraintVersion('1.2.3'))->isHigherThan(new ConstraintVersion('1.2.3')));
-        $this->assertTrue((new ConstraintVersion('1.2.3'))->isHigherThan(new ConstraintVersion('0.99.99')));
-        $this->assertFalse((new ConstraintVersion('1.2.3'))->isHigherThan(new ConstraintVersion('2.0.0')));
+        $this->assertTrue(new ConstraintVersion('1.2.3')->isHigherThan(new ConstraintVersion('1.2.2')));
+        $this->assertFalse(new ConstraintVersion('1.2.3')->isHigherThan(new ConstraintVersion('1.2.4')));
+        $this->assertTrue(new ConstraintVersion('1.2.3')->isHigherThan(new ConstraintVersion('1.1.99')));
+        $this->assertFalse(new ConstraintVersion('1.2.3')->isHigherThan(new ConstraintVersion('1.2.3')));
+        $this->assertTrue(new ConstraintVersion('1.2.3')->isHigherThan(new ConstraintVersion('0.99.99')));
+        $this->assertFalse(new ConstraintVersion('1.2.3')->isHigherThan(new ConstraintVersion('2.0.0')));
     }
 }

--- a/src/Toolkit/tests/Installer/PoolResolverTest.php
+++ b/src/Toolkit/tests/Installer/PoolResolverTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/tests/Installer/PoolTest.php
+++ b/src/Toolkit/tests/Installer/PoolTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/tests/Kit/KitManifestTest.php
+++ b/src/Toolkit/tests/Kit/KitManifestTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/tests/Recipe/RecipeManifestTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeManifestTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/tests/Recipe/RecipeSynchronizerTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeSynchronizerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/tests/Recipe/RecipeTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Symfony package.
  *

--- a/src/Toolkit/tests/Registry/GitHubRegistryTest.php
+++ b/src/Toolkit/tests/Registry/GitHubRegistryTest.php
@@ -99,7 +99,7 @@ final class GitHubRegistryTest extends KernelTestCase
         $folderName = \sprintf('%s-%s', $repo, $version);
         $zip = new \ZipArchive();
         $zip->open($zipPath = \sprintf('%s/%s.zip', $this->tmpDir, $folderName), \ZipArchive::CREATE);
-        foreach ((new Finder())->files()->in($kitPath) as $file) {
+        foreach (new Finder()->files()->in($kitPath) as $file) {
             $zip->addFile($file->getPathname(), Path::join($folderName, $file->getRelativePathname()));
         }
         $zip->close();

--- a/src/Toolkit/tests/bootstrap.php
+++ b/src/Toolkit/tests/bootstrap.php
@@ -14,7 +14,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 require __DIR__.'/../vendor/autoload.php';
 
-(new Filesystem())->remove(__DIR__.'/../var');
+new Filesystem()->remove(__DIR__.'/../var');
 
 // @see https://github.com/symfony/symfony/issues/53812
 ErrorHandler::register(null, false);

--- a/src/Translator/tests/bootstrap.php
+++ b/src/Translator/tests/bootstrap.php
@@ -17,7 +17,7 @@ use Symfony\UX\Translator\Tests\Kernel\FrameworkAppKernel;
 
 require __DIR__.'/../vendor/autoload.php';
 
-(new Filesystem())->remove(__DIR__.'/../var');
+new Filesystem()->remove(__DIR__.'/../var');
 
 // @see https://github.com/symfony/symfony/issues/53812
 ErrorHandler::register(null, false);

--- a/src/Turbo/src/Request/RequestListener.php
+++ b/src/Turbo/src/Request/RequestListener.php
@@ -23,6 +23,6 @@ final class RequestListener
 {
     public function __invoke(): void
     {
-        (new Request())->setFormat(TurboBundle::STREAM_FORMAT, TurboBundle::STREAM_MEDIA_TYPE);
+        new Request()->setFormat(TurboBundle::STREAM_FORMAT, TurboBundle::STREAM_MEDIA_TYPE);
     }
 }

--- a/src/Turbo/tests/Bridge/Mercure/TurboStreamListenRendererTest.php
+++ b/src/Turbo/tests/Bridge/Mercure/TurboStreamListenRendererTest.php
@@ -35,7 +35,7 @@ final class TurboStreamListenRendererTest extends KernelTestCase
      */
     public static function provideTestCases(): iterable
     {
-        $newEscape = (new \ReflectionClass(StimulusAttributes::class))->hasMethod('escape');
+        $newEscape = new \ReflectionClass(StimulusAttributes::class)->hasMethod('escape');
 
         $book = new Book();
         $book->id = 123;

--- a/src/TwigComponent/src/Attribute/AsTwigComponent.php
+++ b/src/TwigComponent/src/Attribute/AsTwigComponent.php
@@ -110,7 +110,7 @@ class AsTwigComponent
      */
     protected static function attributeMethodsFor(string $attribute, object|string $component): \Traversable
     {
-        foreach ((new \ReflectionClass($component))->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+        foreach (new \ReflectionClass($component)->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
             if ($method->getAttributes($attribute, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null) {
                 yield $method;
             }

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -157,7 +157,7 @@ final class ComponentFactory implements ResetInterface
             return;
         }
 
-        $mount = $this->mountMethods[$component::class] ??= (new \ReflectionClass($component))->getMethod('mount');
+        $mount = $this->mountMethods[$component::class] ??= new \ReflectionClass($component)->getMethod('mount');
 
         $parameters = [];
         foreach ($mount->getParameters() as $refParameter) {

--- a/src/TwigComponent/src/ComputedPropertiesProxy.php
+++ b/src/TwigComponent/src/ComputedPropertiesProxy.php
@@ -46,7 +46,7 @@ final class ComputedPropertiesProxy
             return $this->cache[$method];
         }
 
-        if ((new \ReflectionMethod($this->component, $method))->getNumberOfRequiredParameters()) {
+        if (new \ReflectionMethod($this->component, $method)->getNumberOfRequiredParameters()) {
             throw new \LogicException('Cannot use computed methods for methods with required parameters.');
         }
 

--- a/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
+++ b/src/TwigComponent/src/DependencyInjection/Compiler/TwigComponentPass.php
@@ -114,7 +114,7 @@ final class TwigComponentPass implements CompilerPassInterface
     private function getMountMethods(string $component): array
     {
         $preMount = $mount = $postMount = [];
-        foreach ((new \ReflectionClass($component))->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+        foreach (new \ReflectionClass($component)->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
             foreach ($method->getAttributes(PreMount::class) as $attribute) {
                 $preMount[$method->getName()] = $attribute->newInstance()->priority;
             }

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -54,7 +54,7 @@ final class ComponentAttributesTest extends TestCase
             (string) $attributes->defaults(['class' => 'bar', 'style' => 'font-size: 10;'])
         );
 
-        $this->assertSame(['class' => 'foo'], (new ComponentAttributes([], new EscaperRuntime()))->defaults(['class' => 'foo'])->all());
+        $this->assertSame(['class' => 'foo'], new ComponentAttributes([], new EscaperRuntime())->defaults(['class' => 'foo'])->all());
     }
 
     public function testCanGetOnly()


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

I just noticed on https://github.com/symfony/ux/actions/runs/24403121430/job/71278930112?pr=3439 that PHP-CS-Fixer wanted to add `void` return type on `test*()` methods, which is not something we want.

Let's update our PHP-CS-Fixer configuration :)
