### PR TITLE
[Toolkit][Shadcn] Add native-select recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Shadcn] Add `navigation-menu` recipe
 - [Shadcn] Add `popover` recipe
 - [Shadcn] Add `dropdown-menu` recipe
+- [Shadcn] Add `native-select` recipe
 - [Shadcn][Flowbite] Merge component classes with `attributes.defaults({ class: '...'|tailwind_classes })` instead of `tailwind_merge` (consumer classes now override component variants)
 - [Shadcn] Fix Field/Label, InputGroup and Pagination silently dropping their own base classes when forwarding to a child component (their checked/disabled/nested/dark styles now apply)
 - [Shadcn] Fix `dialog` opening on initial render when `open` is `false`

--- a/src/Toolkit/kits/shadcn/native-select/README.md
+++ b/src/Toolkit/kits/shadcn/native-select/README.md
@@ -1,0 +1,113 @@
+# Native Select
+
+A styled native HTML select element with consistent design system integration.
+
+```twig {"preview":true}
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select status</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="todo">Todo</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="in-progress">In Progress</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="done">Done</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="cancelled">Cancelled</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+```twig
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select a fruit</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+## Examples
+
+### Groups
+
+Use `NativeSelect:OptGroup` to organize options into labeled groups.
+
+```twig {"preview":true}
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select department</twig:NativeSelect:Option>
+    <twig:NativeSelect:OptGroup label="Engineering">
+        <twig:NativeSelect:Option value="frontend">Frontend</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="backend">Backend</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="devops">DevOps</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+    <twig:NativeSelect:OptGroup label="Sales">
+        <twig:NativeSelect:Option value="sales-rep">Sales Rep</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="account-manager">Account Manager</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="sales-director">Sales Director</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+    <twig:NativeSelect:OptGroup label="Operations">
+        <twig:NativeSelect:Option value="support">Customer Support</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="product-manager">Product Manager</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="ops-manager">Operations Manager</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+</twig:NativeSelect>
+```
+
+### Disabled
+
+```twig {"preview":true}
+<twig:NativeSelect disabled>
+    <twig:NativeSelect:Option value="">Disabled</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+### Invalid
+
+Set `aria-invalid="true"` to display the error state.
+
+```twig {"preview":true}
+<twig:NativeSelect aria-invalid="true">
+    <twig:NativeSelect:Option value="">Error state</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+```twig {"preview":true}
+<div class="flex flex-col items-center gap-4">
+    {# Arabic #}
+    <div dir="rtl">
+        <twig:NativeSelect>
+            <twig:NativeSelect:Option value="">اختر الحالة</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="todo">مهام</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="in-progress">قيد التنفيذ</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="done">منجز</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="cancelled">ملغي</twig:NativeSelect:Option>
+        </twig:NativeSelect>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl">
+        <twig:NativeSelect>
+            <twig:NativeSelect:Option value="">בחר סטטוס</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="todo">לעשות</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="in-progress">בתהליך</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="done">הושלם</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="cancelled">בוטל</twig:NativeSelect:Option>
+        </twig:NativeSelect>
+    </div>
+</div>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/shadcn/native-select/manifest.json
+++ b/src/Toolkit/kits/shadcn/native-select/manifest.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Native Select",
+    "version-added": "3.5",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["symfony/ux-icons", "tales-from-a-dev/twig-tailwind-extra:^1.0.0"]
+    }
+}

--- a/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect.html.twig
+++ b/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect.html.twig
@@ -1,0 +1,18 @@
+{# @prop size 'default'|'sm' The select size. #}
+{# @block content The select options, typically `NativeSelect:Option` and `NativeSelect:OptGroup` components. #}
+{%- props size = 'default' -%}
+<div
+    data-slot="native-select-wrapper"
+    data-size="{{ size }}"
+    class="{{ ('group/native-select relative w-fit has-[select:disabled]:opacity-50 ' ~ attributes.render('class'))|tailwind_merge }}"
+>
+    <select
+        data-slot="native-select"
+        data-size="{{ size }}"
+        class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 pe-9 text-sm shadow-xs transition-[color,box-shadow] outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/40 data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:[color-scheme:dark] [&_option]:bg-background [&_option]:text-foreground [&_optgroup]:bg-background [&_optgroup]:text-foreground"
+        {{ attributes.without('class') }}
+    >
+        {%- block content %}{% endblock -%}
+    </select>
+    <twig:ux:icon name="lucide:chevron-down" class="pointer-events-none absolute top-1/2 end-3.5 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none" aria-hidden="true" data-slot="native-select-icon" />
+</div>

--- a/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect/OptGroup.html.twig
+++ b/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect/OptGroup.html.twig
@@ -1,0 +1,4 @@
+{# @block content The `NativeSelect:Option` components in this group. #}
+<optgroup data-slot="native-select-optgroup" {{ attributes }}>
+    {%- block content %}{% endblock -%}
+</optgroup>

--- a/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect/Option.html.twig
+++ b/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect/Option.html.twig
@@ -1,0 +1,2 @@
+{# @block content The option label. #}
+<option data-slot="native-select-option" {{ attributes }}>{%- block content %}{% endblock -%}</option>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 0__1.html
@@ -1,0 +1,23 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select status</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="todo">Todo</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="in-progress">In Progress</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="done">Done</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="cancelled">Cancelled</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" data-size="default" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 pe-9 text-sm shadow-xs transition-[color,box-shadow] outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/40 data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:[color-scheme:dark] [&amp;_option]:bg-background [&amp;_option]:text-foreground [&amp;_optgroup]:bg-background [&amp;_optgroup]:text-foreground"><option data-slot="native-select-option" value="">Select status</option>
+    <option data-slot="native-select-option" value="todo">Todo</option>
+    <option data-slot="native-select-option" value="in-progress">In Progress</option>
+    <option data-slot="native-select-option" value="done">Done</option>
+    <option data-slot="native-select-option" value="cancelled">Cancelled</option>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="pointer-events-none absolute top-1/2 end-3.5 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none" aria-hidden="true" data-slot="native-select-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 1__1.html
@@ -1,0 +1,45 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select department</twig:NativeSelect:Option>
+    <twig:NativeSelect:OptGroup label="Engineering">
+        <twig:NativeSelect:Option value="frontend">Frontend</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="backend">Backend</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="devops">DevOps</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+    <twig:NativeSelect:OptGroup label="Sales">
+        <twig:NativeSelect:Option value="sales-rep">Sales Rep</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="account-manager">Account Manager</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="sales-director">Sales Director</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+    <twig:NativeSelect:OptGroup label="Operations">
+        <twig:NativeSelect:Option value="support">Customer Support</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="product-manager">Product Manager</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="ops-manager">Operations Manager</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" data-size="default" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 pe-9 text-sm shadow-xs transition-[color,box-shadow] outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/40 data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:[color-scheme:dark] [&amp;_option]:bg-background [&amp;_option]:text-foreground [&amp;_optgroup]:bg-background [&amp;_optgroup]:text-foreground"><option data-slot="native-select-option" value="">Select department</option>
+    <optgroup data-slot="native-select-optgroup" label="Engineering">
+<option data-slot="native-select-option" value="frontend">Frontend</option>
+        <option data-slot="native-select-option" value="backend">Backend</option>
+        <option data-slot="native-select-option" value="devops">DevOps</option>
+    </optgroup>
+    <optgroup data-slot="native-select-optgroup" label="Sales">
+<option data-slot="native-select-option" value="sales-rep">Sales Rep</option>
+        <option data-slot="native-select-option" value="account-manager">Account Manager</option>
+        <option data-slot="native-select-option" value="sales-director">Sales Director</option>
+    </optgroup>
+    <optgroup data-slot="native-select-optgroup" label="Operations">
+<option data-slot="native-select-option" value="support">Customer Support</option>
+        <option data-slot="native-select-option" value="product-manager">Product Manager</option>
+        <option data-slot="native-select-option" value="ops-manager">Operations Manager</option>
+    </optgroup>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="pointer-events-none absolute top-1/2 end-3.5 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none" aria-hidden="true" data-slot="native-select-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 2__1.html
@@ -1,0 +1,21 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect disabled>
+    <twig:NativeSelect:Option value="">Disabled</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" data-size="default" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 pe-9 text-sm shadow-xs transition-[color,box-shadow] outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/40 data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:[color-scheme:dark] [&amp;_option]:bg-background [&amp;_option]:text-foreground [&amp;_optgroup]:bg-background [&amp;_optgroup]:text-foreground" disabled><option data-slot="native-select-option" value="">Disabled</option>
+    <option data-slot="native-select-option" value="apple">Apple</option>
+    <option data-slot="native-select-option" value="banana">Banana</option>
+    <option data-slot="native-select-option" value="blueberry">Blueberry</option>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="pointer-events-none absolute top-1/2 end-3.5 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none" aria-hidden="true" data-slot="native-select-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 3__1.html
@@ -1,0 +1,21 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect aria-invalid="true">
+    <twig:NativeSelect:Option value="">Error state</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" data-size="default" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 pe-9 text-sm shadow-xs transition-[color,box-shadow] outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/40 data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:[color-scheme:dark] [&amp;_option]:bg-background [&amp;_option]:text-foreground [&amp;_optgroup]:bg-background [&amp;_optgroup]:text-foreground" aria-invalid="true"><option data-slot="native-select-option" value="">Error state</option>
+    <option data-slot="native-select-option" value="apple">Apple</option>
+    <option data-slot="native-select-option" value="banana">Banana</option>
+    <option data-slot="native-select-option" value="blueberry">Blueberry</option>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="pointer-events-none absolute top-1/2 end-3.5 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none" aria-hidden="true" data-slot="native-select-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 4__1.html
@@ -1,0 +1,55 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<div class="flex flex-col items-center gap-4">
+    {# Arabic #}
+    <div dir="rtl">
+        <twig:NativeSelect>
+            <twig:NativeSelect:Option value="">اختر الحالة</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="todo">مهام</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="in-progress">قيد التنفيذ</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="done">منجز</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="cancelled">ملغي</twig:NativeSelect:Option>
+        </twig:NativeSelect>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl">
+        <twig:NativeSelect>
+            <twig:NativeSelect:Option value="">בחר סטטוס</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="todo">לעשות</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="in-progress">בתהליך</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="done">הושלם</twig:NativeSelect:Option>
+            <twig:NativeSelect:Option value="cancelled">בוטל</twig:NativeSelect:Option>
+        </twig:NativeSelect>
+    </div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col items-center gap-4">
+        <div dir="rtl">
+        <div data-slot="native-select-wrapper" data-size="default" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 pe-9 text-sm shadow-xs transition-[color,box-shadow] outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/40 data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:[color-scheme:dark] [&amp;_option]:bg-background [&amp;_option]:text-foreground [&amp;_optgroup]:bg-background [&amp;_optgroup]:text-foreground"><option data-slot="native-select-option" value="">اختر الحالة</option>
+            <option data-slot="native-select-option" value="todo">مهام</option>
+            <option data-slot="native-select-option" value="in-progress">قيد التنفيذ</option>
+            <option data-slot="native-select-option" value="done">منجز</option>
+            <option data-slot="native-select-option" value="cancelled">ملغي</option>
+        </select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="pointer-events-none absolute top-1/2 end-3.5 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none" aria-hidden="true" data-slot="native-select-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>
+    </div>
+
+        <div dir="rtl">
+        <div data-slot="native-select-wrapper" data-size="default" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 pe-9 text-sm shadow-xs transition-[color,box-shadow] outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/40 data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:[color-scheme:dark] [&amp;_option]:bg-background [&amp;_option]:text-foreground [&amp;_optgroup]:bg-background [&amp;_optgroup]:text-foreground"><option data-slot="native-select-option" value="">בחר סטטוס</option>
+            <option data-slot="native-select-option" value="todo">לעשות</option>
+            <option data-slot="native-select-option" value="in-progress">בתהליך</option>
+            <option data-slot="native-select-option" value="done">הושלם</option>
+            <option data-slot="native-select-option" value="cancelled">בוטל</option>
+        </select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="pointer-events-none absolute top-1/2 end-3.5 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none" aria-hidden="true" data-slot="native-select-icon"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>
+    </div>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

This adds a `native-select` recipe to the Toolkit Shadcn kit, styled after the shadcn/radix native select reference.

This continues the work Amoifr started in the original PR. I rebased it onto `3.x` and reworked it on top of changes that landed in the kit since then:

- migrated the recipe to the current self-describing structure: a per-recipe `README.md` with inline `{"preview":true}` example blocks, replacing the old `examples/` directory
- aligned the Tailwind classes with the current shadcn native-select reference: default height `h-9`, `rounded-md`, `px-3 py-2 pe-9`, `shadow-xs`, `transition`, and the `sm` size mapped to `h-8`
- kept RTL support through logical properties (`pe`/`ps`/`end`) and added a dedicated RTL example
- added `NativeSelect:Option` and `NativeSelect:OptGroup` sub-components carrying the `data-slot` markers, for parity with the shadcn component API
- regenerated the test snapshots

The examples cover the status demo, an optgroup groups example, a disabled example, an invalid (`aria-invalid`) example, and an RTL example (Arabic and Hebrew), matching the shadcn/radix reference examples.

symfony/ux.symfony.com#62 added a manual docs page for this recipe, but it's now obsolete: since the self-describing kits change, the Toolkit docs page on ux.symfony.com renders automatically from the recipe's `README.md`, so a manual docs page isn't needed. I'm closing it as part of this PR.

Thanks to @Amoifr for the original contribution.
