### PR TITLE
[Toolkit][Shadcn] Add slider recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Shadcn] Add `dropdown-menu` recipe
 - [Shadcn] Add `native-select` recipe
 - [Shadcn] Add `scroll-area` recipe
+- [Shadcn] Add `slider` recipe
 - [Shadcn][Flowbite] Merge component classes with `attributes.defaults({ class: '...'|tailwind_classes })` instead of `tailwind_merge` (consumer classes now override component variants)
 - [Shadcn] Fix Field/Label, InputGroup and Pagination silently dropping their own base classes when forwarding to a child component (their checked/disabled/nested/dark styles now apply)
 - [Shadcn] Fix `dialog` opening on initial render when `open` is `false`

--- a/src/Toolkit/kits/shadcn/slider/README.md
+++ b/src/Toolkit/kits/shadcn/slider/README.md
@@ -1,0 +1,70 @@
+# Slider
+
+An input where the user selects a value from within a given range.
+
+```twig {"preview":true}
+<twig:Slider name="demo" min="0" max="100" step="1" value="75" class="mx-auto w-full max-w-xs" />
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+```twig
+<twig:Slider name="volume" min="0" max="100" value="50" />
+```
+
+## Examples
+
+### Range
+
+```twig {"preview":true}
+<twig:Slider name="range" min="0" max="100" step="5" value="25,50" labels="Min,Max" class="mx-auto w-full max-w-xs" />
+```
+
+### Multiple Thumbs
+
+```twig {"preview":true}
+<twig:Slider name="multi" min="0" max="100" step="10" value="10,20,70" labels="Low,Medium,High" class="mx-auto w-full max-w-xs" />
+```
+
+### Vertical
+
+```twig {"preview":true}
+<div class="mx-auto flex w-full max-w-xs items-center justify-center gap-6">
+    <twig:Slider name="vertical-1" min="0" max="100" step="1" value="50" orientation="vertical" />
+    <twig:Slider name="vertical-2" min="0" max="100" step="1" value="25" orientation="vertical" />
+</div>
+```
+
+### Disabled
+
+```twig {"preview":true}
+<twig:Slider name="disabled" min="0" max="100" step="1" value="50" disabled class="mx-auto w-full max-w-xs" />
+```
+
+### Controlled
+
+```twig {"preview":true}
+<div class="mx-auto grid w-full max-w-xs gap-3" data-controller="slider-display">
+    <div class="flex items-center justify-between gap-2">
+        <twig:Label for="slider-controlled-temperature">Temperature</twig:Label>
+        <span class="text-sm text-muted-foreground" data-slider-display-target="output">0.3, 0.7</span>
+    </div>
+    <twig:Slider id="slider-controlled-temperature" name="temperature" min="0" max="1" step="0.1" value="0.3,0.7" data-action="input->slider-display#update" />
+</div>
+```
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+```twig {"preview":true}
+<twig:Slider dir="rtl" name="rtl-slider" min="0" max="100" step="1" value="75" class="mx-auto w-full max-w-xs" />
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/shadcn/slider/assets/controllers/slider_controller.js
+++ b/src/Toolkit/kits/shadcn/slider/assets/controllers/slider_controller.js
@@ -1,0 +1,197 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['track', 'range', 'thumb', 'input'];
+    static values = {
+        min: { type: Number, default: 0 },
+        max: { type: Number, default: 100 },
+        step: { type: Number, default: 1 },
+        orientation: { type: String, default: 'horizontal' },
+    };
+
+    connect() {
+        this._activeThumb = null;
+        this._abortController = new AbortController();
+        const { signal } = this._abortController;
+
+        this.thumbTargets.forEach((thumb, index) => {
+            thumb.addEventListener('pointerdown', (e) => this._onThumbDown(e, index), { signal });
+            thumb.addEventListener('keydown', (e) => this._onThumbKey(e, index), { signal });
+        });
+        this.trackTarget.addEventListener('pointerdown', (e) => this._onTrackDown(e), { signal });
+
+        this.update();
+    }
+
+    disconnect() {
+        this._abortController?.abort();
+        this._abortController = null;
+        this._dragAbortController?.abort();
+        this._dragAbortController = null;
+        this._activeThumb = null;
+    }
+
+    _startDrag() {
+        this._dragAbortController?.abort();
+        this._dragAbortController = new AbortController();
+        const { signal } = this._dragAbortController;
+        window.addEventListener('pointermove', (e) => this._onPointerMove(e), { signal });
+        window.addEventListener('pointerup', () => this._onPointerUp(), { signal });
+    }
+
+    _onThumbDown(event, index) {
+        if (this._isDisabled()) return;
+        event.preventDefault();
+        this._activeThumb = index;
+        this.thumbTargets[index].focus();
+        this._startDrag();
+    }
+
+    _onTrackDown(event) {
+        if (this._isDisabled()) return;
+        const ratio = this._pointerRatio(event);
+        const value = this._ratioToValue(ratio);
+        const index = this._nearestThumbIndex(value);
+        this._setThumbValue(index, value);
+        this._activeThumb = index;
+        this.thumbTargets[index].focus();
+        this._startDrag();
+    }
+
+    _onPointerMove(event) {
+        if (this._activeThumb === null) return;
+        const ratio = this._pointerRatio(event);
+        this._setThumbValue(this._activeThumb, this._ratioToValue(ratio));
+    }
+
+    _onPointerUp() {
+        this._activeThumb = null;
+        this._dragAbortController?.abort();
+        this._dragAbortController = null;
+    }
+
+    _onThumbKey(event, index) {
+        if (this._isDisabled()) return;
+        const current = Number(this.inputTargets[index].value);
+        const step = this.stepValue;
+        let next = current;
+        switch (event.key) {
+            case 'ArrowLeft':
+            case 'ArrowDown':
+                next = current - step;
+                break;
+            case 'ArrowRight':
+            case 'ArrowUp':
+                next = current + step;
+                break;
+            case 'Home':
+                next = this.minValue;
+                break;
+            case 'End':
+                next = this.maxValue;
+                break;
+            case 'PageDown':
+                next = current - step * 10;
+                break;
+            case 'PageUp':
+                next = current + step * 10;
+                break;
+            default:
+                return;
+        }
+        event.preventDefault();
+        this._setThumbValue(index, next);
+    }
+
+    _pointerRatio(event) {
+        const rect = this.trackTarget.getBoundingClientRect();
+        const isVertical = this.orientationValue === 'vertical';
+        const isRtl = getComputedStyle(this.element).direction === 'rtl';
+        let ratio;
+        if (isVertical) {
+            ratio = 1 - (event.clientY - rect.top) / rect.height;
+        } else {
+            ratio = (event.clientX - rect.left) / rect.width;
+            if (isRtl) ratio = 1 - ratio;
+        }
+        return Math.max(0, Math.min(1, ratio));
+    }
+
+    _ratioToValue(ratio) {
+        const raw = this.minValue + ratio * (this.maxValue - this.minValue);
+        const stepped = Math.round(raw / this.stepValue) * this.stepValue;
+        return this._roundToStep(stepped);
+    }
+
+    _roundToStep(value) {
+        const stepString = String(this.stepValue);
+        const decimals = stepString.includes('.') ? stepString.split('.')[1].length : 0;
+        return Number(value.toFixed(decimals));
+    }
+
+    _nearestThumbIndex(value) {
+        const values = this.inputTargets.map((i) => Number(i.value));
+        let bestIndex = 0;
+        let bestDelta = Math.abs(values[0] - value);
+        for (let i = 1; i < values.length; i++) {
+            const d = Math.abs(values[i] - value);
+            if (d < bestDelta) {
+                bestDelta = d;
+                bestIndex = i;
+            }
+        }
+        return bestIndex;
+    }
+
+    _setThumbValue(index, value) {
+        value = this._roundToStep(Math.max(this.minValue, Math.min(this.maxValue, value)));
+        const values = this.inputTargets.map((i) => Number(i.value));
+        if (index > 0) value = Math.max(value, values[index - 1]);
+        if (index < values.length - 1) value = Math.min(value, values[index + 1]);
+        if (values[index] === value) return;
+        this.inputTargets[index].value = value;
+        this.update();
+        this.element.dispatchEvent(new Event('input', { bubbles: true }));
+        this.element.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    update() {
+        const values = this.inputTargets.map((i) => Number(i.value));
+        const range = this.maxValue - this.minValue;
+        const toPercent = (v) => (range > 0 ? ((v - this.minValue) / range) * 100 : 0);
+        const percents = values.map(toPercent);
+
+        const isVertical = this.orientationValue === 'vertical';
+        const isRtl = getComputedStyle(this.element).direction === 'rtl';
+
+        const prop = isVertical ? 'bottom' : isRtl ? 'right' : 'left';
+        this.thumbTargets.forEach((thumb, i) => {
+            thumb.style.left = thumb.style.right = thumb.style.bottom = '';
+            thumb.style[prop] = `${percents[i]}%`;
+            thumb.setAttribute('aria-valuenow', values[i]);
+        });
+
+        const lo = percents.length > 1 ? Math.min(...percents) : 0;
+        const hi = Math.max(...percents);
+
+        this.rangeTarget.style.top =
+            this.rangeTarget.style.bottom =
+            this.rangeTarget.style.left =
+            this.rangeTarget.style.right =
+                '';
+        if (isVertical) {
+            this.rangeTarget.style.bottom = `${lo}%`;
+            this.rangeTarget.style.top = `${100 - hi}%`;
+        } else if (isRtl) {
+            this.rangeTarget.style.right = `${lo}%`;
+            this.rangeTarget.style.left = `${100 - hi}%`;
+        } else {
+            this.rangeTarget.style.left = `${lo}%`;
+            this.rangeTarget.style.right = `${100 - hi}%`;
+        }
+    }
+
+    _isDisabled() {
+        return this.element.getAttribute('aria-disabled') === 'true' || this.element.matches('[data-disabled]');
+    }
+}

