### PR TITLE
[Toolkit][Shadcn] Add navigation-menu recipe

### DIFF
--- a/src/Toolkit/kits/shadcn/navigation-menu/README.md
+++ b/src/Toolkit/kits/shadcn/navigation-menu/README.md
@@ -1,0 +1,352 @@
+# Navigation Menu
+
+A collection of navigation links with optional hover-triggered submenus.
+
+```twig {"preview":true}
+<div class="flex items-start justify-center" style="min-height: 340px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>
+                    <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                        Getting started
+                        <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                    </twig:Button>
+                </twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid gap-1 w-96">
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                <div class="text-sm font-medium leading-none">Introduction</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Reusable components built with Tailwind CSS.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                <div class="text-sm font-medium leading-none">Installation</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">How to install dependencies and structure your app.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                <div class="text-sm font-medium leading-none">Typography</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Styles for headings, paragraphs, lists...etc</p>
+                            </a>
+                        </li>
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>
+                    <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                        Components
+                        <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                    </twig:Button>
+                </twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid gap-2 w-[500px] grid-cols-2">
+                        {% set components = [
+                            {title: 'Alert Dialog', href: '/docs/primitives/alert-dialog', description: 'A modal dialog that interrupts the user with important content and expects a response.'},
+                            {title: 'Hover Card', href: '/docs/primitives/hover-card', description: 'For sighted users to preview content available behind a link.'},
+                            {title: 'Progress', href: '/docs/primitives/progress', description: 'Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.'},
+                            {title: 'Scroll-area', href: '/docs/primitives/scroll-area', description: 'Visually or semantically separates content.'},
+                            {title: 'Tabs', href: '/docs/primitives/tabs', description: 'A set of layered sections of content—known as tab panels—that are displayed one at a time.'},
+                            {title: 'Tooltip', href: '/docs/primitives/tooltip', description: 'A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.'},
+                        ] %}
+                        {% for c in components %}
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="{{ c.href }}">
+                                    <div class="text-sm font-medium leading-none">{{ c.title }}</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">{{ c.description }}</p>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+```twig
+<twig:NavigationMenu>
+    <twig:NavigationMenu:List>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Link href="/">Home</twig:NavigationMenu:Link>
+        </twig:NavigationMenu:Item>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Trigger>
+                <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>Docs</twig:Button>
+            </twig:NavigationMenu:Trigger>
+            <twig:NavigationMenu:Content>
+                <twig:NavigationMenu:Link href="/docs">Introduction</twig:NavigationMenu:Link>
+                <twig:NavigationMenu:Link href="/docs/installation">Installation</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Content>
+        </twig:NavigationMenu:Item>
+    </twig:NavigationMenu:List>
+</twig:NavigationMenu>
+```
+
+The submenu opens on hover and on keyboard focus, and stays open while the focus moves between the trigger and the links of the submenu.
+
+## Examples
+
+### Basic
+
+```twig {"preview":true}
+<div class="flex items-start justify-center" style="min-height: 340px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>
+                    <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                        Getting started
+                        <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                    </twig:Button>
+                </twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid gap-1 w-96">
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                <div class="text-sm font-medium leading-none">Introduction</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Reusable components built with Tailwind CSS.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                <div class="text-sm font-medium leading-none">Installation</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">How to install dependencies and structure your app.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                <div class="text-sm font-medium leading-none">Typography</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Styles for headings, paragraphs, lists...etc</p>
+                            </a>
+                        </li>
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>
+                    <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                        Components
+                        <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                    </twig:Button>
+                </twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid gap-2 w-[500px] grid-cols-2">
+                        {% set components = [
+                            {title: 'Alert Dialog', href: '/docs/primitives/alert-dialog', description: 'A modal dialog that interrupts the user with important content and expects a response.'},
+                            {title: 'Hover Card', href: '/docs/primitives/hover-card', description: 'For sighted users to preview content available behind a link.'},
+                            {title: 'Progress', href: '/docs/primitives/progress', description: 'Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.'},
+                            {title: 'Scroll-area', href: '/docs/primitives/scroll-area', description: 'Visually or semantically separates content.'},
+                            {title: 'Tabs', href: '/docs/primitives/tabs', description: 'A set of layered sections of content—known as tab panels—that are displayed one at a time.'},
+                            {title: 'Tooltip', href: '/docs/primitives/tooltip', description: 'A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.'},
+                        ] %}
+                        {% for c in components %}
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="{{ c.href }}">
+                                    <div class="text-sm font-medium leading-none">{{ c.title }}</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">{{ c.description }}</p>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+
+### With delays
+
+Use the `openDelay` and `closeDelay` props of `NavigationMenu:Item` (in milliseconds) to avoid flickering when moving between items.
+
+```twig {"preview":true}
+<div class="flex items-start justify-center" style="min-height: 200px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            {% for item in ['Products', 'Solutions', 'Resources'] %}
+                <twig:NavigationMenu:Item openDelay="150" closeDelay="300">
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            {{ item }}
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content class="w-56">
+                        <twig:NavigationMenu:Link href="#" class="w-full justify-start">Overview</twig:NavigationMenu:Link>
+                        <twig:NavigationMenu:Link href="#" class="w-full justify-start">Pricing</twig:NavigationMenu:Link>
+                        <twig:NavigationMenu:Link href="#" class="w-full justify-start">Changelog</twig:NavigationMenu:Link>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+            {% endfor %}
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+```twig {"preview":true}
+<div class="flex flex-col items-center gap-12" style="min-height: 720px">
+    {# Arabic #}
+    <div dir="rtl">
+        <twig:NavigationMenu>
+            <twig:NavigationMenu:List>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            البدء
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid gap-1 w-96">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">مقدمة</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">مكونات قابلة لإعادة الاستخدام مبنية باستخدام Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">التثبيت</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">كيفية تثبيت التبعيات وتنظيم تطبيقك.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                    <div class="text-sm font-medium leading-none">الطباعة</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">أنماط للعناوين والفقرات والقوائم...إلخ</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            المكونات
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid gap-2 w-[500px] grid-cols-2">
+                            {% set components_ar = [
+                                {title: 'حوار التنبيه', href: '/docs/primitives/alert-dialog', description: 'حوار نافذة يقطع المستخدم بمحتوى مهم ويتوقع استجابة.'},
+                                {title: 'بطاقة التحويم', href: '/docs/primitives/hover-card', description: 'للمستخدمين المبصرين لمعاينة المحتوى المتاح خلف الرابط.'},
+                                {title: 'التقدم', href: '/docs/primitives/progress', description: 'يعرض مؤشرًا يوضح تقدم إتمام المهمة، عادةً يتم عرضه كشريط تقدم.'},
+                                {title: 'منطقة التمرير', href: '/docs/primitives/scroll-area', description: 'يفصل المحتوى بصريًا أو دلاليًا.'},
+                                {title: 'التبويبات', href: '/docs/primitives/tabs', description: 'مجموعة من أقسام المحتوى المتعددة الطبقات—المعروفة بألواح التبويب—التي يتم عرضها واحدة في كل مرة.'},
+                                {title: 'تلميح', href: '/docs/primitives/tooltip', description: 'نافذة منبثقة تعرض معلومات متعلقة بعنصر عند تحويم الماوس فوقه.'},
+                            ] %}
+                            {% for c in components_ar %}
+                                <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="{{ c.href }}">
+                                        <div class="text-sm font-medium leading-none">{{ c.title }}</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">{{ c.description }}</p>
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Link href="/docs">الوثائق</twig:NavigationMenu:Link>
+                </twig:NavigationMenu:Item>
+            </twig:NavigationMenu:List>
+        </twig:NavigationMenu>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl">
+        <twig:NavigationMenu>
+            <twig:NavigationMenu:List>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            התחלה
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid gap-1 w-96">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">הקדמה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">רכיבים לשימוש חוזר שנבנו עם Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">התקנה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">כיצד להתקין תלויות ולבנות את האפליקציה שלך.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                    <div class="text-sm font-medium leading-none">טיפוגרפיה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">סגנונות לכותרות, פסקאות, רשימות...וכו'</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            רכיבים
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid gap-2 w-[500px] grid-cols-2">
+                            {% set components_he = [
+                                {title: 'דיאלוג התראה', href: '/docs/primitives/alert-dialog', description: 'דיאלוג מודאלי שמפריע למשתמש עם תוכן חשוב ומצפה לתגובה.'},
+                                {title: 'כרטיס ריחוף', href: '/docs/primitives/hover-card', description: 'למשתמשים רואים כדי להציג תצוגה מקדימה של תוכן זמין מאחורי קישור.'},
+                                {title: 'התקדמות', href: '/docs/primitives/progress', description: 'מציג אינדיקטור המציג את התקדמות ההשלמה של משימה, בדרך כלל מוצג כסרגל התקדמות.'},
+                                {title: 'אזור גלילה', href: '/docs/primitives/scroll-area', description: 'מפריד תוכן חזותית או סמנטית.'},
+                                {title: 'כרטיסיות', href: '/docs/primitives/tabs', description: 'קבוצה של חלקי תוכן מרובדים—המכונים לוחות כרטיסיות—המוצגים אחד בכל פעם.'},
+                                {title: 'טולטיפ', href: '/docs/primitives/tooltip', description: 'חלון קופץ המציג מידע הקשור לאלמנט כאשר העכבר מרחף מעליו.'},
+                            ] %}
+                            {% for c in components_he %}
+                                <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="{{ c.href }}">
+                                        <div class="text-sm font-medium leading-none">{{ c.title }}</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">{{ c.description }}</p>
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Link href="/docs">תיעוד</twig:NavigationMenu:Link>
+                </twig:NavigationMenu:Item>
+            </twig:NavigationMenu:List>
+        </twig:NavigationMenu>
+    </div>
+</div>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/shadcn/navigation-menu/assets/controllers/navigation_menu_controller.js
+++ b/src/Toolkit/kits/shadcn/navigation-menu/assets/controllers/navigation_menu_controller.js
@@ -1,0 +1,54 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static values = {
+        openDelay: { type: Number, default: 0 },
+        closeDelay: { type: Number, default: 0 },
+    };
+
+    connect() {
+        this.openTimeout = null;
+        this.closeTimeout = null;
+        this.element.dataset.state = 'closed';
+    }
+
+    disconnect() {
+        this.#clearTimeouts();
+    }
+
+    show() {
+        this.#clearTimeouts();
+        this.openTimeout = setTimeout(() => {
+            this.element.dataset.state = 'open';
+            this.openTimeout = null;
+        }, this.openDelayValue);
+    }
+
+    hide() {
+        this.#clearTimeouts();
+        this.closeTimeout = setTimeout(() => {
+            this.element.dataset.state = 'closed';
+            this.closeTimeout = null;
+        }, this.closeDelayValue);
+    }
+
+    // Keep the submenu open while the focus moves between the trigger and its links
+    focusOut(event) {
+        if (event.relatedTarget && this.element.contains(event.relatedTarget)) {
+            return;
+        }
+
+        this.hide();
+    }
+
+    #clearTimeouts() {
+        if (this.openTimeout) {
+            clearTimeout(this.openTimeout);
+            this.openTimeout = null;
+        }
+        if (this.closeTimeout) {
+            clearTimeout(this.closeTimeout);
+            this.closeTimeout = null;
+        }
+    }
+}

