### PR TITLE
[Toolkit][Shadcn] Add hover-card recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Flowbite] Add `avatar` recipe
 - [Flowbite] Add `dropdown` recipe
+- [Shadcn] Add `hover-card` recipe
 - [Shadcn] Add `resizable` recipe
 
 ## 3.0.0

--- a/src/Toolkit/kits/shadcn/hover-card/assets/controllers/hover_card_controller.js
+++ b/src/Toolkit/kits/shadcn/hover-card/assets/controllers/hover_card_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static values = {
+        openDelay: { type: Number, default: 0 },
+        closeDelay: { type: Number, default: 0 },
+    };
+
+    connect() {
+        this.openTimeout = null;
+        this.closeTimeout = null;
+        this.element.dataset.state = 'closed';
+    }
+
+    disconnect() {
+        this.#clearTimeouts();
+    }
+
+    show() {
+        this.#clearTimeouts();
+        this.openTimeout = setTimeout(() => {
+            this.element.dataset.state = 'open';
+            this.openTimeout = null;
+        }, this.openDelayValue);
+    }
+
+    hide() {
+        this.#clearTimeouts();
+        this.closeTimeout = setTimeout(() => {
+            this.element.dataset.state = 'closed';
+            this.closeTimeout = null;
+        }, this.closeDelayValue);
+    }
+
+    #clearTimeouts() {
+        if (this.openTimeout) {
+            clearTimeout(this.openTimeout);
+            this.openTimeout = null;
+        }
+        if (this.closeTimeout) {
+            clearTimeout(this.closeTimeout);
+            this.closeTimeout = null;
+        }
+    }
+}

--- a/src/Toolkit/kits/shadcn/hover-card/examples/Demo.html.twig
+++ b/src/Toolkit/kits/shadcn/hover-card/examples/Demo.html.twig
@@ -1,0 +1,10 @@
+<twig:HoverCard>
+    <twig:HoverCard:Trigger>
+        <twig:Button variant="link" {{ ...hover_card_trigger_attrs }}>Hover Here</twig:Button>
+    </twig:HoverCard:Trigger>
+    <twig:HoverCard:Content class="w-64 flex flex-col gap-0.5">
+        <div class="font-semibold">@symfony</div>
+        <div>The PHP framework for web applications — created by @fabpot.</div>
+        <div class="mt-1 text-xs text-muted-foreground">Joined October 2010</div>
+    </twig:HoverCard:Content>
+</twig:HoverCard>

