### PR TITLE
[Toolkit][Shadcn] Add Arabic and Hebrew RTL examples to typography recipe

### DIFF
--- a/src/Toolkit/kits/shadcn/typography/examples/Arabic.html.twig
+++ b/src/Toolkit/kits/shadcn/typography/examples/Arabic.html.twig
@@ -1,0 +1,66 @@
+<div class="self-start w-full" dir="rtl">
+<twig:Typography:H1>فرض الضرائب على الضحك: سجلات ضريبة النكتة</twig:Typography:H1>
+<twig:Typography:P class="text-xl text-muted-foreground">
+    في قديم الزمان، في أرض بعيدة، كان هناك ملك كسول جداً يقضي يومه كله مستلقياً على عرشه. في أحد الأيام، جاءه مستشاروه بمشكلة: المملكة كانت تنفد من المال.
+</twig:Typography:P>
+<twig:Typography:H2 class="mt-10">خطة الملك</twig:Typography:H2>
+<twig:Typography:P>
+    فكر الملك طويلاً وبجد، وأخيراً توصل إلى <a href="#" class="font-medium text-primary underline underline-offset-4">خطة عبقرية</a>: سيفرض ضريبة على النكات في المملكة.
+</twig:Typography:P>
+<twig:Typography:Blockquote class="border-s-2 ps-6 border-l-0 pl-0">
+    "في النهاية،" قال، "الجميع يستمتع بنكتة جيدة، لذا من العدل أن يدفعوا مقابل هذا الامتياز."
+</twig:Typography:Blockquote>
+<twig:Typography:H3 class="mt-8">ضريبة النكتة</twig:Typography:H3>
+<twig:Typography:P>
+    لم يكن رعايا الملك سعداء. تذمروا واشتكوا، لكن الملك كان حازماً:
+</twig:Typography:P>
+<twig:Typography:List>
+    <li>المستوى الأول من التورية: 5 قطع ذهبية</li>
+    <li>المستوى الثاني من النكات: 10 قطع ذهبية</li>
+    <li>المستوى الثالث من النكات القصيرة: 20 قطعة ذهبية</li>
+</twig:Typography:List>
+<twig:Typography:P>
+    نتيجة لذلك، توقف الناس عن رواية النكات، وغرقت المملكة في الكآبة. لكن كان هناك شخص واحد رفض أن تحبطه حماقة الملك: مهرج البلاط المسمى المازح.
+</twig:Typography:P>
+<twig:Typography:H3 class="mt-8">ثورة المازح</twig:Typography:H3>
+<twig:Typography:P>
+    بدأ المازح يتسلل إلى القلعة في منتصف الليل ويترك النكات في كل مكان: تحت وسادة الملك، في حسائه، حتى في المرحاض الملكي. كان الملك غاضباً، لكنه لم يستطع إيقاف المازح.
+</twig:Typography:P>
+<twig:Typography:P>
+    وبعد ذلك، في يوم من الأيام، اكتشف سكان المملكة أن النكات التي تركها المازح كانت مضحكة جداً لدرجة أنهم لم يستطيعوا منع أنفسهم من الضحك. وبمجرد أن بدأوا بالضحك، لم يستطيعوا التوقف.
+</twig:Typography:P>
+<twig:Typography:H3 class="mt-8">ثورة الشعب</twig:Typography:H3>
+<twig:Typography:P>
+    شعر سكان المملكة بالبهجة من الضحك، وبدأوا في رواية النكات والتورية مرة أخرى، وسرعان ما أصبحت المملكة بأكملها جزءاً من النكتة.
+</twig:Typography:P>
+<div class="my-6 w-full overflow-y-auto">
+    <table class="w-full">
+        <thead>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <th class="border px-4 py-2 text-start font-bold">خزينة الملك</th>
+                <th class="border px-4 py-2 text-start font-bold">سعادة الشعب</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">فارغة</td>
+                <td class="border px-4 py-2 text-start">فائضة</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">متواضعة</td>
+                <td class="border px-4 py-2 text-start">راضٍ</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">ممتلئة</td>
+                <td class="border px-4 py-2 text-start">منتشٍ</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<twig:Typography:P>
+    الملك، عندما رأى مدى سعادة رعاياه، أدرك خطأ طرقه وألغى ضريبة النكتة. أُعلن المازح بطلاً، وعاشت المملكة في سعادة دائمة.
+</twig:Typography:P>
+<twig:Typography:P>
+    مغزى القصة هو: لا تستهن أبداً بقوة الضحك الجيد وكن دائماً حذراً من الأفكار السيئة.
+</twig:Typography:P>
+</div>

