### PR TITLE
 Revert "Stop publishing extra package minor versions with no changes"

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -20,8 +20,5 @@
         "ux-turbo": "src/Turbo",
         "ux-twig-component": "src/TwigComponent",
         "ux-vue": "src/Vue"
-    },
-    "defaults": {
-        "tag_skip": "minor"
     }
 }


### PR DESCRIPTION
Reverts symfony/ux#3516. As seen together, the easiest way to deal with our NPM releases issue it to revert the PR.

Close #3517.