### PR TITLE
[Toolkit][Shadcn] Add resizable recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Toolkit] Add `avatar` recipe
 - [Toolkit] Add `dropdown` recipe
+- [Shadcn] Add `resizable` recipe
 
 ## 3.0.0
 

--- a/src/Toolkit/kits/shadcn/resizable/assets/controllers/resizable_controller.js
+++ b/src/Toolkit/kits/shadcn/resizable/assets/controllers/resizable_controller.js
@@ -1,0 +1,84 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['panel', 'handle'];
+    static values = { orientation: { type: String, default: 'horizontal' } };
+
+    connect() {
+        this.handleTargets.forEach((handle) => {
+            handle.addEventListener('pointerdown', (event) => this._onPointerDown(event, handle));
+            handle.addEventListener('keydown', (event) => this._onKeyDown(event, handle));
+        });
+    }
+
+    _onPointerDown(event, handle) {
+        if (event.button !== 0 && event.pointerType === 'mouse') return;
+        event.preventDefault();
+        handle.setPointerCapture?.(event.pointerId);
+
+        const isVertical = this.orientationValue === 'vertical';
+        const isRtl = !isVertical && getComputedStyle(this.element).direction === 'rtl';
+        const siblings = this._neighborPanels(handle);
+        if (!siblings) return;
+        const { prev, next } = siblings;
+
+        const startCoord = isVertical ? event.clientY : event.clientX;
+        const prevStart = isVertical ? prev.getBoundingClientRect().height : prev.getBoundingClientRect().width;
+        const nextStart = isVertical ? next.getBoundingClientRect().height : next.getBoundingClientRect().width;
+        const total = prevStart + nextStart;
+        const min = 20;
+
+        const onMove = (e) => {
+            const cur = isVertical ? e.clientY : e.clientX;
+            let delta = cur - startCoord;
+            if (isRtl) delta = -delta;
+            let newPrev = Math.max(min, Math.min(total - min, prevStart + delta));
+            let newNext = total - newPrev;
+            prev.style.flex = `${newPrev} 1 0%`;
+            next.style.flex = `${newNext} 1 0%`;
+        };
+        const onUp = () => {
+            window.removeEventListener('pointermove', onMove);
+            window.removeEventListener('pointerup', onUp);
+        };
+        window.addEventListener('pointermove', onMove);
+        window.addEventListener('pointerup', onUp);
+    }
+
+    _onKeyDown(event, handle) {
+        const isVertical = this.orientationValue === 'vertical';
+        const isRtl = !isVertical && getComputedStyle(this.element).direction === 'rtl';
+        const step = event.shiftKey ? 40 : 8;
+
+        let direction = 0;
+        if (isVertical) {
+            if (event.key === 'ArrowUp') direction = -1;
+            else if (event.key === 'ArrowDown') direction = 1;
+        } else {
+            if (event.key === 'ArrowLeft') direction = isRtl ? 1 : -1;
+            else if (event.key === 'ArrowRight') direction = isRtl ? -1 : 1;
+        }
+        if (direction === 0) return;
+        event.preventDefault();
+
+        const siblings = this._neighborPanels(handle);
+        if (!siblings) return;
+        const { prev, next } = siblings;
+
+        const prevStart = isVertical ? prev.getBoundingClientRect().height : prev.getBoundingClientRect().width;
+        const nextStart = isVertical ? next.getBoundingClientRect().height : next.getBoundingClientRect().width;
+        const total = prevStart + nextStart;
+        const min = 20;
+        let newPrev = Math.max(min, Math.min(total - min, prevStart + direction * step));
+        let newNext = total - newPrev;
+        prev.style.flex = `${newPrev} 1 0%`;
+        next.style.flex = `${newNext} 1 0%`;
+    }
+
+    _neighborPanels(handle) {
+        const children = Array.from(this.element.children);
+        const index = children.indexOf(handle);
+        if (index <= 0 || index >= children.length - 1) return null;
+        return { prev: children[index - 1], next: children[index + 1] };
+    }
+}

