### PR TITLE
[Toolkit][Shadcn] Align collapsible File Tree and RTL examples with shadcn reference

### DIFF
--- a/src/Toolkit/kits/shadcn/collapsible/examples/File Tree.html.twig
+++ b/src/Toolkit/kits/shadcn/collapsible/examples/File Tree.html.twig
@@ -18,13 +18,51 @@
                 </twig:Collapsible:Trigger>
                 <twig:Collapsible:Content>
                     <div class="ml-4 flex flex-col gap-0.5">
+                        {# Nested folder: components/ui #}
+                        <twig:Collapsible>
+                            <twig:Collapsible:Trigger>
+                                <twig:Button variant="ghost" class="group w-full justify-start gap-1.5 h-7 px-2 text-sm" {{ ...collapsible_trigger_attrs }}>
+                                    <twig:ux:icon name="lucide:chevron-right" class="size-3.5 transition-transform group-data-[state=open]:rotate-90" />
+                                    <twig:ux:icon name="lucide:folder" class="size-3.5 text-muted-foreground" />
+                                    ui
+                                </twig:Button>
+                            </twig:Collapsible:Trigger>
+                            <twig:Collapsible:Content>
+                                <div class="ml-4 flex flex-col gap-0.5">
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        button.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        card.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        dialog.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        input.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        select.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        table.tsx
+                                    </twig:Button>
+                                </div>
+                            </twig:Collapsible:Content>
+                        </twig:Collapsible>
                         <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
-                            button.tsx
+                            login-form.tsx
                         </twig:Button>
                         <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
-                            card.tsx
+                            register-form.tsx
                         </twig:Button>
                     </div>
                 </twig:Collapsible:Content>
@@ -45,6 +83,14 @@
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
                             utils.ts
                         </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            cn.ts
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            api.ts
+                        </twig:Button>
                     </div>
                 </twig:Collapsible:Content>
             </twig:Collapsible>
@@ -62,7 +108,15 @@
                     <div class="ml-4 flex flex-col gap-0.5">
                         <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
-                            use-toast.ts
+                            use-media-query.ts
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            use-debounce.ts
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            use-local-storage.ts
                         </twig:Button>
                     </div>
                 </twig:Collapsible:Content>
@@ -83,6 +137,10 @@
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
                             index.d.ts
                         </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            api.d.ts
+                        </twig:Button>
                     </div>
                 </twig:Collapsible:Content>
             </twig:Collapsible>
@@ -101,6 +159,14 @@
                         <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
                             favicon.ico
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            logo.svg
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            images
                         </twig:Button>
                     </div>
                 </twig:Collapsible:Content>

--- a/src/Toolkit/kits/shadcn/collapsible/examples/RTL.html.twig
+++ b/src/Toolkit/kits/shadcn/collapsible/examples/RTL.html.twig
@@ -1,25 +1,82 @@
-<twig:Collapsible class="flex w-[350px] flex-col gap-2" dir="rtl">
-    <div class="flex items-center justify-between gap-4 px-4">
-        <h4 class="text-sm font-semibold">الطلب #4189</h4>
-        <twig:Collapsible:Trigger>
-            <twig:Button variant="ghost" size="icon" class="size-8" {{ ...collapsible_trigger_attrs }}>
-                <twig:ux:icon name="lucide:chevrons-up-down" class="size-4" />
-                <span class="sr-only">Toggle details</span>
-            </twig:Button>
-        </twig:Collapsible:Trigger>
-    </div>
-    <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
-        <span class="text-muted-foreground">الحالة</span>
-        <span class="font-medium">تم الشحن</span>
-    </div>
-    <twig:Collapsible:Content class="flex flex-col gap-2">
-        <div class="rounded-md border px-4 py-2 text-sm">
-            <p class="font-medium">عنوان الشحن</p>
-            <p class="text-muted-foreground">100 Market St, San Francisco</p>
+<div class="flex w-[350px] flex-col gap-4">
+    {# Arabic #}
+    <twig:Collapsible class="flex flex-col gap-2" dir="rtl">
+        <div class="flex items-center justify-between gap-4 px-4">
+            <h4 class="text-sm font-semibold">الطلب #4189</h4>
+            <twig:Collapsible:Trigger>
+                <twig:Button variant="ghost" size="icon" class="size-8" {{ ...collapsible_trigger_attrs }}>
+                    <twig:ux:icon name="lucide:chevrons-up-down" class="size-4" />
+                    <span class="sr-only">Toggle details</span>
+                </twig:Button>
+            </twig:Collapsible:Trigger>
         </div>
-        <div class="rounded-md border px-4 py-2 text-sm">
-            <p class="font-medium">العناصر</p>
-            <p class="text-muted-foreground">2x سماعات الاستوديو</p>
+        <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
+            <span class="text-muted-foreground">الحالة</span>
+            <span class="font-medium">تم الشحن</span>
         </div>
-    </twig:Collapsible:Content>
-</twig:Collapsible>
+        <twig:Collapsible:Content class="flex flex-col gap-2">
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">عنوان الشحن</p>
+                <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            </div>
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">العناصر</p>
+                <p class="text-muted-foreground">2x سماعات الاستوديو</p>
+            </div>
+        </twig:Collapsible:Content>
+    </twig:Collapsible>
+
+    {# English #}
+    <twig:Collapsible class="flex flex-col gap-2" dir="ltr">
+        <div class="flex items-center justify-between gap-4 px-4">
+            <h4 class="text-sm font-semibold">Order #4189</h4>
+            <twig:Collapsible:Trigger>
+                <twig:Button variant="ghost" size="icon" class="size-8" {{ ...collapsible_trigger_attrs }}>
+                    <twig:ux:icon name="lucide:chevrons-up-down" class="size-4" />
+                    <span class="sr-only">Toggle details</span>
+                </twig:Button>
+            </twig:Collapsible:Trigger>
+        </div>
+        <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
+            <span class="text-muted-foreground">Status</span>
+            <span class="font-medium">Shipped</span>
+        </div>
+        <twig:Collapsible:Content class="flex flex-col gap-2">
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">Shipping address</p>
+                <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            </div>
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">Items</p>
+                <p class="text-muted-foreground">2x Studio Headphones</p>
+            </div>
+        </twig:Collapsible:Content>
+    </twig:Collapsible>
+
+    {# Hebrew #}
+    <twig:Collapsible class="flex flex-col gap-2" dir="rtl">
+        <div class="flex items-center justify-between gap-4 px-4">
+            <h4 class="text-sm font-semibold">הזמנה #4189</h4>
+            <twig:Collapsible:Trigger>
+                <twig:Button variant="ghost" size="icon" class="size-8" {{ ...collapsible_trigger_attrs }}>
+                    <twig:ux:icon name="lucide:chevrons-up-down" class="size-4" />
+                    <span class="sr-only">Toggle details</span>
+                </twig:Button>
+            </twig:Collapsible:Trigger>
+        </div>
+        <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
+            <span class="text-muted-foreground">סטטוס</span>
+            <span class="font-medium">נשלח</span>
+        </div>
+        <twig:Collapsible:Content class="flex flex-col gap-2">
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">כתובת משלוח</p>
+                <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            </div>
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">פריטים</p>
+                <p class="text-muted-foreground">2x אוזניות סטודיו</p>
+            </div>
+        </twig:Collapsible:Content>
+    </twig:Collapsible>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component collapsible, code file File Tree.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component collapsible, code file File Tree.html.twig__1.html
@@ -23,13 +23,51 @@
                 </twig:Collapsible:Trigger>
                 <twig:Collapsible:Content>
                     <div class="ml-4 flex flex-col gap-0.5">
+                        {# Nested folder: components/ui #}
+                        <twig:Collapsible>
+                            <twig:Collapsible:Trigger>
+                                <twig:Button variant="ghost" class="group w-full justify-start gap-1.5 h-7 px-2 text-sm" {{ ...collapsible_trigger_attrs }}>
+                                    <twig:ux:icon name="lucide:chevron-right" class="size-3.5 transition-transform group-data-[state=open]:rotate-90" />
+                                    <twig:ux:icon name="lucide:folder" class="size-3.5 text-muted-foreground" />
+                                    ui
+                                </twig:Button>
+                            </twig:Collapsible:Trigger>
+                            <twig:Collapsible:Content>
+                                <div class="ml-4 flex flex-col gap-0.5">
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        button.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        card.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        dialog.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        input.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        select.tsx
+                                    </twig:Button>
+                                    <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                                        <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                                        table.tsx
+                                    </twig:Button>
+                                </div>
+                            </twig:Collapsible:Content>
+                        </twig:Collapsible>
                         <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
-                            button.tsx
+                            login-form.tsx
                         </twig:Button>
                         <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
-                            card.tsx
+                            register-form.tsx
                         </twig:Button>
                     </div>
                 </twig:Collapsible:Content>
@@ -50,6 +88,14 @@
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
                             utils.ts
                         </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            cn.ts
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            api.ts
+                        </twig:Button>
                     </div>
                 </twig:Collapsible:Content>
             </twig:Collapsible>
@@ -67,7 +113,15 @@
                     <div class="ml-4 flex flex-col gap-0.5">
                         <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
-                            use-toast.ts
+                            use-media-query.ts
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            use-debounce.ts
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            use-local-storage.ts
                         </twig:Button>
                     </div>
                 </twig:Collapsible:Content>
@@ -88,6 +142,10 @@
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
                             index.d.ts
                         </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            api.d.ts
+                        </twig:Button>
                     </div>
                 </twig:Collapsible:Content>
             </twig:Collapsible>
@@ -106,6 +164,14 @@
                         <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
                             <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
                             favicon.ico
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            logo.svg
+                        </twig:Button>
+                        <twig:Button variant="ghost" class="w-full justify-start gap-1.5 h-7 px-2 text-sm">
+                            <twig:ux:icon name="lucide:file" class="size-3.5 text-muted-foreground" />
+                            images
                         </twig:Button>
                     </div>
                 </twig:Collapsible:Content>
@@ -161,11 +227,39 @@
                     </button>
                                 <div data-slot="collapsible-content" data-collapsible-target="content" aria-hidden="true" data-state="closed" hidden="">
 <div class="ml-4 flex flex-col gap-0.5">
+                                                <div class="group" data-slot="collapsible" data-controller="collapsible" data-collapsible-open-value="false" data-state="closed">
+<button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 group w-full justify-start h-7 px-2" data-collapsible-target="trigger" data-action="click-&gt;collapsible#toggle" aria-expanded="false" data-state="closed"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 transition-transform group-data-[state=open]:rotate-90" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"></path></svg>
+                                    ui
+                                </button>
+                                                        <div data-slot="collapsible-content" data-collapsible-target="content" aria-hidden="true" data-state="closed" hidden="">
+<div class="ml-4 flex flex-col gap-0.5">
+                                    <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                                        button.tsx
+                                    </button>
+                                    <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                                        card.tsx
+                                    </button>
+                                    <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                                        dialog.tsx
+                                    </button>
+                                    <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                                        input.tsx
+                                    </button>
+                                    <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                                        select.tsx
+                                    </button>
+                                    <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                                        table.tsx
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
                         <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
-                            button.tsx
+                            login-form.tsx
                         </button>
                         <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
-                            card.tsx
+                            register-form.tsx
                         </button>
                     </div>
                 </div>
@@ -181,6 +275,12 @@
                         <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
                             utils.ts
                         </button>
+                        <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                            cn.ts
+                        </button>
+                        <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                            api.ts
+                        </button>
                     </div>
                 </div>
             </div>
@@ -193,7 +293,13 @@
                                 <div data-slot="collapsible-content" data-collapsible-target="content" aria-hidden="true" data-state="closed" hidden="">
 <div class="ml-4 flex flex-col gap-0.5">
                         <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
-                            use-toast.ts
+                            use-media-query.ts
+                        </button>
+                        <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                            use-debounce.ts
+                        </button>
+                        <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                            use-local-storage.ts
                         </button>
                     </div>
                 </div>
@@ -209,6 +315,9 @@
                         <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
                             index.d.ts
                         </button>
+                        <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                            api.d.ts
+                        </button>
                     </div>
                 </div>
             </div>
@@ -222,6 +331,12 @@
 <div class="ml-4 flex flex-col gap-0.5">
                         <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
                             favicon.ico
+                        </button>
+                        <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                            logo.svg
+                        </button>
+                        <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground gap-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 w-full justify-start h-7 px-2"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-3.5 text-muted-foreground" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"></path><path d="M14 2v5a1 1 0 0 0 1 1h5"></path></g></svg>
+                            images
                         </button>
                     </div>
                 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component collapsible, code file RTL.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component collapsible, code file RTL.html.twig__1.html
@@ -3,52 +3,157 @@
 - Component: Collapsible
 - Code:
 ```twig
-<twig:Collapsible class="flex w-[350px] flex-col gap-2" dir="rtl">
-    <div class="flex items-center justify-between gap-4 px-4">
-        <h4 class="text-sm font-semibold">الطلب #4189</h4>
-        <twig:Collapsible:Trigger>
-            <twig:Button variant="ghost" size="icon" class="size-8" {{ ...collapsible_trigger_attrs }}>
-                <twig:ux:icon name="lucide:chevrons-up-down" class="size-4" />
-                <span class="sr-only">Toggle details</span>
-            </twig:Button>
-        </twig:Collapsible:Trigger>
-    </div>
-    <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
-        <span class="text-muted-foreground">الحالة</span>
-        <span class="font-medium">تم الشحن</span>
-    </div>
-    <twig:Collapsible:Content class="flex flex-col gap-2">
-        <div class="rounded-md border px-4 py-2 text-sm">
-            <p class="font-medium">عنوان الشحن</p>
-            <p class="text-muted-foreground">100 Market St, San Francisco</p>
+<div class="flex w-[350px] flex-col gap-4">
+    {# Arabic #}
+    <twig:Collapsible class="flex flex-col gap-2" dir="rtl">
+        <div class="flex items-center justify-between gap-4 px-4">
+            <h4 class="text-sm font-semibold">الطلب #4189</h4>
+            <twig:Collapsible:Trigger>
+                <twig:Button variant="ghost" size="icon" class="size-8" {{ ...collapsible_trigger_attrs }}>
+                    <twig:ux:icon name="lucide:chevrons-up-down" class="size-4" />
+                    <span class="sr-only">Toggle details</span>
+                </twig:Button>
+            </twig:Collapsible:Trigger>
         </div>
-        <div class="rounded-md border px-4 py-2 text-sm">
-            <p class="font-medium">العناصر</p>
-            <p class="text-muted-foreground">2x سماعات الاستوديو</p>
+        <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
+            <span class="text-muted-foreground">الحالة</span>
+            <span class="font-medium">تم الشحن</span>
         </div>
-    </twig:Collapsible:Content>
-</twig:Collapsible>
+        <twig:Collapsible:Content class="flex flex-col gap-2">
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">عنوان الشحن</p>
+                <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            </div>
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">العناصر</p>
+                <p class="text-muted-foreground">2x سماعات الاستوديو</p>
+            </div>
+        </twig:Collapsible:Content>
+    </twig:Collapsible>
+
+    {# English #}
+    <twig:Collapsible class="flex flex-col gap-2" dir="ltr">
+        <div class="flex items-center justify-between gap-4 px-4">
+            <h4 class="text-sm font-semibold">Order #4189</h4>
+            <twig:Collapsible:Trigger>
+                <twig:Button variant="ghost" size="icon" class="size-8" {{ ...collapsible_trigger_attrs }}>
+                    <twig:ux:icon name="lucide:chevrons-up-down" class="size-4" />
+                    <span class="sr-only">Toggle details</span>
+                </twig:Button>
+            </twig:Collapsible:Trigger>
+        </div>
+        <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
+            <span class="text-muted-foreground">Status</span>
+            <span class="font-medium">Shipped</span>
+        </div>
+        <twig:Collapsible:Content class="flex flex-col gap-2">
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">Shipping address</p>
+                <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            </div>
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">Items</p>
+                <p class="text-muted-foreground">2x Studio Headphones</p>
+            </div>
+        </twig:Collapsible:Content>
+    </twig:Collapsible>
+
+    {# Hebrew #}
+    <twig:Collapsible class="flex flex-col gap-2" dir="rtl">
+        <div class="flex items-center justify-between gap-4 px-4">
+            <h4 class="text-sm font-semibold">הזמנה #4189</h4>
+            <twig:Collapsible:Trigger>
+                <twig:Button variant="ghost" size="icon" class="size-8" {{ ...collapsible_trigger_attrs }}>
+                    <twig:ux:icon name="lucide:chevrons-up-down" class="size-4" />
+                    <span class="sr-only">Toggle details</span>
+                </twig:Button>
+            </twig:Collapsible:Trigger>
+        </div>
+        <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
+            <span class="text-muted-foreground">סטטוס</span>
+            <span class="font-medium">נשלח</span>
+        </div>
+        <twig:Collapsible:Content class="flex flex-col gap-2">
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">כתובת משלוח</p>
+                <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            </div>
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">פריטים</p>
+                <p class="text-muted-foreground">2x אוזניות סטודיו</p>
+            </div>
+        </twig:Collapsible:Content>
+    </twig:Collapsible>
+</div>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<div class="group flex w-[350px] flex-col gap-2" data-slot="collapsible" data-controller="collapsible" data-collapsible-open-value="false" data-state="closed" dir="rtl">
+<div class="flex w-[350px] flex-col gap-4">
+        <div class="group flex flex-col gap-2" data-slot="collapsible" data-controller="collapsible" data-collapsible-open-value="false" data-state="closed" dir="rtl">
 <div class="flex items-center justify-between gap-4 px-4">
-        <h4 class="text-sm font-semibold">&Oslash;&sect;&Ugrave;&#132;&Oslash;&middot;&Ugrave;&#132;&Oslash;&uml; #4189</h4>
-        <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8" data-collapsible-target="trigger" data-action="click-&gt;collapsible#toggle" aria-expanded="false" data-state="closed"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m7 15l5 5l5-5M7 9l5-5l5 5"></path></svg>
-                <span class="sr-only">Toggle details</span>
-            </button>
-            </div>
-    <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
-        <span class="text-muted-foreground">&Oslash;&sect;&Ugrave;&#132;&Oslash;&shy;&Oslash;&sect;&Ugrave;&#132;&Oslash;&copy;</span>
-        <span class="font-medium">&Oslash;&ordf;&Ugrave;&#133; &Oslash;&sect;&Ugrave;&#132;&Oslash;&acute;&Oslash;&shy;&Ugrave;&#134;</span>
-    </div>
-    <div data-slot="collapsible-content" data-collapsible-target="content" aria-hidden="true" data-state="closed" hidden="" class="flex flex-col gap-2">
-<div class="rounded-md border px-4 py-2 text-sm">
-            <p class="font-medium">&Oslash;&sup1;&Ugrave;&#134;&Ugrave;&#136;&Oslash;&sect;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Oslash;&acute;&Oslash;&shy;&Ugrave;&#134;</p>
-            <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            <h4 class="text-sm font-semibold">&Oslash;&sect;&Ugrave;&#132;&Oslash;&middot;&Ugrave;&#132;&Oslash;&uml; #4189</h4>
+            <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8" data-collapsible-target="trigger" data-action="click-&gt;collapsible#toggle" aria-expanded="false" data-state="closed"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m7 15l5 5l5-5M7 9l5-5l5 5"></path></svg>
+                    <span class="sr-only">Toggle details</span>
+                </button>
+                    </div>
+        <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
+            <span class="text-muted-foreground">&Oslash;&sect;&Ugrave;&#132;&Oslash;&shy;&Oslash;&sect;&Ugrave;&#132;&Oslash;&copy;</span>
+            <span class="font-medium">&Oslash;&ordf;&Ugrave;&#133; &Oslash;&sect;&Ugrave;&#132;&Oslash;&acute;&Oslash;&shy;&Ugrave;&#134;</span>
         </div>
-        <div class="rounded-md border px-4 py-2 text-sm">
-            <p class="font-medium">&Oslash;&sect;&Ugrave;&#132;&Oslash;&sup1;&Ugrave;&#134;&Oslash;&sect;&Oslash;&micro;&Oslash;&plusmn;</p>
-            <p class="text-muted-foreground">2x &Oslash;&sup3;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup1;&Oslash;&sect;&Oslash;&ordf; &Oslash;&sect;&Ugrave;&#132;&Oslash;&sect;&Oslash;&sup3;&Oslash;&ordf;&Ugrave;&#136;&Oslash;&macr;&Ugrave;&#138;&Ugrave;&#136;</p>
+        <div data-slot="collapsible-content" data-collapsible-target="content" aria-hidden="true" data-state="closed" hidden="" class="flex flex-col gap-2">
+<div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">&Oslash;&sup1;&Ugrave;&#134;&Ugrave;&#136;&Oslash;&sect;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Oslash;&acute;&Oslash;&shy;&Ugrave;&#134;</p>
+                <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            </div>
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">&Oslash;&sect;&Ugrave;&#132;&Oslash;&sup1;&Ugrave;&#134;&Oslash;&sect;&Oslash;&micro;&Oslash;&plusmn;</p>
+                <p class="text-muted-foreground">2x &Oslash;&sup3;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup1;&Oslash;&sect;&Oslash;&ordf; &Oslash;&sect;&Ugrave;&#132;&Oslash;&sect;&Oslash;&sup3;&Oslash;&ordf;&Ugrave;&#136;&Oslash;&macr;&Ugrave;&#138;&Ugrave;&#136;</p>
+            </div>
+        </div>
+    </div>
+
+        <div class="group flex flex-col gap-2" data-slot="collapsible" data-controller="collapsible" data-collapsible-open-value="false" data-state="closed" dir="ltr">
+<div class="flex items-center justify-between gap-4 px-4">
+            <h4 class="text-sm font-semibold">Order #4189</h4>
+            <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8" data-collapsible-target="trigger" data-action="click-&gt;collapsible#toggle" aria-expanded="false" data-state="closed"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m7 15l5 5l5-5M7 9l5-5l5 5"></path></svg>
+                    <span class="sr-only">Toggle details</span>
+                </button>
+                    </div>
+        <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
+            <span class="text-muted-foreground">Status</span>
+            <span class="font-medium">Shipped</span>
+        </div>
+        <div data-slot="collapsible-content" data-collapsible-target="content" aria-hidden="true" data-state="closed" hidden="" class="flex flex-col gap-2">
+<div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">Shipping address</p>
+                <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            </div>
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">Items</p>
+                <p class="text-muted-foreground">2x Studio Headphones</p>
+            </div>
+        </div>
+    </div>
+
+        <div class="group flex flex-col gap-2" data-slot="collapsible" data-controller="collapsible" data-collapsible-open-value="false" data-state="closed" dir="rtl">
+<div class="flex items-center justify-between gap-4 px-4">
+            <h4 class="text-sm font-semibold">&times;&#148;&times;&#150;&times;&#158;&times;&nbsp;&times;&#148; #4189</h4>
+            <button data-slot="button" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&amp;_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-8" data-collapsible-target="trigger" data-action="click-&gt;collapsible#toggle" aria-expanded="false" data-state="closed"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m7 15l5 5l5-5M7 9l5-5l5 5"></path></svg>
+                    <span class="sr-only">Toggle details</span>
+                </button>
+                    </div>
+        <div class="flex items-center justify-between rounded-md border px-4 py-2 text-sm">
+            <span class="text-muted-foreground">&times;&iexcl;&times;&#152;&times;&#152;&times;&#149;&times;&iexcl;</span>
+            <span class="font-medium">&times;&nbsp;&times;&copy;&times;&#156;&times;&#151;</span>
+        </div>
+        <div data-slot="collapsible-content" data-collapsible-target="content" aria-hidden="true" data-state="closed" hidden="" class="flex flex-col gap-2">
+<div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">&times;&#155;&times;&ordf;&times;&#149;&times;&#145;&times;&ordf; &times;&#158;&times;&copy;&times;&#156;&times;&#149;&times;&#151;</p>
+                <p class="text-muted-foreground">100 Market St, San Francisco</p>
+            </div>
+            <div class="rounded-md border px-4 py-2 text-sm">
+                <p class="font-medium">&times;&curren;&times;&uml;&times;&#153;&times;&#152;&times;&#153;&times;&#157;</p>
+                <p class="text-muted-foreground">2x &times;&#144;&times;&#149;&times;&#150;&times;&nbsp;&times;&#153;&times;&#149;&times;&ordf; &times;&iexcl;&times;&#152;&times;&#149;&times;&#147;&times;&#153;&times;&#149;</p>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

Aligns the `collapsible` examples with the shadcn reference:

- **File Tree** (`apps/v4/examples/radix/collapsible-file-tree.tsx`):
  - Adds a nested `ui/` folder inside `components/` with 6 files (button, card, dialog, input, select, table)
  - Adds `login-form.tsx`, `register-form.tsx` as siblings of `ui/` in `components/`
  - Enriches `lib/` with `cn.ts`, `api.ts`
  - Replaces `use-toast.ts` with `use-media-query.ts`, `use-debounce.ts`, `use-local-storage.ts` in `hooks/`
  - Adds `api.d.ts` to `types/`
  - Adds `logo.svg`, `images` to `public/`
- **RTL** (`apps/v4/examples/radix/collapsible-rtl.tsx`):
  - Shadcn uses a shared `language-selector` component (React state + `<Select>`) to swap between English / Arabic / Hebrew. We don't have an equivalent in the Twig toolkit, so instead the example now stacks three independent `Collapsible`s — one per language with its own `dir` — which shows the same intent (RTL + LTR side-by-side) without introducing new JS infrastructure.

Follow-up to #3464.

Snapshots regenerated.