### PR TITLE
[LiveComponent] Return StimulusAttributes from live_action() so it can be spread in a Twig component tag

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1
 
 - Use `aria-busy` attribute during component re-render
+- Return a `StimulusAttributes` object from the `live_action()` Twig function so it can be spread into a Twig component tag (`<twig:Foo {{ ...live_action('bar') }}>`), aligning its behavior with `stimulus_action()`.
 
 ## 3.0.0
 

--- a/src/LiveComponent/src/Twig/LiveComponentRuntime.php
+++ b/src/LiveComponent/src/Twig/LiveComponentRuntime.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\LiveComponent\Twig;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Metadata\LiveComponentMetadataFactory;
+use Symfony\UX\StimulusBundle\Dto\StimulusAttributes;
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
 use Symfony\UX\TwigComponent\ComponentFactory;
 
@@ -48,7 +49,7 @@ final class LiveComponentRuntime
         return $this->urlGenerator->generate($metadata->get('route'), $params, $metadata->get('url_reference_type'));
     }
 
-    public function liveAction(string $actionName, array $parameters = [], array $modifiers = [], ?string $event = null): string
+    public function liveAction(string $actionName, array $parameters = [], array $modifiers = [], ?string $event = null): StimulusAttributes
     {
         $attributes = $this->stimulusHelper->createStimulusAttributes();
 
@@ -70,6 +71,6 @@ final class LiveComponentRuntime
 
         $attributes->addAction('live', $name, $event, $parameters);
 
-        return (string) $attributes;
+        return $attributes;
     }
 }

--- a/src/LiveComponent/tests/Unit/Twig/LiveComponentRuntimeTest.php
+++ b/src/LiveComponent/tests/Unit/Twig/LiveComponentRuntimeTest.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\LiveComponent\Tests\Unit;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\LiveComponent\Twig\LiveComponentRuntime;
+use Symfony\UX\StimulusBundle\Dto\StimulusAttributes;
 
 final class LiveComponentRuntimeTest extends KernelTestCase
 {
@@ -22,21 +23,22 @@ final class LiveComponentRuntimeTest extends KernelTestCase
         \assert($runtime instanceof LiveComponentRuntime);
 
         $props = $runtime->liveAction('action-name');
-        $this->assertSame('data-action="live#action" data-live-action-param="action-name"', $props);
+        $this->assertInstanceOf(StimulusAttributes::class, $props);
+        $this->assertSame('data-action="live#action" data-live-action-param="action-name"', (string) $props);
 
         $props = $runtime->liveAction('action-name', ['prop1' => 'val1', 'someProp' => 'val2']);
-        $this->assertSame('data-action="live#action" data-live-prop1-param="val1" data-live-some-prop-param="val2" data-live-action-param="action-name"', $props);
+        $this->assertSame('data-action="live#action" data-live-prop1-param="val1" data-live-some-prop-param="val2" data-live-action-param="action-name"', (string) $props);
 
         $props = $runtime->liveAction('action-name', ['prop1' => 'val1', 'prop2' => 'val2'], ['debounce' => 300]);
-        $this->assertSame('data-action="live#action" data-live-prop1-param="val1" data-live-prop2-param="val2" data-live-action-param="debounce(300)|action-name"', $props);
+        $this->assertSame('data-action="live#action" data-live-prop1-param="val1" data-live-prop2-param="val2" data-live-action-param="debounce(300)|action-name"', (string) $props);
 
         $props = $runtime->liveAction('action-name:prevent', ['pro1' => 'val1', 'prop2' => 'val2'], ['debounce' => 300]);
-        $this->assertSame('data-action="live#action:prevent" data-live-pro1-param="val1" data-live-prop2-param="val2" data-live-action-param="debounce(300)|action-name"', $props);
+        $this->assertSame('data-action="live#action:prevent" data-live-pro1-param="val1" data-live-prop2-param="val2" data-live-action-param="debounce(300)|action-name"', (string) $props);
 
         $props = $runtime->liveAction('action-name:prevent', [], ['debounce' => 300]);
-        $this->assertSame('data-action="live#action:prevent" data-live-action-param="debounce(300)|action-name"', $props);
+        $this->assertSame('data-action="live#action:prevent" data-live-action-param="debounce(300)|action-name"', (string) $props);
 
         $props = $runtime->liveAction('action-name', [], [], 'keydown.esc');
-        $this->assertSame('data-action="keydown.esc->live#action" data-live-action-param="action-name"', $props);
+        $this->assertSame('data-action="keydown.esc->live#action" data-live-action-param="action-name"', (string) $props);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #3413
| License       | MIT

Today, `live_action()` casts its return value to a `string`, which prevents it from being spread into a Twig component tag:

```twig
{# ❌ doesn't work: the spread receives a plain string #}
<twig:Table:Head {{ ...live_action('sort', {sortBy: 'id'}) }}>
```

`stimulus_action()` already returns a `StimulusAttributes` object (which is both `\Stringable` and `\IteratorAggregate`), so the same call written against it does work. The asymmetry was [pointed out by @squrious](https://github.com/symfony/ux/issues/3413#issuecomment-4379725306) in the issue discussion.

This PR aligns `live_action()` with `stimulus_action()` by returning the same `StimulusAttributes` object directly. Existing usages remain unaffected because Twig calls `__toString()` automatically when rendering the value (e.g. `<button {{ live_action('save') }}>`), and the helper is marked `@internal` on the PHP side.

The existing `LiveComponentRuntimeTest::testGetLiveAction` is adapted to cast the value to string for the equality assertion and gains a new `assertInstanceOf` to lock the return type.