### PR TITLE
[Toolkit] Populate `version-added` on Flowbite 4 and recent Shadcn UI recipes

### DIFF
--- a/src/Toolkit/kits/flowbite-4/alert/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/alert/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Alert",
     "description": "The alert component can be used to provide information to your users such as success or error messages, but also highlighted information complementing the normal flow of paragraphs and headers on a page.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/avatar/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/avatar/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Avatar",
     "description": "Use the avatar component to show a visual representation of a user profile using an image element or SVG object based on multiple styles and sizes",
+    "version-added": "3.0",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/badge/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/badge/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Badge",
     "description": "The badge component can be used to complement other elements such as buttons or text elements as a label or to show the count of a given data, such as the number of comments for an article or how much time has passed by since a comment has been made.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/button-group/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/button-group/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Button Group",
     "description": "The button group component from Flowbite can be used to stack together multiple buttons and links inside a single element.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/button/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/button/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Button",
     "description": "Use the button component inside forms, as links, social login, payment options with support for multiple styles, colors, sizes, gradients, and shadows",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/card/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/card/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Card",
     "description": "Use these responsive card components to show data entries and information to your users in multiple forms and contexts such as for your blog, application, user profiles, and more.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/checkbox/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/checkbox/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Checkbox",
     "description": "The checkbox component can be used to receive one or more selected options from the user in the form of a square box available in multiple styles, sizes, colors, and variants coded with the utility classes from Tailwind CSS and with support for dark mode.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/dropdown/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/dropdown/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Dropdown",
     "description": "The dropdown component can be used to show a list of menu items when clicking on an element such as a button and hiding it when focusing outside of the triggering element.",
+    "version-added": "3.0",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/flowbite-4/indicator/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/indicator/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Indicator",
     "description": "Use the indicator component to show a number count, account status, or as a loading label positioned relative to the parent component coded with Tailwind CSS",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/input/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/input/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Input",
     "description": "The input field is an important part of the form element that can be used to create interactive controls to accept data from the user based on multiple input types, such as text, email, number, password, URL, phone number, and more.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/kbd/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/kbd/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Kbd",
     "description": "The KBD (Keyboard) component can be used to indicate a textual user input from the keyboard inside other elements such as in text, tables, cards, and more.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/label/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/label/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Label",
     "description": "A text element that identifies form controls and other content.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/modal/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/modal/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Modal",
     "description": "Use the modal component to show interactive dialogs and notifications to your website users available in multiple sizes, colors, and styles",
+    "version-added": "2.35",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/flowbite-4/pagination/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/pagination/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Pagination",
     "description": "Use the Tailwind CSS pagination element to indicate a series of content across various pages based on multiple styles and sizes",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/radio/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/radio/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Radio",
     "description": "The radio component can be used to allow the user to choose a single option from one or more available options coded with the utility classes from Tailwind CSS and available in multiple styles, variants, and colors and support dark mode.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/select/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/select/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Select",
     "description": "Get started with the select component to allow the user to choose from one or more options from a dropdown list based on multiple styles, sizes, and variants",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/skeleton/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/skeleton/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Skeleton",
     "description": "Use the skeleton component to indicate a loading status with placeholder elements that look very similar to the type of content that is being loaded such as paragraphs, heading, images, videos, and more.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/spinner/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/spinner/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Spinner",
     "description": "An indicator that can be used to show a loading state.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/table/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/table/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Table",
     "description": "Use the table component to show text, images, links, and other elements inside a structured set of data made up of rows and columns of table cells",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/tabs/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/tabs/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Tabs",
     "description": "Use the following default tabs component example to show a list of links that the user can navigate from on your website.",
+    "version-added": "2.35",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/flowbite-4/textarea/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/textarea/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Textarea",
     "description": "The textarea component is a multi-line text field input that can be used to receive longer chunks of text from the user in the form of a comment box, description field, and more.",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/flowbite-4/toggle/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/toggle/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Toggle",
     "description": "Use the toggle component to switch between a binary state of true or false using a single click available in multiple sizes, variants, and colors",
+    "version-added": "2.35",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/shadcn/accordion/manifest.json
+++ b/src/Toolkit/kits/shadcn/accordion/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Accordion",
     "description": "A vertically stacked set of interactive headings that each reveal a section of content.",
