### PR TITLE
[Toolkit][Shadcn] Rework `alert-dialog` recipe to use `provide()`/`inject()`

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [Shadcn] Add `hover-card` recipe
 - [Shadcn] Add `resizable` recipe
 - [Shadcn] Rework `accordion` recipe to use `provide()`/`inject()`
+- [Shadcn] Rework `alert-dialog` recipe to use `provide()`/`inject()`
 - [Shadcn] Rework `dialog` recipe to use `provide()`/`inject()`
 - [Shadcn] Rework `toggle-group` recipe to use `provide()`/`inject()`
 - [Shadcn] Rework `tabs` recipe to use `provide()`/`inject()`

--- a/src/Toolkit/kits/shadcn/alert-dialog/manifest.json
+++ b/src/Toolkit/kits/shadcn/alert-dialog/manifest.json
@@ -13,7 +13,7 @@
             "twig/extra-bundle",
             "twig/html-extra:^3.24.0",
             "tales-from-a-dev/twig-tailwind-extra:^1.0.0",
-            "symfony/ux-twig-component:^2.35"
+            "symfony/ux-twig-component:^3.1"
         ]
     }
 }

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog.html.twig
@@ -3,14 +3,17 @@
 {# @block content The dialog structure, typically includes `AlertDialog:Trigger` and `AlertDialog:Content` #}
 {%- props id, open = false -%}
 
-{%- set _alert_dialog_id = 'alert-dialog-' ~ id -%}
-{%- set _alert_dialog_title_id = _alert_dialog_id ~ '-title' -%}
-{%- set _alert_dialog_description_id = _alert_dialog_id ~ '-description' -%}
+{%- set _alertDialog_id = 'alert-dialog-' ~ id -%}
+{%- set _alertDialog_titleId = _alertDialog_id ~ '-title' -%}
+{%- set _alertDialog_descriptionId = _alertDialog_id ~ '-description' -%}
+{%- do provide('alertDialog.id', _alertDialog_id) -%}
+{%- do provide('alertDialog.titleId', _alertDialog_titleId) -%}
+{%- do provide('alertDialog.descriptionId', _alertDialog_descriptionId) -%}
 <div {{ attributes.defaults({
     'data-controller': 'alert-dialog',
     'data-alert-dialog-open-value': open,
-    'aria-labelledby': _alert_dialog_title_id,
-    'aria-describedby': _alert_dialog_description_id,
+    'aria-labelledby': _alertDialog_titleId,
+    'aria-describedby': _alertDialog_descriptionId,
 }) }}>
     {% block content %}{% endblock %}
 </div>

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Content.html.twig
@@ -1,6 +1,7 @@
 {# @block content The dialog content, typically includes `AlertDialog:Header` and `AlertDialog:Footer` #}
+{%- set _alertDialog_id = inject('alertDialog.id') -%}
 <dialog
-    id="{{ _alert_dialog_id }}"
+    id="{{ _alertDialog_id }}"
     class="{{ ('text-foreground bg-background fixed top-[50%] left-[50%] z-50 max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] scale-95 gap-4 rounded-lg border p-6 opacity-0 shadow-lg transition-all transition-discrete duration-200 backdrop:transition-discrete backdrop:duration-150 open:grid open:scale-100 open:opacity-100 open:backdrop:bg-black/50 sm:max-w-lg starting:open:scale-95 starting:open:opacity-0 ' ~ attributes.render('class'))|tailwind_merge }}"
     data-alert-dialog-target="dialog"
     data-action="keydown.esc->alert-dialog#close:prevent"

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Description.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Description.html.twig
@@ -1,6 +1,7 @@
 {# @block content The descriptive text explaining the alert dialog purpose #}
+{%- set _alertDialog_descriptionId = inject('alertDialog.descriptionId') -%}
 <p
-    id="{{ _alert_dialog_description_id }}"
+    id="{{ _alertDialog_descriptionId }}"
     class="{{ ('text-muted-foreground text-sm ' ~ attributes.render('class'))|tailwind_merge }}"
     {{ attributes.without('id') }}
 >

--- a/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Title.html.twig
+++ b/src/Toolkit/kits/shadcn/alert-dialog/templates/components/AlertDialog/Title.html.twig
@@ -1,6 +1,7 @@
 {# @block content The title text of the alert dialog #}
+{%- set _alertDialog_titleId = inject('alertDialog.titleId') -%}
 <h2
-    id="{{ _alert_dialog_title_id }}"
+    id="{{ _alertDialog_titleId }}"
     class="{{ ('text-lg font-semibold ' ~ attributes.render('class'))|tailwind_merge }}"
     {{ attributes.without('id') }}
 >


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Following #3512
