### PR TITLE
 Remove old "deprecated: 2.x" directives

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -16,9 +16,9 @@ rules:
     composer_dev_option_not_at_the_end: ~
     correct_code_block_directive_based_on_the_content: ~
     deprecated_directive_major_version:
-        major_version: 2
+        major_version: 3
     deprecated_directive_min_version:
-        min_version: '2.0'
+        min_version: '3.0'
     deprecated_directive_should_have_version: ~
     ensure_bash_prompt_before_composer_command: ~
     ensure_exactly_one_space_before_directive_type: ~

--- a/src/Map/doc/index.rst
+++ b/src/Map/doc/index.rst
@@ -581,12 +581,6 @@ abstraction limiting and need to configure low-level options directly.
 Fortunately, you can customize these low-level options through the UX Map
 events ``ux:map:*:before-create`` using the special ``bridgeOptions`` property:
 
-.. deprecated:: 2.27
-
-    The ``rawOptions`` property was deprecated in UX Map 2.27, and will be removed in 3.0.
-    Use ``bridgeOptions`` instead, which better reflect the purpose of these options (options that are
-    specific to the renderer bridge).
-
 .. code-block:: javascript
 
     // assets/controllers/mymap_controller.js


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | yes <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | 
| License        | MIT

Update doctor rst config and documentation for 3.x

Related to https://github.com/symfony/ux/pull/3505#issuecomment-4367083898