+    "version-added": "2.33",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/shadcn/collapsible/manifest.json
+++ b/src/Toolkit/kits/shadcn/collapsible/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Collapsible",
     "description": "An interactive component which expands and collapses a section of content.",
+    "version-added": "3.0",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/shadcn/hover-card/manifest.json
+++ b/src/Toolkit/kits/shadcn/hover-card/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Hover Card",
     "description": "A popup that displays rich content when a trigger is hovered.",
+    "version-added": "3.0",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/shadcn/radio-group/manifest.json
+++ b/src/Toolkit/kits/shadcn/radio-group/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Radio Group",
     "description": "A set of checkable buttons where no more than one of the buttons can be checked at a time.",
+    "version-added": "3.0",
     "copy-files": {
         "templates/": "templates/"
     },

--- a/src/Toolkit/kits/shadcn/resizable/manifest.json
+++ b/src/Toolkit/kits/shadcn/resizable/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Resizable",
     "description": "A split-pane layout with draggable handles to redistribute space between panels.",
+    "version-added": "3.0",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/shadcn/tabs/manifest.json
+++ b/src/Toolkit/kits/shadcn/tabs/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Tabs",
     "description": "A set of layered sections of content known as tab panels that are displayed one at a time.",
+    "version-added": "2.33",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/shadcn/toggle-group/manifest.json
+++ b/src/Toolkit/kits/shadcn/toggle-group/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Toggle Group",
     "description": "A set of two-state buttons that can be toggled on or off.",
+    "version-added": "3.0",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/shadcn/toggle/manifest.json
+++ b/src/Toolkit/kits/shadcn/toggle/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Toggle",
     "description": "A two-state button that can be either on or off.",
+    "version-added": "2.35",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/shadcn/tooltip/manifest.json
+++ b/src/Toolkit/kits/shadcn/tooltip/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Tooltip",
     "description": "A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.",
+    "version-added": "2.33",
     "copy-files": {
         "assets/": "assets/",
         "templates/": "templates/"

--- a/src/Toolkit/kits/shadcn/typography/manifest.json
+++ b/src/Toolkit/kits/shadcn/typography/manifest.json
@@ -3,6 +3,7 @@
     "type": "component",
     "name": "Typography",
     "description": "Styled HTML text elements for headings, paragraphs, quotes, lists and inline code.",
+    "version-added": "3.0",
     "copy-files": {
         "templates/": "templates/"
     },


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Issues         | Fix #3509
| License        | MIT

Follow-up to #3531 (which added the `version-added` schema entry): this populates the field for the most recent recipes, so [ux.symfony.com](https://ux.symfony.com) can surface the required Toolkit version to users — the original use case behind #3509.

Two commits, one per period, so the second can be dropped if reviewers prefer to wait for the 3.0 tag:

- `[Toolkit] Populate version-added for Flowbite 4 and recent Shadcn UI recipes` — 24 manifests:
  - `2.33` — `shadcn/{accordion,tabs,tooltip}`
  - `2.35` — `shadcn/toggle` + the 20 Flowbite 4 recipes released with 2.35 (`alert`, `badge`, `button`, `button-group`, `card`, `checkbox`, `indicator`, `input`, `kbd`, `label`, `modal`, `pagination`, `radio`, `select`, `skeleton`, `spinner`, `table`, `tabs`, `textarea`, `toggle`)
- `[Toolkit] Mark unreleased Flowbite 4 and Shadcn UI recipes as added in 3.0` — 8 manifests only present on `3.x`:
  - `flowbite-4/{avatar,dropdown}`
  - `shadcn/{collapsible,hover-card,radio-group,resizable,toggle-group,typography}`

Versions were determined by checking each recipe's presence at the corresponding git tag (e.g. `git ls-tree -r v2.33.0 -- src/Toolkit/kits/`), to avoid being misled by the 2.32 → 2.33 kits reshuffle (#3107) which would have made `git log --follow` unreliable.

Happy to split, narrow scope (e.g. drop the 3.0 commit until release), or change the version format (e.g. `2.35.0` instead of `2.35`) — whatever fits best!