--- a/src/Toolkit/kits/shadcn/typography/examples/Hebrew.html.twig
+++ b/src/Toolkit/kits/shadcn/typography/examples/Hebrew.html.twig
@@ -1,0 +1,66 @@
+<div class="self-start w-full" dir="rtl">
+<twig:Typography:H1>מיסוי הצחוק: כרוניקות מס הבדיחה</twig:Typography:H1>
+<twig:Typography:P class="text-xl text-muted-foreground">
+    היה היה פעם, בארץ רחוקה, מלך עצלן מאוד שבילה את כל היום בהתרווחות על כס מלכותו. יום אחד, יועציו באו אליו עם בעיה: הממלכה נגמר לה הכסף.
+</twig:Typography:P>
+<twig:Typography:H2 class="mt-10">התוכנית של המלך</twig:Typography:H2>
+<twig:Typography:P>
+    המלך חשב ארוכות וקשות, ולבסוף העלה <a href="#" class="font-medium text-primary underline underline-offset-4">תוכנית גאונית</a>: הוא ימסה את הבדיחות בממלכה.
+</twig:Typography:P>
+<twig:Typography:Blockquote class="border-s-2 ps-6 border-l-0 pl-0">
+    "אחרי הכל," אמר, "כולם נהנים מבדיחה טובה, אז זה רק הוגן שישלמו על הזכות הזו."
+</twig:Typography:Blockquote>
+<twig:Typography:H3 class="mt-8">מס הבדיחה</twig:Typography:H3>
+<twig:Typography:P>
+    נתיני המלך לא היו מרוצים. הם התלוננו והתרעמו, אבל המלך היה נחוש:
+</twig:Typography:P>
+<twig:Typography:List>
+    <li>רמה ראשונה של משחקי מילים: 5 מטבעות זהב</li>
+    <li>רמה שנייה של בדיחות: 10 מטבעות זהב</li>
+    <li>רמה שלישית של חידודים: 20 מטבעות זהב</li>
+</twig:Typography:List>
+<twig:Typography:P>
+    כתוצאה מכך, אנשים הפסיקו לספר בדיחות, והממלכה שקעה בעצב. אבל היה אדם אחד שסירב לתת לטיפשות המלך להפיל אותו: ליצן חצר בשם הבדחן.
+</twig:Typography:P>
+<twig:Typography:H3 class="mt-8">המרד של הבדחן</twig:Typography:H3>
+<twig:Typography:P>
+    הבדחן התחיל להתגנב לטירה באמצע הלילה ולהשאיר בדיחות בכל מקום: מתחת לכרית המלך, במרק שלו, אפילו בשירותים המלכותיים. המלך היה זועם, אבל הוא לא הצליח לעצור את הבדחן.
+</twig:Typography:P>
+<twig:Typography:P>
+    ואז, יום אחד, תושבי הממלכה גילו שהבדיחות שהבדחן השאיר היו כל כך מצחיקות שהם לא יכלו להתאפק מלצחוק. וברגע שהתחילו לצחוק, הם לא יכלו להפסיק.
+</twig:Typography:P>
+<twig:Typography:H3 class="mt-8">המרד של העם</twig:Typography:H3>
+<twig:Typography:P>
+    תושבי הממלכה, שהרגישו מרוממים מהצחוק, התחילו לספר בדיחות ומשחקי מילים שוב, ובקרוב כל הממלכה הייתה חלק מהבדיחה.
+</twig:Typography:P>
+<div class="my-6 w-full overflow-y-auto">
+    <table class="w-full">
+        <thead>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <th class="border px-4 py-2 text-start font-bold">אוצר המלך</th>
+                <th class="border px-4 py-2 text-start font-bold">אושר העם</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">ריק</td>
+                <td class="border px-4 py-2 text-start">גדוש</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">צנוע</td>
+                <td class="border px-4 py-2 text-start">מרוצה</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">מלא</td>
+                <td class="border px-4 py-2 text-start">אקסטטי</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<twig:Typography:P>
+    המלך, כשראה כמה מאושרים נתיניו, הבין את טעותו וביטל את מס הבדיחה. הבדחן הוכרז כגיבור, והממלכה חיה באושר לנצח.
+</twig:Typography:P>
+<twig:Typography:P>
+    המוסר של הסיפור הוא: לעולם אל תזלזל בכוח של צחוק טוב ותמיד היזהר מרעיונות רעים.
+</twig:Typography:P>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component typography, code file Arabic.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component typography, code file Arabic.html.twig__1.html
@@ -1,0 +1,129 @@
+<!--
+- Kit: Shadcn UI
+- Component: Typography
+- Code:
+```twig
+<div class="self-start w-full" dir="rtl">
+<twig:Typography:H1>فرض الضرائب على الضحك: سجلات ضريبة النكتة</twig:Typography:H1>
+<twig:Typography:P class="text-xl text-muted-foreground">
+    في قديم الزمان، في أرض بعيدة، كان هناك ملك كسول جداً يقضي يومه كله مستلقياً على عرشه. في أحد الأيام، جاءه مستشاروه بمشكلة: المملكة كانت تنفد من المال.
+</twig:Typography:P>
+<twig:Typography:H2 class="mt-10">خطة الملك</twig:Typography:H2>
+<twig:Typography:P>
+    فكر الملك طويلاً وبجد، وأخيراً توصل إلى <a href="#" class="font-medium text-primary underline underline-offset-4">خطة عبقرية</a>: سيفرض ضريبة على النكات في المملكة.
+</twig:Typography:P>
+<twig:Typography:Blockquote class="border-s-2 ps-6 border-l-0 pl-0">
+    "في النهاية،" قال، "الجميع يستمتع بنكتة جيدة، لذا من العدل أن يدفعوا مقابل هذا الامتياز."
+</twig:Typography:Blockquote>
+<twig:Typography:H3 class="mt-8">ضريبة النكتة</twig:Typography:H3>
+<twig:Typography:P>
+    لم يكن رعايا الملك سعداء. تذمروا واشتكوا، لكن الملك كان حازماً:
+</twig:Typography:P>
+<twig:Typography:List>
+    <li>المستوى الأول من التورية: 5 قطع ذهبية</li>
+    <li>المستوى الثاني من النكات: 10 قطع ذهبية</li>
+    <li>المستوى الثالث من النكات القصيرة: 20 قطعة ذهبية</li>
+</twig:Typography:List>
+<twig:Typography:P>
+    نتيجة لذلك، توقف الناس عن رواية النكات، وغرقت المملكة في الكآبة. لكن كان هناك شخص واحد رفض أن تحبطه حماقة الملك: مهرج البلاط المسمى المازح.
+</twig:Typography:P>
+<twig:Typography:H3 class="mt-8">ثورة المازح</twig:Typography:H3>
+<twig:Typography:P>
+    بدأ المازح يتسلل إلى القلعة في منتصف الليل ويترك النكات في كل مكان: تحت وسادة الملك، في حسائه، حتى في المرحاض الملكي. كان الملك غاضباً، لكنه لم يستطع إيقاف المازح.
+</twig:Typography:P>
+<twig:Typography:P>
+    وبعد ذلك، في يوم من الأيام، اكتشف سكان المملكة أن النكات التي تركها المازح كانت مضحكة جداً لدرجة أنهم لم يستطيعوا منع أنفسهم من الضحك. وبمجرد أن بدأوا بالضحك، لم يستطيعوا التوقف.
+</twig:Typography:P>
+<twig:Typography:H3 class="mt-8">ثورة الشعب</twig:Typography:H3>
+<twig:Typography:P>
+    شعر سكان المملكة بالبهجة من الضحك، وبدأوا في رواية النكات والتورية مرة أخرى، وسرعان ما أصبحت المملكة بأكملها جزءاً من النكتة.
+</twig:Typography:P>
+<div class="my-6 w-full overflow-y-auto">
+    <table class="w-full">
+        <thead>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <th class="border px-4 py-2 text-start font-bold">خزينة الملك</th>
+                <th class="border px-4 py-2 text-start font-bold">سعادة الشعب</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">فارغة</td>
+                <td class="border px-4 py-2 text-start">فائضة</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">متواضعة</td>
+                <td class="border px-4 py-2 text-start">راضٍ</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">ممتلئة</td>
+                <td class="border px-4 py-2 text-start">منتشٍ</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<twig:Typography:P>
+    الملك، عندما رأى مدى سعادة رعاياه، أدرك خطأ طرقه وألغى ضريبة النكتة. أُعلن المازح بطلاً، وعاشت المملكة في سعادة دائمة.
+</twig:Typography:P>
+<twig:Typography:P>
+    مغزى القصة هو: لا تستهن أبداً بقوة الضحك الجيد وكن دائماً حذراً من الأفكار السيئة.
+</twig:Typography:P>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="self-start w-full" dir="rtl">
+<h1 class="scroll-m-20 text-4xl font-extrabold tracking-tight text-balance" data-slot="typography-h1">&Ugrave;&#129;&Oslash;&plusmn;&Oslash;&para; &Oslash;&sect;&Ugrave;&#132;&Oslash;&para;&Oslash;&plusmn;&Oslash;&sect;&Oslash;&brvbar;&Oslash;&uml; &Oslash;&sup1;&Ugrave;&#132;&Ugrave;&#137; &Oslash;&sect;&Ugrave;&#132;&Oslash;&para;&Oslash;&shy;&Ugrave;&#131;: &Oslash;&sup3;&Oslash;&not;&Ugrave;&#132;&Oslash;&sect;&Oslash;&ordf; &Oslash;&para;&Oslash;&plusmn;&Ugrave;&#138;&Oslash;&uml;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&ordf;&Oslash;&copy;</h1>
+<p class="[&amp;:not(:first-child)]:mt-6 text-xl text-muted-foreground" data-slot="typography-p">&Ugrave;&#129;&Ugrave;&#138; &Ugrave;&#130;&Oslash;&macr;&Ugrave;&#138;&Ugrave;&#133; &Oslash;&sect;&Ugrave;&#132;&Oslash;&sup2;&Ugrave;&#133;&Oslash;&sect;&Ugrave;&#134;&Oslash;&#140; &Ugrave;&#129;&Ugrave;&#138; &Oslash;&pound;&Oslash;&plusmn;&Oslash;&para; &Oslash;&uml;&Oslash;&sup1;&Ugrave;&#138;&Oslash;&macr;&Oslash;&copy;&Oslash;&#140; &Ugrave;&#131;&Oslash;&sect;&Ugrave;&#134; &Ugrave;&#135;&Ugrave;&#134;&Oslash;&sect;&Ugrave;&#131; &Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131; &Ugrave;&#131;&Oslash;&sup3;&Ugrave;&#136;&Ugrave;&#132; &Oslash;&not;&Oslash;&macr;&Oslash;&sect;&Ugrave;&#139; &Ugrave;&#138;&Ugrave;&#130;&Oslash;&para;&Ugrave;&#138; &Ugrave;&#138;&Ugrave;&#136;&Ugrave;&#133;&Ugrave;&#135; &Ugrave;&#131;&Ugrave;&#132;&Ugrave;&#135; &Ugrave;&#133;&Oslash;&sup3;&Oslash;&ordf;&Ugrave;&#132;&Ugrave;&#130;&Ugrave;&#138;&Oslash;&sect;&Ugrave;&#139; &Oslash;&sup1;&Ugrave;&#132;&Ugrave;&#137; &Oslash;&sup1;&Oslash;&plusmn;&Oslash;&acute;&Ugrave;&#135;. &Ugrave;&#129;&Ugrave;&#138; &Oslash;&pound;&Oslash;&shy;&Oslash;&macr; &Oslash;&sect;&Ugrave;&#132;&Oslash;&pound;&Ugrave;&#138;&Oslash;&sect;&Ugrave;&#133;&Oslash;&#140; &Oslash;&not;&Oslash;&sect;&Oslash;&iexcl;&Ugrave;&#135; &Ugrave;&#133;&Oslash;&sup3;&Oslash;&ordf;&Oslash;&acute;&Oslash;&sect;&Oslash;&plusmn;&Ugrave;&#136;&Ugrave;&#135; &Oslash;&uml;&Ugrave;&#133;&Oslash;&acute;&Ugrave;&#131;&Ugrave;&#132;&Oslash;&copy;: &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&copy; &Ugrave;&#131;&Oslash;&sect;&Ugrave;&#134;&Oslash;&ordf; &Oslash;&ordf;&Ugrave;&#134;&Ugrave;&#129;&Oslash;&macr; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sect;&Ugrave;&#132;.
+</p>
+<h2 class="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0 mt-10" data-slot="typography-h2">&Oslash;&reg;&Oslash;&middot;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;</h2>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&Ugrave;&#129;&Ugrave;&#131;&Oslash;&plusmn; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131; &Oslash;&middot;&Ugrave;&#136;&Ugrave;&#138;&Ugrave;&#132;&Oslash;&sect;&Ugrave;&#139; &Ugrave;&#136;&Oslash;&uml;&Oslash;&not;&Oslash;&macr;&Oslash;&#140; &Ugrave;&#136;&Oslash;&pound;&Oslash;&reg;&Ugrave;&#138;&Oslash;&plusmn;&Oslash;&sect;&Ugrave;&#139; &Oslash;&ordf;&Ugrave;&#136;&Oslash;&micro;&Ugrave;&#132; &Oslash;&yen;&Ugrave;&#132;&Ugrave;&#137; <a href="#" class="font-medium text-primary underline underline-offset-4">&Oslash;&reg;&Oslash;&middot;&Oslash;&copy; &Oslash;&sup1;&Oslash;&uml;&Ugrave;&#130;&Oslash;&plusmn;&Ugrave;&#138;&Oslash;&copy;</a>: &Oslash;&sup3;&Ugrave;&#138;&Ugrave;&#129;&Oslash;&plusmn;&Oslash;&para; &Oslash;&para;&Oslash;&plusmn;&Ugrave;&#138;&Oslash;&uml;&Oslash;&copy; &Oslash;&sup1;&Ugrave;&#132;&Ugrave;&#137; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&sect;&Oslash;&ordf; &Ugrave;&#129;&Ugrave;&#138; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&copy;.
+</p>
+<blockquote class="mt-6 italic border-s-2 ps-6 border-l-0 pl-0" data-slot="typography-blockquote">"&Ugrave;&#129;&Ugrave;&#138; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#135;&Oslash;&sect;&Ugrave;&#138;&Oslash;&copy;&Oslash;&#140;" &Ugrave;&#130;&Oslash;&sect;&Ugrave;&#132;&Oslash;&#140; "&Oslash;&sect;&Ugrave;&#132;&Oslash;&not;&Ugrave;&#133;&Ugrave;&#138;&Oslash;&sup1; &Ugrave;&#138;&Oslash;&sup3;&Oslash;&ordf;&Ugrave;&#133;&Oslash;&ordf;&Oslash;&sup1; &Oslash;&uml;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&ordf;&Oslash;&copy; &Oslash;&not;&Ugrave;&#138;&Oslash;&macr;&Oslash;&copy;&Oslash;&#140; &Ugrave;&#132;&Oslash;&deg;&Oslash;&sect; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Oslash;&sup1;&Oslash;&macr;&Ugrave;&#132; &Oslash;&pound;&Ugrave;&#134; &Ugrave;&#138;&Oslash;&macr;&Ugrave;&#129;&Oslash;&sup1;&Ugrave;&#136;&Oslash;&sect; &Ugrave;&#133;&Ugrave;&#130;&Oslash;&sect;&Oslash;&uml;&Ugrave;&#132; &Ugrave;&#135;&Oslash;&deg;&Oslash;&sect; &Oslash;&sect;&Ugrave;&#132;&Oslash;&sect;&Ugrave;&#133;&Oslash;&ordf;&Ugrave;&#138;&Oslash;&sect;&Oslash;&sup2;."
+</blockquote>
+<h3 class="scroll-m-20 text-2xl font-semibold tracking-tight mt-8" data-slot="typography-h3">&Oslash;&para;&Oslash;&plusmn;&Ugrave;&#138;&Oslash;&uml;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&ordf;&Oslash;&copy;</h3>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&Ugrave;&#132;&Ugrave;&#133; &Ugrave;&#138;&Ugrave;&#131;&Ugrave;&#134; &Oslash;&plusmn;&Oslash;&sup1;&Oslash;&sect;&Ugrave;&#138;&Oslash;&sect; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131; &Oslash;&sup3;&Oslash;&sup1;&Oslash;&macr;&Oslash;&sect;&Oslash;&iexcl;. &Oslash;&ordf;&Oslash;&deg;&Ugrave;&#133;&Oslash;&plusmn;&Ugrave;&#136;&Oslash;&sect; &Ugrave;&#136;&Oslash;&sect;&Oslash;&acute;&Oslash;&ordf;&Ugrave;&#131;&Ugrave;&#136;&Oslash;&sect;&Oslash;&#140; &Ugrave;&#132;&Ugrave;&#131;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131; &Ugrave;&#131;&Oslash;&sect;&Ugrave;&#134; &Oslash;&shy;&Oslash;&sect;&Oslash;&sup2;&Ugrave;&#133;&Oslash;&sect;&Ugrave;&#139;:
+</p>
+<ul class="my-6 ml-6 list-disc [&amp;&gt;li]:mt-2" data-slot="typography-list">
+<li>&Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sup3;&Oslash;&ordf;&Ugrave;&#136;&Ugrave;&#137; &Oslash;&sect;&Ugrave;&#132;&Oslash;&pound;&Ugrave;&#136;&Ugrave;&#132; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Oslash;&ordf;&Ugrave;&#136;&Oslash;&plusmn;&Ugrave;&#138;&Oslash;&copy;: 5 &Ugrave;&#130;&Oslash;&middot;&Oslash;&sup1; &Oslash;&deg;&Ugrave;&#135;&Oslash;&uml;&Ugrave;&#138;&Oslash;&copy;</li>
+    <li>&Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sup3;&Oslash;&ordf;&Ugrave;&#136;&Ugrave;&#137; &Oslash;&sect;&Ugrave;&#132;&Oslash;&laquo;&Oslash;&sect;&Ugrave;&#134;&Ugrave;&#138; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&sect;&Oslash;&ordf;: 10 &Ugrave;&#130;&Oslash;&middot;&Oslash;&sup1; &Oslash;&deg;&Ugrave;&#135;&Oslash;&uml;&Ugrave;&#138;&Oslash;&copy;</li>
+    <li>&Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sup3;&Oslash;&ordf;&Ugrave;&#136;&Ugrave;&#137; &Oslash;&sect;&Ugrave;&#132;&Oslash;&laquo;&Oslash;&sect;&Ugrave;&#132;&Oslash;&laquo; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&sect;&Oslash;&ordf; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#130;&Oslash;&micro;&Ugrave;&#138;&Oslash;&plusmn;&Oslash;&copy;: 20 &Ugrave;&#130;&Oslash;&middot;&Oslash;&sup1;&Oslash;&copy; &Oslash;&deg;&Ugrave;&#135;&Oslash;&uml;&Ugrave;&#138;&Oslash;&copy;</li>
+</ul>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&Ugrave;&#134;&Oslash;&ordf;&Ugrave;&#138;&Oslash;&not;&Oslash;&copy; &Ugrave;&#132;&Oslash;&deg;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&#140; &Oslash;&ordf;&Ugrave;&#136;&Ugrave;&#130;&Ugrave;&#129; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Oslash;&sect;&Oslash;&sup3; &Oslash;&sup1;&Ugrave;&#134; &Oslash;&plusmn;&Ugrave;&#136;&Oslash;&sect;&Ugrave;&#138;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&sect;&Oslash;&ordf;&Oslash;&#140; &Ugrave;&#136;&Oslash;&ordm;&Oslash;&plusmn;&Ugrave;&#130;&Oslash;&ordf; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&copy; &Ugrave;&#129;&Ugrave;&#138; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&cent;&Oslash;&uml;&Oslash;&copy;. &Ugrave;&#132;&Ugrave;&#131;&Ugrave;&#134; &Ugrave;&#131;&Oslash;&sect;&Ugrave;&#134; &Ugrave;&#135;&Ugrave;&#134;&Oslash;&sect;&Ugrave;&#131; &Oslash;&acute;&Oslash;&reg;&Oslash;&micro; &Ugrave;&#136;&Oslash;&sect;&Oslash;&shy;&Oslash;&macr; &Oslash;&plusmn;&Ugrave;&#129;&Oslash;&para; &Oslash;&pound;&Ugrave;&#134; &Oslash;&ordf;&Oslash;&shy;&Oslash;&uml;&Oslash;&middot;&Ugrave;&#135; &Oslash;&shy;&Ugrave;&#133;&Oslash;&sect;&Ugrave;&#130;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;: &Ugrave;&#133;&Ugrave;&#135;&Oslash;&plusmn;&Oslash;&not; &Oslash;&sect;&Ugrave;&#132;&Oslash;&uml;&Ugrave;&#132;&Oslash;&sect;&Oslash;&middot; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sup3;&Ugrave;&#133;&Ugrave;&#137; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup2;&Oslash;&shy;.
+</p>
+<h3 class="scroll-m-20 text-2xl font-semibold tracking-tight mt-8" data-slot="typography-h3">&Oslash;&laquo;&Ugrave;&#136;&Oslash;&plusmn;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup2;&Oslash;&shy;</h3>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&Oslash;&uml;&Oslash;&macr;&Oslash;&pound; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup2;&Oslash;&shy; &Ugrave;&#138;&Oslash;&ordf;&Oslash;&sup3;&Ugrave;&#132;&Ugrave;&#132; &Oslash;&yen;&Ugrave;&#132;&Ugrave;&#137; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#130;&Ugrave;&#132;&Oslash;&sup1;&Oslash;&copy; &Ugrave;&#129;&Ugrave;&#138; &Ugrave;&#133;&Ugrave;&#134;&Oslash;&ordf;&Oslash;&micro;&Ugrave;&#129; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#132;&Ugrave;&#138;&Ugrave;&#132; &Ugrave;&#136;&Ugrave;&#138;&Oslash;&ordf;&Oslash;&plusmn;&Ugrave;&#131; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&sect;&Oslash;&ordf; &Ugrave;&#129;&Ugrave;&#138; &Ugrave;&#131;&Ugrave;&#132; &Ugrave;&#133;&Ugrave;&#131;&Oslash;&sect;&Ugrave;&#134;: &Oslash;&ordf;&Oslash;&shy;&Oslash;&ordf; &Ugrave;&#136;&Oslash;&sup3;&Oslash;&sect;&Oslash;&macr;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&#140; &Ugrave;&#129;&Ugrave;&#138; &Oslash;&shy;&Oslash;&sup3;&Oslash;&sect;&Oslash;&brvbar;&Ugrave;&#135;&Oslash;&#140; &Oslash;&shy;&Oslash;&ordf;&Ugrave;&#137; &Ugrave;&#129;&Ugrave;&#138; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&plusmn;&Oslash;&shy;&Oslash;&sect;&Oslash;&para; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Ugrave;&#138;. &Ugrave;&#131;&Oslash;&sect;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131; &Oslash;&ordm;&Oslash;&sect;&Oslash;&para;&Oslash;&uml;&Oslash;&sect;&Ugrave;&#139;&Oslash;&#140; &Ugrave;&#132;&Ugrave;&#131;&Ugrave;&#134;&Ugrave;&#135; &Ugrave;&#132;&Ugrave;&#133; &Ugrave;&#138;&Oslash;&sup3;&Oslash;&ordf;&Oslash;&middot;&Oslash;&sup1; &Oslash;&yen;&Ugrave;&#138;&Ugrave;&#130;&Oslash;&sect;&Ugrave;&#129; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup2;&Oslash;&shy;.
+</p>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&Ugrave;&#136;&Oslash;&uml;&Oslash;&sup1;&Oslash;&macr; &Oslash;&deg;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&#140; &Ugrave;&#129;&Ugrave;&#138; &Ugrave;&#138;&Ugrave;&#136;&Ugrave;&#133; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Oslash;&pound;&Ugrave;&#138;&Oslash;&sect;&Ugrave;&#133;&Oslash;&#140; &Oslash;&sect;&Ugrave;&#131;&Oslash;&ordf;&Oslash;&acute;&Ugrave;&#129; &Oslash;&sup3;&Ugrave;&#131;&Oslash;&sect;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&copy; &Oslash;&pound;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&sect;&Oslash;&ordf; &Oslash;&sect;&Ugrave;&#132;&Oslash;&ordf;&Ugrave;&#138; &Oslash;&ordf;&Oslash;&plusmn;&Ugrave;&#131;&Ugrave;&#135;&Oslash;&sect; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup2;&Oslash;&shy; &Ugrave;&#131;&Oslash;&sect;&Ugrave;&#134;&Oslash;&ordf; &Ugrave;&#133;&Oslash;&para;&Oslash;&shy;&Ugrave;&#131;&Oslash;&copy; &Oslash;&not;&Oslash;&macr;&Oslash;&sect;&Ugrave;&#139; &Ugrave;&#132;&Oslash;&macr;&Oslash;&plusmn;&Oslash;&not;&Oslash;&copy; &Oslash;&pound;&Ugrave;&#134;&Ugrave;&#135;&Ugrave;&#133; &Ugrave;&#132;&Ugrave;&#133; &Ugrave;&#138;&Oslash;&sup3;&Oslash;&ordf;&Oslash;&middot;&Ugrave;&#138;&Oslash;&sup1;&Ugrave;&#136;&Oslash;&sect; &Ugrave;&#133;&Ugrave;&#134;&Oslash;&sup1; &Oslash;&pound;&Ugrave;&#134;&Ugrave;&#129;&Oslash;&sup3;&Ugrave;&#135;&Ugrave;&#133; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Oslash;&para;&Oslash;&shy;&Ugrave;&#131;. &Ugrave;&#136;&Oslash;&uml;&Ugrave;&#133;&Oslash;&not;&Oslash;&plusmn;&Oslash;&macr; &Oslash;&pound;&Ugrave;&#134; &Oslash;&uml;&Oslash;&macr;&Oslash;&pound;&Ugrave;&#136;&Oslash;&sect; &Oslash;&uml;&Oslash;&sect;&Ugrave;&#132;&Oslash;&para;&Oslash;&shy;&Ugrave;&#131;&Oslash;&#140; &Ugrave;&#132;&Ugrave;&#133; &Ugrave;&#138;&Oslash;&sup3;&Oslash;&ordf;&Oslash;&middot;&Ugrave;&#138;&Oslash;&sup1;&Ugrave;&#136;&Oslash;&sect; &Oslash;&sect;&Ugrave;&#132;&Oslash;&ordf;&Ugrave;&#136;&Ugrave;&#130;&Ugrave;&#129;.
+</p>
+<h3 class="scroll-m-20 text-2xl font-semibold tracking-tight mt-8" data-slot="typography-h3">&Oslash;&laquo;&Ugrave;&#136;&Oslash;&plusmn;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Oslash;&acute;&Oslash;&sup1;&Oslash;&uml;</h3>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&Oslash;&acute;&Oslash;&sup1;&Oslash;&plusmn; &Oslash;&sup3;&Ugrave;&#131;&Oslash;&sect;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&copy; &Oslash;&uml;&Oslash;&sect;&Ugrave;&#132;&Oslash;&uml;&Ugrave;&#135;&Oslash;&not;&Oslash;&copy; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Oslash;&para;&Oslash;&shy;&Ugrave;&#131;&Oslash;&#140; &Ugrave;&#136;&Oslash;&uml;&Oslash;&macr;&Oslash;&pound;&Ugrave;&#136;&Oslash;&sect; &Ugrave;&#129;&Ugrave;&#138; &Oslash;&plusmn;&Ugrave;&#136;&Oslash;&sect;&Ugrave;&#138;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&sect;&Oslash;&ordf; &Ugrave;&#136;&Oslash;&sect;&Ugrave;&#132;&Oslash;&ordf;&Ugrave;&#136;&Oslash;&plusmn;&Ugrave;&#138;&Oslash;&copy; &Ugrave;&#133;&Oslash;&plusmn;&Oslash;&copy; &Oslash;&pound;&Oslash;&reg;&Oslash;&plusmn;&Ugrave;&#137;&Oslash;&#140; &Ugrave;&#136;&Oslash;&sup3;&Oslash;&plusmn;&Oslash;&sup1;&Oslash;&sect;&Ugrave;&#134; &Ugrave;&#133;&Oslash;&sect; &Oslash;&pound;&Oslash;&micro;&Oslash;&uml;&Oslash;&shy;&Oslash;&ordf; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&copy; &Oslash;&uml;&Oslash;&pound;&Ugrave;&#131;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#135;&Oslash;&sect; &Oslash;&not;&Oslash;&sup2;&Oslash;&iexcl;&Oslash;&sect;&Ugrave;&#139; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&ordf;&Oslash;&copy;.
+</p>
+<div class="my-6 w-full overflow-y-auto">
+    <table class="w-full">
+        <thead>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <th class="border px-4 py-2 text-start font-bold">&Oslash;&reg;&Oslash;&sup2;&Ugrave;&#138;&Ugrave;&#134;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;</th>
+                <th class="border px-4 py-2 text-start font-bold">&Oslash;&sup3;&Oslash;&sup1;&Oslash;&sect;&Oslash;&macr;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Oslash;&acute;&Oslash;&sup1;&Oslash;&uml;</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">&Ugrave;&#129;&Oslash;&sect;&Oslash;&plusmn;&Oslash;&ordm;&Oslash;&copy;</td>
+                <td class="border px-4 py-2 text-start">&Ugrave;&#129;&Oslash;&sect;&Oslash;&brvbar;&Oslash;&para;&Oslash;&copy;</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">&Ugrave;&#133;&Oslash;&ordf;&Ugrave;&#136;&Oslash;&sect;&Oslash;&para;&Oslash;&sup1;&Oslash;&copy;</td>
+                <td class="border px-4 py-2 text-start">&Oslash;&plusmn;&Oslash;&sect;&Oslash;&para;&Ugrave;&#141;</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">&Ugrave;&#133;&Ugrave;&#133;&Oslash;&ordf;&Ugrave;&#132;&Oslash;&brvbar;&Oslash;&copy;</td>
+                <td class="border px-4 py-2 text-start">&Ugrave;&#133;&Ugrave;&#134;&Oslash;&ordf;&Oslash;&acute;&Ugrave;&#141;</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&#140; &Oslash;&sup1;&Ugrave;&#134;&Oslash;&macr;&Ugrave;&#133;&Oslash;&sect; &Oslash;&plusmn;&Oslash;&pound;&Ugrave;&#137; &Ugrave;&#133;&Oslash;&macr;&Ugrave;&#137; &Oslash;&sup3;&Oslash;&sup1;&Oslash;&sect;&Oslash;&macr;&Oslash;&copy; &Oslash;&plusmn;&Oslash;&sup1;&Oslash;&sect;&Ugrave;&#138;&Oslash;&sect;&Ugrave;&#135;&Oslash;&#140; &Oslash;&pound;&Oslash;&macr;&Oslash;&plusmn;&Ugrave;&#131; &Oslash;&reg;&Oslash;&middot;&Oslash;&pound; &Oslash;&middot;&Oslash;&plusmn;&Ugrave;&#130;&Ugrave;&#135; &Ugrave;&#136;&Oslash;&pound;&Ugrave;&#132;&Oslash;&ordm;&Ugrave;&#137; &Oslash;&para;&Oslash;&plusmn;&Ugrave;&#138;&Oslash;&uml;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#134;&Ugrave;&#131;&Oslash;&ordf;&Oslash;&copy;. &Oslash;&pound;&Ugrave;&#143;&Oslash;&sup1;&Ugrave;&#132;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Oslash;&sect;&Oslash;&sup2;&Oslash;&shy; &Oslash;&uml;&Oslash;&middot;&Ugrave;&#132;&Oslash;&sect;&Ugrave;&#139;&Oslash;&#140; &Ugrave;&#136;&Oslash;&sup1;&Oslash;&sect;&Oslash;&acute;&Oslash;&ordf; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#133;&Ugrave;&#132;&Ugrave;&#131;&Oslash;&copy; &Ugrave;&#129;&Ugrave;&#138; &Oslash;&sup3;&Oslash;&sup1;&Oslash;&sect;&Oslash;&macr;&Oslash;&copy; &Oslash;&macr;&Oslash;&sect;&Oslash;&brvbar;&Ugrave;&#133;&Oslash;&copy;.
+</p>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&Ugrave;&#133;&Oslash;&ordm;&Oslash;&sup2;&Ugrave;&#137; &Oslash;&sect;&Ugrave;&#132;&Ugrave;&#130;&Oslash;&micro;&Oslash;&copy; &Ugrave;&#135;&Ugrave;&#136;: &Ugrave;&#132;&Oslash;&sect; &Oslash;&ordf;&Oslash;&sup3;&Oslash;&ordf;&Ugrave;&#135;&Ugrave;&#134; &Oslash;&pound;&Oslash;&uml;&Oslash;&macr;&Oslash;&sect;&Ugrave;&#139; &Oslash;&uml;&Ugrave;&#130;&Ugrave;&#136;&Oslash;&copy; &Oslash;&sect;&Ugrave;&#132;&Oslash;&para;&Oslash;&shy;&Ugrave;&#131; &Oslash;&sect;&Ugrave;&#132;&Oslash;&not;&Ugrave;&#138;&Oslash;&macr; &Ugrave;&#136;&Ugrave;&#131;&Ugrave;&#134; &Oslash;&macr;&Oslash;&sect;&Oslash;&brvbar;&Ugrave;&#133;&Oslash;&sect;&Ugrave;&#139; &Oslash;&shy;&Oslash;&deg;&Oslash;&plusmn;&Oslash;&sect;&Ugrave;&#139; &Ugrave;&#133;&Ugrave;&#134; &Oslash;&sect;&Ugrave;&#132;&Oslash;&pound;&Ugrave;&#129;&Ugrave;&#131;&Oslash;&sect;&Oslash;&plusmn; &Oslash;&sect;&Ugrave;&#132;&Oslash;&sup3;&Ugrave;&#138;&Oslash;&brvbar;&Oslash;&copy;.
+</p>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component typography, code file Hebrew.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component typography, code file Hebrew.html.twig__1.html
@@ -1,0 +1,129 @@
+<!--
+- Kit: Shadcn UI
+- Component: Typography
+- Code:
+```twig
+<div class="self-start w-full" dir="rtl">
+<twig:Typography:H1>מיסוי הצחוק: כרוניקות מס הבדיחה</twig:Typography:H1>
+<twig:Typography:P class="text-xl text-muted-foreground">
+    היה היה פעם, בארץ רחוקה, מלך עצלן מאוד שבילה את כל היום בהתרווחות על כס מלכותו. יום אחד, יועציו באו אליו עם בעיה: הממלכה נגמר לה הכסף.
+</twig:Typography:P>
+<twig:Typography:H2 class="mt-10">התוכנית של המלך</twig:Typography:H2>
+<twig:Typography:P>
+    המלך חשב ארוכות וקשות, ולבסוף העלה <a href="#" class="font-medium text-primary underline underline-offset-4">תוכנית גאונית</a>: הוא ימסה את הבדיחות בממלכה.
+</twig:Typography:P>
+<twig:Typography:Blockquote class="border-s-2 ps-6 border-l-0 pl-0">
+    "אחרי הכל," אמר, "כולם נהנים מבדיחה טובה, אז זה רק הוגן שישלמו על הזכות הזו."
+</twig:Typography:Blockquote>
+<twig:Typography:H3 class="mt-8">מס הבדיחה</twig:Typography:H3>
+<twig:Typography:P>
+    נתיני המלך לא היו מרוצים. הם התלוננו והתרעמו, אבל המלך היה נחוש:
+</twig:Typography:P>
+<twig:Typography:List>
+    <li>רמה ראשונה של משחקי מילים: 5 מטבעות זהב</li>
+    <li>רמה שנייה של בדיחות: 10 מטבעות זהב</li>
+    <li>רמה שלישית של חידודים: 20 מטבעות זהב</li>
+</twig:Typography:List>
+<twig:Typography:P>
+    כתוצאה מכך, אנשים הפסיקו לספר בדיחות, והממלכה שקעה בעצב. אבל היה אדם אחד שסירב לתת לטיפשות המלך להפיל אותו: ליצן חצר בשם הבדחן.
+</twig:Typography:P>
+<twig:Typography:H3 class="mt-8">המרד של הבדחן</twig:Typography:H3>
+<twig:Typography:P>
+    הבדחן התחיל להתגנב לטירה באמצע הלילה ולהשאיר בדיחות בכל מקום: מתחת לכרית המלך, במרק שלו, אפילו בשירותים המלכותיים. המלך היה זועם, אבל הוא לא הצליח לעצור את הבדחן.
+</twig:Typography:P>
+<twig:Typography:P>
+    ואז, יום אחד, תושבי הממלכה גילו שהבדיחות שהבדחן השאיר היו כל כך מצחיקות שהם לא יכלו להתאפק מלצחוק. וברגע שהתחילו לצחוק, הם לא יכלו להפסיק.
+</twig:Typography:P>
+<twig:Typography:H3 class="mt-8">המרד של העם</twig:Typography:H3>
+<twig:Typography:P>
+    תושבי הממלכה, שהרגישו מרוממים מהצחוק, התחילו לספר בדיחות ומשחקי מילים שוב, ובקרוב כל הממלכה הייתה חלק מהבדיחה.
+</twig:Typography:P>
+<div class="my-6 w-full overflow-y-auto">
+    <table class="w-full">
+        <thead>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <th class="border px-4 py-2 text-start font-bold">אוצר המלך</th>
+                <th class="border px-4 py-2 text-start font-bold">אושר העם</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">ריק</td>
+                <td class="border px-4 py-2 text-start">גדוש</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">צנוע</td>
+                <td class="border px-4 py-2 text-start">מרוצה</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">מלא</td>
+                <td class="border px-4 py-2 text-start">אקסטטי</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<twig:Typography:P>
+    המלך, כשראה כמה מאושרים נתיניו, הבין את טעותו וביטל את מס הבדיחה. הבדחן הוכרז כגיבור, והממלכה חיה באושר לנצח.
+</twig:Typography:P>
+<twig:Typography:P>
+    המוסר של הסיפור הוא: לעולם אל תזלזל בכוח של צחוק טוב ותמיד היזהר מרעיונות רעים.
+</twig:Typography:P>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="self-start w-full" dir="rtl">
+<h1 class="scroll-m-20 text-4xl font-extrabold tracking-tight text-balance" data-slot="typography-h1">&times;&#158;&times;&#153;&times;&iexcl;&times;&#149;&times;&#153; &times;&#148;&times;&brvbar;&times;&#151;&times;&#149;&times;&sect;: &times;&#155;&times;&uml;&times;&#149;&times;&nbsp;&times;&#153;&times;&sect;&times;&#149;&times;&ordf; &times;&#158;&times;&iexcl; &times;&#148;&times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#148;</h1>
+<p class="[&amp;:not(:first-child)]:mt-6 text-xl text-muted-foreground" data-slot="typography-p">&times;&#148;&times;&#153;&times;&#148; &times;&#148;&times;&#153;&times;&#148; &times;&curren;&times;&cent;&times;&#157;, &times;&#145;&times;&#144;&times;&uml;&times;&yen; &times;&uml;&times;&#151;&times;&#149;&times;&sect;&times;&#148;, &times;&#158;&times;&#156;&times;&#154; &times;&cent;&times;&brvbar;&times;&#156;&times;&#159; &times;&#158;&times;&#144;&times;&#149;&times;&#147; &times;&copy;&times;&#145;&times;&#153;&times;&#156;&times;&#148; &times;&#144;&times;&ordf; &times;&#155;&times;&#156; &times;&#148;&times;&#153;&times;&#149;&times;&#157; &times;&#145;&times;&#148;&times;&ordf;&times;&uml;&times;&#149;&times;&#149;&times;&#151;&times;&#149;&times;&ordf; &times;&cent;&times;&#156; &times;&#155;&times;&iexcl; &times;&#158;&times;&#156;&times;&#155;&times;&#149;&times;&ordf;&times;&#149;. &times;&#153;&times;&#149;&times;&#157; &times;&#144;&times;&#151;&times;&#147;, &times;&#153;&times;&#149;&times;&cent;&times;&brvbar;&times;&#153;&times;&#149; &times;&#145;&times;&#144;&times;&#149; &times;&#144;&times;&#156;&times;&#153;&times;&#149; &times;&cent;&times;&#157; &times;&#145;&times;&cent;&times;&#153;&times;&#148;: &times;&#148;&times;&#158;&times;&#158;&times;&#156;&times;&#155;&times;&#148; &times;&nbsp;&times;&#146;&times;&#158;&times;&uml; &times;&#156;&times;&#148; &times;&#148;&times;&#155;&times;&iexcl;&times;&pound;.
+</p>
+<h2 class="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0 mt-10" data-slot="typography-h2">&times;&#148;&times;&ordf;&times;&#149;&times;&#155;&times;&nbsp;&times;&#153;&times;&ordf; &times;&copy;&times;&#156; &times;&#148;&times;&#158;&times;&#156;&times;&#154;</h2>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&times;&#148;&times;&#158;&times;&#156;&times;&#154; &times;&#151;&times;&copy;&times;&#145; &times;&#144;&times;&uml;&times;&#149;&times;&#155;&times;&#149;&times;&ordf; &times;&#149;&times;&sect;&times;&copy;&times;&#149;&times;&ordf;, &times;&#149;&times;&#156;&times;&#145;&times;&iexcl;&times;&#149;&times;&pound; &times;&#148;&times;&cent;&times;&#156;&times;&#148; <a href="#" class="font-medium text-primary underline underline-offset-4">&times;&ordf;&times;&#149;&times;&#155;&times;&nbsp;&times;&#153;&times;&ordf; &times;&#146;&times;&#144;&times;&#149;&times;&nbsp;&times;&#153;&times;&ordf;</a>: &times;&#148;&times;&#149;&times;&#144; &times;&#153;&times;&#158;&times;&iexcl;&times;&#148; &times;&#144;&times;&ordf; &times;&#148;&times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#149;&times;&ordf; &times;&#145;&times;&#158;&times;&#158;&times;&#156;&times;&#155;&times;&#148;.
+</p>
+<blockquote class="mt-6 italic border-s-2 ps-6 border-l-0 pl-0" data-slot="typography-blockquote">"&times;&#144;&times;&#151;&times;&uml;&times;&#153; &times;&#148;&times;&#155;&times;&#156;," &times;&#144;&times;&#158;&times;&uml;, "&times;&#155;&times;&#149;&times;&#156;&times;&#157; &times;&nbsp;&times;&#148;&times;&nbsp;&times;&#153;&times;&#157; &times;&#158;&times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#148; &times;&#152;&times;&#149;&times;&#145;&times;&#148;, &times;&#144;&times;&#150; &times;&#150;&times;&#148; &times;&uml;&times;&sect; &times;&#148;&times;&#149;&times;&#146;&times;&#159; &times;&copy;&times;&#153;&times;&copy;&times;&#156;&times;&#158;&times;&#149; &times;&cent;&times;&#156; &times;&#148;&times;&#150;&times;&#155;&times;&#149;&times;&ordf; &times;&#148;&times;&#150;&times;&#149;."
+</blockquote>
+<h3 class="scroll-m-20 text-2xl font-semibold tracking-tight mt-8" data-slot="typography-h3">&times;&#158;&times;&iexcl; &times;&#148;&times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#148;</h3>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&times;&nbsp;&times;&ordf;&times;&#153;&times;&nbsp;&times;&#153; &times;&#148;&times;&#158;&times;&#156;&times;&#154; &times;&#156;&times;&#144; &times;&#148;&times;&#153;&times;&#149; &times;&#158;&times;&uml;&times;&#149;&times;&brvbar;&times;&#153;&times;&#157;. &times;&#148;&times;&#157; &times;&#148;&times;&ordf;&times;&#156;&times;&#149;&times;&nbsp;&times;&nbsp;&times;&#149; &times;&#149;&times;&#148;&times;&ordf;&times;&uml;&times;&cent;&times;&#158;&times;&#149;, &times;&#144;&times;&#145;&times;&#156; &times;&#148;&times;&#158;&times;&#156;&times;&#154; &times;&#148;&times;&#153;&times;&#148; &times;&nbsp;&times;&#151;&times;&#149;&times;&copy;:
+</p>
+<ul class="my-6 ml-6 list-disc [&amp;&gt;li]:mt-2" data-slot="typography-list">
+<li>&times;&uml;&times;&#158;&times;&#148; &times;&uml;&times;&#144;&times;&copy;&times;&#149;&times;&nbsp;&times;&#148; &times;&copy;&times;&#156; &times;&#158;&times;&copy;&times;&#151;&times;&sect;&times;&#153; &times;&#158;&times;&#153;&times;&#156;&times;&#153;&times;&#157;: 5 &times;&#158;&times;&#152;&times;&#145;&times;&cent;&times;&#149;&times;&ordf; &times;&#150;&times;&#148;&times;&#145;</li>
+    <li>&times;&uml;&times;&#158;&times;&#148; &times;&copy;&times;&nbsp;&times;&#153;&times;&#153;&times;&#148; &times;&copy;&times;&#156; &times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#149;&times;&ordf;: 10 &times;&#158;&times;&#152;&times;&#145;&times;&cent;&times;&#149;&times;&ordf; &times;&#150;&times;&#148;&times;&#145;</li>
+    <li>&times;&uml;&times;&#158;&times;&#148; &times;&copy;&times;&#156;&times;&#153;&times;&copy;&times;&#153;&times;&ordf; &times;&copy;&times;&#156; &times;&#151;&times;&#153;&times;&#147;&times;&#149;&times;&#147;&times;&#153;&times;&#157;: 20 &times;&#158;&times;&#152;&times;&#145;&times;&cent;&times;&#149;&times;&ordf; &times;&#150;&times;&#148;&times;&#145;</li>
+</ul>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&times;&#155;&times;&ordf;&times;&#149;&times;&brvbar;&times;&#144;&times;&#148; &times;&#158;&times;&#155;&times;&#154;, &times;&#144;&times;&nbsp;&times;&copy;&times;&#153;&times;&#157; &times;&#148;&times;&curren;&times;&iexcl;&times;&#153;&times;&sect;&times;&#149; &times;&#156;&times;&iexcl;&times;&curren;&times;&uml; &times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#149;&times;&ordf;, &times;&#149;&times;&#148;&times;&#158;&times;&#158;&times;&#156;&times;&#155;&times;&#148; &times;&copy;&times;&sect;&times;&cent;&times;&#148; &times;&#145;&times;&cent;&times;&brvbar;&times;&#145;. &times;&#144;&times;&#145;&times;&#156; &times;&#148;&times;&#153;&times;&#148; &times;&#144;&times;&#147;&times;&#157; &times;&#144;&times;&#151;&times;&#147; &times;&copy;&times;&iexcl;&times;&#153;&times;&uml;&times;&#145; &times;&#156;&times;&ordf;&times;&ordf; &times;&#156;&times;&#152;&times;&#153;&times;&curren;&times;&copy;&times;&#149;&times;&ordf; &times;&#148;&times;&#158;&times;&#156;&times;&#154; &times;&#156;&times;&#148;&times;&curren;&times;&#153;&times;&#156; &times;&#144;&times;&#149;&times;&ordf;&times;&#149;: &times;&#156;&times;&#153;&times;&brvbar;&times;&#159; &times;&#151;&times;&brvbar;&times;&uml; &times;&#145;&times;&copy;&times;&#157; &times;&#148;&times;&#145;&times;&#147;&times;&#151;&times;&#159;.
+</p>
+<h3 class="scroll-m-20 text-2xl font-semibold tracking-tight mt-8" data-slot="typography-h3">&times;&#148;&times;&#158;&times;&uml;&times;&#147; &times;&copy;&times;&#156; &times;&#148;&times;&#145;&times;&#147;&times;&#151;&times;&#159;</h3>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&times;&#148;&times;&#145;&times;&#147;&times;&#151;&times;&#159; &times;&#148;&times;&ordf;&times;&#151;&times;&#153;&times;&#156; &times;&#156;&times;&#148;&times;&ordf;&times;&#146;&times;&nbsp;&times;&#145; &times;&#156;&times;&#152;&times;&#153;&times;&uml;&times;&#148; &times;&#145;&times;&#144;&times;&#158;&times;&brvbar;&times;&cent; &times;&#148;&times;&#156;&times;&#153;&times;&#156;&times;&#148; &times;&#149;&times;&#156;&times;&#148;&times;&copy;&times;&#144;&times;&#153;&times;&uml; &times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#149;&times;&ordf; &times;&#145;&times;&#155;&times;&#156; &times;&#158;&times;&sect;&times;&#149;&times;&#157;: &times;&#158;&times;&ordf;&times;&#151;&times;&ordf; &times;&#156;&times;&#155;&times;&uml;&times;&#153;&times;&ordf; &times;&#148;&times;&#158;&times;&#156;&times;&#154;, &times;&#145;&times;&#158;&times;&uml;&times;&sect; &times;&copy;&times;&#156;&times;&#149;, &times;&#144;&times;&curren;&times;&#153;&times;&#156;&times;&#149; &times;&#145;&times;&copy;&times;&#153;&times;&uml;&times;&#149;&times;&ordf;&times;&#153;&times;&#157; &times;&#148;&times;&#158;&times;&#156;&times;&#155;&times;&#149;&times;&ordf;&times;&#153;&times;&#153;&times;&#157;. &times;&#148;&times;&#158;&times;&#156;&times;&#154; &times;&#148;&times;&#153;&times;&#148; &times;&#150;&times;&#149;&times;&cent;&times;&#157;, &times;&#144;&times;&#145;&times;&#156; &times;&#148;&times;&#149;&times;&#144; &times;&#156;&times;&#144; &times;&#148;&times;&brvbar;&times;&#156;&times;&#153;&times;&#151; &times;&#156;&times;&cent;&times;&brvbar;&times;&#149;&times;&uml; &times;&#144;&times;&ordf; &times;&#148;&times;&#145;&times;&#147;&times;&#151;&times;&#159;.
+</p>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&times;&#149;&times;&#144;&times;&#150;, &times;&#153;&times;&#149;&times;&#157; &times;&#144;&times;&#151;&times;&#147;, &times;&ordf;&times;&#149;&times;&copy;&times;&#145;&times;&#153; &times;&#148;&times;&#158;&times;&#158;&times;&#156;&times;&#155;&times;&#148; &times;&#146;&times;&#153;&times;&#156;&times;&#149; &times;&copy;&times;&#148;&times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#149;&times;&ordf; &times;&copy;&times;&#148;&times;&#145;&times;&#147;&times;&#151;&times;&#159; &times;&#148;&times;&copy;&times;&#144;&times;&#153;&times;&uml; &times;&#148;&times;&#153;&times;&#149; &times;&#155;&times;&#156; &times;&#155;&times;&#154; &times;&#158;&times;&brvbar;&times;&#151;&times;&#153;&times;&sect;&times;&#149;&times;&ordf; &times;&copy;&times;&#148;&times;&#157; &times;&#156;&times;&#144; &times;&#153;&times;&#155;&times;&#156;&times;&#149; &times;&#156;&times;&#148;&times;&ordf;&times;&#144;&times;&curren;&times;&sect; &times;&#158;&times;&#156;&times;&brvbar;&times;&#151;&times;&#149;&times;&sect;. &times;&#149;&times;&#145;&times;&uml;&times;&#146;&times;&cent; &times;&copy;&times;&#148;&times;&ordf;&times;&#151;&times;&#153;&times;&#156;&times;&#149; &times;&#156;&times;&brvbar;&times;&#151;&times;&#149;&times;&sect;, &times;&#148;&times;&#157; &times;&#156;&times;&#144; &times;&#153;&times;&#155;&times;&#156;&times;&#149; &times;&#156;&times;&#148;&times;&curren;&times;&iexcl;&times;&#153;&times;&sect;.
+</p>
+<h3 class="scroll-m-20 text-2xl font-semibold tracking-tight mt-8" data-slot="typography-h3">&times;&#148;&times;&#158;&times;&uml;&times;&#147; &times;&copy;&times;&#156; &times;&#148;&times;&cent;&times;&#157;</h3>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&times;&ordf;&times;&#149;&times;&copy;&times;&#145;&times;&#153; &times;&#148;&times;&#158;&times;&#158;&times;&#156;&times;&#155;&times;&#148;, &times;&copy;&times;&#148;&times;&uml;&times;&#146;&times;&#153;&times;&copy;&times;&#149; &times;&#158;&times;&uml;&times;&#149;&times;&#158;&times;&#158;&times;&#153;&times;&#157; &times;&#158;&times;&#148;&times;&brvbar;&times;&#151;&times;&#149;&times;&sect;, &times;&#148;&times;&ordf;&times;&#151;&times;&#153;&times;&#156;&times;&#149; &times;&#156;&times;&iexcl;&times;&curren;&times;&uml; &times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#149;&times;&ordf; &times;&#149;&times;&#158;&times;&copy;&times;&#151;&times;&sect;&times;&#153; &times;&#158;&times;&#153;&times;&#156;&times;&#153;&times;&#157; &times;&copy;&times;&#149;&times;&#145;, &times;&#149;&times;&#145;&times;&sect;&times;&uml;&times;&#149;&times;&#145; &times;&#155;&times;&#156; &times;&#148;&times;&#158;&times;&#158;&times;&#156;&times;&#155;&times;&#148; &times;&#148;&times;&#153;&times;&#153;&times;&ordf;&times;&#148; &times;&#151;&times;&#156;&times;&sect; &times;&#158;&times;&#148;&times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#148;.
+</p>
+<div class="my-6 w-full overflow-y-auto">
+    <table class="w-full">
+        <thead>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <th class="border px-4 py-2 text-start font-bold">&times;&#144;&times;&#149;&times;&brvbar;&times;&uml; &times;&#148;&times;&#158;&times;&#156;&times;&#154;</th>
+                <th class="border px-4 py-2 text-start font-bold">&times;&#144;&times;&#149;&times;&copy;&times;&uml; &times;&#148;&times;&cent;&times;&#157;</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">&times;&uml;&times;&#153;&times;&sect;</td>
+                <td class="border px-4 py-2 text-start">&times;&#146;&times;&#147;&times;&#149;&times;&copy;</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">&times;&brvbar;&times;&nbsp;&times;&#149;&times;&cent;</td>
+                <td class="border px-4 py-2 text-start">&times;&#158;&times;&uml;&times;&#149;&times;&brvbar;&times;&#148;</td>
+            </tr>
+            <tr class="m-0 border-t p-0 even:bg-muted">
+                <td class="border px-4 py-2 text-start">&times;&#158;&times;&#156;&times;&#144;</td>
+                <td class="border px-4 py-2 text-start">&times;&#144;&times;&sect;&times;&iexcl;&times;&#152;&times;&#152;&times;&#153;</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&times;&#148;&times;&#158;&times;&#156;&times;&#154;, &times;&#155;&times;&copy;&times;&uml;&times;&#144;&times;&#148; &times;&#155;&times;&#158;&times;&#148; &times;&#158;&times;&#144;&times;&#149;&times;&copy;&times;&uml;&times;&#153;&times;&#157; &times;&nbsp;&times;&ordf;&times;&#153;&times;&nbsp;&times;&#153;&times;&#149;, &times;&#148;&times;&#145;&times;&#153;&times;&#159; &times;&#144;&times;&ordf; &times;&#152;&times;&cent;&times;&#149;&times;&ordf;&times;&#149; &times;&#149;&times;&#145;&times;&#153;&times;&#152;&times;&#156; &times;&#144;&times;&ordf; &times;&#158;&times;&iexcl; &times;&#148;&times;&#145;&times;&#147;&times;&#153;&times;&#151;&times;&#148;. &times;&#148;&times;&#145;&times;&#147;&times;&#151;&times;&#159; &times;&#148;&times;&#149;&times;&#155;&times;&uml;&times;&#150; &times;&#155;&times;&#146;&times;&#153;&times;&#145;&times;&#149;&times;&uml;, &times;&#149;&times;&#148;&times;&#158;&times;&#158;&times;&#156;&times;&#155;&times;&#148; &times;&#151;&times;&#153;&times;&#148; &times;&#145;&times;&#144;&times;&#149;&times;&copy;&times;&uml; &times;&#156;&times;&nbsp;&times;&brvbar;&times;&#151;.
+</p>
+<p class="leading-7 [&amp;:not(:first-child)]:mt-6" data-slot="typography-p">&times;&#148;&times;&#158;&times;&#149;&times;&iexcl;&times;&uml; &times;&copy;&times;&#156; &times;&#148;&times;&iexcl;&times;&#153;&times;&curren;&times;&#149;&times;&uml; &times;&#148;&times;&#149;&times;&#144;: &times;&#156;&times;&cent;&times;&#149;&times;&#156;&times;&#157; &times;&#144;&times;&#156; &times;&ordf;&times;&#150;&times;&#156;&times;&#150;&times;&#156; &times;&#145;&times;&#155;&times;&#149;&times;&#151; &times;&copy;&times;&#156; &times;&brvbar;&times;&#151;&times;&#149;&times;&sect; &times;&#152;&times;&#149;&times;&#145; &times;&#149;&times;&ordf;&times;&#158;&times;&#153;&times;&#147; &times;&#148;&times;&#153;&times;&#150;&times;&#148;&times;&uml; &times;&#158;&times;&uml;&times;&cent;&times;&#153;&times;&#149;&times;&nbsp;&times;&#149;&times;&ordf; &times;&uml;&times;&cent;&times;&#153;&times;&#157;.
+</p>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

Adds RTL examples to the `typography` recipe, aligning with the shadcn reference (`apps/v4/examples/radix/typography-rtl.tsx`):

- `Arabic.html.twig` — Arabic version of the existing Demo
- `Hebrew.html.twig` — Hebrew version of the existing Demo

Both wrap the content in `dir="rtl"` and use logical Tailwind utilities (`border-s-2`, `ps-6`, `text-start`) so the layout flips correctly.

Shadcn's upstream handles all three languages (en/ar/he) via a shared `language-selector` React component with `useState` + `<Select>`. Since the Twig toolkit has no equivalent, the example is split into two files instead (the English version is already shipped as `Demo.html.twig`).

Follow-up to #3464.

Snapshots regenerated.
