### PR TITLE
 Misc doc fixes

### DIFF
--- a/src/Autocomplete/doc/index.rst
+++ b/src/Autocomplete/doc/index.rst
@@ -442,7 +442,7 @@ Managing plugins
 
 .. note::
 
-    Some configuration could not be supported through the `tom_select_options.plugins` option,
+    Some configuration could not be supported through the ``tom_select_options.plugins`` option,
     for example when a plugin requires a JavaScript function as configuration value.
     In that case, you must use the `Extending Tom Select`_ approach to configure plugins.
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1281,8 +1281,8 @@ words, you benefit from CSRF protection effortlessly, thanks to the
 
 .. warning::
 
-	To ensure this built-in CSRF protection remains effective, pay attention
-	to your CORS headers (e.g. *DO NOT* use ``Access-Control-Allow-Origin: *``).
+    To ensure this built-in CSRF protection remains effective, pay attention
+    to your CORS headers (e.g. *DO NOT* use ``Access-Control-Allow-Origin: *``).
 
 In test-mode, the CSRF protection is disabled to make testing easier.
 
@@ -4068,3 +4068,4 @@ promise. However, any internal implementation in the JavaScript files
 .. _`Symfony TypeInfo`: https://symfony.com/doc/current/components/type_info.html
 .. _`Symfony PropertyInfo`: https://symfony.com/doc/current/components/property_info.html
 .. _`credentials option of the fetch() API`: https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials
+.. _`Symfony MakerBundle`: https://github.com/symfony/maker-bundle


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

This fixes the following doc issues:

```
Errors for ux-autocomplete

Found invalid reference "tom_select_options.plugins` option, for example when a plugin requires a JavaScript function as configuration value. In that case, you must use the `Extending Tom Select" in file "index"

Errors for ux-live-component

Error while processing "warning" directive: "Content expected, none found." in file "index" at line 1285
Found invalid reference "Symfony MakerBundle" in file "index"
```

The exact same issues happen in 3.x branch.
