### PR TITLE
 feat(toolkit): add MultiSelect component for shadcn kit

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.1
 
+- [Shadcn] Add `multi-select` recipe
 - [Flowbite] Add `avatar` recipe
 - [Flowbite] Add `dropdown` recipe
 - [Shadcn] Add `hover-card` recipe

--- a/src/Toolkit/kits/shadcn/multi-select/assets/controllers/multi_select_controller.js
+++ b/src/Toolkit/kits/shadcn/multi-select/assets/controllers/multi_select_controller.js
@@ -1,0 +1,109 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['trigger', 'dropdown', 'option', 'badgeContainer', 'placeholder', 'input'];
+    static values = {
+        open: { type: Boolean, default: false },
+    };
+
+    /** @type {Map<string, string>} */
+    #selected = new Map();
+
+    openValueChanged() {
+        this.dropdownTarget.classList.toggle('hidden', !this.openValue);
+        this.triggerTarget.setAttribute('aria-expanded', String(this.openValue));
+    }
+
+    toggle() {
+        this.openValue = !this.openValue;
+    }
+
+    /**
+     * @param {Event} event
+     */
+    toggleOption(event) {
+        const option = event.currentTarget;
+        const { value, label } = option.dataset;
+
+        if (this.#selected.has(value)) {
+            this.#selected.delete(value);
+            option.setAttribute('aria-selected', 'false');
+            option.querySelector('[data-checked]')?.removeAttribute('data-checked');
+        } else {
+            this.#selected.set(value, label);
+            option.setAttribute('aria-selected', 'true');
+            option.querySelector('[data-unchecked]')?.setAttribute('data-checked', '');
+        }
+
+        this.#renderBadges();
+        this.#syncInput();
+    }
+
+    /**
+     * @param {Event} event
+     */
+    removeOption(event) {
+        event.stopPropagation();
+        const { value } = event.currentTarget.dataset;
+        this.#selected.delete(value);
+
+        const option = this.optionTargets.find((o) => o.dataset.value === value);
+        if (option) {
+            option.setAttribute('aria-selected', 'false');
+            option.querySelector('[data-checked]')?.removeAttribute('data-checked');
+        }
+
+        this.#renderBadges();
+        this.#syncInput();
+    }
+
+    /**
+     * @param {MouseEvent} event
+     */
+    closeOnOutside(event) {
+        if (!this.element.contains(event.target)) {
+            this.openValue = false;
+        }
+    }
+
+    #renderBadges() {
+        const container = this.badgeContainerTarget;
+
+        container.querySelectorAll('[data-badge]').forEach((el) => el.remove());
+
+        if (this.#selected.size === 0) {
+            this.placeholderTarget.classList.remove('hidden');
+            return;
+        }
+
+        this.placeholderTarget.classList.add('hidden');
+
+        for (const [value, label] of this.#selected) {
+            const badge = document.createElement('span');
+            badge.dataset.badge = '';
+            badge.className =
+                'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium bg-primary text-primary-foreground';
+            badge.innerHTML =
+                `${label}` +
+                `<button type="button" data-action="click->multi-select#removeOption" data-value="${value}" ` +
+                `class="ml-0.5 rounded-full hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" ` +
+                `aria-label="Remove ${label}">` +
+                `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">` +
+                `<path d="M18 6 6 18"/><path d="m6 6 12 12"/>` +
+                `</svg></button>`;
+            container.insertBefore(badge, this.placeholderTarget);
+        }
+    }
+
+    #syncInput() {
+        const select = this.inputTarget;
+        select.innerHTML = '';
+        for (const [value, label] of this.#selected) {
+            const option = document.createElement('option');
+            option.value = value;
+            option.text = label;
+            option.selected = true;
+            select.appendChild(option);
+        }
+    }
+}

--- a/src/Toolkit/kits/shadcn/multi-select/examples/Demo.html.twig
+++ b/src/Toolkit/kits/shadcn/multi-select/examples/Demo.html.twig
@@ -1,0 +1,7 @@
+<twig:MultiSelect name="fruits" placeholder="Select fruits..." class="max-w-xs">
+    <twig:MultiSelect:Option value="apple" label="Apple" />
+    <twig:MultiSelect:Option value="banana" label="Banana" />
+    <twig:MultiSelect:Option value="blueberry" label="Blueberry" />
+    <twig:MultiSelect:Option value="grapes" label="Grapes" />
+    <twig:MultiSelect:Option value="pineapple" label="Pineapple" />
+</twig:MultiSelect>