--- a/src/Toolkit/kits/shadcn/resizable/examples/Demo.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/examples/Demo.html.twig
@@ -1,0 +1,23 @@
+<twig:Resizable orientation="horizontal" class="max-w-sm rounded-lg border h-[200px]">
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">One</span>
+        </div>
+    </twig:Resizable:Panel>
+    <twig:Resizable:Handle withHandle />
+    <twig:Resizable:Panel>
+        <twig:Resizable orientation="vertical">
+            <twig:Resizable:Panel size="25">
+                <div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">Two</span>
+                </div>
+            </twig:Resizable:Panel>
+            <twig:Resizable:Handle withHandle />
+            <twig:Resizable:Panel size="75">
+                <div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">Three</span>
+                </div>
+            </twig:Resizable:Panel>
+        </twig:Resizable>
+    </twig:Resizable:Panel>
+</twig:Resizable>

--- a/src/Toolkit/kits/shadcn/resizable/examples/Handle.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/examples/Handle.html.twig
@@ -1,0 +1,13 @@
+<twig:Resizable orientation="horizontal" class="max-w-md rounded-lg border h-[200px]">
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Sidebar</span>
+        </div>
+    </twig:Resizable:Panel>
+    <twig:Resizable:Handle withHandle />
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Content</span>
+        </div>
+    </twig:Resizable:Panel>
+</twig:Resizable>

--- a/src/Toolkit/kits/shadcn/resizable/examples/RTL.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/examples/RTL.html.twig
@@ -1,0 +1,55 @@
+<div class="flex flex-col items-center gap-6">
+    {# Arabic #}
+    <div dir="rtl" class="w-full max-w-xl">
+        <twig:Resizable orientation="horizontal" class="rounded-lg border h-[200px]">
+            <twig:Resizable:Panel>
+                <div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">واحد</span>
+                </div>
+            </twig:Resizable:Panel>
+            <twig:Resizable:Handle withHandle />
+            <twig:Resizable:Panel>
+                <twig:Resizable orientation="vertical">
+                    <twig:Resizable:Panel size="25">
+                        <div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">اثنان</span>
+                        </div>
+                    </twig:Resizable:Panel>
+                    <twig:Resizable:Handle withHandle />
+                    <twig:Resizable:Panel size="75">
+                        <div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">ثلاثة</span>
+                        </div>
+                    </twig:Resizable:Panel>
+                </twig:Resizable>
+            </twig:Resizable:Panel>
+        </twig:Resizable>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl" class="w-full max-w-xl">
+        <twig:Resizable orientation="horizontal" class="rounded-lg border h-[200px]">
+            <twig:Resizable:Panel>
+                <div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">אחד</span>
+                </div>
+            </twig:Resizable:Panel>
+            <twig:Resizable:Handle withHandle />
+            <twig:Resizable:Panel>
+                <twig:Resizable orientation="vertical">
+                    <twig:Resizable:Panel size="25">
+                        <div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">שניים</span>
+                        </div>
+                    </twig:Resizable:Panel>
+                    <twig:Resizable:Handle withHandle />
+                    <twig:Resizable:Panel size="75">
+                        <div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">שלושה</span>
+                        </div>
+                    </twig:Resizable:Panel>
+                </twig:Resizable>
+            </twig:Resizable:Panel>
+        </twig:Resizable>
+    </div>
+</div>

--- a/src/Toolkit/kits/shadcn/resizable/examples/Usage.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/examples/Usage.html.twig
@@ -1,0 +1,3 @@
+<twig:Resizable class="h-40 w-64 p-4">
+    <p>Drag the bottom-right corner to resize me in any direction.</p>
+</twig:Resizable>

--- a/src/Toolkit/kits/shadcn/resizable/examples/Vertical.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/examples/Vertical.html.twig
@@ -1,0 +1,13 @@
+<twig:Resizable orientation="vertical" class="max-w-md rounded-lg border min-h-[200px] h-[200px]">
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Header</span>
+        </div>
+    </twig:Resizable:Panel>
+    <twig:Resizable:Handle />
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Content</span>
+        </div>
+    </twig:Resizable:Panel>
+</twig:Resizable>

--- a/src/Toolkit/kits/shadcn/resizable/manifest.json
+++ b/src/Toolkit/kits/shadcn/resizable/manifest.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Resizable",
+    "description": "A split-pane layout with draggable handles to redistribute space between panels.",
+    "copy-files": {
+        "assets/": "assets/",
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["tales-from-a-dev/twig-tailwind-extra:^1.0.0"]
+    }
+}