--- a/src/Toolkit/kits/shadcn/hover-card/examples/RTL.html.twig
+++ b/src/Toolkit/kits/shadcn/hover-card/examples/RTL.html.twig
@@ -1,0 +1,87 @@
+<div class="flex flex-col items-center gap-24 py-12">
+    {# Arabic #}
+    <div class="flex flex-wrap justify-center gap-2" dir="rtl">
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>يسار</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-1/2 left-auto right-full translate-x-0 -translate-y-1/2 mt-0 mr-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">سماعات لاسلكية</div>
+                <div class="text-sm text-muted-foreground">٩٩.٩٩ $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>أعلى</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-auto bottom-full mt-0 mb-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">سماعات لاسلكية</div>
+                <div class="text-sm text-muted-foreground">٩٩.٩٩ $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>أسفل</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="w-64 flex flex-col gap-1">
+                <div class="font-semibold">سماعات لاسلكية</div>
+                <div class="text-sm text-muted-foreground">٩٩.٩٩ $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>يمين</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-1/2 left-full translate-x-0 -translate-y-1/2 mt-0 ml-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">سماعات لاسلكية</div>
+                <div class="text-sm text-muted-foreground">٩٩.٩٩ $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+    </div>
+
+    {# Hebrew #}
+    <div class="flex flex-wrap justify-center gap-2" dir="rtl">
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>שמאל</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-1/2 left-auto right-full translate-x-0 -translate-y-1/2 mt-0 mr-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">אוזניות אלחוטיות</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>למעלה</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-auto bottom-full mt-0 mb-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">אוזניות אלחוטיות</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>למטה</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="w-64 flex flex-col gap-1">
+                <div class="font-semibold">אוזניות אלחוטיות</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>ימין</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-1/2 left-full translate-x-0 -translate-y-1/2 mt-0 ml-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">אוזניות אלחוטיות</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+    </div>
+</div>

--- a/src/Toolkit/kits/shadcn/hover-card/examples/Sides.html.twig
+++ b/src/Toolkit/kits/shadcn/hover-card/examples/Sides.html.twig
@@ -1,0 +1,53 @@
+<div class="flex flex-wrap justify-center gap-12 py-12">
+    {# Left #}
+    <twig:HoverCard>
+        <twig:HoverCard:Trigger>
+            <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>Left</twig:Button>
+        </twig:HoverCard:Trigger>
+        <twig:HoverCard:Content class="top-1/2 left-auto right-full translate-x-0 -translate-y-1/2 mt-0 mr-2">
+            <div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the left side of the trigger.</p>
+            </div>
+        </twig:HoverCard:Content>
+    </twig:HoverCard>
+
+    {# Top #}
+    <twig:HoverCard>
+        <twig:HoverCard:Trigger>
+            <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>Top</twig:Button>
+        </twig:HoverCard:Trigger>
+        <twig:HoverCard:Content class="top-auto bottom-full mt-0 mb-2">
+            <div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the top side of the trigger.</p>
+            </div>
+        </twig:HoverCard:Content>
+    </twig:HoverCard>
+
+    {# Bottom (default) #}
+    <twig:HoverCard>
+        <twig:HoverCard:Trigger>
+            <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>Bottom</twig:Button>
+        </twig:HoverCard:Trigger>
+        <twig:HoverCard:Content>
+            <div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the bottom side of the trigger.</p>
+            </div>
+        </twig:HoverCard:Content>
+    </twig:HoverCard>
+
+    {# Right #}
+    <twig:HoverCard>
+        <twig:HoverCard:Trigger>
+            <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>Right</twig:Button>
+        </twig:HoverCard:Trigger>
+        <twig:HoverCard:Content class="top-1/2 left-full translate-x-0 -translate-y-1/2 mt-0 ml-2">
+            <div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the right side of the trigger.</p>
+            </div>
+        </twig:HoverCard:Content>
+    </twig:HoverCard>
+</div>

--- a/src/Toolkit/kits/shadcn/hover-card/examples/Usage.html.twig
+++ b/src/Toolkit/kits/shadcn/hover-card/examples/Usage.html.twig
@@ -1,0 +1,8 @@
+<twig:HoverCard>
+    <twig:HoverCard:Trigger>
+        <a href="#" class="underline" {{ ...hover_card_trigger_attrs }}>@symfony</a>
+    </twig:HoverCard:Trigger>
+    <twig:HoverCard:Content>
+        The Symfony PHP framework — official organization on GitHub.
+    </twig:HoverCard:Content>
+</twig:HoverCard>

--- a/src/Toolkit/kits/shadcn/hover-card/manifest.json
+++ b/src/Toolkit/kits/shadcn/hover-card/manifest.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Hover Card",
+    "description": "A popup that displays rich content when a trigger is hovered.",
+    "copy-files": {
+        "assets/": "assets/",
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["tales-from-a-dev/twig-tailwind-extra:^1.0.0"]
+    }
+}

--- a/src/Toolkit/kits/shadcn/hover-card/templates/components/HoverCard.html.twig
+++ b/src/Toolkit/kits/shadcn/hover-card/templates/components/HoverCard.html.twig
@@ -1,0 +1,16 @@
+{# @prop openDelay number Delay in milliseconds before showing the content. Defaults to `0` #}
+{# @prop closeDelay number Delay in milliseconds before hiding the content. Defaults to `0` #}
+{# @block content The hover card structure, typically a `HoverCard:Trigger` and `HoverCard:Content` #}
+{%- props openDelay = 0, closeDelay = 0 -%}
+<span
+    class="{{ ('relative inline-block ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'hover-card',
+        'data-controller': 'hover-card',
+        'data-hover-card-open-delay-value': openDelay,
+        'data-hover-card-close-delay-value': closeDelay,
+        'data-action': 'mouseenter->hover-card#show mouseleave->hover-card#hide',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</span>

--- a/src/Toolkit/kits/shadcn/hover-card/templates/components/HoverCard/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/hover-card/templates/components/HoverCard/Content.html.twig
@@ -1,0 +1,10 @@
+{# @block content The content revealed on hover #}
+<span
+    role="tooltip"
+    class="{{ ('invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute left-1/2 top-full z-50 mt-2 w-64 -translate-x-1/2 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'hover-card-content',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</span>

--- a/src/Toolkit/kits/shadcn/hover-card/templates/components/HoverCard/Trigger.html.twig
+++ b/src/Toolkit/kits/shadcn/hover-card/templates/components/HoverCard/Trigger.html.twig
@@ -1,0 +1,7 @@
+{# @block content The element that reveals the hover card on hover or focus #}
+{%- set hover_card_trigger_attrs = {
+    'data-slot': 'hover-card-trigger',
+    tabindex: 0,
+    'data-action': 'focus->hover-card#show blur->hover-card#hide'|html_attr_type('sst'),
+} -%}
+{%- block content %}{% endblock -%}

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component hover-card, code file Demo.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component hover-card, code file Demo.html.twig__1.html
@@ -1,0 +1,23 @@
+<!--
+- Kit: Shadcn UI
+- Component: Hover Card
+- Code:
+```twig
+<twig:HoverCard>
+    <twig:HoverCard:Trigger>
+        <twig:Button variant="link" {{ ...hover_card_trigger_attrs }}>Hover Here</twig:Button>
+    </twig:HoverCard:Trigger>
+    <twig:HoverCard:Content class="w-64 flex flex-col gap-0.5">
+        <div class="font-semibold">@symfony</div>
+        <div>The PHP framework for web applications — created by @fabpot.</div>
+        <div class="mt-1 text-xs text-muted-foreground">Joined October 2010</div>
+    </twig:HoverCard:Content>
+</twig:HoverCard>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none text-primary underline-offset-4 hover:underline h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">Hover Here</button>
+        <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none w-64 flex flex-col gap-0.5" data-slot="hover-card-content"><div class="font-semibold">@symfony</div>
+        <div>The PHP framework for web applications &acirc;&#128;&#148; created by @fabpot.</div>
+        <div class="mt-1 text-xs text-muted-foreground">Joined October 2010</div>
+    </span>
+</span>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component hover-card, code file RTL.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component hover-card, code file RTL.html.twig__1.html
@@ -1,0 +1,147 @@
+<!--
+- Kit: Shadcn UI
+- Component: Hover Card
+- Code:
+```twig
+<div class="flex flex-col items-center gap-24 py-12">
+    {# Arabic #}
+    <div class="flex flex-wrap justify-center gap-2" dir="rtl">
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>يسار</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-1/2 left-auto right-full translate-x-0 -translate-y-1/2 mt-0 mr-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">سماعات لاسلكية</div>
+                <div class="text-sm text-muted-foreground">٩٩.٩٩ $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>أعلى</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-auto bottom-full mt-0 mb-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">سماعات لاسلكية</div>
+                <div class="text-sm text-muted-foreground">٩٩.٩٩ $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>أسفل</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="w-64 flex flex-col gap-1">
+                <div class="font-semibold">سماعات لاسلكية</div>
+                <div class="text-sm text-muted-foreground">٩٩.٩٩ $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>يمين</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-1/2 left-full translate-x-0 -translate-y-1/2 mt-0 ml-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">سماعات لاسلكية</div>
+                <div class="text-sm text-muted-foreground">٩٩.٩٩ $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+    </div>
+
+    {# Hebrew #}
+    <div class="flex flex-wrap justify-center gap-2" dir="rtl">
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>שמאל</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-1/2 left-auto right-full translate-x-0 -translate-y-1/2 mt-0 mr-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">אוזניות אלחוטיות</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>למעלה</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-auto bottom-full mt-0 mb-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">אוזניות אלחוטיות</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>למטה</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="w-64 flex flex-col gap-1">
+                <div class="font-semibold">אוזניות אלחוטיות</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+
+        <twig:HoverCard>
+            <twig:HoverCard:Trigger>
+                <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>ימין</twig:Button>
+            </twig:HoverCard:Trigger>
+            <twig:HoverCard:Content class="top-1/2 left-full translate-x-0 -translate-y-1/2 mt-0 ml-2 w-64 flex flex-col gap-1">
+                <div class="font-semibold">אוזניות אלחוטיות</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </twig:HoverCard:Content>
+        </twig:HoverCard>
+    </div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col items-center gap-24 py-12">
+        <div class="flex flex-wrap justify-center gap-2" dir="rtl">
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">&Ugrave;&#138;&Oslash;&sup3;&Oslash;&sect;&Oslash;&plusmn;</button>
+                        <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute z-50 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none top-1/2 left-auto right-full translate-x-0 -translate-y-1/2 mt-0 mr-2 w-64 flex flex-col gap-1" data-slot="hover-card-content"><div class="font-semibold">&Oslash;&sup3;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup1;&Oslash;&sect;&Oslash;&ordf; &Ugrave;&#132;&Oslash;&sect;&Oslash;&sup3;&Ugrave;&#132;&Ugrave;&#131;&Ugrave;&#138;&Oslash;&copy;</div>
+                <div class="text-sm text-muted-foreground">&Ugrave;&copy;&Ugrave;&copy;.&Ugrave;&copy;&Ugrave;&copy; $</div>
+            </span>
+        </span>
+
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">&Oslash;&pound;&Oslash;&sup1;&Ugrave;&#132;&Ugrave;&#137;</button>
+                        <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute left-1/2 z-50 -translate-x-1/2 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none top-auto bottom-full mt-0 mb-2 w-64 flex flex-col gap-1" data-slot="hover-card-content"><div class="font-semibold">&Oslash;&sup3;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup1;&Oslash;&sect;&Oslash;&ordf; &Ugrave;&#132;&Oslash;&sect;&Oslash;&sup3;&Ugrave;&#132;&Ugrave;&#131;&Ugrave;&#138;&Oslash;&copy;</div>
+                <div class="text-sm text-muted-foreground">&Ugrave;&copy;&Ugrave;&copy;.&Ugrave;&copy;&Ugrave;&copy; $</div>
+            </span>
+        </span>
+
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">&Oslash;&pound;&Oslash;&sup3;&Ugrave;&#129;&Ugrave;&#132;</button>
+                        <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none w-64 flex flex-col gap-1" data-slot="hover-card-content"><div class="font-semibold">&Oslash;&sup3;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup1;&Oslash;&sect;&Oslash;&ordf; &Ugrave;&#132;&Oslash;&sect;&Oslash;&sup3;&Ugrave;&#132;&Ugrave;&#131;&Ugrave;&#138;&Oslash;&copy;</div>
+                <div class="text-sm text-muted-foreground">&Ugrave;&copy;&Ugrave;&copy;.&Ugrave;&copy;&Ugrave;&copy; $</div>
+            </span>
+        </span>
+
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">&Ugrave;&#138;&Ugrave;&#133;&Ugrave;&#138;&Ugrave;&#134;</button>
+                        <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute z-50 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none top-1/2 left-full translate-x-0 -translate-y-1/2 mt-0 ml-2 w-64 flex flex-col gap-1" data-slot="hover-card-content"><div class="font-semibold">&Oslash;&sup3;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup1;&Oslash;&sect;&Oslash;&ordf; &Ugrave;&#132;&Oslash;&sect;&Oslash;&sup3;&Ugrave;&#132;&Ugrave;&#131;&Ugrave;&#138;&Oslash;&copy;</div>
+                <div class="text-sm text-muted-foreground">&Ugrave;&copy;&Ugrave;&copy;.&Ugrave;&copy;&Ugrave;&copy; $</div>
+            </span>
+        </span>
+    </div>
+
+        <div class="flex flex-wrap justify-center gap-2" dir="rtl">
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">&times;&copy;&times;&#158;&times;&#144;&times;&#156;</button>
+                        <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute z-50 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none top-1/2 left-auto right-full translate-x-0 -translate-y-1/2 mt-0 mr-2 w-64 flex flex-col gap-1" data-slot="hover-card-content"><div class="font-semibold">&times;&#144;&times;&#149;&times;&#150;&times;&nbsp;&times;&#153;&times;&#149;&times;&ordf; &times;&#144;&times;&#156;&times;&#151;&times;&#149;&times;&#152;&times;&#153;&times;&#149;&times;&ordf;</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </span>
+        </span>
+
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">&times;&#156;&times;&#158;&times;&cent;&times;&#156;&times;&#148;</button>
+                        <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute left-1/2 z-50 -translate-x-1/2 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none top-auto bottom-full mt-0 mb-2 w-64 flex flex-col gap-1" data-slot="hover-card-content"><div class="font-semibold">&times;&#144;&times;&#149;&times;&#150;&times;&nbsp;&times;&#153;&times;&#149;&times;&ordf; &times;&#144;&times;&#156;&times;&#151;&times;&#149;&times;&#152;&times;&#153;&times;&#149;&times;&ordf;</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </span>
+        </span>
+
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">&times;&#156;&times;&#158;&times;&#152;&times;&#148;</button>
+                        <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none w-64 flex flex-col gap-1" data-slot="hover-card-content"><div class="font-semibold">&times;&#144;&times;&#149;&times;&#150;&times;&nbsp;&times;&#153;&times;&#149;&times;&ordf; &times;&#144;&times;&#156;&times;&#151;&times;&#149;&times;&#152;&times;&#153;&times;&#149;&times;&ordf;</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </span>
+        </span>
+
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">&times;&#153;&times;&#158;&times;&#153;&times;&#159;</button>
+                        <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute z-50 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none top-1/2 left-full translate-x-0 -translate-y-1/2 mt-0 ml-2 w-64 flex flex-col gap-1" data-slot="hover-card-content"><div class="font-semibold">&times;&#144;&times;&#149;&times;&#150;&times;&nbsp;&times;&#153;&times;&#149;&times;&ordf; &times;&#144;&times;&#156;&times;&#151;&times;&#149;&times;&#152;&times;&#153;&times;&#149;&times;&ordf;</div>
+                <div class="text-sm text-muted-foreground">99.99 $</div>
+            </span>
+        </span>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component hover-card, code file Sides.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component hover-card, code file Sides.html.twig__1.html
@@ -1,0 +1,93 @@
+<!--
+- Kit: Shadcn UI
+- Component: Hover Card
+- Code:
+```twig
+<div class="flex flex-wrap justify-center gap-12 py-12">
+    {# Left #}
+    <twig:HoverCard>
+        <twig:HoverCard:Trigger>
+            <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>Left</twig:Button>
+        </twig:HoverCard:Trigger>
+        <twig:HoverCard:Content class="top-1/2 left-auto right-full translate-x-0 -translate-y-1/2 mt-0 mr-2">
+            <div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the left side of the trigger.</p>
+            </div>
+        </twig:HoverCard:Content>
+    </twig:HoverCard>
+
+    {# Top #}
+    <twig:HoverCard>
+        <twig:HoverCard:Trigger>
+            <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>Top</twig:Button>
+        </twig:HoverCard:Trigger>
+        <twig:HoverCard:Content class="top-auto bottom-full mt-0 mb-2">
+            <div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the top side of the trigger.</p>
+            </div>
+        </twig:HoverCard:Content>
+    </twig:HoverCard>
+
+    {# Bottom (default) #}
+    <twig:HoverCard>
+        <twig:HoverCard:Trigger>
+            <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>Bottom</twig:Button>
+        </twig:HoverCard:Trigger>
+        <twig:HoverCard:Content>
+            <div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the bottom side of the trigger.</p>
+            </div>
+        </twig:HoverCard:Content>
+    </twig:HoverCard>
+
+    {# Right #}
+    <twig:HoverCard>
+        <twig:HoverCard:Trigger>
+            <twig:Button variant="outline" {{ ...hover_card_trigger_attrs }}>Right</twig:Button>
+        </twig:HoverCard:Trigger>
+        <twig:HoverCard:Content class="top-1/2 left-full translate-x-0 -translate-y-1/2 mt-0 ml-2">
+            <div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the right side of the trigger.</p>
+            </div>
+        </twig:HoverCard:Content>
+    </twig:HoverCard>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-wrap justify-center gap-12 py-12">
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">Left</button>
+                <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute z-50 w-64 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none top-1/2 left-auto right-full translate-x-0 -translate-y-1/2 mt-0 mr-2" data-slot="hover-card-content"><div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the left side of the trigger.</p>
+            </div>
+        </span>
+    </span>
+
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">Top</button>
+                <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute left-1/2 z-50 w-64 -translate-x-1/2 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none top-auto bottom-full mt-0 mb-2" data-slot="hover-card-content"><div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the top side of the trigger.</p>
+            </div>
+        </span>
+    </span>
+
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">Bottom</button>
+                <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute left-1/2 top-full z-50 mt-2 w-64 -translate-x-1/2 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none" data-slot="hover-card-content"><div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the bottom side of the trigger.</p>
+            </div>
+        </span>
+    </span>
+
+        <span class="relative inline-block" data-slot="hover-card" data-controller="hover-card" data-hover-card-open-delay-value="0" data-hover-card-close-delay-value="0" data-action="mouseenter-&gt;hover-card#show mouseleave-&gt;hover-card#hide"><button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2" tabindex="0" data-action="focus-&gt;hover-card#show blur-&gt;hover-card#hide">Right</button>
+                <span role="tooltip" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute z-50 w-64 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none top-1/2 left-full translate-x-0 -translate-y-1/2 mt-0 ml-2" data-slot="hover-card-content"><div class="flex flex-col gap-1">
+                <h4 class="font-medium">Hover Card</h4>
+                <p>This hover card appears on the right side of the trigger.</p>
+            </div>
+        </span>
+    </span>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

Adds the `hover-card` recipe to the Shadcn kit.

Part of the split of #3466 into one PR per component, tracking #3233.

Snapshots will be regenerated after rework.