--- a/src/Toolkit/kits/shadcn/multi-select/examples/Usage.html.twig
+++ b/src/Toolkit/kits/shadcn/multi-select/examples/Usage.html.twig
@@ -1,0 +1,5 @@
+<twig:MultiSelect name="tags" placeholder="Select tags...">
+    <twig:MultiSelect:Option value="1" label="Option 1" />
+    <twig:MultiSelect:Option value="2" label="Option 2" />
+    <twig:MultiSelect:Option value="3" label="Option 3" />
+</twig:MultiSelect>

--- a/src/Toolkit/kits/shadcn/multi-select/manifest.json
+++ b/src/Toolkit/kits/shadcn/multi-select/manifest.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "MultiSelect",
+    "description": "A select control that allows choosing multiple options, displaying selections as removable badges.",
+    "copy-files": {
+        "assets/": "assets/",
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": [
+            "twig/extra-bundle",
+            "twig/html-extra:^3.12.0",
+            "tales-from-a-dev/twig-tailwind-extra:^1.0.0"
+        ]
+    }
+}

--- a/src/Toolkit/kits/shadcn/multi-select/templates/components/MultiSelect.html.twig
+++ b/src/Toolkit/kits/shadcn/multi-select/templates/components/MultiSelect.html.twig
@@ -1,0 +1,45 @@
+{# @prop placeholder string Placeholder text shown when no options are selected. Defaults to `'Select options...'` #}
+{# @prop name string The name attribute for form submission #}
+{# @prop disabled boolean Whether the component is disabled. Defaults to `false` #}
+{# @block content The selectable options, typically multiple `MultiSelect:Option` components #}
+{%- props placeholder = 'Select options...', name = '', disabled = false -%}
+<div
+    class="{{ ('relative w-full ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.defaults({
+        'data-controller': 'multi-select',
+        'data-action': 'click@window->multi-select#closeOnOutside',
+    }).without('class') }}
+>
+    <button
+        type="button"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        {% if disabled %}disabled{% endif %}
+        data-multi-select-target="trigger"
+        data-action="click->multi-select#toggle"
+        class="flex min-h-10 w-full items-center gap-1 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+        <span class="flex flex-1 flex-wrap gap-1 items-center" data-multi-select-target="badgeContainer">
+            <span class="text-muted-foreground" data-multi-select-target="placeholder">{{ placeholder }}</span>
+        </span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="ml-2 shrink-0 opacity-50" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+    </button>
+
+    <div
+        role="listbox"
+        aria-multiselectable="true"
+        data-multi-select-target="dropdown"
+        class="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md hidden"
+    >
+        {%- block content %}{% endblock -%}
+    </div>
+
+    <select
+        multiple
+        name="{{ name }}"
+        tabindex="-1"
+        aria-hidden="true"
+        data-multi-select-target="input"
+        class="sr-only"
+    ></select>
+</div>

