### PR TITLE
[Toolkit][Shadcn] Add scroll-area recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Shadcn] Add `popover` recipe
 - [Shadcn] Add `dropdown-menu` recipe
 - [Shadcn] Add `native-select` recipe
+- [Shadcn] Add `scroll-area` recipe
 - [Shadcn][Flowbite] Merge component classes with `attributes.defaults({ class: '...'|tailwind_classes })` instead of `tailwind_merge` (consumer classes now override component variants)
 - [Shadcn] Fix Field/Label, InputGroup and Pagination silently dropping their own base classes when forwarding to a child component (their checked/disabled/nested/dark styles now apply)
 - [Shadcn] Fix `dialog` opening on initial render when `open` is `false`

--- a/src/Toolkit/kits/shadcn/scroll-area/README.md
+++ b/src/Toolkit/kits/shadcn/scroll-area/README.md
@@ -1,0 +1,99 @@
+# Scroll Area
+
+Augments the native scroll functionality for custom, cross-browser styling.
+
+```twig {"preview":true}
+<twig:ScrollArea class="h-72 w-48 rounded-md border">
+    <div class="p-4">
+        <h4 class="mb-4 text-sm leading-none font-medium">Tags</h4>
+        {% for i in range(50, 1, -1) %}
+            <div class="text-sm">v1.2.0-beta.{{ i }}</div>
+            <twig:Separator class="my-2" />
+        {% endfor %}
+    </div>
+</twig:ScrollArea>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+```twig
+<twig:ScrollArea class="h-[200px] w-[350px] rounded-md border p-4">
+    Your scrollable content here.
+</twig:ScrollArea>
+```
+
+## Examples
+
+### Horizontal
+
+```twig {"preview":true}
+<twig:ScrollArea class="w-96 rounded-md border whitespace-nowrap">
+    <div class="flex w-max space-x-4 p-4">
+        <figure class="shrink-0">
+            <div class="overflow-hidden rounded-md">
+                <img src="https://images.unsplash.com/photo-1465869185982-5a1a7522cbcb?auto=format&fit=crop&w=300&q=80" alt="Photo by Ornella Binni" class="aspect-[3/4] h-fit w-fit object-cover" width="300" height="400">
+            </div>
+            <figcaption class="pt-2 text-xs text-muted-foreground">
+                Photo by
+                <span class="font-semibold text-foreground">Ornella Binni</span>
+            </figcaption>
+        </figure>
+        <figure class="shrink-0">
+            <div class="overflow-hidden rounded-md">
+                <img src="https://images.unsplash.com/photo-1548516173-3cabfa4607e9?auto=format&fit=crop&w=300&q=80" alt="Photo by Tom Byrom" class="aspect-[3/4] h-fit w-fit object-cover" width="300" height="400">
+            </div>
+            <figcaption class="pt-2 text-xs text-muted-foreground">
+                Photo by
+                <span class="font-semibold text-foreground">Tom Byrom</span>
+            </figcaption>
+        </figure>
+        <figure class="shrink-0">
+            <div class="overflow-hidden rounded-md">
+                <img src="https://images.unsplash.com/photo-1494337480532-3725c85fd2ab?auto=format&fit=crop&w=300&q=80" alt="Photo by Vladimir Malyavko" class="aspect-[3/4] h-fit w-fit object-cover" width="300" height="400">
+            </div>
+            <figcaption class="pt-2 text-xs text-muted-foreground">
+                Photo by
+                <span class="font-semibold text-foreground">Vladimir Malyavko</span>
+            </figcaption>
+        </figure>
+    </div>
+</twig:ScrollArea>
+```
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+```twig {"preview":true}
+<div class="flex flex-col items-center gap-8">
+    {# Arabic #}
+    <twig:ScrollArea dir="rtl" class="h-72 w-48 rounded-md border">
+        <div class="p-4">
+            <h4 class="mb-4 text-sm leading-none font-medium">العلامات</h4>
+            {% for i in range(50, 1, -1) %}
+                <div class="text-sm">v1.2.0-beta.{{ i }}</div>
+                <twig:Separator class="my-2" />
+            {% endfor %}
+        </div>
+    </twig:ScrollArea>
+
+    {# Hebrew #}
+    <twig:ScrollArea dir="rtl" class="h-72 w-48 rounded-md border">
+        <div class="p-4">
+            <h4 class="mb-4 text-sm leading-none font-medium">תגיות</h4>
+            {% for i in range(50, 1, -1) %}
+                <div class="text-sm">v1.2.0-beta.{{ i }}</div>
+                <twig:Separator class="my-2" />
+            {% endfor %}
+        </div>
+    </twig:ScrollArea>
+</div>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/shadcn/scroll-area/manifest.json
+++ b/src/Toolkit/kits/shadcn/scroll-area/manifest.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Scroll Area",
+    "version-added": "3.5",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": [
+            "twig/html-extra:^3.24.0",
+            "symfony/ux-twig-component:^3.5",
+            "tales-from-a-dev/twig-tailwind-extra:^1.3.0"
+        ]
+    }
+}

