### PR TITLE
[Toolkit] Add `version-added` key in toolkit manifest

### DIFF
--- a/src/Toolkit/schema-kit-recipe-v1.json
+++ b/src/Toolkit/schema-kit-recipe-v1.json
@@ -18,6 +18,10 @@
             "description": "A brief description of the Recipe",
             "type": "string"
         },
+        "version-added": {
+            "type": "string",
+            "description": "The version of Symfony UX Toolkit in which this Recipe was added, e.g., '2.35'"
+        },
         "copy-files": {
             "description": "Relative files or directories to copy into the project",
             "type": "object"

--- a/src/Toolkit/src/Recipe/RecipeManifest.php
+++ b/src/Toolkit/src/Recipe/RecipeManifest.php
@@ -31,6 +31,7 @@ final class RecipeManifest
      * @param non-empty-string                          $description
      * @param array<non-empty-string, non-empty-string> $copyFiles
      * @param list<DependencyInterface>                 $dependencies
+     * @param ?non-empty-string                         $versionAdded
      */
     public function __construct(
         public readonly RecipeType $type,
@@ -38,6 +39,7 @@ final class RecipeManifest
         public readonly string $description,
         public readonly array $copyFiles,
         public readonly array $dependencies = [],
+        public readonly ?string $versionAdded = null,
     ) {
         foreach ($this->copyFiles as $source => $destination) {
             if (!Path::isRelative($source)) {
@@ -125,12 +127,18 @@ final class RecipeManifest
             }
         }
 
+        $versionAdded = $data['version-added'] ?? null;
+        if (null !== $versionAdded && (!\is_string($versionAdded) || '' === $versionAdded)) {
+            throw new \InvalidArgumentException('The "version-added" property must be a non-empty string.');
+        }
+
         return new self(
             type: $type,
             name: $data['name'] ?? throw new \InvalidArgumentException('Property "name" is required.'),
             description: $data['description'] ?? throw new \InvalidArgumentException('Property "description" is required.'),
             copyFiles: $data['copy-files'] ?? [],
             dependencies: $dependencies,
+            versionAdded: $versionAdded,
         );
     }
 }

--- a/src/Toolkit/tests/Recipe/RecipeManifestTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeManifestTest.php
@@ -179,6 +179,24 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
+    public function testFromJsonWithInvalidVersionAdded()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "version-added" property must be a non-empty string.');
+
+        RecipeManifest::fromJson(<<<JSON
+                {
+                    "type": "component",
+                    "name": "MyComponent",
+                    "description": "An incredible component",
+                    "version-added": "",
+                    "copy-files": {
+                        "templates/": "templates/"
+                    }
+                }
+            JSON);
+    }
+
     public function testFromJsonWithMinimumValidData()
     {
         $manifest = RecipeManifest::fromJson(<<<JSON
@@ -197,6 +215,7 @@ final class RecipeManifestTest extends TestCase
         $this->assertSame('An incredible component', $manifest->description);
         $this->assertSame(['templates/' => 'templates/'], $manifest->copyFiles);
         $this->assertEquals([], $manifest->dependencies);
+        $this->assertNull($manifest->versionAdded);
     }
 
     public function testFromJsonWithValidData()
@@ -206,6 +225,7 @@ final class RecipeManifestTest extends TestCase
                     "type": "component",
                     "name": "MyComponent",
                     "description": "An incredible component",
+                    "version-added": "2.35",
                     "copy-files": {
                         "templates/": "templates/"
                     },
@@ -232,6 +252,7 @@ final class RecipeManifestTest extends TestCase
         $this->assertSame(RecipeType::Component, $manifest->type);
         $this->assertSame('MyComponent', $manifest->name);
         $this->assertSame('An incredible component', $manifest->description);
+        $this->assertSame('2.35', $manifest->versionAdded);
         $this->assertSame(['templates/' => 'templates/'], $manifest->copyFiles);
         $this->assertEquals([
             new RecipeDependency('OtherComponent'),


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Fix #3509 
| License        | MIT

Allow a new `version-added` key in Toolkit manifest to add it in documentation
I make it `nullable` cause I think for components which exists for a long time this information is less important. And it allow us to not add it for all components right now 