--- a/src/Toolkit/kits/shadcn/navigation-menu/manifest.json
+++ b/src/Toolkit/kits/shadcn/navigation-menu/manifest.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Navigation Menu",
+    "version-added": "3.6",
+    "copy-files": {
+        "assets/": "assets/",
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": [
+            "twig/html-extra:^3.24.0",
+            "symfony/ux-twig-component:^3.5",
+            "tales-from-a-dev/twig-tailwind-extra:^1.3.0"
+        ]
+    }
+}

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu.html.twig
@@ -1,0 +1,12 @@
+{# @prop label string The accessible name of the navigation landmark. #}
+{# @block content A `NavigationMenu:List` containing `NavigationMenu:Item` children. #}
+{%- props label = 'Main' -%}
+<nav
+    data-slot="navigation-menu"
+    aria-label="{{ label }}"
+    {{ attributes.defaults({
+        class: 'relative flex max-w-max flex-1 items-center justify-center'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</nav>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Content.html.twig
@@ -1,0 +1,9 @@
+{# @block content The submenu revealed on hover or focus. #}
+<div
+    data-slot="navigation-menu-content"
+    {{ attributes.defaults({
+        class: 'invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Item.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Item.html.twig
@@ -1,0 +1,16 @@
+{# @prop openDelay number Delay in milliseconds before showing the submenu. #}
+{# @prop closeDelay number Delay in milliseconds before hiding the submenu. #}
+{# @block content The trigger and optional submenu content. #}
+{%- props openDelay = 0, closeDelay = 0 -%}
+<li
+    data-slot="navigation-menu-item"
+    data-navigation-menu-open-delay-value="{{ openDelay }}"
+    data-navigation-menu-close-delay-value="{{ closeDelay }}"
+    {{ attributes.defaults({
+        class: 'relative'|tailwind_classes,
+        'data-controller': 'navigation-menu',
+        'data-action': 'mouseenter->navigation-menu#show mouseleave->navigation-menu#hide focusin->navigation-menu#show focusout->navigation-menu#focusOut',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</li>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Link.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Link.html.twig
@@ -1,0 +1,12 @@
+{# @prop href string The target URL. #}
+{# @block content The link label. #}
+{%- props href -%}
+<a
+    href="{{ href }}"
+    data-slot="navigation-menu-link"
+    {{ attributes.defaults({
+        class: 'inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</a>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/List.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/List.html.twig
@@ -1,0 +1,9 @@
+{# @block content The `NavigationMenu:Item` children. #}
+<ul
+    data-slot="navigation-menu-list"
+    {{ attributes.defaults({
+        class: 'group flex flex-1 list-none items-center justify-center gap-1'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</ul>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Trigger.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Trigger.html.twig
@@ -1,0 +1,6 @@
+{# @block content The trigger label (e.g. a `Button`) that opens the submenu on hover or focus. #}
+{%- set navigation_menu_trigger_attrs = {
+    'data-slot': 'navigation-menu-trigger',
+    tabindex: 0,
+} -%}
+{%- block content %}{% endblock -%}

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 0__1.html
@@ -1,0 +1,154 @@
+<!--
+- Kit: Shadcn UI
+- Component: Navigation Menu
+- Code:
+```twig
+<div class="flex items-start justify-center" style="min-height: 340px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>
+                    <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                        Getting started
+                        <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                    </twig:Button>
+                </twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid gap-1 w-96">
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                <div class="text-sm font-medium leading-none">Introduction</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Reusable components built with Tailwind CSS.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                <div class="text-sm font-medium leading-none">Installation</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">How to install dependencies and structure your app.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                <div class="text-sm font-medium leading-none">Typography</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Styles for headings, paragraphs, lists...etc</p>
+                            </a>
+                        </li>
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>
+                    <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                        Components
+                        <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                    </twig:Button>
+                </twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid gap-2 w-[500px] grid-cols-2">
+                        {% set components = [
+                            {title: 'Alert Dialog', href: '/docs/primitives/alert-dialog', description: 'A modal dialog that interrupts the user with important content and expects a response.'},
+                            {title: 'Hover Card', href: '/docs/primitives/hover-card', description: 'For sighted users to preview content available behind a link.'},
+                            {title: 'Progress', href: '/docs/primitives/progress', description: 'Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.'},
+                            {title: 'Scroll-area', href: '/docs/primitives/scroll-area', description: 'Visually or semantically separates content.'},
+                            {title: 'Tabs', href: '/docs/primitives/tabs', description: 'A set of layered sections of content—known as tab panels—that are displayed one at a time.'},
+                            {title: 'Tooltip', href: '/docs/primitives/tooltip', description: 'A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.'},
+                        ] %}
+                        {% for c in components %}
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="{{ c.href }}">
+                                    <div class="text-sm font-medium leading-none">{{ c.title }}</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">{{ c.description }}</p>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex items-start justify-center" style="min-height: 340px">
+    <nav data-slot="navigation-menu" aria-label="Main" class="relative flex max-w-max flex-1 items-center justify-center"><ul data-slot="navigation-menu-list" class="group flex flex-1 list-none items-center justify-center gap-1">
+<li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">Getting started
+                        <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                    </button>
+                                <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+<ul class="grid gap-1 w-96">
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                <div class="text-sm font-medium leading-none">Introduction</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Reusable components built with Tailwind CSS.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                <div class="text-sm font-medium leading-none">Installation</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">How to install dependencies and structure your app.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                <div class="text-sm font-medium leading-none">Typography</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Styles for headings, paragraphs, lists...etc</p>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+            <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">Components
+                        <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                    </button>
+                                <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+<ul class="grid gap-2 w-[500px] grid-cols-2">
+                                                                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/alert-dialog">
+                                    <div class="text-sm font-medium leading-none">Alert Dialog</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">A modal dialog that interrupts the user with important content and expects a response.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/hover-card">
+                                    <div class="text-sm font-medium leading-none">Hover Card</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">For sighted users to preview content available behind a link.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/progress">
+                                    <div class="text-sm font-medium leading-none">Progress</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/scroll-area">
+                                    <div class="text-sm font-medium leading-none">Scroll-area</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Visually or semantically separates content.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tabs">
+                                    <div class="text-sm font-medium leading-none">Tabs</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">A set of layered sections of content—known as tab panels—that are displayed one at a time.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tooltip">
+                                    <div class="text-sm font-medium leading-none">Tooltip</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.</p>
+                                </a>
+                            </li>
+                                            </ul>
+                </div>
+            </li>
+            <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<a href="/docs" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">Docs</a>
+            </li>
+        </ul>
+    </nav>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 1__1.html
@@ -1,0 +1,154 @@
+<!--
+- Kit: Shadcn UI
+- Component: Navigation Menu
+- Code:
+```twig
+<div class="flex items-start justify-center" style="min-height: 340px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>
+                    <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                        Getting started
+                        <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                    </twig:Button>
+                </twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid gap-1 w-96">
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                <div class="text-sm font-medium leading-none">Introduction</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Reusable components built with Tailwind CSS.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                <div class="text-sm font-medium leading-none">Installation</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">How to install dependencies and structure your app.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                <div class="text-sm font-medium leading-none">Typography</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Styles for headings, paragraphs, lists...etc</p>
+                            </a>
+                        </li>
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>
+                    <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                        Components
+                        <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                    </twig:Button>
+                </twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid gap-2 w-[500px] grid-cols-2">
+                        {% set components = [
+                            {title: 'Alert Dialog', href: '/docs/primitives/alert-dialog', description: 'A modal dialog that interrupts the user with important content and expects a response.'},
+                            {title: 'Hover Card', href: '/docs/primitives/hover-card', description: 'For sighted users to preview content available behind a link.'},
+                            {title: 'Progress', href: '/docs/primitives/progress', description: 'Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.'},
+                            {title: 'Scroll-area', href: '/docs/primitives/scroll-area', description: 'Visually or semantically separates content.'},
+                            {title: 'Tabs', href: '/docs/primitives/tabs', description: 'A set of layered sections of content—known as tab panels—that are displayed one at a time.'},
+                            {title: 'Tooltip', href: '/docs/primitives/tooltip', description: 'A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.'},
+                        ] %}
+                        {% for c in components %}
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="{{ c.href }}">
+                                    <div class="text-sm font-medium leading-none">{{ c.title }}</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">{{ c.description }}</p>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex items-start justify-center" style="min-height: 340px">
+    <nav data-slot="navigation-menu" aria-label="Main" class="relative flex max-w-max flex-1 items-center justify-center"><ul data-slot="navigation-menu-list" class="group flex flex-1 list-none items-center justify-center gap-1">
+<li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">Getting started
+                        <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                    </button>
+                                <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+<ul class="grid gap-1 w-96">
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                <div class="text-sm font-medium leading-none">Introduction</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Reusable components built with Tailwind CSS.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                <div class="text-sm font-medium leading-none">Installation</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">How to install dependencies and structure your app.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                <div class="text-sm font-medium leading-none">Typography</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Styles for headings, paragraphs, lists...etc</p>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+            <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">Components
+                        <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                    </button>
+                                <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+<ul class="grid gap-2 w-[500px] grid-cols-2">
+                                                                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/alert-dialog">
+                                    <div class="text-sm font-medium leading-none">Alert Dialog</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">A modal dialog that interrupts the user with important content and expects a response.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/hover-card">
+                                    <div class="text-sm font-medium leading-none">Hover Card</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">For sighted users to preview content available behind a link.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/progress">
+                                    <div class="text-sm font-medium leading-none">Progress</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/scroll-area">
+                                    <div class="text-sm font-medium leading-none">Scroll-area</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Visually or semantically separates content.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tabs">
+                                    <div class="text-sm font-medium leading-none">Tabs</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">A set of layered sections of content—known as tab panels—that are displayed one at a time.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tooltip">
+                                    <div class="text-sm font-medium leading-none">Tooltip</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.</p>
+                                </a>
+                            </li>
+                                            </ul>
+                </div>
+            </li>
+            <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<a href="/docs" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">Docs</a>
+            </li>
+        </ul>
+    </nav>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 2__1.html
@@ -1,0 +1,62 @@
+<!--
+- Kit: Shadcn UI
+- Component: Navigation Menu
+- Code:
+```twig
+<div class="flex items-start justify-center" style="min-height: 200px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            {% for item in ['Products', 'Solutions', 'Resources'] %}
+                <twig:NavigationMenu:Item openDelay="150" closeDelay="300">
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            {{ item }}
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content class="w-56">
+                        <twig:NavigationMenu:Link href="#" class="w-full justify-start">Overview</twig:NavigationMenu:Link>
+                        <twig:NavigationMenu:Link href="#" class="w-full justify-start">Pricing</twig:NavigationMenu:Link>
+                        <twig:NavigationMenu:Link href="#" class="w-full justify-start">Changelog</twig:NavigationMenu:Link>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+            {% endfor %}
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex items-start justify-center" style="min-height: 200px">
+    <nav data-slot="navigation-menu" aria-label="Main" class="relative flex max-w-max flex-1 items-center justify-center"><ul data-slot="navigation-menu-list" class="group flex flex-1 list-none items-center justify-center gap-1">                <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="150" data-navigation-menu-close-delay-value="300" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">Products
+                            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                        </button>
+                                        <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md w-56">
+<a href="#" data-slot="navigation-menu-link" class="inline-flex h-9 items-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 w-full justify-start">Overview</a>
+                        <a href="#" data-slot="navigation-menu-link" class="inline-flex h-9 items-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 w-full justify-start">Pricing</a>
+                        <a href="#" data-slot="navigation-menu-link" class="inline-flex h-9 items-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 w-full justify-start">Changelog</a>
+                    </div>
+                </li>
+                            <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="150" data-navigation-menu-close-delay-value="300" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">Solutions
+                            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                        </button>
+                                        <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md w-56">
+<a href="#" data-slot="navigation-menu-link" class="inline-flex h-9 items-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 w-full justify-start">Overview</a>
+                        <a href="#" data-slot="navigation-menu-link" class="inline-flex h-9 items-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 w-full justify-start">Pricing</a>
+                        <a href="#" data-slot="navigation-menu-link" class="inline-flex h-9 items-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 w-full justify-start">Changelog</a>
+                    </div>
+                </li>
+                            <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="150" data-navigation-menu-close-delay-value="300" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">Resources
+                            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                        </button>
+                                        <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md w-56">
+<a href="#" data-slot="navigation-menu-link" class="inline-flex h-9 items-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 w-full justify-start">Overview</a>
+                        <a href="#" data-slot="navigation-menu-link" class="inline-flex h-9 items-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 w-full justify-start">Pricing</a>
+                        <a href="#" data-slot="navigation-menu-link" class="inline-flex h-9 items-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 w-full justify-start">Changelog</a>
+                    </div>
+                </li>
+                    </ul>
+    </nav>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 3__1.html
@@ -1,0 +1,309 @@
+<!--
+- Kit: Shadcn UI
+- Component: Navigation Menu
+- Code:
+```twig
+<div class="flex flex-col items-center gap-12" style="min-height: 720px">
+    {# Arabic #}
+    <div dir="rtl">
+        <twig:NavigationMenu>
+            <twig:NavigationMenu:List>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            البدء
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid gap-1 w-96">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">مقدمة</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">مكونات قابلة لإعادة الاستخدام مبنية باستخدام Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">التثبيت</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">كيفية تثبيت التبعيات وتنظيم تطبيقك.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                    <div class="text-sm font-medium leading-none">الطباعة</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">أنماط للعناوين والفقرات والقوائم...إلخ</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            المكونات
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid gap-2 w-[500px] grid-cols-2">
+                            {% set components_ar = [
+                                {title: 'حوار التنبيه', href: '/docs/primitives/alert-dialog', description: 'حوار نافذة يقطع المستخدم بمحتوى مهم ويتوقع استجابة.'},
+                                {title: 'بطاقة التحويم', href: '/docs/primitives/hover-card', description: 'للمستخدمين المبصرين لمعاينة المحتوى المتاح خلف الرابط.'},
+                                {title: 'التقدم', href: '/docs/primitives/progress', description: 'يعرض مؤشرًا يوضح تقدم إتمام المهمة، عادةً يتم عرضه كشريط تقدم.'},
+                                {title: 'منطقة التمرير', href: '/docs/primitives/scroll-area', description: 'يفصل المحتوى بصريًا أو دلاليًا.'},
+                                {title: 'التبويبات', href: '/docs/primitives/tabs', description: 'مجموعة من أقسام المحتوى المتعددة الطبقات—المعروفة بألواح التبويب—التي يتم عرضها واحدة في كل مرة.'},
+                                {title: 'تلميح', href: '/docs/primitives/tooltip', description: 'نافذة منبثقة تعرض معلومات متعلقة بعنصر عند تحويم الماوس فوقه.'},
+                            ] %}
+                            {% for c in components_ar %}
+                                <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="{{ c.href }}">
+                                        <div class="text-sm font-medium leading-none">{{ c.title }}</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">{{ c.description }}</p>
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Link href="/docs">الوثائق</twig:NavigationMenu:Link>
+                </twig:NavigationMenu:Item>
+            </twig:NavigationMenu:List>
+        </twig:NavigationMenu>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl">
+        <twig:NavigationMenu>
+            <twig:NavigationMenu:List>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            התחלה
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid gap-1 w-96">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">הקדמה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">רכיבים לשימוש חוזר שנבנו עם Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">התקנה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">כיצד להתקין תלויות ולבנות את האפליקציה שלך.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                    <div class="text-sm font-medium leading-none">טיפוגרפיה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">סגנונות לכותרות, פסקאות, רשימות...וכו'</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>
+                        <twig:Button variant="ghost" size="sm" {{ ...navigation_menu_trigger_attrs }}>
+                            רכיבים
+                            <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true" />
+                        </twig:Button>
+                    </twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid gap-2 w-[500px] grid-cols-2">
+                            {% set components_he = [
+                                {title: 'דיאלוג התראה', href: '/docs/primitives/alert-dialog', description: 'דיאלוג מודאלי שמפריע למשתמש עם תוכן חשוב ומצפה לתגובה.'},
+                                {title: 'כרטיס ריחוף', href: '/docs/primitives/hover-card', description: 'למשתמשים רואים כדי להציג תצוגה מקדימה של תוכן זמין מאחורי קישור.'},
+                                {title: 'התקדמות', href: '/docs/primitives/progress', description: 'מציג אינדיקטור המציג את התקדמות ההשלמה של משימה, בדרך כלל מוצג כסרגל התקדמות.'},
+                                {title: 'אזור גלילה', href: '/docs/primitives/scroll-area', description: 'מפריד תוכן חזותית או סמנטית.'},
+                                {title: 'כרטיסיות', href: '/docs/primitives/tabs', description: 'קבוצה של חלקי תוכן מרובדים—המכונים לוחות כרטיסיות—המוצגים אחד בכל פעם.'},
+                                {title: 'טולטיפ', href: '/docs/primitives/tooltip', description: 'חלון קופץ המציג מידע הקשור לאלמנט כאשר העכבר מרחף מעליו.'},
+                            ] %}
+                            {% for c in components_he %}
+                                <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="{{ c.href }}">
+                                        <div class="text-sm font-medium leading-none">{{ c.title }}</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">{{ c.description }}</p>
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Link href="/docs">תיעוד</twig:NavigationMenu:Link>
+                </twig:NavigationMenu:Item>
+            </twig:NavigationMenu:List>
+        </twig:NavigationMenu>
+    </div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col items-center gap-12" style="min-height: 720px">
+        <div dir="rtl">
+        <nav data-slot="navigation-menu" aria-label="Main" class="relative flex max-w-max flex-1 items-center justify-center"><ul data-slot="navigation-menu-list" class="group flex flex-1 list-none items-center justify-center gap-1">
+<li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">البدء
+                            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                        </button>
+                                        <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+<ul class="grid gap-1 w-96">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">مقدمة</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">مكونات قابلة لإعادة الاستخدام مبنية باستخدام Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">التثبيت</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">كيفية تثبيت التبعيات وتنظيم تطبيقك.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                    <div class="text-sm font-medium leading-none">الطباعة</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">أنماط للعناوين والفقرات والقوائم...إلخ</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+                <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">المكونات
+                            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                        </button>
+                                        <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+<ul class="grid gap-2 w-[500px] grid-cols-2">
+                                                                                        <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/alert-dialog">
+                                        <div class="text-sm font-medium leading-none">حوار التنبيه</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">حوار نافذة يقطع المستخدم بمحتوى مهم ويتوقع استجابة.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/hover-card">
+                                        <div class="text-sm font-medium leading-none">بطاقة التحويم</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">للمستخدمين المبصرين لمعاينة المحتوى المتاح خلف الرابط.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/progress">
+                                        <div class="text-sm font-medium leading-none">التقدم</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">يعرض مؤشرًا يوضح تقدم إتمام المهمة، عادةً يتم عرضه كشريط تقدم.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/scroll-area">
+                                        <div class="text-sm font-medium leading-none">منطقة التمرير</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">يفصل المحتوى بصريًا أو دلاليًا.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tabs">
+                                        <div class="text-sm font-medium leading-none">التبويبات</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">مجموعة من أقسام المحتوى المتعددة الطبقات—المعروفة بألواح التبويب—التي يتم عرضها واحدة في كل مرة.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tooltip">
+                                        <div class="text-sm font-medium leading-none">تلميح</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">نافذة منبثقة تعرض معلومات متعلقة بعنصر عند تحويم الماوس فوقه.</p>
+                                    </a>
+                                </li>
+                                                    </ul>
+                    </div>
+                </li>
+                <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<a href="/docs" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">الوثائق</a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+
+        <div dir="rtl">
+        <nav data-slot="navigation-menu" aria-label="Main" class="relative flex max-w-max flex-1 items-center justify-center"><ul data-slot="navigation-menu-list" class="group flex flex-1 list-none items-center justify-center gap-1">
+<li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">התחלה
+                            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                        </button>
+                                        <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+<ul class="grid gap-1 w-96">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">הקדמה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">רכיבים לשימוש חוזר שנבנו עם Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">התקנה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">כיצד להתקין תלויות ולבנות את האפליקציה שלך.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                    <div class="text-sm font-medium leading-none">טיפוגרפיה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">סגנונות לכותרות, פסקאות, רשימות...וכו'</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+                <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<button data-slot="button" data-size="sm" data-variant="ghost" class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg ltr:has-data-[icon=inline-end]:pr-1.5 rtl:has-data-[icon=inline-end]:pe-1.5 ltr:has-data-[icon=inline-start]:pl-1.5 rtl:has-data-[icon=inline-start]:ps-1.5 [&amp;_svg:not([class*='size-'])]:size-3.5" type="button" tabindex="0">רכיבים
+                            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 in-data-[state=open]:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+                        </button>
+                                        <div data-slot="navigation-menu-content" class="invisible opacity-0 in-data-[state=open]:visible in-data-[state=open]:opacity-100 transition-opacity absolute start-0 top-full z-50 min-w-48 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+<ul class="grid gap-2 w-[500px] grid-cols-2">
+                                                                                        <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/alert-dialog">
+                                        <div class="text-sm font-medium leading-none">דיאלוג התראה</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">דיאלוג מודאלי שמפריע למשתמש עם תוכן חשוב ומצפה לתגובה.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/hover-card">
+                                        <div class="text-sm font-medium leading-none">כרטיס ריחוף</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">למשתמשים רואים כדי להציג תצוגה מקדימה של תוכן זמין מאחורי קישור.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/progress">
+                                        <div class="text-sm font-medium leading-none">התקדמות</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">מציג אינדיקטור המציג את התקדמות ההשלמה של משימה, בדרך כלל מוצג כסרגל התקדמות.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/scroll-area">
+                                        <div class="text-sm font-medium leading-none">אזור גלילה</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">מפריד תוכן חזותית או סמנטית.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tabs">
+                                        <div class="text-sm font-medium leading-none">כרטיסיות</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">קבוצה של חלקי תוכן מרובדים—המכונים לוחות כרטיסיות—המוצגים אחד בכל פעם.</p>
+                                    </a>
+                                </li>
+                                                            <li>
+                                    <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tooltip">
+                                        <div class="text-sm font-medium leading-none">טולטיפ</div>
+                                        <p class="line-clamp-2 text-sm text-muted-foreground">חלון קופץ המציג מידע הקשור לאלמנט כאשר העכבר מרחף מעליו.</p>
+                                    </a>
+                                </li>
+                                                    </ul>
+                    </div>
+                </li>
+                <li data-slot="navigation-menu-item" data-navigation-menu-open-delay-value="0" data-navigation-menu-close-delay-value="0" class="relative" data-controller="navigation-menu" data-action="mouseenter-&gt;navigation-menu#show mouseleave-&gt;navigation-menu#hide focusin-&gt;navigation-menu#show focusout-&gt;navigation-menu#focusOut">
+<a href="/docs" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">תיעוד</a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

Adds the `navigation-menu` recipe to the Shadcn kit.

Part of the split of #3467 into one PR per component, tracking #3233.

The submenu opens on hover and on keyboard focus (a Stimulus controller toggles `data-state` on each `Item`), and stays open while the focus moves between the trigger and the links of the submenu.

Note: the ux.symfony.com companion PR (symfony/ux.symfony.com#68) is obsolete since kits are auto-discovered there.