--- a/src/Toolkit/kits/shadcn/multi-select/templates/components/MultiSelect/Option.html.twig
+++ b/src/Toolkit/kits/shadcn/multi-select/templates/components/MultiSelect/Option.html.twig
@@ -1,0 +1,22 @@
+{# @prop value string The value submitted with the form #}
+{# @prop label string The human-readable label displayed in the dropdown and as a badge #}
+{%- props value = '', label = '' -%}
+<div
+    role="option"
+    aria-selected="false"
+    data-value="{{ value }}"
+    data-label="{{ label }}"
+    data-multi-select-target="option"
+    data-action="click->multi-select#toggleOption"
+    class="{{ ('relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.without('class') }}
+>
+    <span
+        class="mr-2 flex h-4 w-4 items-center justify-center text-primary opacity-0 [[aria-selected=true]>&]:opacity-100"
+        data-unchecked
+        aria-hidden="true"
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+    </span>
+    {{ label }}
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component multi-select, code file Demo.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component multi-select, code file Demo.html.twig__1.html
@@ -1,0 +1,62 @@
+<!--
+- Kit: Shadcn UI
+- Component: MultiSelect
+- Code:
+```twig
+<twig:MultiSelect name="fruits" placeholder="Select fruits..." class="max-w-xs">
+    <twig:MultiSelect:Option value="apple" label="Apple" />
+    <twig:MultiSelect:Option value="banana" label="Banana" />
+    <twig:MultiSelect:Option value="blueberry" label="Blueberry" />
+    <twig:MultiSelect:Option value="grapes" label="Grapes" />
+    <twig:MultiSelect:Option value="pineapple" label="Pineapple" />
+</twig:MultiSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="relative w-full max-w-xs" data-controller="multi-select" data-action="click@window-&gt;multi-select#closeOnOutside">
+    <button type="button" aria-expanded="false" aria-haspopup="listbox" data-multi-select-target="trigger" data-action="click-&gt;multi-select#toggle" class="flex min-h-10 w-full items-center gap-1 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50">
+        <span class="flex flex-1 flex-wrap gap-1 items-center" data-multi-select-target="badgeContainer">
+            <span class="text-muted-foreground" data-multi-select-target="placeholder">Select fruits...</span>
+        </span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="ml-2 shrink-0 opacity-50" aria-hidden="true"><path d="m6 9 6 6 6-6"></path></svg>
+    </button>
+
+    <div role="listbox" aria-multiselectable="true" data-multi-select-target="dropdown" class="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md hidden">
+<div role="option" aria-selected="false" data-value="apple" data-label="Apple" data-multi-select-target="option" data-action="click-&gt;multi-select#toggleOption" class="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground">
+    <span class="mr-2 flex h-4 w-4 items-center justify-center text-primary opacity-0 [[aria-selected=true]&gt;&amp;]:opacity-100" data-unchecked aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+    </span>
+    Apple
+</div>
+
+    <div role="option" aria-selected="false" data-value="banana" data-label="Banana" data-multi-select-target="option" data-action="click-&gt;multi-select#toggleOption" class="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground">
+    <span class="mr-2 flex h-4 w-4 items-center justify-center text-primary opacity-0 [[aria-selected=true]&gt;&amp;]:opacity-100" data-unchecked aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+    </span>
+    Banana
+</div>
+
+    <div role="option" aria-selected="false" data-value="blueberry" data-label="Blueberry" data-multi-select-target="option" data-action="click-&gt;multi-select#toggleOption" class="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground">
+    <span class="mr-2 flex h-4 w-4 items-center justify-center text-primary opacity-0 [[aria-selected=true]&gt;&amp;]:opacity-100" data-unchecked aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+    </span>
+    Blueberry
+</div>
+
+    <div role="option" aria-selected="false" data-value="grapes" data-label="Grapes" data-multi-select-target="option" data-action="click-&gt;multi-select#toggleOption" class="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground">
+    <span class="mr-2 flex h-4 w-4 items-center justify-center text-primary opacity-0 [[aria-selected=true]&gt;&amp;]:opacity-100" data-unchecked aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+    </span>
+    Grapes
+</div>
+
+    <div role="option" aria-selected="false" data-value="pineapple" data-label="Pineapple" data-multi-select-target="option" data-action="click-&gt;multi-select#toggleOption" class="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground">
+    <span class="mr-2 flex h-4 w-4 items-center justify-center text-primary opacity-0 [[aria-selected=true]&gt;&amp;]:opacity-100" data-unchecked aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+    </span>
+    Pineapple
+</div>
+
+</div>
+
+    <select multiple name="fruits" tabindex="-1" aria-hidden="true" data-multi-select-target="input" class="sr-only"></select>
+</div>


### PR DESCRIPTION
Adds a multi-select component that displays selected options as removable badges, backed by a Stimulus controller and a hidden select multiple for standard form submission.

Relates to #3233

| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | #3233
| License        | MIT

Adds a `MultiSelect` component to the shadcn kit. Selected options are displayed as removable badges inside the trigger. A hidden `<select multiple>` handles standard Symfony form submission.

**Usage**                                                                               
```twig
<twig:MultiSelect name="fruits" placeholder="Select fruits...">
    <twig:MultiSelect:Option value="apple" label="Apple" />
    <twig:MultiSelect:Option value="banana" label="Banana" />
</twig:MultiSelect>