--- a/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable.html.twig
@@ -1,0 +1,14 @@
+{# @prop orientation 'horizontal'|'vertical' Layout direction. Defaults to `horizontal` #}
+{# @block content One or more `Resizable:Panel` separated by `Resizable:Handle` #}
+{%- props orientation = 'horizontal' -%}
+<div
+    class="{{ ('group/resizable flex h-full w-full ' ~ (orientation == 'vertical' ? 'flex-col ' : '') ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-slot': 'resizable',
+        'data-controller': 'resizable',
+        'data-resizable-orientation-value': orientation,
+        'data-orientation': orientation,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable/Handle.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable/Handle.html.twig
@@ -1,0 +1,17 @@
+{# @prop withHandle bool Show a visible grip icon on the handle. Defaults to `false` #}
+{%- props withHandle = false -%}
+<div
+    class="{{ ('relative flex items-center justify-center bg-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[orientation=horizontal]/resizable:w-px group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize ' ~ attributes.render('class'))|tailwind_merge }}"
+    tabindex="0"
+    role="separator"
+    {{ attributes.defaults({
+        'data-slot': 'resizable-handle',
+        'data-resizable-target': 'handle',
+    }) }}
+>
+    {% if withHandle %}
+        <div class="z-10 flex items-center justify-center rounded-sm border bg-border group-data-[orientation=horizontal]/resizable:h-4 group-data-[orientation=horizontal]/resizable:w-3 group-data-[orientation=vertical]/resizable:h-3 group-data-[orientation=vertical]/resizable:w-4">
+            <twig:ux:icon name="lucide:grip-vertical" class="size-2.5 group-data-[orientation=vertical]/resizable:rotate-90" aria-hidden="true" />
+        </div>
+    {% endif %}
+</div>

--- a/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable/Panel.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable/Panel.html.twig
@@ -1,0 +1,13 @@
+{# @prop size int|null Initial size as a flex-grow value (proportional). If omitted, panels share space equally. #}
+{# @block content The panel content #}
+{%- props size = null -%}
+<div
+    class="{{ ('overflow-auto ' ~ attributes.render('class'))|tailwind_merge }}"
+    style="flex: {{ size ?? 1 }} 1 0%;"
+    {{ attributes.defaults({
+        'data-slot': 'resizable-panel',
+        'data-resizable-target': 'panel',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Demo.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Demo.html.twig__1.html
@@ -1,0 +1,63 @@
+<!--
+- Kit: Shadcn UI
+- Component: Resizable
+- Code:
+```twig
+<twig:Resizable orientation="horizontal" class="max-w-sm rounded-lg border h-[200px]">
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">One</span>
+        </div>
+    </twig:Resizable:Panel>
+    <twig:Resizable:Handle withHandle />
+    <twig:Resizable:Panel>
+        <twig:Resizable orientation="vertical">
+            <twig:Resizable:Panel size="25">
+                <div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">Two</span>
+                </div>
+            </twig:Resizable:Panel>
+            <twig:Resizable:Handle withHandle />
+            <twig:Resizable:Panel size="75">
+                <div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">Three</span>
+                </div>
+            </twig:Resizable:Panel>
+        </twig:Resizable>
+    </twig:Resizable:Panel>
+</twig:Resizable>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="group/resizable flex w-full max-w-sm rounded-lg border h-[200px]" data-slot="resizable" data-controller="resizable" data-resizable-orientation-value="horizontal" data-orientation="horizontal">
+<div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">One</span>
+        </div>
+    </div>
+    <div class="relative flex items-center justify-center bg-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[orientation=horizontal]/resizable:w-px group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize" tabindex="0" role="separator" data-slot="resizable-handle" data-resizable-target="handle">
+            <div class="z-10 flex items-center justify-center rounded-sm border bg-border group-data-[orientation=horizontal]/resizable:h-4 group-data-[orientation=horizontal]/resizable:w-3 group-data-[orientation=vertical]/resizable:h-3 group-data-[orientation=vertical]/resizable:w-4">
+            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-2.5 group-data-[orientation=vertical]/resizable:rotate-90" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="9" cy="12" r="1"></circle><circle cx="9" cy="5" r="1"></circle><circle cx="9" cy="19" r="1"></circle><circle cx="15" cy="12" r="1"></circle><circle cx="15" cy="5" r="1"></circle><circle cx="15" cy="19" r="1"></circle></g></svg>
+        </div>
+    </div>
+
+    <div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="group/resizable flex h-full w-full flex-col" data-slot="resizable" data-controller="resizable" data-resizable-orientation-value="vertical" data-orientation="vertical">
+<div class="overflow-auto" style="flex: 25 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">Two</span>
+                </div>
+            </div>
+            <div class="relative flex items-center justify-center bg-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[orientation=horizontal]/resizable:w-px group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize" tabindex="0" role="separator" data-slot="resizable-handle" data-resizable-target="handle">
+            <div class="z-10 flex items-center justify-center rounded-sm border bg-border group-data-[orientation=horizontal]/resizable:h-4 group-data-[orientation=horizontal]/resizable:w-3 group-data-[orientation=vertical]/resizable:h-3 group-data-[orientation=vertical]/resizable:w-4">
+            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-2.5 group-data-[orientation=vertical]/resizable:rotate-90" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="9" cy="12" r="1"></circle><circle cx="9" cy="5" r="1"></circle><circle cx="9" cy="19" r="1"></circle><circle cx="15" cy="12" r="1"></circle><circle cx="15" cy="5" r="1"></circle><circle cx="15" cy="19" r="1"></circle></g></svg>
+        </div>
+    </div>
+
+            <div class="overflow-auto" style="flex: 75 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">Three</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Demo.html__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Demo.html__1.html
@@ -1,0 +1,27 @@
+<!--
+- Kit: Shadcn UI
+- Component: Resizable
+- Code:
+```twig
+<div class="flex flex-col gap-6">
+    <twig:Resizable direction="horizontal" class="h-32 w-64 p-4">
+        <p>Horizontal resize — drag the right edge.</p>
+    </twig:Resizable>
+    <twig:Resizable direction="vertical" class="h-32 w-64 p-4">
+        <p>Vertical resize — drag the bottom edge.</p>
+    </twig:Resizable>
+    <twig:Resizable class="h-32 w-64 p-4">
+        <p>Both axes — drag the bottom-right corner.</p>
+    </twig:Resizable>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col gap-6">
+    <div class="overflow-auto rounded-md border bg-background resize-x min-w-48 h-32 w-64 p-4" data-slot="resizable" data-direction="horizontal">
+<p>Horizontal resize &acirc;&#128;&#148; drag the right edge.</p>
+    </div>    <div class="overflow-auto rounded-md border bg-background resize-y min-h-24 h-32 w-64 p-4" data-slot="resizable" data-direction="vertical">
+<p>Vertical resize &acirc;&#128;&#148; drag the bottom edge.</p>
+    </div>    <div class="overflow-auto rounded-md border bg-background resize min-h-24 min-w-48 h-32 w-64 p-4" data-slot="resizable" data-direction="both">
+<p>Both axes &acirc;&#128;&#148; drag the bottom-right corner.</p>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Handle.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Handle.html.twig__1.html
@@ -1,0 +1,38 @@
+<!--
+- Kit: Shadcn UI
+- Component: Resizable
+- Code:
+```twig
+<twig:Resizable orientation="horizontal" class="max-w-md rounded-lg border h-[200px]">
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Sidebar</span>
+        </div>
+    </twig:Resizable:Panel>
+    <twig:Resizable:Handle withHandle />
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Content</span>
+        </div>
+    </twig:Resizable:Panel>
+</twig:Resizable>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="group/resizable flex w-full max-w-md rounded-lg border h-[200px]" data-slot="resizable" data-controller="resizable" data-resizable-orientation-value="horizontal" data-orientation="horizontal">
+<div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Sidebar</span>
+        </div>
+    </div>
+    <div class="relative flex items-center justify-center bg-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[orientation=horizontal]/resizable:w-px group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize" tabindex="0" role="separator" data-slot="resizable-handle" data-resizable-target="handle">
+            <div class="z-10 flex items-center justify-center rounded-sm border bg-border group-data-[orientation=horizontal]/resizable:h-4 group-data-[orientation=horizontal]/resizable:w-3 group-data-[orientation=vertical]/resizable:h-3 group-data-[orientation=vertical]/resizable:w-4">
+            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-2.5 group-data-[orientation=vertical]/resizable:rotate-90" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="9" cy="12" r="1"></circle><circle cx="9" cy="5" r="1"></circle><circle cx="9" cy="19" r="1"></circle><circle cx="15" cy="12" r="1"></circle><circle cx="15" cy="5" r="1"></circle><circle cx="15" cy="19" r="1"></circle></g></svg>
+        </div>
+    </div>
+
+    <div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Content</span>
+        </div>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file RTL.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file RTL.html.twig__1.html
@@ -1,0 +1,135 @@
+<!--
+- Kit: Shadcn UI
+- Component: Resizable
+- Code:
+```twig
+<div class="flex flex-col items-center gap-6">
+    {# Arabic #}
+    <div dir="rtl" class="w-full max-w-xl">
+        <twig:Resizable orientation="horizontal" class="rounded-lg border h-[200px]">
+            <twig:Resizable:Panel>
+                <div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">واحد</span>
+                </div>
+            </twig:Resizable:Panel>
+            <twig:Resizable:Handle withHandle />
+            <twig:Resizable:Panel>
+                <twig:Resizable orientation="vertical">
+                    <twig:Resizable:Panel size="25">
+                        <div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">اثنان</span>
+                        </div>
+                    </twig:Resizable:Panel>
+                    <twig:Resizable:Handle withHandle />
+                    <twig:Resizable:Panel size="75">
+                        <div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">ثلاثة</span>
+                        </div>
+                    </twig:Resizable:Panel>
+                </twig:Resizable>
+            </twig:Resizable:Panel>
+        </twig:Resizable>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl" class="w-full max-w-xl">
+        <twig:Resizable orientation="horizontal" class="rounded-lg border h-[200px]">
+            <twig:Resizable:Panel>
+                <div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">אחד</span>
+                </div>
+            </twig:Resizable:Panel>
+            <twig:Resizable:Handle withHandle />
+            <twig:Resizable:Panel>
+                <twig:Resizable orientation="vertical">
+                    <twig:Resizable:Panel size="25">
+                        <div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">שניים</span>
+                        </div>
+                    </twig:Resizable:Panel>
+                    <twig:Resizable:Handle withHandle />
+                    <twig:Resizable:Panel size="75">
+                        <div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">שלושה</span>
+                        </div>
+                    </twig:Resizable:Panel>
+                </twig:Resizable>
+            </twig:Resizable:Panel>
+        </twig:Resizable>
+    </div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col items-center gap-6">
+        <div dir="rtl" class="w-full max-w-xl">
+        <div class="group/resizable flex w-full rounded-lg border h-[200px]" data-slot="resizable" data-controller="resizable" data-resizable-orientation-value="horizontal" data-orientation="horizontal">
+<div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">&Ugrave;&#136;&Oslash;&sect;&Oslash;&shy;&Oslash;&macr;</span>
+                </div>
+            </div>
+            <div class="relative flex items-center justify-center bg-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[orientation=horizontal]/resizable:w-px group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize" tabindex="0" role="separator" data-slot="resizable-handle" data-resizable-target="handle">
+            <div class="z-10 flex items-center justify-center rounded-sm border bg-border group-data-[orientation=horizontal]/resizable:h-4 group-data-[orientation=horizontal]/resizable:w-3 group-data-[orientation=vertical]/resizable:h-3 group-data-[orientation=vertical]/resizable:w-4">
+            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-2.5 group-data-[orientation=vertical]/resizable:rotate-90" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="9" cy="12" r="1"></circle><circle cx="9" cy="5" r="1"></circle><circle cx="9" cy="19" r="1"></circle><circle cx="15" cy="12" r="1"></circle><circle cx="15" cy="5" r="1"></circle><circle cx="15" cy="19" r="1"></circle></g></svg>
+        </div>
+    </div>
+
+            <div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="group/resizable flex h-full w-full flex-col" data-slot="resizable" data-controller="resizable" data-resizable-orientation-value="vertical" data-orientation="vertical">
+<div class="overflow-auto" style="flex: 25 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">&Oslash;&sect;&Oslash;&laquo;&Ugrave;&#134;&Oslash;&sect;&Ugrave;&#134;</span>
+                        </div>
+                    </div>
+                    <div class="relative flex items-center justify-center bg-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[orientation=horizontal]/resizable:w-px group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize" tabindex="0" role="separator" data-slot="resizable-handle" data-resizable-target="handle">
+            <div class="z-10 flex items-center justify-center rounded-sm border bg-border group-data-[orientation=horizontal]/resizable:h-4 group-data-[orientation=horizontal]/resizable:w-3 group-data-[orientation=vertical]/resizable:h-3 group-data-[orientation=vertical]/resizable:w-4">
+            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-2.5 group-data-[orientation=vertical]/resizable:rotate-90" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="9" cy="12" r="1"></circle><circle cx="9" cy="5" r="1"></circle><circle cx="9" cy="19" r="1"></circle><circle cx="15" cy="12" r="1"></circle><circle cx="15" cy="5" r="1"></circle><circle cx="15" cy="19" r="1"></circle></g></svg>
+        </div>
+    </div>
+
+                    <div class="overflow-auto" style="flex: 75 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">&Oslash;&laquo;&Ugrave;&#132;&Oslash;&sect;&Oslash;&laquo;&Oslash;&copy;</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+        <div dir="rtl" class="w-full max-w-xl">
+        <div class="group/resizable flex w-full rounded-lg border h-[200px]" data-slot="resizable" data-controller="resizable" data-resizable-orientation-value="horizontal" data-orientation="horizontal">
+<div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+                    <span class="font-semibold">&times;&#144;&times;&#151;&times;&#147;</span>
+                </div>
+            </div>
+            <div class="relative flex items-center justify-center bg-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[orientation=horizontal]/resizable:w-px group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize" tabindex="0" role="separator" data-slot="resizable-handle" data-resizable-target="handle">
+            <div class="z-10 flex items-center justify-center rounded-sm border bg-border group-data-[orientation=horizontal]/resizable:h-4 group-data-[orientation=horizontal]/resizable:w-3 group-data-[orientation=vertical]/resizable:h-3 group-data-[orientation=vertical]/resizable:w-4">
+            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-2.5 group-data-[orientation=vertical]/resizable:rotate-90" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="9" cy="12" r="1"></circle><circle cx="9" cy="5" r="1"></circle><circle cx="9" cy="19" r="1"></circle><circle cx="15" cy="12" r="1"></circle><circle cx="15" cy="5" r="1"></circle><circle cx="15" cy="19" r="1"></circle></g></svg>
+        </div>
+    </div>
+
+            <div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="group/resizable flex h-full w-full flex-col" data-slot="resizable" data-controller="resizable" data-resizable-orientation-value="vertical" data-orientation="vertical">
+<div class="overflow-auto" style="flex: 25 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">&times;&copy;&times;&nbsp;&times;&#153;&times;&#153;&times;&#157;</span>
+                        </div>
+                    </div>
+                    <div class="relative flex items-center justify-center bg-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[orientation=horizontal]/resizable:w-px group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize" tabindex="0" role="separator" data-slot="resizable-handle" data-resizable-target="handle">
+            <div class="z-10 flex items-center justify-center rounded-sm border bg-border group-data-[orientation=horizontal]/resizable:h-4 group-data-[orientation=horizontal]/resizable:w-3 group-data-[orientation=vertical]/resizable:h-3 group-data-[orientation=vertical]/resizable:w-4">
+            <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-2.5 group-data-[orientation=vertical]/resizable:rotate-90" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="9" cy="12" r="1"></circle><circle cx="9" cy="5" r="1"></circle><circle cx="9" cy="19" r="1"></circle><circle cx="15" cy="12" r="1"></circle><circle cx="15" cy="5" r="1"></circle><circle cx="15" cy="19" r="1"></circle></g></svg>
+        </div>
+    </div>
+
+                    <div class="overflow-auto" style="flex: 75 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+                            <span class="font-semibold">&times;&copy;&times;&#156;&times;&#149;&times;&copy;&times;&#148;</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Usage.html__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Usage.html__1.html
@@ -1,0 +1,13 @@
+<!--
+- Kit: Shadcn UI
+- Component: Resizable
+- Code:
+```twig
+<twig:Resizable class="h-40 w-64 p-4">
+    <p>Drag the bottom-right corner to resize me in any direction.</p>
+</twig:Resizable>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="overflow-auto rounded-md border bg-background resize min-h-24 min-w-48 h-40 w-64 p-4" data-slot="resizable" data-direction="both">
+<p>Drag the bottom-right corner to resize me in any direction.</p>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Vertical.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component resizable, code file Vertical.html.twig__1.html
@@ -1,0 +1,35 @@
+<!--
+- Kit: Shadcn UI
+- Component: Resizable
+- Code:
+```twig
+<twig:Resizable orientation="vertical" class="max-w-md rounded-lg border min-h-[200px] h-[200px]">
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Header</span>
+        </div>
+    </twig:Resizable:Panel>
+    <twig:Resizable:Handle />
+    <twig:Resizable:Panel>
+        <div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Content</span>
+        </div>
+    </twig:Resizable:Panel>
+</twig:Resizable>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="group/resizable flex w-full flex-col max-w-md rounded-lg border min-h-[200px] h-[200px]" data-slot="resizable" data-controller="resizable" data-resizable-orientation-value="vertical" data-orientation="vertical">
+<div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Header</span>
+        </div>
+    </div>
+    <div class="relative flex items-center justify-center bg-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[orientation=horizontal]/resizable:w-px group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize" tabindex="0" role="separator" data-slot="resizable-handle" data-resizable-target="handle">
+    </div>
+
+    <div class="overflow-auto" style="flex: 1 1 0%;" data-slot="resizable-panel" data-resizable-target="panel">
+<div class="flex h-full items-center justify-center p-6">
+            <span class="font-semibold">Content</span>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

Adds the `resizable` recipe to the Shadcn kit.

Part of the split of #3467 into one PR per component, tracking #3233.

Snapshots will be regenerated after rework.