### PR TITLE
[Toolkit] Add `added-in-version` property to Recipe manifests

### DIFF
--- a/src/Toolkit/schema-kit-recipe-v1.json
+++ b/src/Toolkit/schema-kit-recipe-v1.json
@@ -18,6 +18,10 @@
             "description": "A brief description of the Recipe",
             "type": "string"
         },
+        "added-in-version": {
+            "type": "string",
+            "description": "The first UX Toolkit version in which this Recipe was made available, e.g., '2.35'"
+        },
         "copy-files": {
             "description": "Relative files or directories to copy into the project",
             "type": "object"

--- a/src/Toolkit/src/Recipe/RecipeManifest.php
+++ b/src/Toolkit/src/Recipe/RecipeManifest.php
@@ -31,6 +31,7 @@ final class RecipeManifest
      * @param non-empty-string                          $description
      * @param array<non-empty-string, non-empty-string> $copyFiles
      * @param list<DependencyInterface>                 $dependencies
+     * @param non-empty-string|null                     $addedInVersion The first UX Toolkit version in which this Recipe was made available
      */
     public function __construct(
         public readonly RecipeType $type,
@@ -38,6 +39,7 @@ final class RecipeManifest
         public readonly string $description,
         public readonly array $copyFiles,
         public readonly array $dependencies = [],
+        public readonly ?string $addedInVersion = null,
     ) {
         foreach ($this->copyFiles as $source => $destination) {
             if (!Path::isRelative($source)) {
@@ -125,12 +127,18 @@ final class RecipeManifest
             }
         }
 
+        $addedInVersion = $data['added-in-version'] ?? null;
+        if (null !== $addedInVersion && (!\is_string($addedInVersion) || '' === $addedInVersion)) {
+            throw new \InvalidArgumentException('The "added-in-version" property must be a non-empty string.');
+        }
+
         return new self(
             type: $type,
             name: $data['name'] ?? throw new \InvalidArgumentException('Property "name" is required.'),
             description: $data['description'] ?? throw new \InvalidArgumentException('Property "description" is required.'),
             copyFiles: $data['copy-files'] ?? [],
             dependencies: $dependencies,
+            addedInVersion: $addedInVersion,
         );
     }
 }

--- a/src/Toolkit/tests/Recipe/RecipeManifestTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeManifestTest.php
@@ -199,6 +199,51 @@ final class RecipeManifestTest extends TestCase
         $this->assertSame('An incredible component', $manifest->description);
         $this->assertSame(['templates/' => 'templates/'], $manifest->copyFiles);
         $this->assertEquals([], $manifest->dependencies);
+        $this->assertNull($manifest->addedInVersion);
+    }
+
+    public function testFromJsonWithAddedInVersion()
+    {
+        $manifest = RecipeManifest::fromJson(<<<JSON
+                {
+                    "type": "component",
+                    "name": "MyComponent",
+                    "description": "An incredible component",
+                    "added-in-version": "2.35"
+                }
+            JSON);
+
+        $this->assertSame('2.35', $manifest->addedInVersion);
+    }
+
+    public function testFromJsonWithEmptyAddedInVersion()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "added-in-version" property must be a non-empty string.');
+
+        RecipeManifest::fromJson(<<<JSON
+                {
+                    "type": "component",
+                    "name": "MyComponent",
+                    "description": "An incredible component",
+                    "added-in-version": ""
+                }
+            JSON);
+    }
+
+    public function testFromJsonWithNonStringAddedInVersion()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "added-in-version" property must be a non-empty string.');
+
+        RecipeManifest::fromJson(<<<JSON
+                {
+                    "type": "component",
+                    "name": "MyComponent",
+                    "description": "An incredible component",
+                    "added-in-version": 235
+                }
+            JSON);
     }
 
     public function testFromJsonWithValidData()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | Refs #3509
| License       | MIT

Following @Kocal's suggestion in #3509, this PR introduces an optional `added-in-version` property in the Recipe manifest schema. It exposes the value as `RecipeManifest::$addedInVersion`, ready to be consumed by ux.symfony.com to advertise the minimum UX Toolkit version required for each recipe.

## Changes

- `schema-kit-recipe-v1.json`: declare the optional `added-in-version` property.
- `Recipe/RecipeManifest.php`: new constructor argument + parsing with validation (`null` or non-empty string).
- `Tests/Recipe/RecipeManifestTest.php`: three new tests (with value, with empty string, with non-string).

## Scope

Intentionally minimal. **Existing manifests are not touched** — the field is purely additive and they remain valid. The follow-up effort (populating `added-in-version` on the 51 existing recipes) is more delicate, since several recipes were renamed/restructured (e.g. #3107) and the introduction version doesn't always match the file's git creation date. That part is better driven by the maintainers who know the history, or split into smaller PRs per kit.

cc @Kocal — happy to take a stab at the manifest-population follow-up too once this foundation lands, if you'd like.
