### PR TITLE
[TwigComponent] Fix PreLexer confusing `{#` inside output expressions with comments

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for dynamic component names in the HTML syntax using `<twig:component is="myComponent" ...`
 - Capture `## <description>` documentation comments written above props inside `{% props %}` (Twig 3.29+), exposed per prop via `PropsNode::getPropDocumentation()`
 - Fix `{% props %}` treating a prop explicitly passed as `null` as missing: a required prop no longer throws, and a prop declaring a default value now keeps the `null` it was given
+- Fix the pre-lexer treating a `{#` inside a `{{ ... }}` expression as the start of a Twig comment, which silently stopped every component after it from being rendered
 - Fix HTML/`{% component %}` syntax failing when a prop uses the null-safe operator (`?.`)
 
 ## 3.4.0

--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -70,6 +70,31 @@ class TwigPreLexer
                 }
             }
 
+            // ignore content inside twig output expressions, see #3514
+            // (so that e.g. `{{ '{# foo #}' }}` doesn't trip the comment handler above)
+            if ($this->check('{{')) {
+                // a Twig expression is content: open the default block if we're inside a component
+                if (!empty($this->currentComponents)
+                    && !$this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock']
+                ) {
+                    $output .= '{% block content %}';
+                    $this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock'] = true;
+                }
+
+                $this->consume('{{');
+                $output .= '{{';
+                $output .= $this->consumeTwigExpressionContent();
+                if ($this->consume('}}')) {
+                    $output .= '}}';
+                }
+
+                if ($this->position === $this->length) {
+                    break;
+                }
+
+                continue;
+            }
+
             if ($this->consume('{% embed')) {
                 $inTwigEmbed = true;
                 $output .= '{% embed';
@@ -452,6 +477,66 @@ class TwigPreLexer
         }
 
         return substr($this->input, $start, $this->position - $start);
+    }
+
+    /**
+     * Consumes the body of a Twig output expression (between `{{` and `}}`),
+     * respecting string literals so that `}}` appearing inside a string does
+     * not end the expression early.
+     */
+    private function consumeTwigExpressionContent(): string
+    {
+        $start = $this->position;
+
+        while ($this->position < $this->length) {
+            if ($this->check('}}')) {
+                return substr($this->input, $start, $this->position - $start);
+            }
+
+            $char = $this->input[$this->position];
+
+            if ("'" === $char || '"' === $char) {
+                $this->skipStringLiteral($char);
+                continue;
+            }
+
+            if ("\n" === $char) {
+                ++$this->line;
+            }
+
+            ++$this->position;
+        }
+
+        return substr($this->input, $start);
+    }
+
+    private function skipStringLiteral(string $quote): void
+    {
+        ++$this->position; // opening quote
+
+        while ($this->position < $this->length) {
+            $char = $this->input[$this->position];
+
+            if ('\\' === $char && $this->position + 1 < $this->length) {
+                if ("\n" === $this->input[$this->position + 1]) {
+                    ++$this->line;
+                }
+                $this->position += 2;
+                continue;
+            }
+
+            if ($char === $quote) {
+                ++$this->position;
+
+                return;
+            }
+
+            if ("\n" === $char) {
+                ++$this->line;
+            }
+
+            ++$this->position;
+        }
     }
 
     private function consumeAttributeValue(string $quote): string

--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -76,6 +76,31 @@ class TwigPreLexer
                 }
             }
 
+            // ignore content inside twig output expressions, see #3514
+            // (so that e.g. `{{ '{# foo #}' }}` doesn't trip the comment handler above)
+            if ($this->check('{{')) {
+                // a Twig expression is content: open the default block if we're inside a component
+                if (!empty($this->currentComponents)
+                    && !$this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock']
+                ) {
+                    $output .= '{% block content %}';
+                    $this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock'] = true;
+                }
+
+                $this->consume('{{');
+                $output .= '{{';
+                $output .= $this->consumeTwigExpressionContent();
+                if ($this->consume('}}')) {
+                    $output .= '}}';
+                }
+
+                if ($this->position === $this->length) {
+                    break;
+                }
+
+                continue;
+            }
+
             if ($this->consume('{% embed')) {
                 $inTwigEmbed = true;
                 $output .= '{% embed';
@@ -563,6 +588,66 @@ class TwigPreLexer
         }
 
         return substr($this->input, $start, $this->position - $start);
+    }
+
+    /**
+     * Consumes the body of a Twig output expression (between `{{` and `}}`),
+     * respecting string literals so that `}}` appearing inside a string does
+     * not end the expression early.
+     */
+    private function consumeTwigExpressionContent(): string
+    {
+        $start = $this->position;
+
+        while ($this->position < $this->length) {
+            if ($this->check('}}')) {
+                return substr($this->input, $start, $this->position - $start);
+            }
+
+            $char = $this->input[$this->position];
+
+            if ("'" === $char || '"' === $char) {
+                $this->skipStringLiteral($char);
+                continue;
+            }
+
+            if ("\n" === $char) {
+                ++$this->line;
+            }
+
+            ++$this->position;
+        }
+
+        return substr($this->input, $start);
+    }
+
+    private function skipStringLiteral(string $quote): void
+    {
+        ++$this->position; // opening quote
+
+        while ($this->position < $this->length) {
+            $char = $this->input[$this->position];
+
+            if ('\\' === $char && $this->position + 1 < $this->length) {
+                if ("\n" === $this->input[$this->position + 1]) {
+                    ++$this->line;
+                }
+                $this->position += 2;
+                continue;
+            }
+
+            if ($char === $quote) {
+                ++$this->position;
+
+                return;
+            }
+
+            if ("\n" === $char) {
+                ++$this->line;
+            }
+
+            ++$this->position;
+        }
     }
 
     private function consumeAttributeValue(string $quote): string

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -351,6 +351,31 @@ final class TwigPreLexerTest extends TestCase
             '{% verbatim %}<twig:Alert/>{% endverbatim %}',
         ];
 