--- a/src/Toolkit/kits/shadcn/slider/assets/controllers/slider_display_controller.js
+++ b/src/Toolkit/kits/shadcn/slider/assets/controllers/slider_display_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * @value  separator  The string used to join the thumb values shown in the output.
+ * @target output     The element whose text content displays the slider's current values.
+ * @action update     Writes the slider's current values into the output target.
+ */
+export default class extends Controller {
+    static targets = ['output'];
+    static values = {
+        separator: { type: String, default: ', ' },
+    };
+
+    update(event) {
+        const slider = event.currentTarget;
+        const values = Array.from(slider.querySelectorAll('[data-slider-target="input"]')).map((i) => i.value);
+        this.outputTarget.textContent = values.join(this.separatorValue);
+    }
+}

--- a/src/Toolkit/kits/shadcn/slider/manifest.json
+++ b/src/Toolkit/kits/shadcn/slider/manifest.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Slider",
+    "version-added": "3.5",
+    "copy-files": {
+        "assets/": "assets/",
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": [
+            "twig/html-extra:^3.24.0",
+            "symfony/ux-twig-component:^3.5",
+            "tales-from-a-dev/twig-tailwind-extra:^1.3.0"
+        ]
+    }
+}

--- a/src/Toolkit/kits/shadcn/slider/templates/components/Slider.html.twig
+++ b/src/Toolkit/kits/shadcn/slider/templates/components/Slider.html.twig
@@ -1,0 +1,83 @@
+{# @prop min int The minimum value. #}
+{# @prop max int The maximum value. #}
+{# @prop step int The step between two adjacent values. #}
+{# @prop value int|string|array A single value, a comma-separated string, or an array of values (one per thumb). #}
+{# @prop orientation 'horizontal'|'vertical' The slider orientation. #}
+{# @prop disabled bool Whether the slider is disabled. #}
+{# @prop name string The form field name. If multiple thumbs, `[]` is appended. #}
+{# @prop labels string|array A label per thumb (comma-separated string or array). When omitted, single-thumb sliders fall back to `Slider` and multi-thumb sliders fall back to `Slider thumb X of Y`. #}
+{%- props min = 0, max = 100, step = 1, value = null, orientation = 'horizontal', disabled = false, name = null, labels = null -%}
+{%- if value is null -%}{%- set value = min -%}{%- endif -%}
+{%- set _raw_values = value is iterable ? value : value|split(',') -%}
+{%- set values = [] -%}
+{%- for v in _raw_values -%}
+    {%- set values = values|merge([v * 1]) -%}
+{%- endfor -%}
+{%- set _range = max - min -%}
+{%- set _is_vertical = orientation == 'vertical' -%}
+{%- set _percents = [] -%}
+{%- for v in values -%}
+    {%- set _p = _range > 0 ? ((v - min) / _range * 100) : 0 -%}
+    {%- set _percents = _percents|merge([_p]) -%}
+{%- endfor -%}
+{%- set _lo = values|length > 1 ? min(_percents) : 0 -%}
+{%- set _hi = max(_percents) -%}
+{%- if labels is null -%}
+    {%- set _labels = [] -%}
+{%- elseif labels is iterable -%}
+    {%- set _labels = labels -%}
+{%- else -%}
+    {%- set _labels = labels|split(',') -%}
+{%- endif -%}
+{%- set _classes = 'group/slider relative flex touch-none select-none items-center '
+    ~ (_is_vertical ? 'h-40 w-1.5 flex-col justify-center ' : 'w-full h-4 ')
+    ~ (disabled ? 'opacity-50 pointer-events-none ' : '') -%}
+<div
+    data-slot="slider"
+    data-orientation="{{ orientation }}"
+    data-slider-min-value="{{ min }}"
+    data-slider-max-value="{{ max }}"
+    data-slider-step-value="{{ step }}"
+    data-slider-orientation-value="{{ orientation }}"
+    {{ attributes.defaults({
+        class: _classes|tailwind_classes,
+        'data-controller': 'slider',
+    }) }}
+>
+    <div
+        class="relative {{ _is_vertical ? 'h-full w-1.5' : 'h-1.5 w-full' }} grow overflow-hidden rounded-full bg-muted"
+        data-slot="slider-track"
+        data-slider-target="track"
+    >
+        <div
+            class="absolute {{ _is_vertical ? 'left-0 right-0' : 'top-0 bottom-0' }} bg-primary"
+            style="{% if _is_vertical %}bottom: {{ _lo }}%; top: {{ 100 - _hi }}%{% else %}inset-inline-start: {{ _lo }}%; inset-inline-end: {{ 100 - _hi }}%{% endif %};"
+            data-slot="slider-range"
+            data-slider-target="range"
+        ></div>
+    </div>
+    {% for v in values %}
+        {%- set _percent = _percents[loop.index0] -%}
+        {%- set _label = _labels[loop.index0] ?? null -%}
+        {%- if _label is null -%}
+            {%- set _label = values|length > 1 ? 'Slider thumb ' ~ loop.index ~ ' of ' ~ values|length : 'Slider' -%}
+        {%- endif -%}
+        <span
+            role="slider"
+            tabindex="{{ disabled ? -1 : 0 }}"
+            aria-valuemin="{{ min }}"
+            aria-valuemax="{{ max }}"
+            aria-valuenow="{{ v }}"
+            aria-orientation="{{ orientation }}"
+            aria-label="{{ _label }}"
+            {% if disabled %}aria-disabled="true"{% endif %}
+            class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 {{ _is_vertical ? '-translate-x-1/2 translate-y-1/2 left-1/2' : '-translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2' }}"
+            style="{% if _is_vertical %}bottom: {{ _percent }}%{% else %}inset-inline-start: {{ _percent }}%{% endif %};"
+            data-slot="slider-thumb"
+            data-slider-target="thumb"
+        ></span>
+    {% endfor %}
+    {% for v in values %}
+        <input type="hidden"{% if name %} name="{{ values|length > 1 ? name ~ '[]' : name }}"{% endif %} value="{{ v }}" data-slider-target="input">
+    {% endfor %}
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 0__1.html
@@ -1,0 +1,15 @@
+<!--
+- Kit: Shadcn UI
+- Component: Slider
+- Code:
+```twig
+<twig:Slider name="demo" min="0" max="100" step="1" value="75" class="mx-auto w-full max-w-xs" />
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="slider" data-orientation="horizontal" data-slider-min-value="0" data-slider-max-value="100" data-slider-step-value="1" data-slider-orientation-value="horizontal" class="group/slider relative flex touch-none select-none items-center h-4 mx-auto w-full max-w-xs" data-controller="slider">
+    <div class="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted" data-slot="slider-track" data-slider-target="track">
+        <div class="absolute top-0 bottom-0 bg-primary" style="inset-inline-start: 0%; inset-inline-end: 25%;" data-slot="slider-range" data-slider-target="range"></div>
+    </div>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-orientation="horizontal" aria-label="Slider" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 75%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+                <input type="hidden" name="demo" value="75" data-slider-target="input">
+    </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 1__1.html
@@ -1,0 +1,17 @@
+<!--
+- Kit: Shadcn UI
+- Component: Slider
+- Code:
+```twig
+<twig:Slider name="range" min="0" max="100" step="5" value="25,50" labels="Min,Max" class="mx-auto w-full max-w-xs" />
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="slider" data-orientation="horizontal" data-slider-min-value="0" data-slider-max-value="100" data-slider-step-value="5" data-slider-orientation-value="horizontal" class="group/slider relative flex touch-none select-none items-center h-4 mx-auto w-full max-w-xs" data-controller="slider">
+    <div class="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted" data-slot="slider-track" data-slider-target="track">
+        <div class="absolute top-0 bottom-0 bg-primary" style="inset-inline-start: 25%; inset-inline-end: 50%;" data-slot="slider-range" data-slider-target="range"></div>
+    </div>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="25" aria-orientation="horizontal" aria-label="Min" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 25%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" aria-orientation="horizontal" aria-label="Max" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 50%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+                <input type="hidden" name="range[]" value="25" data-slider-target="input">
+            <input type="hidden" name="range[]" value="50" data-slider-target="input">
+    </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 2__1.html
@@ -1,0 +1,19 @@
+<!--
+- Kit: Shadcn UI
+- Component: Slider
+- Code:
+```twig
+<twig:Slider name="multi" min="0" max="100" step="10" value="10,20,70" labels="Low,Medium,High" class="mx-auto w-full max-w-xs" />
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="slider" data-orientation="horizontal" data-slider-min-value="0" data-slider-max-value="100" data-slider-step-value="10" data-slider-orientation-value="horizontal" class="group/slider relative flex touch-none select-none items-center h-4 mx-auto w-full max-w-xs" data-controller="slider">
+    <div class="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted" data-slot="slider-track" data-slider-target="track">
+        <div class="absolute top-0 bottom-0 bg-primary" style="inset-inline-start: 10%; inset-inline-end: 30%;" data-slot="slider-range" data-slider-target="range"></div>
+    </div>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="10" aria-orientation="horizontal" aria-label="Low" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 10%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="20" aria-orientation="horizontal" aria-label="Medium" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 20%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="70" aria-orientation="horizontal" aria-label="High" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 70%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+                <input type="hidden" name="multi[]" value="10" data-slider-target="input">
+            <input type="hidden" name="multi[]" value="20" data-slider-target="input">
+            <input type="hidden" name="multi[]" value="70" data-slider-target="input">
+    </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 3__1.html
@@ -1,0 +1,29 @@
+<!--
+- Kit: Shadcn UI
+- Component: Slider
+- Code:
+```twig
+<div class="mx-auto flex w-full max-w-xs items-center justify-center gap-6">
+    <twig:Slider name="vertical-1" min="0" max="100" step="1" value="50" orientation="vertical" />
+    <twig:Slider name="vertical-2" min="0" max="100" step="1" value="25" orientation="vertical" />
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="mx-auto flex w-full max-w-xs items-center justify-center gap-6">
+    <div data-slot="slider" data-orientation="vertical" data-slider-min-value="0" data-slider-max-value="100" data-slider-step-value="1" data-slider-orientation-value="vertical" class="group/slider relative flex touch-none select-none items-center h-40 w-1.5 flex-col justify-center" data-controller="slider">
+    <div class="relative h-full w-1.5 grow overflow-hidden rounded-full bg-muted" data-slot="slider-track" data-slider-target="track">
+        <div class="absolute left-0 right-0 bg-primary" style="bottom: 0%; top: 50%;" data-slot="slider-range" data-slider-target="range"></div>
+    </div>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" aria-orientation="vertical" aria-label="Slider" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 translate-y-1/2 left-1/2" style="bottom: 50%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+                <input type="hidden" name="vertical-1" value="50" data-slider-target="input">
+    </div>
+
+    <div data-slot="slider" data-orientation="vertical" data-slider-min-value="0" data-slider-max-value="100" data-slider-step-value="1" data-slider-orientation-value="vertical" class="group/slider relative flex touch-none select-none items-center h-40 w-1.5 flex-col justify-center" data-controller="slider">
+    <div class="relative h-full w-1.5 grow overflow-hidden rounded-full bg-muted" data-slot="slider-track" data-slider-target="track">
+        <div class="absolute left-0 right-0 bg-primary" style="bottom: 0%; top: 75%;" data-slot="slider-range" data-slider-target="range"></div>
+    </div>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="25" aria-orientation="vertical" aria-label="Slider" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 translate-y-1/2 left-1/2" style="bottom: 25%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+                <input type="hidden" name="vertical-2" value="25" data-slider-target="input">
+    </div>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 4__1.html
@@ -1,0 +1,15 @@
+<!--
+- Kit: Shadcn UI
+- Component: Slider
+- Code:
+```twig
+<twig:Slider name="disabled" min="0" max="100" step="1" value="50" disabled class="mx-auto w-full max-w-xs" />
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="slider" data-orientation="horizontal" data-slider-min-value="0" data-slider-max-value="100" data-slider-step-value="1" data-slider-orientation-value="horizontal" class="group/slider relative flex touch-none select-none items-center h-4 opacity-50 pointer-events-none mx-auto w-full max-w-xs" data-controller="slider">
+    <div class="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted" data-slot="slider-track" data-slider-target="track">
+        <div class="absolute top-0 bottom-0 bg-primary" style="inset-inline-start: 0%; inset-inline-end: 50%;" data-slot="slider-range" data-slider-target="range"></div>
+    </div>
+    <span role="slider" tabindex="-1" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" aria-orientation="horizontal" aria-label="Slider" aria-disabled="true" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 50%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+                <input type="hidden" name="disabled" value="50" data-slider-target="input">
+    </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 5__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 5__1.html
@@ -1,0 +1,30 @@
+<!--
+- Kit: Shadcn UI
+- Component: Slider
+- Code:
+```twig
+<div class="mx-auto grid w-full max-w-xs gap-3" data-controller="slider-display">
+    <div class="flex items-center justify-between gap-2">
+        <twig:Label for="slider-controlled-temperature">Temperature</twig:Label>
+        <span class="text-sm text-muted-foreground" data-slider-display-target="output">0.3, 0.7</span>
+    </div>
+    <twig:Slider id="slider-controlled-temperature" name="temperature" min="0" max="1" step="0.1" value="0.3,0.7" data-action="input->slider-display#update" />
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="mx-auto grid w-full max-w-xs gap-3" data-controller="slider-display">
+    <div class="flex items-center justify-between gap-2">
+        <label data-slot="label" class="flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50" for="slider-controlled-temperature">Temperature</label>
+        <span class="text-sm text-muted-foreground" data-slider-display-target="output">0.3, 0.7</span>
+    </div>
+    <div data-slot="slider" data-orientation="horizontal" data-slider-min-value="0" data-slider-max-value="1" data-slider-step-value="0.1" data-slider-orientation-value="horizontal" class="group/slider relative flex touch-none select-none items-center w-full h-4" data-controller="slider" id="slider-controlled-temperature" data-action="input-&gt;slider-display#update">
+    <div class="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted" data-slot="slider-track" data-slider-target="track">
+        <div class="absolute top-0 bottom-0 bg-primary" style="inset-inline-start: 30%; inset-inline-end: 30%;" data-slot="slider-range" data-slider-target="range"></div>
+    </div>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="1" aria-valuenow="0.3" aria-orientation="horizontal" aria-label="Slider thumb 1 of 2" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 30%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="1" aria-valuenow="0.7" aria-orientation="horizontal" aria-label="Slider thumb 2 of 2" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 70%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+                <input type="hidden" name="temperature[]" value="0.3" data-slider-target="input">
+            <input type="hidden" name="temperature[]" value="0.7" data-slider-target="input">
+    </div>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 6__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component slider, example 6__1.html
@@ -1,0 +1,15 @@
+<!--
+- Kit: Shadcn UI
+- Component: Slider
+- Code:
+```twig
+<twig:Slider dir="rtl" name="rtl-slider" min="0" max="100" step="1" value="75" class="mx-auto w-full max-w-xs" />
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="slider" data-orientation="horizontal" data-slider-min-value="0" data-slider-max-value="100" data-slider-step-value="1" data-slider-orientation-value="horizontal" class="group/slider relative flex touch-none select-none items-center h-4 mx-auto w-full max-w-xs" data-controller="slider" dir="rtl">
+    <div class="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted" data-slot="slider-track" data-slider-target="track">
+        <div class="absolute top-0 bottom-0 bg-primary" style="inset-inline-start: 0%; inset-inline-end: 25%;" data-slot="slider-range" data-slider-target="range"></div>
+    </div>
+    <span role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-orientation="horizontal" aria-label="Slider" class="absolute block size-3.5 shrink-0 rounded-full border border-primary bg-background shadow-sm ring-ring/50 transition-[color,box-shadow] outline-none hover:ring-4 focus-visible:ring-4 -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 top-1/2" style="inset-inline-start: 75%;" data-slot="slider-thumb" data-slider-target="thumb"></span>
+                <input type="hidden" name="rtl-slider" value="75" data-slider-target="input">
+    </div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

Adds the `slider` recipe to the Shadcn kit.

It's a fully interactive component built with Twig and Stimulus only, no external JS slider library. It supports keyboard navigation (arrows, Home, End, PageUp, PageDown), pointer drag, multiple thumbs, vertical orientation and RTL.

Examples are synced with the current shadcn base slider reference (https://ui.shadcn.com/docs/components/base/slider): default/hero, Range, Multiple Thumbs, Vertical, Disabled, Controlled and RTL.

Follows the current kit conventions, with examples inlined directly in the recipe's `README.md`. Part of splitting #3466 into one PR per component, tracked by #3233.
