### PR TITLE
[TwigComponent] Include attribute name in null value error message

### DIFF
--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -49,7 +49,7 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
             }
 
             if (null === $value) {
-                throw new RuntimeException('Attribute values cannot be null. If you want to remove an attribute, use the "remove()" method.');
+                throw new RuntimeException(\sprintf('Attribute "%s" value cannot be null. If you want to remove an attribute, use the "remove()" method.', $key));
             }
 
             if (false === $value) {

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -41,6 +41,15 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(' class="foo" style="color:black;" value="" autofocus', (string) $attributes);
     }
 
+    public function testThrowsOnNullAttributeValue()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Attribute "data-foo" value cannot be null.');
+
+        $attributes = new ComponentAttributes(['data-foo' => null], new EscaperRuntime());
+        (string) $attributes;
+    }
+
     public function testCanSetDefaults()
     {
         $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;'], new EscaperRuntime());


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Improve error message clarity by including the specific attribute name that cannot be null, making debugging easier.