+        yield 'ignore_comment_like_token_inside_output_expression' => [
+            "There are {{ '{count, plural, one {# item} other {# items}}'|trans({'count': 42}) }}!\n<twig:Alert/>",
+            "There are {{ '{count, plural, one {# item} other {# items}}'|trans({'count': 42}) }}!\n{{ component('Alert') }}",
+        ];
+
+        yield 'ignore_double_close_inside_string_in_output_expression' => [
+            '{{ "}}" }} <twig:Alert/>',
+            '{{ "}}" }} {{ component(\'Alert\') }}',
+        ];
+
+        yield 'ignore_comment_like_token_inside_double_quoted_string' => [
+            '{{ "{# not a comment #}" }} <twig:Alert/>',
+            '{{ "{# not a comment #}" }} {{ component(\'Alert\') }}',
+        ];
+
+        yield 'preserve_escaped_quote_inside_output_expression' => [
+            "{{ 'it\\'s }}' }} <twig:Alert/>",
+            "{{ 'it\\'s }}' }} {{ component('Alert') }}",
+        ];
+
+        yield 'output_expression_inside_component_opens_default_block' => [
+            '<twig:Foo>{{ bar }}</twig:Foo>',
+            "{% component 'Foo' %}{% block content %}{{ bar }}{% endblock %}{% endcomponent %}",
+        ];
+
         yield 'component_attr_spreading_self_closing' => [
             '<twig:foobar bar="baz"{{...attr}}/>',
             '{{ component(\'foobar\', { bar: \'baz\', ...attr }) }}',

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -449,6 +449,31 @@ final class TwigPreLexerTest extends TestCase
             '{% component \'foo\' %}{% block content %}a{% verbatim %}<twig:Alert/>{% endverbatim %}{% endblock %}{% endcomponent %}',
         ];
 
+        yield 'ignore_comment_like_token_inside_output_expression' => [
+            "There are {{ '{count, plural, one {# item} other {# items}}'|trans({'count': 42}) }}!\n<twig:Alert/>",
+            "There are {{ '{count, plural, one {# item} other {# items}}'|trans({'count': 42}) }}!\n{{ component('Alert') }}",
+        ];
+
+        yield 'ignore_double_close_inside_string_in_output_expression' => [
+            '{{ "}}" }} <twig:Alert/>',
+            '{{ "}}" }} {{ component(\'Alert\') }}',
+        ];
+
+        yield 'ignore_comment_like_token_inside_double_quoted_string' => [
+            '{{ "{# not a comment #}" }} <twig:Alert/>',
+            '{{ "{# not a comment #}" }} {{ component(\'Alert\') }}',
+        ];
+
+        yield 'preserve_escaped_quote_inside_output_expression' => [
+            "{{ 'it\\'s }}' }} <twig:Alert/>",
+            "{{ 'it\\'s }}' }} {{ component('Alert') }}",
+        ];
+
+        yield 'output_expression_inside_component_opens_default_block' => [
+            '<twig:Foo>{{ bar }}</twig:Foo>',
+            "{% component 'Foo' %}{% block content %}{{ bar }}{% endblock %}{% endcomponent %}",
+        ];
+
         yield 'component_attr_spreading_self_closing' => [
             '<twig:foobar bar="baz"{{...attr}}/>',
             '{{ component(\'foobar\', { bar: \'baz\', ...attr }) }}',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #3514
| License       | MIT

The `TwigPreLexer` was treating any `{#` it encountered as the opening of a Twig comment, even when that `{#` actually lived inside a Twig output expression (e.g. inside a string literal passed to `|trans`). When the matching `#}` was missing — typically the case for ICU MessageFormat plural strings like `{count, plural, one {# item} other {# items}}` — the lexer consumed the rest of the template as a fake comment, swallowing any `<twig:…>` tags after it.

This PR adds a top-level handler for `{{ … }}` in the PreLexer's main loop. The new helper `consumeTwigExpressionContent()` walks the expression body with string-literal awareness (single quotes, double quotes, `\\`-escapes), so that `}}` or `{#` appearing inside a string don't end the expression early or trigger comment mode. The implicit `{% block content %}` injection still kicks in when the expression appears as content inside a component.

5 regression tests added covering:
- the original ICU plural example from the issue
- `}}` inside a string literal in `{{ … }}`
- `{#…#}` inside a double-quoted string
- escaped quotes inside the expression
- `{{ … }}` inside a component (default-block injection)

Marking as draft pending @Kocal's input on the scope question raised in #3514: should this same protection be extended to `{% … %}` (where `{% set foo = '{# bar #}' %}` has the same latent issue), or kept focused on `{{ … }}` ?