### PR TITLE
[E2E] Remove "." prefix to Playwright report and output folders

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -117,8 +117,8 @@ jobs:
               with:
                   name: Playwright report and output (${{ matrix.symfony }}, ${{ matrix.browser }})
                   path: |
-                      src/**/assets/.playwright-report/
-                      src/**/assets/.playwright-output/
+                      src/**/assets/playwright-report/
+                      src/**/assets/playwright-output/
                   retention-days: 7
                   include-hidden-files: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ node_modules
 /vendor
 
 /browsers
-.playwright-report/
-.playwright-output/
+playwright-report/
+playwright-output/

--- a/playwright.config.base.ts
+++ b/playwright.config.base.ts
@@ -20,10 +20,10 @@ export default defineConfig({
 
     reporter: [
         ['list'],
-        ['html', { open: process.env.CI ? 'never' : 'on-failure', outputFolder: '.playwright-report' }],
+        ['html', { open: process.env.CI ? 'never' : 'on-failure', outputFolder: 'playwright-report' }],
     ],
 
-    outputDir: '.playwright-output',
+    outputDir: 'playwright-output',
 
     use: {
         // Base URL to use in actions like `await page.goto('/')`.


### PR DESCRIPTION

| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

While working on #3499 and other PRs that involve E2E tests, I often get a little confused when trying to find the Playwright reports/output in the artifacts downloaded from GitHub, because their folder names start with a `.`, and are therefore hidden by default.

Note: even the default values from Playwright (https://playwright.dev/docs/api/class-testproject#test-project-output-dir and https://playwright.dev/docs/test-reporters#html-reporter) do not start with `.`