--- a/src/Toolkit/kits/shadcn/scroll-area/templates/components/ScrollArea.html.twig
+++ b/src/Toolkit/kits/shadcn/scroll-area/templates/components/ScrollArea.html.twig
@@ -1,0 +1,9 @@
+{# @block content The scrollable content. #}
+<div
+    data-slot="scroll-area"
+    {{ attributes.defaults({
+        class: 'relative overflow-auto [&::-webkit-scrollbar]:h-2.5 [&::-webkit-scrollbar]:w-2.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border [&::-webkit-scrollbar-thumb]:border-transparent [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-thumb]:bg-clip-padding [&::-webkit-scrollbar-thumb:hover]:bg-muted-foreground/50'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component scroll-area, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component scroll-area, example 0__1.html
@@ -1,0 +1,171 @@
+<!--
+- Kit: Shadcn UI
+- Component: Scroll Area
+- Code:
+```twig
+<twig:ScrollArea class="h-72 w-48 rounded-md border">
+    <div class="p-4">
+        <h4 class="mb-4 text-sm leading-none font-medium">Tags</h4>
+        {% for i in range(50, 1, -1) %}
+            <div class="text-sm">v1.2.0-beta.{{ i }}</div>
+            <twig:Separator class="my-2" />
+        {% endfor %}
+    </div>
+</twig:ScrollArea>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="scroll-area" class="relative overflow-auto [&amp;::-webkit-scrollbar]:h-2.5 [&amp;::-webkit-scrollbar]:w-2.5 [&amp;::-webkit-scrollbar-track]:bg-transparent [&amp;::-webkit-scrollbar-thumb]:rounded-full [&amp;::-webkit-scrollbar-thumb]:border [&amp;::-webkit-scrollbar-thumb]:border-transparent [&amp;::-webkit-scrollbar-thumb]:bg-border [&amp;::-webkit-scrollbar-thumb]:bg-clip-padding [&amp;::-webkit-scrollbar-thumb:hover]:bg-muted-foreground/50 h-72 w-48 rounded-md border">
+<div class="p-4">
+        <h4 class="mb-4 text-sm leading-none font-medium">Tags</h4>
+                    <div class="text-sm">v1.2.0-beta.50</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.49</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.48</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.47</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.46</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.45</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.44</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.43</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.42</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.41</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.40</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.39</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.38</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.37</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.36</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.35</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.34</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.33</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.32</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.31</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.30</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.29</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.28</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.27</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.26</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.25</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.24</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.23</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.22</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.21</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.20</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.19</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.18</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.17</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.16</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.15</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.14</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.13</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.12</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.11</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.10</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.9</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.8</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.7</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.6</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.5</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.4</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.3</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.2</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    <div class="text-sm">v1.2.0-beta.1</div>
+            <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+            </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component scroll-area, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component scroll-area, example 1__1.html
@@ -1,0 +1,69 @@
+<!--
+- Kit: Shadcn UI
+- Component: Scroll Area
+- Code:
+```twig
+<twig:ScrollArea class="w-96 rounded-md border whitespace-nowrap">
+    <div class="flex w-max space-x-4 p-4">
+        <figure class="shrink-0">
+            <div class="overflow-hidden rounded-md">
+                <img src="https://images.unsplash.com/photo-1465869185982-5a1a7522cbcb?auto=format&fit=crop&w=300&q=80" alt="Photo by Ornella Binni" class="aspect-[3/4] h-fit w-fit object-cover" width="300" height="400">
+            </div>
+            <figcaption class="pt-2 text-xs text-muted-foreground">
+                Photo by
+                <span class="font-semibold text-foreground">Ornella Binni</span>
+            </figcaption>
+        </figure>
+        <figure class="shrink-0">
+            <div class="overflow-hidden rounded-md">
+                <img src="https://images.unsplash.com/photo-1548516173-3cabfa4607e9?auto=format&fit=crop&w=300&q=80" alt="Photo by Tom Byrom" class="aspect-[3/4] h-fit w-fit object-cover" width="300" height="400">
+            </div>
+            <figcaption class="pt-2 text-xs text-muted-foreground">
+                Photo by
+                <span class="font-semibold text-foreground">Tom Byrom</span>
+            </figcaption>
+        </figure>
+        <figure class="shrink-0">
+            <div class="overflow-hidden rounded-md">
+                <img src="https://images.unsplash.com/photo-1494337480532-3725c85fd2ab?auto=format&fit=crop&w=300&q=80" alt="Photo by Vladimir Malyavko" class="aspect-[3/4] h-fit w-fit object-cover" width="300" height="400">
+            </div>
+            <figcaption class="pt-2 text-xs text-muted-foreground">
+                Photo by
+                <span class="font-semibold text-foreground">Vladimir Malyavko</span>
+            </figcaption>
+        </figure>
+    </div>
+</twig:ScrollArea>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="scroll-area" class="relative overflow-auto [&amp;::-webkit-scrollbar]:h-2.5 [&amp;::-webkit-scrollbar]:w-2.5 [&amp;::-webkit-scrollbar-track]:bg-transparent [&amp;::-webkit-scrollbar-thumb]:rounded-full [&amp;::-webkit-scrollbar-thumb]:border [&amp;::-webkit-scrollbar-thumb]:border-transparent [&amp;::-webkit-scrollbar-thumb]:bg-border [&amp;::-webkit-scrollbar-thumb]:bg-clip-padding [&amp;::-webkit-scrollbar-thumb:hover]:bg-muted-foreground/50 w-96 rounded-md border whitespace-nowrap">
+<div class="flex w-max space-x-4 p-4">
+        <figure class="shrink-0">
+            <div class="overflow-hidden rounded-md">
+                <img src="https://images.unsplash.com/photo-1465869185982-5a1a7522cbcb?auto=format&amp;fit=crop&amp;w=300&amp;q=80" alt="Photo by Ornella Binni" class="aspect-[3/4] h-fit w-fit object-cover" width="300" height="400">
+            </div>
+            <figcaption class="pt-2 text-xs text-muted-foreground">
+                Photo by
+                <span class="font-semibold text-foreground">Ornella Binni</span>
+            </figcaption>
+        </figure>
+        <figure class="shrink-0">
+            <div class="overflow-hidden rounded-md">
+                <img src="https://images.unsplash.com/photo-1548516173-3cabfa4607e9?auto=format&amp;fit=crop&amp;w=300&amp;q=80" alt="Photo by Tom Byrom" class="aspect-[3/4] h-fit w-fit object-cover" width="300" height="400">
+            </div>
+            <figcaption class="pt-2 text-xs text-muted-foreground">
+                Photo by
+                <span class="font-semibold text-foreground">Tom Byrom</span>
+            </figcaption>
+        </figure>
+        <figure class="shrink-0">
+            <div class="overflow-hidden rounded-md">
+                <img src="https://images.unsplash.com/photo-1494337480532-3725c85fd2ab?auto=format&amp;fit=crop&amp;w=300&amp;q=80" alt="Photo by Vladimir Malyavko" class="aspect-[3/4] h-fit w-fit object-cover" width="300" height="400">
+            </div>
+            <figcaption class="pt-2 text-xs text-muted-foreground">
+                Photo by
+                <span class="font-semibold text-foreground">Vladimir Malyavko</span>
+            </figcaption>
+        </figure>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component scroll-area, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component scroll-area, example 2__1.html
@@ -1,0 +1,343 @@
+<!--
+- Kit: Shadcn UI
+- Component: Scroll Area
+- Code:
+```twig
+<div class="flex flex-col items-center gap-8">
+    {# Arabic #}
+    <twig:ScrollArea dir="rtl" class="h-72 w-48 rounded-md border">
+        <div class="p-4">
+            <h4 class="mb-4 text-sm leading-none font-medium">العلامات</h4>
+            {% for i in range(50, 1, -1) %}
+                <div class="text-sm">v1.2.0-beta.{{ i }}</div>
+                <twig:Separator class="my-2" />
+            {% endfor %}
+        </div>
+    </twig:ScrollArea>
+
+    {# Hebrew #}
+    <twig:ScrollArea dir="rtl" class="h-72 w-48 rounded-md border">
+        <div class="p-4">
+            <h4 class="mb-4 text-sm leading-none font-medium">תגיות</h4>
+            {% for i in range(50, 1, -1) %}
+                <div class="text-sm">v1.2.0-beta.{{ i }}</div>
+                <twig:Separator class="my-2" />
+            {% endfor %}
+        </div>
+    </twig:ScrollArea>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col items-center gap-8">
+        <div data-slot="scroll-area" class="relative overflow-auto [&amp;::-webkit-scrollbar]:h-2.5 [&amp;::-webkit-scrollbar]:w-2.5 [&amp;::-webkit-scrollbar-track]:bg-transparent [&amp;::-webkit-scrollbar-thumb]:rounded-full [&amp;::-webkit-scrollbar-thumb]:border [&amp;::-webkit-scrollbar-thumb]:border-transparent [&amp;::-webkit-scrollbar-thumb]:bg-border [&amp;::-webkit-scrollbar-thumb]:bg-clip-padding [&amp;::-webkit-scrollbar-thumb:hover]:bg-muted-foreground/50 h-72 w-48 rounded-md border" dir="rtl">
+<div class="p-4">
+            <h4 class="mb-4 text-sm leading-none font-medium">العلامات</h4>
+                            <div class="text-sm">v1.2.0-beta.50</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.49</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.48</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.47</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.46</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.45</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.44</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.43</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.42</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.41</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.40</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.39</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.38</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.37</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.36</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.35</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.34</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.33</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.32</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.31</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.30</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.29</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.28</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.27</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.26</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.25</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.24</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.23</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.22</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.21</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.20</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.19</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.18</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.17</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.16</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.15</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.14</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.13</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.12</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.11</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.10</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.9</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.8</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.7</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.6</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.5</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.4</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.3</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.2</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.1</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    </div>
+    </div>
+
+        <div data-slot="scroll-area" class="relative overflow-auto [&amp;::-webkit-scrollbar]:h-2.5 [&amp;::-webkit-scrollbar]:w-2.5 [&amp;::-webkit-scrollbar-track]:bg-transparent [&amp;::-webkit-scrollbar-thumb]:rounded-full [&amp;::-webkit-scrollbar-thumb]:border [&amp;::-webkit-scrollbar-thumb]:border-transparent [&amp;::-webkit-scrollbar-thumb]:bg-border [&amp;::-webkit-scrollbar-thumb]:bg-clip-padding [&amp;::-webkit-scrollbar-thumb:hover]:bg-muted-foreground/50 h-72 w-48 rounded-md border" dir="rtl">
+<div class="p-4">
+            <h4 class="mb-4 text-sm leading-none font-medium">תגיות</h4>
+                            <div class="text-sm">v1.2.0-beta.50</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.49</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.48</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.47</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.46</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.45</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.44</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.43</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.42</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.41</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.40</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.39</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.38</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.37</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.36</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.35</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.34</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.33</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.32</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.31</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.30</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.29</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.28</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.27</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.26</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.25</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.24</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.23</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.22</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.21</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.20</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.19</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.18</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.17</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.16</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.15</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.14</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.13</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.12</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.11</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.10</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.9</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.8</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.7</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.6</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.5</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.4</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.3</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.2</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                            <div class="text-sm">v1.2.0-beta.1</div>
+                <div data-slot="separator" data-orientation="horizontal" role="none" class="shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch my-2"></div>
+
+                    </div>
+    </div>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

This adds the `scroll-area` recipe to the Shadcn kit: a native-scroll container styled entirely in Twig/CSS, no Radix/Base UI primitive and no JavaScript involved.

The examples (a vertical "Tags" list, a horizontal image strip, and an RTL example with Arabic and Hebrew) are synced with the current shadcn base scroll-area reference at https://ui.shadcn.com/docs/components/base/scroll-area.

The recipe follows the current kit conventions: `data-slot` rendered as a literal attribute, classes merged via `attributes.defaults({class: '...'|tailwind_classes})`, and examples inlined in the recipe's `README.md` instead of a separate `examples/` directory.

Part of splitting #3466 into one PR per component, tracked by #3233.
