### PR TITLE
[LiveComponent] Fix dynamic template resolution when using "loading" attribute

### DIFF
--- a/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/DeferLiveComponentSubscriber.php
@@ -72,7 +72,7 @@ final class DeferLiveComponentSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $componentTemplate = $event->getMetadata()->getTemplate();
+        $componentTemplate = $event->getTemplate();
         $event->setTemplate('@LiveComponent/deferred.html.twig');
 
         $variables = $event->getVariables();

--- a/src/LiveComponent/tests/Unit/EventListener/DeferLiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Unit/EventListener/DeferLiveComponentSubscriberTest.php
@@ -14,8 +14,12 @@ namespace Symfony\UX\LiveComponent\Tests\Unit\EventListener;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\LiveComponent\EventListener\DeferLiveComponentSubscriber;
+use Symfony\UX\TwigComponent\ComponentAttributes;
 use Symfony\UX\TwigComponent\ComponentMetadata;
 use Symfony\UX\TwigComponent\Event\PostMountEvent;
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
+use Symfony\UX\TwigComponent\MountedComponent;
+use Twig\Runtime\EscaperRuntime;
 
 /**
  * @author Simon André <smn.andre@gmail.com>
@@ -84,6 +88,63 @@ class DeferLiveComponentSubscriberTest extends TestCase
             [['foo']],
             ['false'],
         ];
+    }
+
+    public function testOnPreRenderUsesEventTemplateInsteadOfMetadataTemplate()
+    {
+        $subscriber = new DeferLiveComponentSubscriber();
+
+        $metadata = new ComponentMetadata(['template' => 'original_metadata_template.html.twig']);
+
+        $escaper = new EscaperRuntime();
+        $attributes = new ComponentAttributes([], $escaper);
+
+        $mountedComponent = new MountedComponent(
+            'test_component',
+            $metadata,
+            $attributes,
+            [],
+            ['loading' => 'lazy']
+        );
+
+        $event = new PreRenderEvent($mountedComponent, $metadata, ['existing_var' => 'value']);
+
+        $event->setTemplate('dynamically_changed_template.html.twig');
+
+        $subscriber->onPreRender($event);
+
+        $this->assertSame('@LiveComponent/deferred.html.twig', $event->getTemplate());
+
+        $variables = $event->getVariables();
+        $this->assertArrayHasKey('componentTemplate', $variables);
+        $this->assertSame('dynamically_changed_template.html.twig', $variables['componentTemplate']);
+
+        $this->assertSame('lazy', $variables['loading']);
+        $this->assertSame('value', $variables['existing_var']);
+    }
+
+    public function testOnPreRenderDoesNothingWhenNoLoadingMetadata()
+    {
+        $subscriber = new DeferLiveComponentSubscriber();
+
+        $metadata = new ComponentMetadata(['template' => 'original_template.html.twig']);
+
+        $escaper = new EscaperRuntime();
+        $attributes = new ComponentAttributes([], $escaper);
+
+        $mountedComponent = new MountedComponent(
+            'test_component',
+            $metadata,
+            $attributes,
+            [],
+            []
+        );
+
+        $event = new PreRenderEvent($mountedComponent, $metadata, []);
+
+        $subscriber->onPreRender($event);
+
+        $this->assertSame('original_template.html.twig', $event->getTemplate());
     }
 
     private function createPostMountEvent(array $data): PostMountEvent


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

### Bug Description
When using a dynamic template in a `LiveComponent` (via `FromMethod`) along with a `loading` attribute (e.g., `loading="defer"` or `loading="lazy"`), the dynamic template path was being ignored and replaced by the default static template defined in the metadata.

### Root Cause
In `DeferLiveComponentSubscriber::onPreRender()`, the subscriber was fetching the template path directly from the component's metadata using `$event->getMetadata()->getTemplate()`. 

However, `PreRenderEvent` already resolves the dynamic template in its constructor and stores it. By calling the metadata directly, the subscriber was bypassing the resolved dynamic template and falling back to the static one.

### Solution
Updated `DeferLiveComponentSubscriber` to use `$event->getTemplate()` instead of `$event->getMetadata()->getTemplate()`. This ensures that if a dynamic template is resolved via a method, it is correctly passed to the deferred template variables.

This fix can also be applied to the previous `2.x version.`