### PR TITLE
[LiveComponent] added basic error rendering of fetch failure and added request:error hook

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -78,6 +78,9 @@ type ComponentHooks = {
   'response:error': (backendResponse: export_default$2, controls: {
     displayError: boolean;
   }) => MaybePromise;
+  'request:error': (error: any, requestConfig: any, controls: {
+    displayError: boolean;
+  }) => MaybePromise;
   'loading.state:started': (element: HTMLElement, request: export_default$1) => MaybePromise;
   'loading.state:finished': (element: HTMLElement) => MaybePromise;
   'model:set': (model: string, value: any, component: Component) => MaybePromise;

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -6,7 +6,7 @@ var BackendRequest_default = class {
 		this.promise.then((response) => {
 			this.isResolved = true;
 			return response;
-		});
+		}).catch(() => {});
 		this.actions = actions;
 		this.updatedModels = updateModels;
 	}
@@ -1532,6 +1532,15 @@ var Component = class {
 				this.performRequest();
 			}
 			return response;
+		}).catch((error) => {
+			const controls = { displayError: true };
+			this.hooks.triggerHook("request:error", error, requestConfig, controls);
+			if (controls.displayError) this.renderError(`<p>${error}</p>`);
+			this.backendRequest = null;
+			if (this.isRequestPending) {
+				this.isRequestPending = false;
+				this.performRequest();
+			}
 		});
 	}
 	processRerender(html, backendResponse) {

--- a/src/LiveComponent/assets/src/Backend/BackendRequest.ts
+++ b/src/LiveComponent/assets/src/Backend/BackendRequest.ts
@@ -6,11 +6,13 @@ export default class {
 
     constructor(promise: Promise<Response>, actions: string[], updateModels: string[]) {
         this.promise = promise;
-        this.promise.then((response) => {
-            this.isResolved = true;
+        this.promise
+            .then((response) => {
+                this.isResolved = true;
 
-            return response;
-        }).catch(() => {});
+                return response;
+            })
+            .catch(() => {});
 
         this.actions = actions;
         this.updatedModels = updateModels;

--- a/src/LiveComponent/assets/src/Backend/BackendRequest.ts
+++ b/src/LiveComponent/assets/src/Backend/BackendRequest.ts
@@ -10,7 +10,8 @@ export default class {
             this.isResolved = true;
 
             return response;
-        });
+        }).catch(() => {});
+
         this.actions = actions;
         this.updatedModels = updateModels;
     }

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -299,74 +299,76 @@ export default class Component {
         this.valueStore.flushDirtyPropsToPending();
         this.isRequestPending = false;
 
-        this.backendRequest.promise.then(async (response) => {
-            const backendResponse = new BackendResponse(response);
-            const html = await backendResponse.getBody();
+        this.backendRequest.promise
+            .then(async (response) => {
+                const backendResponse = new BackendResponse(response);
+                const html = await backendResponse.getBody();
 
-            // clear sent files inputs
-            for (const input of Object.values(this.pendingFiles)) {
-                input.value = '';
-            }
-
-            // if the response does not contain a component, render as an error
-            const headers = backendResponse.response.headers;
-            if (
-                !headers.get('Content-Type')?.includes('application/vnd.live-component+html') &&
-                !headers.get('X-Live-Redirect')
-            ) {
-                const controls = { displayError: true };
-                this.valueStore.pushPendingPropsBackToDirty();
-                this.hooks.triggerHook('response:error', backendResponse, controls);
-
-                if (controls.displayError) {
-                    this.renderError(html);
+                // clear sent files inputs
+                for (const input of Object.values(this.pendingFiles)) {
+                    input.value = '';
                 }
 
+                // if the response does not contain a component, render as an error
+                const headers = backendResponse.response.headers;
+                if (
+                    !headers.get('Content-Type')?.includes('application/vnd.live-component+html') &&
+                    !headers.get('X-Live-Redirect')
+                ) {
+                    const controls = { displayError: true };
+                    this.valueStore.pushPendingPropsBackToDirty();
+                    this.hooks.triggerHook('response:error', backendResponse, controls);
+
+                    if (controls.displayError) {
+                        this.renderError(html);
+                    }
+
+                    this.backendRequest = null;
+                    thisPromiseResolve(backendResponse);
+
+                    return response;
+                }
+
+                const liveUrl = backendResponse.getLiveUrl();
+                if (liveUrl) {
+                    history.replaceState(
+                        history.state,
+                        '',
+                        new URL(liveUrl + window.location.hash, window.location.origin)
+                    );
+                }
+
+                this.processRerender(html, backendResponse);
+
+                // finally resolve this promise
                 this.backendRequest = null;
                 thisPromiseResolve(backendResponse);
 
+                // do we already have another request pending?
+                if (this.isRequestPending) {
+                    this.isRequestPending = false;
+                    this.performRequest();
+                }
+
                 return response;
-            }
+            })
+            .catch((error: any) => {
+                const controls = { displayError: true };
 
-            const liveUrl = backendResponse.getLiveUrl();
-            if (liveUrl) {
-                history.replaceState(
-                    history.state,
-                    '',
-                    new URL(liveUrl + window.location.hash, window.location.origin)
-                );
-            }
+                this.hooks.triggerHook('request:error', error, requestConfig, controls);
 
-            this.processRerender(html, backendResponse);
+                if (controls.displayError) {
+                    this.renderError(`<p>${error}</p>`);
+                }
 
-            // finally resolve this promise
-            this.backendRequest = null;
-            thisPromiseResolve(backendResponse);
+                this.backendRequest = null;
 
-            // do we already have another request pending?
-            if (this.isRequestPending) {
-                this.isRequestPending = false;
-                this.performRequest();
-            }
-
-            return response;
-        }).catch((error: any) => {
-            const controls = { displayError: true };
-
-            this.hooks.triggerHook('request:error', error, requestConfig, controls);
-
-            if (controls.displayError) {
-                this.renderError(`<p>${error}</p>`);
-            }
-
-            this.backendRequest = null;
-
-            // if we have a pending request, try it now
-            if (this.isRequestPending) {
-                this.isRequestPending = false;
-                this.performRequest();
-            }
-        });
+                // if we have a pending request, try it now
+                if (this.isRequestPending) {
+                    this.isRequestPending = false;
+                    this.performRequest();
+                }
+            });
     }
 
     private processRerender(html: string, backendResponse: BackendResponse) {

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -22,6 +22,7 @@ export type ComponentHooks = {
     'request:started': (requestConfig: any) => MaybePromise;
     'render:finished': (component: Component) => MaybePromise;
     'response:error': (backendResponse: BackendResponse, controls: { displayError: boolean }) => MaybePromise;
+    'request:error': (error: any, requestConfig: any, controls: { displayError: boolean }) => MaybePromise;
     'loading.state:started': (element: HTMLElement, request: BackendRequest) => MaybePromise;
     'loading.state:finished': (element: HTMLElement) => MaybePromise;
     'model:set': (model: string, value: any, component: Component) => MaybePromise;
@@ -349,6 +350,22 @@ export default class Component {
             }
 
             return response;
+        }).catch((error: any) => {
+            const controls = { displayError: true };
+
+            this.hooks.triggerHook('request:error', error, requestConfig, controls);
+
+            if (controls.displayError) {
+                this.renderError(`<p>${error}</p>`);
+            }
+
+            this.backendRequest = null;
+
+            // if we have a pending request, try it now
+            if (this.isRequestPending) {
+                this.isRequestPending = false;
+                this.performRequest();
+            }
         });
     }
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -982,6 +982,7 @@ The following hooks are available (along with the arguments that are passed):
 * ``disconnect`` args ``(component: Component)``
 * ``render:started`` args ``(html: string, response: BackendResponse, controls: { shouldRender: boolean })``
 * ``render:finished`` args ``(component: Component)``
+* ``request:error`` args ``(error: any, requestConfig: any, controls: { displayError: boolean })``
 * ``response:error`` args ``(backendResponse: BackendResponse, controls: { displayError: boolean })``
 * ``loading.state:started`` args ``(element: HTMLElement, request: BackendRequest)``
 * ``loading.state:finished`` args ``(element: HTMLElement)``


### PR DESCRIPTION

| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | Fix #1986
| License        | MIT

Hello, as described in the Issue currently there is problem that if an request fails the js freezes.
I looked into it and the issue is that there is currently no fetch.catch() to handle errors with the fetch itself. 
As far as can see currently the code only handles faulty responses.

This Pr add:
- prevention of the Js freeze
- showing the error message in the error model
- add a new request:error hook to handle this kind off errors

The request:error hook works mostly like response:error, so to prevent the modal from showing up you can do this:

```javascript
this.component.on('request:error', (component, requestData, controls) => {
        controls.displayError = false;
});
```

## Steps to reproduce the Error

1. Create a LiveComponent with an Input for example a select.
2. Open the Page
3. In the Browser Dev Tools go to the Network Tab and set throttling to offline
4. Change the Input to trigger a Request 
