### PR TITLE
[LiveComponent] Rebuild Component on reconnect when props changed in between

### DIFF
--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -93,6 +93,16 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
     }
 
     connect() {
+        // Stimulus only calls initialize() once per controller instance. When
+        // the same DOM element is disconnected then reconnected (e.g. a parent
+        // morphs it back in with new props), connect() is called again on the
+        // existing controller. If the props now differ from what the Component
+        // was built with, the ValueStore is stale and would reject any model
+        // matching the new server-rendered HTML — so rebuild the Component.
+        if (JSON.stringify(this.propsValue) !== JSON.stringify(this.component.valueStore.getOriginalProps())) {
+            this.createComponent();
+        }
+
         this.connectComponent();
 
         this.mutationObserver.observe(this.element, {

--- a/src/LiveComponent/assets/test/unit/controller/basic.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/basic.test.ts
@@ -12,7 +12,7 @@ import Component from '../../../src/Component';
 import { findComponents } from '../../../src/ComponentRegistry';
 import { htmlToElement } from '../../../src/dom_utils';
 import { getComponent } from '../../../src/live_controller';
-import { createTest, initComponent, shutdownTests, startStimulus } from '../../tools';
+import { createTest, getStimulusApplication, initComponent, shutdownTests, startStimulus } from '../../tools';
 
 describe('LiveController Basic Tests', () => {
     afterEach(() => {
@@ -51,5 +51,33 @@ describe('LiveController Basic Tests', () => {
         document.body.innerHTML = '';
         await expect(getComponent(test.element)).rejects.toThrow('Component not found for element');
         expect(findComponents(test.component, false, null)).toEqual([]);
+    });
+
+    it('rebuilds the Component on reconnect when props changed in between', async () => {
+        const test = await createTest({ greeting: 'aloha' }, (data: any) => `<div ${initComponent(data)}></div>`);
+
+        const controller = getStimulusApplication().getControllerForElementAndIdentifier(test.element, 'live') as any;
+        const originalComponent = controller.component;
+        expect(originalComponent.valueStore.getOriginalProps()).toEqual({ greeting: 'aloha' });
+
+        // simulate a parent morph: same controller instance, fresh props from the server
+        controller.disconnect();
+        controller.propsValue = { greeting: 'hello' };
+        controller.connect();
+
+        expect(controller.component).not.toBe(originalComponent);
+        expect(controller.component.valueStore.getOriginalProps()).toEqual({ greeting: 'hello' });
+    });
+
+    it('keeps the existing Component on reconnect when props are unchanged', async () => {
+        const test = await createTest({ greeting: 'aloha' }, (data: any) => `<div ${initComponent(data)}></div>`);
+
+        const controller = getStimulusApplication().getControllerForElementAndIdentifier(test.element, 'live') as any;
+        const originalComponent = controller.component;
+
+        controller.disconnect();
+        controller.connect();
+
+        expect(controller.component).toBe(originalComponent);
     });
 });


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3424
| License        | MIT

## Summary

When a parent live component action removes and re-adds a child live component on the **same DOM element**, Stimulus keeps the controller instance alive — it only calls `disconnect()` then `connect()` again, not `initialize()`. Because `createComponent()` only runs in `initialize()`, the `Component` (and its `ValueStore`) keep the **stale props** from before the parent action, even though the server-rendered HTML now exposes a fresh set.

The next user input then throws `Uncaught Error: Invalid model name "xyz.content"` — the model name has changed, but `ValueStore.has()` still looks up against the old props.

### Fix

In `connect()`, compare the current `propsValue` (which Stimulus has refreshed from the live `data-live-props-value` attribute) against `component.valueStore.getOriginalProps()`. When they differ, rebuild the `Component`.

- First `connect()` after `initialize()`: props match by construction → no rebuild.
- Plain disconnect/reconnect without any prop change: props match → no rebuild.
- Parent morph that swaps props on the same element: props diverge → rebuild.

The diagnosis and proposed fix are from @Pechynho in #3424 (confirmed working by another reporter in the thread).

## Test plan

- [x] New unit test `rebuilds the Component on reconnect when props changed in between` exercises the bug scenario by calling `controller.disconnect()` / mutating `propsValue` / `controller.connect()`, and asserts the `Component` instance has been swapped and the new `ValueStore` reflects the fresh props.
- [x] New unit test `keeps the existing Component on reconnect when props are unchanged` asserts that a no-op reconnect cycle does **not** recreate the `Component`.
- [x] Full LiveComponent controller test suite still green (109 tests).
- [x] `oxlint` + `oxfmt --check` clean.

Fixes #3424
