### PR TITLE
[LiveComponent] Document IDOR / write-surface sharp edges on LiveProp

### DIFF
--- a/src/LiveComponent/src/Attribute/LiveProp.php
+++ b/src/LiveComponent/src/Attribute/LiveProp.php
@@ -34,6 +34,14 @@ final class LiveProp
          * Or set to an array of paths within this object/array
          * that are writable.
          *
+         * Security: when the underlying property type is a Doctrine entity (or
+         * any object loaded via {@see HydrationExtensionInterface}), an
+         * "updated" payload of the form `{"prop": <id>}` will load *any*
+         * entity of that class by its identifier — no authorization check is
+         * performed at hydration time. Make sure the action that consumes the
+         * value enforces access (#[IsGranted], voter, manual check) before
+         * persisting or rendering anything sensitive.
+         *
          * @var bool|string[]
          */
         private bool|array $writable = false,

--- a/src/LiveComponent/src/Attribute/LiveProp.php
+++ b/src/LiveComponent/src/Attribute/LiveProp.php
@@ -102,6 +102,16 @@ final class LiveProp
          * Whether to synchronize this property with a query parameter
          * in the URL. Pass true to configure the mapping automatically, or a
          * {@see UrlMapping} instance to configure the mapping.
+         *
+         * Security: when the underlying property type is a Doctrine entity (or
+         * any object loaded via {@see HydrationExtensionInterface}), the
+         * identifier read from the URL is trusted as-is — there is no
+         * authorization check at hydration time. A user visiting
+         * "?article=999" will receive the corresponding entity loaded into the
+         * component, regardless of whether they would otherwise have access to
+         * it. Enforce the access decision yourself, e.g. via a #[PostMount] or
+         * #[PreReRender] hook that calls Security::isGranted() or denies via
+         * AccessDeniedHttpException.
          */
         private bool|UrlMapping $url = false,
 

--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -634,6 +634,14 @@ final class LiveComponentHydrator
         }
 
         if (\is_array($value)) {
+            // Security note: when a "plain" object (non-entity, non-enum, non-Uid)
+            // is hydrated for a writable LiveProp, the property names below come
+            // from the client-supplied $value. PropertyAccessor still honours
+            // visibility (it requires a public property or setter), so the surface
+            // is bounded by the class's own write surface — but any public setter
+            // is reachable from the frontend. Component authors using
+            // writable: true on plain DTOs must keep that in mind when adding
+            // setters (e.g. setRole(), setIsAdmin()).
             $object = new $className();
             foreach ($value as $propertyName => $propertyValue) {
                 $reflectionClass = new \ReflectionClass($className);


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Fix #3540
| License        | MIT

Documentation-only change (docblocks + one inline comment), no behaviour change.

`#[LiveProp]` has a few intentional, by-design sharp edges that aren't surfaced where the attribute is declared:

- **`url: true` on an entity-typed prop** — the identifier comes from the query string and is loaded with no authorization check (same trust model as `#[MapEntity]`).
- **`writable: true` on an entity-typed prop** — same via the `updated` payload.
- **`writable: true` on a plain object prop** — `hydrateObjectValue()` writes client-supplied property names; `PropertyAccessor` bounds this to the class's public write surface, but any public setter is reachable.

These are documented tradeoffs of the component model, not bugs — the change just makes them visible at the call site so a developer doesn't have to derive them from the hydrator internals.

### Commits

- `[LiveComponent] Document IDOR risk of url-mapped LiveProp on entity types` — note on `LiveProp::$url`
- `[LiveComponent] Document IDOR risk of writable LiveProp on entity types` — note on `LiveProp::$writable`
- `[LiveComponent] Note write-surface exposure when hydrating plain object props` — inline comment in `LiveComponentHydrator::hydrateObjectValue()`

cc @kbond @smnandre — wording is open for discussion; happy to move some of this into the reference docs instead if you'd rather keep the docblocks terse.