### PR TITLE
[Toolkit][Shadcn] Add input-otp recipe

### DIFF
--- a/src/Toolkit/.gitignore
+++ b/src/Toolkit/.gitignore
@@ -1,5 +1,6 @@
 /vendor/
 /config/reference.php
+/config/schema.json
 /composer.lock
 /phpunit.xml
 /.phpunit.cache

--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for blocks: ready-to-use page sections built from a kit's components, installed and previewed as a unit
 - [Shadcn] Add the `login-01` and `login-02` login blocks
+- [Shadcn] Add `input-otp` recipe
 - [Shadcn][Flowbite] Merge component classes with `attributes.defaults({ class: '...'|tailwind_classes })` instead of `tailwind_merge` (consumer classes now override component variants)
 - [Shadcn] Fix Field/Label, InputGroup and Pagination silently dropping their own base classes when forwarding to a child component (their checked/disabled/nested/dark styles now apply)
 - Remove the now-obsolete `ClassMergeSpacingChecker` linter

--- a/src/Toolkit/kits/shadcn/input-otp/README.md
+++ b/src/Toolkit/kits/shadcn/input-otp/README.md
@@ -1,0 +1,254 @@
+# Input OTP
+
+A group of single-character inputs for one-time passwords and verification codes.
+
+```twig {"preview":true}
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        {% for i in 1..6 %}
+            <twig:InputOtp:Slot input="{{ i }}" value="{{ i }}" />
+        {% endfor %}
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+```twig
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Slot input="1" />
+    <twig:InputOtp:Slot input="2" />
+    <twig:InputOtp:Slot input="3" />
+    <twig:InputOtp:Slot input="4" />
+    <twig:InputOtp:Slot input="5" />
+    <twig:InputOtp:Slot input="6" />
+</twig:InputOtp>
+```
+
+## Examples
+
+### Four Digits
+
+Use the `inputs` prop on `InputOtp` to control the number of slots; each `InputOtp:Slot` derives its accessible label and `name` from it and its own `input` position.
+
+```twig {"preview":true}
+<twig:InputOtp inputs="4">
+    <twig:InputOtp:Group>
+        {% for i in 1..4 %}
+            <twig:InputOtp:Slot input="{{ i }}" pattern="[0-9]" />
+        {% endfor %}
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+
+### Separator
+
+Use `InputOtp:Separator` between `InputOtp:Group` components to visually split the code.
+
+```twig {"preview":true}
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="1" />
+        <twig:InputOtp:Slot input="2" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="3" />
+        <twig:InputOtp:Slot input="4" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="5" />
+        <twig:InputOtp:Slot input="6" />
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+
+### Pattern
+
+Use the `pattern` attribute on each `InputOtp:Slot` to restrict the accepted characters.
+
+```twig {"preview":true}
+<div class="flex flex-col gap-2 w-fit">
+    <twig:Label for="digits-only">Digits Only</twig:Label>
+    <twig:InputOtp inputs="6" id="digits-only">
+        <twig:InputOtp:Group>
+            {% for i in 1..6 %}
+                <twig:InputOtp:Slot input="{{ i }}" pattern="[0-9]" />
+            {% endfor %}
+        </twig:InputOtp:Group>
+    </twig:InputOtp>
+</div>
+```
+
+### Alphanumeric
+
+Combine `inputmode="text"` with a `pattern` to accept letters and digits.
+
+```twig {"preview":true}
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="1" inputmode="text" pattern="[A-Za-z0-9]" />
+        <twig:InputOtp:Slot input="2" inputmode="text" pattern="[A-Za-z0-9]" />
+        <twig:InputOtp:Slot input="3" inputmode="text" pattern="[A-Za-z0-9]" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="4" inputmode="text" pattern="[A-Za-z0-9]" />
+        <twig:InputOtp:Slot input="5" inputmode="text" pattern="[A-Za-z0-9]" />
+        <twig:InputOtp:Slot input="6" inputmode="text" pattern="[A-Za-z0-9]" />
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+
+### Controlled
+
+Listen to the `input` event to react to the value as the user types, here with a small display controller.
+
+```twig {"preview":true}
+<div class="space-y-2" data-controller="input-otp-display">
+    <twig:InputOtp inputs="6" data-action="input->input-otp-display#update">
+        <twig:InputOtp:Group>
+            {% for i in 1..6 %}
+                <twig:InputOtp:Slot input="{{ i }}" />
+            {% endfor %}
+        </twig:InputOtp:Group>
+    </twig:InputOtp>
+    <div class="text-center text-sm">
+        <span data-input-otp-display-target="empty">Enter your one-time password.</span>
+        <span data-input-otp-display-target="filled" hidden>You entered: <span data-input-otp-display-target="output"></span></span>
+    </div>
+</div>
+```
+
+### Disabled
+
+Use the `disabled` attribute on the slots to disable the OTP input.
+
+```twig {"preview":true}
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="1" value="1" disabled />
+        <twig:InputOtp:Slot input="2" value="2" disabled />
+        <twig:InputOtp:Slot input="3" value="3" disabled />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="4" value="4" disabled />
+        <twig:InputOtp:Slot input="5" value="5" disabled />
+        <twig:InputOtp:Slot input="6" value="6" disabled />
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+
+### Invalid
+
+Use `aria-invalid="true"` on the slots to mark the code as invalid.
+
+```twig {"preview":true}
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="1" value="0" aria-invalid="true" />
+        <twig:InputOtp:Slot input="2" value="0" aria-invalid="true" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="3" value="0" aria-invalid="true" />
+        <twig:InputOtp:Slot input="4" value="0" aria-invalid="true" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="5" value="0" aria-invalid="true" />
+        <twig:InputOtp:Slot input="6" value="0" aria-invalid="true" />
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+
+### Form
+
+A complete verification form combining `InputOtp` with `Card`, `Label` and `Button`.
+
+```twig {"preview":true,"collapseClass":true}
+<twig:Card class="mx-auto max-w-md">
+    <twig:Card:Header>
+        <twig:Card:Title>Verify your login</twig:Card:Title>
+        <twig:Card:Description>
+            Enter the verification code we sent to your email address: <span class="font-medium">m@example.com</span>.
+        </twig:Card:Description>
+    </twig:Card:Header>
+    <twig:Card:Content>
+        <div class="flex flex-col gap-2">
+            <div class="flex items-center justify-between">
+                <twig:Label for="otp-verification">Verification code</twig:Label>
+                <twig:Button variant="outline" size="sm" class="gap-1.5">
+                    <twig:ux:icon name="lucide:refresh-cw" class="size-3.5" />
+                    Resend Code
+                </twig:Button>
+            </div>
+            <twig:InputOtp inputs="6" id="otp-verification">
+                <twig:InputOtp:Group class="*:data-[slot=input-otp-slot]:h-12 *:data-[slot=input-otp-slot]:w-11 *:data-[slot=input-otp-slot]:text-xl">
+                    <twig:InputOtp:Slot input="1" required />
+                    <twig:InputOtp:Slot input="2" required />
+                    <twig:InputOtp:Slot input="3" required />
+                </twig:InputOtp:Group>
+                <twig:InputOtp:Separator class="mx-2" />
+                <twig:InputOtp:Group class="*:data-[slot=input-otp-slot]:h-12 *:data-[slot=input-otp-slot]:w-11 *:data-[slot=input-otp-slot]:text-xl">
+                    <twig:InputOtp:Slot input="4" required />
+                    <twig:InputOtp:Slot input="5" required />
+                    <twig:InputOtp:Slot input="6" required />
+                </twig:InputOtp:Group>
+            </twig:InputOtp>
+            <p class="text-sm text-muted-foreground">
+                <a href="#" class="underline underline-offset-4 hover:text-primary">I no longer have access to this email address.</a>
+            </p>
+        </div>
+    </twig:Card:Content>
+    <twig:Card:Footer class="flex flex-col gap-2">
+        <twig:Button type="submit" class="w-full">Verify</twig:Button>
+        <div class="text-sm text-muted-foreground">
+            Having trouble signing in?
+            <a href="#" class="underline underline-offset-4 hover:text-primary">Contact support</a>
+        </div>
+    </twig:Card:Footer>
+</twig:Card>
+```
+
+### RTL
+
+Use the `name` prop on `InputOtp` to change the base name of the inputs; here with right-to-left layouts in Arabic and Hebrew.
+
+```twig {"preview":true}
+<div class="flex flex-col items-center gap-4">
+    {# Arabic #}
+    <div dir="rtl" class="flex flex-col gap-2 w-fit">
+        <twig:Label for="ar-otp">رمز التحقق</twig:Label>
+        <twig:InputOtp inputs="6" name="ar-otp" id="ar-otp">
+            <twig:InputOtp:Group>
+                {% for i in 1..6 %}
+                    <twig:InputOtp:Slot input="{{ i }}" />
+                {% endfor %}
+            </twig:InputOtp:Group>
+        </twig:InputOtp>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl" class="flex flex-col gap-2 w-fit">
+        <twig:Label for="he-otp">קוד אימות</twig:Label>
+        <twig:InputOtp inputs="6" name="he-otp" id="he-otp">
+            <twig:InputOtp:Group>
+                {% for i in 1..6 %}
+                    <twig:InputOtp:Slot input="{{ i }}" />
+                {% endfor %}
+            </twig:InputOtp:Group>
+        </twig:InputOtp>
+    </div>
+</div>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/shadcn/input-otp/assets/controllers/input_otp_controller.js
+++ b/src/Toolkit/kits/shadcn/input-otp/assets/controllers/input_otp_controller.js
@@ -1,0 +1,91 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['slot'];
+
+    _patternCache = new Map();
+
+    onInput(event) {
+        const slot = event.target;
+
+        if (slot.value.length > 1) {
+            slot.value = slot.value.slice(-1);
+        }
+        if (!slot.value) return;
+
+        // Native `pattern` only validates on submit; enforce it here to block disallowed characters as they are typed.
+        if (!this._matchesPattern(slot, slot.value)) {
+            slot.value = '';
+            return;
+        }
+
+        this._focusNext(slot);
+    }
+
+    onKeyDown(event) {
+        const slots = this.slotTargets;
+        const index = slots.indexOf(event.target);
+
+        if (index > 0 && (event.key === 'ArrowLeft' || (event.key === 'Backspace' && !event.target.value))) {
+            event.preventDefault();
+            this._focusSlot(slots[index - 1]);
+            return;
+        }
+
+        if (event.key === 'ArrowRight' && index < slots.length - 1) {
+            event.preventDefault();
+            this._focusSlot(slots[index + 1]);
+        }
+    }
+
+    onPaste(event) {
+        const pasted = (event.clipboardData || window.clipboardData).getData('text');
+        if (!pasted) return;
+        event.preventDefault();
+
+        const slots = this.slotTargets;
+        const startIndex = slots.indexOf(event.target);
+
+        let filled = 0;
+        for (const char of pasted) {
+            const slot = slots[startIndex + filled];
+            if (!slot) break;
+            if (!this._matchesPattern(slot, char)) continue;
+            slot.value = char;
+            filled++;
+        }
+        if (filled === 0) return;
+
+        this._focusSlot(slots[Math.min(startIndex + filled, slots.length - 1)]);
+        this.element.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    _focusNext(slot) {
+        const slots = this.slotTargets;
+        const index = slots.indexOf(slot);
+        if (index >= 0 && index < slots.length - 1) {
+            this._focusSlot(slots[index + 1]);
+        }
+    }
+
+    _focusSlot(slot) {
+        slot.focus();
+        slot.select();
+    }
+
+    _matchesPattern(slot, value) {
+        const pattern = slot.getAttribute('pattern');
+        if (!pattern) return true;
+
+        let regex = this._patternCache.get(pattern);
+        if (regex === undefined) {
+            try {
+                regex = new RegExp(`^(?:${pattern})$`);
+            } catch {
+                regex = null;
+            }
+            this._patternCache.set(pattern, regex);
+        }
+        return regex === null || regex.test(value);
+    }
+}

--- a/src/Toolkit/kits/shadcn/input-otp/assets/controllers/input_otp_display_controller.js
+++ b/src/Toolkit/kits/shadcn/input-otp/assets/controllers/input_otp_display_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['output', 'empty', 'filled'];
+
+    update(event) {
+        const otp = event.currentTarget;
+        const slots = Array.from(otp.querySelectorAll('[data-slot="input-otp-slot"]'));
+        const value = slots.map((s) => s.value).join('');
+
+        if (this.hasOutputTarget) {
+            this.outputTarget.textContent = value;
+        }
+        if (this.hasEmptyTarget && this.hasFilledTarget) {
+            this.emptyTarget.hidden = value !== '';
+            this.filledTarget.hidden = value === '';
+        }
+    }
+}

--- a/src/Toolkit/kits/shadcn/input-otp/manifest.json
+++ b/src/Toolkit/kits/shadcn/input-otp/manifest.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Input OTP",
+    "version-added": "3.5",
+    "copy-files": {
+        "assets/": "assets/",
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": [
+            "twig/html-extra:^3.24.0",
+            "symfony/ux-icons",
+            "symfony/ux-twig-component:^3.5",
+            "tales-from-a-dev/twig-tailwind-extra:^1.3.0"
+        ]
+    }
+}

--- a/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp.html.twig
+++ b/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp.html.twig
@@ -1,0 +1,15 @@
+{# @prop inputs int|null Total number of slots in this OTP, shared with the `InputOtp:Slot` children to build their accessible "Input X of Y" label. #}
+{# @prop name string Base name of the OTP inputs, shared with the `InputOtp:Slot` children to build their default `name`, e.g. `otp` yields `otp[0]`, `otp[1]`, ... #}
+{# @block content The OTP slot inputs, typically multiple `InputOtp:Slot` components. #}
+{%- props inputs = null, name = 'otp' -%}
+{%- do provide('inputOtp.inputs', inputs) -%}
+{%- do provide('inputOtp.name', name) -%}
+<div
+    data-slot="input-otp"
+    {{ attributes.defaults({
+        class: 'flex items-center gap-2 has-[:disabled]:opacity-50'|tailwind_classes,
+        'data-controller': 'input-otp',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Group.html.twig
+++ b/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Group.html.twig
@@ -1,0 +1,9 @@
+{# @block content The `InputOtp:Slot` components within this group. #}
+<div
+    data-slot="input-otp-group"
+    {{ attributes.defaults({
+        class: 'flex items-center'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Separator.html.twig
+++ b/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Separator.html.twig
@@ -1,0 +1,10 @@
+<span
+    role="separator"
+    aria-hidden="true"
+    data-slot="input-otp-separator"
+    {{ attributes.defaults({
+        class: 'text-muted-foreground [&>svg]:size-4'|tailwind_classes,
+    }) }}
+>
+    <twig:ux:icon name="lucide:minus" />
+</span>

--- a/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Slot.html.twig
+++ b/src/Toolkit/kits/shadcn/input-otp/templates/components/InputOtp/Slot.html.twig
@@ -1,0 +1,23 @@
+{# @prop input int|null Position of this slot (1-based), combined with the `inputs` and `name` props of the parent `InputOtp` to build the accessible "Input X of Y" label and the default `name`. #}
+{# @prop label string|null Accessible label of this slot, overriding the "Input X of Y" one built from `input`. #}
+{%- props input = null, label = null -%}
+{%- set _inputOtp_name = null -%}
+{%- if input is not null -%}
+    {%- set _inputOtp_inputs = inject('inputOtp.inputs') -%}
+    {%- set label = label ?? ('Input ' ~ input ~ (_inputOtp_inputs is not null ? ' of ' ~ _inputOtp_inputs : '')) -%}
+    {%- set _inputOtp_name = inject('inputOtp.name', 'otp') ~ '[' ~ (input - 1) ~ ']' -%}
+{%- endif -%}
+<input
+    data-slot="input-otp-slot"
+    data-input-otp-target="slot"
+    {% if label %}aria-label="{{ label }}"{% endif %}
+    {{ attributes.defaults({
+        class: 'relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md'|tailwind_classes,
+        'data-action': 'input->input-otp#onInput keydown->input-otp#onKeyDown paste->input-otp#onPaste',
+        type: 'text',
+        inputmode: 'numeric',
+        maxlength: 1,
+        autocomplete: 'one-time-code',
+        name: _inputOtp_name,
+    }) }}
+>

--- a/src/Toolkit/tests/Fixtures/icons/lucide/refresh-cw.svg
+++ b/src/Toolkit/tests/Fixtures/icons/lucide/refresh-cw.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12a9 9 0 0 1 9-9a9.75 9.75 0 0 1 6.74 2.74L21 8M21 3v5h-5m5 4a9 9 0 0 1-9 9a9.75 9.75 0 0 1-6.74-2.74L3 16m5 0H3v5"/></svg>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 0__1.html
@@ -1,0 +1,29 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        {% for i in 1..6 %}
+            <twig:InputOtp:Slot input="{{ i }}" value="{{ i }}" />
+        {% endfor %}
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp">
+<div data-slot="input-otp-group" class="flex items-center">            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[0]" value="1">
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[1]" value="2">
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[2]" value="3">
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[3]" value="4">
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[4]" value="5">
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[5]" value="6">
+
+            </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 1__1.html
@@ -1,0 +1,25 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<twig:InputOtp inputs="4">
+    <twig:InputOtp:Group>
+        {% for i in 1..4 %}
+            <twig:InputOtp:Slot input="{{ i }}" pattern="[0-9]" />
+        {% endfor %}
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp">
+<div data-slot="input-otp-group" class="flex items-center">            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 4" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[0]" pattern="[0-9]">
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 4" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[1]" pattern="[0-9]">
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 4" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[2]" pattern="[0-9]">
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 4" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[3]" pattern="[0-9]">
+
+            </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 2__1.html
@@ -1,0 +1,51 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="1" />
+        <twig:InputOtp:Slot input="2" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="3" />
+        <twig:InputOtp:Slot input="4" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="5" />
+        <twig:InputOtp:Slot input="6" />
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp">
+<div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[0]">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[1]">
+
+    </div>
+    <span role="separator" aria-hidden="true" data-slot="input-otp-separator" class="text-muted-foreground [&amp;&gt;svg]:size-4">
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14"></path></svg>
+</span>
+
+    <div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[2]">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[3]">
+
+    </div>
+    <span role="separator" aria-hidden="true" data-slot="input-otp-separator" class="text-muted-foreground [&amp;&gt;svg]:size-4">
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14"></path></svg>
+</span>
+
+    <div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[4]">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[5]">
+
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 3__1.html
@@ -1,0 +1,35 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<div class="flex flex-col gap-2 w-fit">
+    <twig:Label for="digits-only">Digits Only</twig:Label>
+    <twig:InputOtp inputs="6" id="digits-only">
+        <twig:InputOtp:Group>
+            {% for i in 1..6 %}
+                <twig:InputOtp:Slot input="{{ i }}" pattern="[0-9]" />
+            {% endfor %}
+        </twig:InputOtp:Group>
+    </twig:InputOtp>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col gap-2 w-fit">
+    <label data-slot="label" class="flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50" for="digits-only">Digits Only</label>
+    <div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp" id="digits-only">
+<div data-slot="input-otp-group" class="flex items-center">                <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[0]" pattern="[0-9]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[1]" pattern="[0-9]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[2]" pattern="[0-9]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[3]" pattern="[0-9]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[4]" pattern="[0-9]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[5]" pattern="[0-9]">
+
+                    </div>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 4__1.html
@@ -1,0 +1,42 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="1" inputmode="text" pattern="[A-Za-z0-9]" />
+        <twig:InputOtp:Slot input="2" inputmode="text" pattern="[A-Za-z0-9]" />
+        <twig:InputOtp:Slot input="3" inputmode="text" pattern="[A-Za-z0-9]" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="4" inputmode="text" pattern="[A-Za-z0-9]" />
+        <twig:InputOtp:Slot input="5" inputmode="text" pattern="[A-Za-z0-9]" />
+        <twig:InputOtp:Slot input="6" inputmode="text" pattern="[A-Za-z0-9]" />
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp">
+<div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="text" maxlength="1" autocomplete="one-time-code" name="otp[0]" pattern="[A-Za-z0-9]">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="text" maxlength="1" autocomplete="one-time-code" name="otp[1]" pattern="[A-Za-z0-9]">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="text" maxlength="1" autocomplete="one-time-code" name="otp[2]" pattern="[A-Za-z0-9]">
+
+    </div>
+    <span role="separator" aria-hidden="true" data-slot="input-otp-separator" class="text-muted-foreground [&amp;&gt;svg]:size-4">
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14"></path></svg>
+</span>
+
+    <div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="text" maxlength="1" autocomplete="one-time-code" name="otp[3]" pattern="[A-Za-z0-9]">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="text" maxlength="1" autocomplete="one-time-code" name="otp[4]" pattern="[A-Za-z0-9]">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="text" maxlength="1" autocomplete="one-time-code" name="otp[5]" pattern="[A-Za-z0-9]">
+
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 5__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 5__1.html
@@ -1,0 +1,41 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<div class="space-y-2" data-controller="input-otp-display">
+    <twig:InputOtp inputs="6" data-action="input->input-otp-display#update">
+        <twig:InputOtp:Group>
+            {% for i in 1..6 %}
+                <twig:InputOtp:Slot input="{{ i }}" />
+            {% endfor %}
+        </twig:InputOtp:Group>
+    </twig:InputOtp>
+    <div class="text-center text-sm">
+        <span data-input-otp-display-target="empty">Enter your one-time password.</span>
+        <span data-input-otp-display-target="filled" hidden>You entered: <span data-input-otp-display-target="output"></span></span>
+    </div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="space-y-2" data-controller="input-otp-display">
+    <div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp" data-action="input-&gt;input-otp-display#update">
+<div data-slot="input-otp-group" class="flex items-center">                <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[0]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[1]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[2]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[3]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[4]">
+
+                            <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[5]">
+
+                    </div>
+    </div>
+    <div class="text-center text-sm">
+        <span data-input-otp-display-target="empty">Enter your one-time password.</span>
+        <span data-input-otp-display-target="filled" hidden>You entered: <span data-input-otp-display-target="output"></span></span>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 6__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 6__1.html
@@ -1,0 +1,42 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="1" value="1" disabled />
+        <twig:InputOtp:Slot input="2" value="2" disabled />
+        <twig:InputOtp:Slot input="3" value="3" disabled />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="4" value="4" disabled />
+        <twig:InputOtp:Slot input="5" value="5" disabled />
+        <twig:InputOtp:Slot input="6" value="6" disabled />
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp">
+<div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[0]" value="1" disabled>
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[1]" value="2" disabled>
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[2]" value="3" disabled>
+
+    </div>
+    <span role="separator" aria-hidden="true" data-slot="input-otp-separator" class="text-muted-foreground [&amp;&gt;svg]:size-4">
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14"></path></svg>
+</span>
+
+    <div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[3]" value="4" disabled>
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[4]" value="5" disabled>
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[5]" value="6" disabled>
+
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 7__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 7__1.html
@@ -1,0 +1,51 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<twig:InputOtp inputs="6">
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="1" value="0" aria-invalid="true" />
+        <twig:InputOtp:Slot input="2" value="0" aria-invalid="true" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="3" value="0" aria-invalid="true" />
+        <twig:InputOtp:Slot input="4" value="0" aria-invalid="true" />
+    </twig:InputOtp:Group>
+    <twig:InputOtp:Separator />
+    <twig:InputOtp:Group>
+        <twig:InputOtp:Slot input="5" value="0" aria-invalid="true" />
+        <twig:InputOtp:Slot input="6" value="0" aria-invalid="true" />
+    </twig:InputOtp:Group>
+</twig:InputOtp>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp">
+<div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[0]" value="0" aria-invalid="true">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[1]" value="0" aria-invalid="true">
+
+    </div>
+    <span role="separator" aria-hidden="true" data-slot="input-otp-separator" class="text-muted-foreground [&amp;&gt;svg]:size-4">
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14"></path></svg>
+</span>
+
+    <div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[2]" value="0" aria-invalid="true">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[3]" value="0" aria-invalid="true">
+
+    </div>
+    <span role="separator" aria-hidden="true" data-slot="input-otp-separator" class="text-muted-foreground [&amp;&gt;svg]:size-4">
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14"></path></svg>
+</span>
+
+    <div data-slot="input-otp-group" class="flex items-center">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[4]" value="0" aria-invalid="true">
+
+        <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[5]" value="0" aria-invalid="true">
+
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 8__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 8__1.html
@@ -1,0 +1,98 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<twig:Card class="mx-auto max-w-md">
+    <twig:Card:Header>
+        <twig:Card:Title>Verify your login</twig:Card:Title>
+        <twig:Card:Description>
+            Enter the verification code we sent to your email address: <span class="font-medium">m@example.com</span>.
+        </twig:Card:Description>
+    </twig:Card:Header>
+    <twig:Card:Content>
+        <div class="flex flex-col gap-2">
+            <div class="flex items-center justify-between">
+                <twig:Label for="otp-verification">Verification code</twig:Label>
+                <twig:Button variant="outline" size="sm" class="gap-1.5">
+                    <twig:ux:icon name="lucide:refresh-cw" class="size-3.5" />
+                    Resend Code
+                </twig:Button>
+            </div>
+            <twig:InputOtp inputs="6" id="otp-verification">
+                <twig:InputOtp:Group class="*:data-[slot=input-otp-slot]:h-12 *:data-[slot=input-otp-slot]:w-11 *:data-[slot=input-otp-slot]:text-xl">
+                    <twig:InputOtp:Slot input="1" required />
+                    <twig:InputOtp:Slot input="2" required />
+                    <twig:InputOtp:Slot input="3" required />
+                </twig:InputOtp:Group>
+                <twig:InputOtp:Separator class="mx-2" />
+                <twig:InputOtp:Group class="*:data-[slot=input-otp-slot]:h-12 *:data-[slot=input-otp-slot]:w-11 *:data-[slot=input-otp-slot]:text-xl">
+                    <twig:InputOtp:Slot input="4" required />
+                    <twig:InputOtp:Slot input="5" required />
+                    <twig:InputOtp:Slot input="6" required />
+                </twig:InputOtp:Group>
+            </twig:InputOtp>
+            <p class="text-sm text-muted-foreground">
+                <a href="#" class="underline underline-offset-4 hover:text-primary">I no longer have access to this email address.</a>
+            </p>
+        </div>
+    </twig:Card:Content>
+    <twig:Card:Footer class="flex flex-col gap-2">
+        <twig:Button type="submit" class="w-full">Verify</twig:Button>
+        <div class="text-sm text-muted-foreground">
+            Having trouble signing in?
+            <a href="#" class="underline underline-offset-4 hover:text-primary">Contact support</a>
+        </div>
+    </twig:Card:Footer>
+</twig:Card>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl mx-auto max-w-md">
+<div data-slot="card-header" class="group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3">
+<div data-slot="card-title" class="cn-font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm">Verify your login</div>
+        <div data-slot="card-description" class="text-sm text-muted-foreground">Enter the verification code we sent to your email address: <span class="font-medium">m@example.com</span>.
+        </div>
+    </div>
+    <div data-slot="card-content" class="px-4 group-data-[size=sm]/card:px-3">
+<div class="flex flex-col gap-2">
+            <div class="flex items-center justify-between">
+                <label data-slot="label" class="flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50" for="otp-verification">Verification code</label>
+                <button data-slot="button" data-size="sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5 gap-1.5" type="button"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12a9 9 0 0 1 9-9a9.75 9.75 0 0 1 6.74 2.74L21 8M21 3v5h-5m5 4a9 9 0 0 1-9 9a9.75 9.75 0 0 1-6.74-2.74L3 16m5 0H3v5"></path></svg>
+                    Resend Code
+                </button>
+            </div>
+            <div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp" id="otp-verification">
+<div data-slot="input-otp-group" class="flex items-center *:data-[slot=input-otp-slot]:h-12 *:data-[slot=input-otp-slot]:w-11 *:data-[slot=input-otp-slot]:text-xl">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[0]" required>
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[1]" required>
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[2]" required>
+
+                </div>
+                <span role="separator" aria-hidden="true" data-slot="input-otp-separator" class="text-muted-foreground [&amp;&gt;svg]:size-4 mx-2">
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14"></path></svg>
+</span>
+
+                <div data-slot="input-otp-group" class="flex items-center *:data-[slot=input-otp-slot]:h-12 *:data-[slot=input-otp-slot]:w-11 *:data-[slot=input-otp-slot]:text-xl">
+<input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[3]" required>
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[4]" required>
+
+                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="otp[5]" required>
+
+                </div>
+            </div>
+            <p class="text-sm text-muted-foreground">
+                <a href="#" class="underline underline-offset-4 hover:text-primary">I no longer have access to this email address.</a>
+            </p>
+        </div>
+    </div>
+    <div data-slot="card-footer" class="items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3 flex flex-col gap-2">
+<button data-slot="button" data-size="default" data-variant="default" class="group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 bg-primary text-primary-foreground [a]:hover:bg-primary/80 h-8 gap-1.5 px-2.5 ltr:has-data-[icon=inline-end]:pr-2 rtl:has-data-[icon=inline-end]:pe-2 ltr:has-data-[icon=inline-start]:pl-2 rtl:has-data-[icon=inline-start]:ps-2 w-full" type="submit">Verify</button>
+        <div class="text-sm text-muted-foreground">
+            Having trouble signing in?
+            <a href="#" class="underline underline-offset-4 hover:text-primary">Contact support</a>
+        </div>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 9__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component input-otp, example 9__1.html
@@ -1,0 +1,71 @@
+<!--
+- Kit: Shadcn UI
+- Component: Input OTP
+- Code:
+```twig
+<div class="flex flex-col items-center gap-4">
+    {# Arabic #}
+    <div dir="rtl" class="flex flex-col gap-2 w-fit">
+        <twig:Label for="ar-otp">رمز التحقق</twig:Label>
+        <twig:InputOtp inputs="6" name="ar-otp" id="ar-otp">
+            <twig:InputOtp:Group>
+                {% for i in 1..6 %}
+                    <twig:InputOtp:Slot input="{{ i }}" />
+                {% endfor %}
+            </twig:InputOtp:Group>
+        </twig:InputOtp>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl" class="flex flex-col gap-2 w-fit">
+        <twig:Label for="he-otp">קוד אימות</twig:Label>
+        <twig:InputOtp inputs="6" name="he-otp" id="he-otp">
+            <twig:InputOtp:Group>
+                {% for i in 1..6 %}
+                    <twig:InputOtp:Slot input="{{ i }}" />
+                {% endfor %}
+            </twig:InputOtp:Group>
+        </twig:InputOtp>
+    </div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col items-center gap-4">
+        <div dir="rtl" class="flex flex-col gap-2 w-fit">
+        <label data-slot="label" class="flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50" for="ar-otp">رمز التحقق</label>
+        <div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp" id="ar-otp">
+<div data-slot="input-otp-group" class="flex items-center">                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="ar-otp[0]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="ar-otp[1]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="ar-otp[2]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="ar-otp[3]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="ar-otp[4]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="ar-otp[5]">
+
+                            </div>
+        </div>
+    </div>
+
+        <div dir="rtl" class="flex flex-col gap-2 w-fit">
+        <label data-slot="label" class="flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50" for="he-otp">קוד אימות</label>
+        <div data-slot="input-otp" class="flex items-center gap-2 has-[:disabled]:opacity-50" data-controller="input-otp" id="he-otp">
+<div data-slot="input-otp-group" class="flex items-center">                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 1 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="he-otp[0]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 2 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="he-otp[1]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 3 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="he-otp[2]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 4 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="he-otp[3]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 5 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="he-otp[4]">
+
+                                    <input data-slot="input-otp-slot" data-input-otp-target="slot" aria-label="Input 6 of 6" class="relative flex h-10 w-10 items-center justify-center border-y border-e border-input bg-transparent text-center text-sm shadow-xs transition-all outline-none focus-visible:z-10 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/60 first:rounded-s-md first:border-s last:rounded-e-md" data-action="input-&gt;input-otp#onInput keydown-&gt;input-otp#onKeyDown paste-&gt;input-otp#onPaste" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" name="he-otp[5]">
+
+                            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

Adds the `input-otp` recipe to the Shadcn kit.

Part of the split of #3467 into one PR per component, tracking #3233.

Snapshots will be regenerated after rework.