### PR TITLE
[Chartjs][LiveComponent][Notify][React][StimulusBundle][Turbo][TwigComponent][Vue] Deprecate Twig functions/filters in favor of ux_ prefixed names

### DIFF
--- a/src/Chartjs/CHANGELOG.md
+++ b/src/Chartjs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.3.0
+
+- Deprecate Twig function `render_chart()`, use `ux_chartjs()` instead
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/Chartjs/src/Twig/ChartExtension.php
+++ b/src/Chartjs/src/Twig/ChartExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\Chartjs\Twig;
 
 use Symfony\UX\Chartjs\Model\Chart;
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -30,7 +31,13 @@ class ChartExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('render_chart', [$this, 'renderChart'], ['is_safe' => ['html']]),
+            new TwigFunction('render_chart', [$this, 'renderChart'], [
+                'is_safe' => ['html'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-chartjs', '3.1', 'ux_chartjs')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-chartjs', 'alternative' => 'ux_chartjs']),
+            ]),
+            new TwigFunction('ux_chartjs', [$this, 'renderChart'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 3.3.0
+
+- Deprecate Twig function `component_url()`, use `ux_live_component_url()` instead
+- Deprecate Twig function `live_action()`, use `ux_live_action()` instead
+
 ## 3.1
 
 - Fix dynamic template resolution when using the `loading` attribute on a deferred component

--- a/src/LiveComponent/src/Twig/LiveComponentExtension.php
+++ b/src/LiveComponent/src/Twig/LiveComponentExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\LiveComponent\Twig;
 
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -24,8 +25,19 @@ final class LiveComponentExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('component_url', [LiveComponentRuntime::class, 'getComponentUrl']),
-            new TwigFunction('live_action', [LiveComponentRuntime::class, 'liveAction'], ['is_safe' => ['html_attr']]),
+            new TwigFunction('component_url', [LiveComponentRuntime::class, 'getComponentUrl'], [
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-live-component', '3.1', 'ux_live_component_url')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-live-component', 'alternative' => 'ux_live_component_url']),
+            ]),
+            new TwigFunction('ux_live_component_url', [LiveComponentRuntime::class, 'getComponentUrl']),
+            new TwigFunction('live_action', [LiveComponentRuntime::class, 'liveAction'], [
+                'is_safe' => ['html_attr'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-live-component', '3.1', 'ux_live_action')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-live-component', 'alternative' => 'ux_live_action']),
+            ]),
+            new TwigFunction('ux_live_action', [LiveComponentRuntime::class, 'liveAction'], ['is_safe' => ['html_attr']]),
         ];
     }
 }

--- a/src/LiveComponent/tests/Fixtures/templates/component_url.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/component_url.html.twig
@@ -1,3 +1,3 @@
-{{ component_url('component1', {prop1: null, prop2: date}) }}
-{{ component_url('alternate_route') }}
-{{ component_url('with_absolute_url') }}
+{{ ux_live_component_url('component1', {prop1: null, prop2: date}) }}
+{{ ux_live_component_url('alternate_route') }}
+{{ ux_live_component_url('with_absolute_url') }}

--- a/src/Notify/CHANGELOG.md
+++ b/src/Notify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.3.0
+
+- Deprecate Twig function `stream_notifications()`, use `ux_notify()` instead
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/Notify/src/Twig/NotifyExtension.php
+++ b/src/Notify/src/Twig/NotifyExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\Notify\Twig;
 
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -25,7 +26,13 @@ final class NotifyExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('stream_notifications', [NotifyRuntime::class, 'renderStreamNotifications'], ['is_safe' => ['html']]),
+            new TwigFunction('stream_notifications', [NotifyRuntime::class, 'renderStreamNotifications'], [
+                'is_safe' => ['html'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-notify', '3.1', 'ux_notify')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-notify', 'alternative' => 'ux_notify']),
+            ]),
+            new TwigFunction('ux_notify', [NotifyRuntime::class, 'renderStreamNotifications'], ['is_safe' => ['html']]),
         ];
     }
 }

--- a/src/React/CHANGELOG.md
+++ b/src/React/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.3.0
+
+- Deprecate Twig function `react_component()`, use `ux_react_component()` instead
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/React/src/Twig/ReactComponentExtension.php
+++ b/src/React/src/Twig/ReactComponentExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\React\Twig;
 
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -29,7 +30,13 @@ class ReactComponentExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('react_component', [$this, 'renderReactComponent'], ['is_safe' => ['html_attr']]),
+            new TwigFunction('react_component', [$this, 'renderReactComponent'], [
+                'is_safe' => ['html_attr'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-react', '3.1', 'ux_react_component')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-react', 'alternative' => 'ux_react_component']),
+            ]),
+            new TwigFunction('ux_react_component', [$this, 'renderReactComponent'], ['is_safe' => ['html_attr']]),
         ];
     }
 

--- a/src/StimulusBundle/CHANGELOG.md
+++ b/src/StimulusBundle/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 3.3.0
 
 - Detect the `stimulusFetch: 'lazy'` directive inside preserved comments (`/*! ... */`)
+- Deprecate Twig function `stimulus_controller()`, use `ux_stimulus_controller()` instead
+- Deprecate Twig function `stimulus_action()`, use `ux_stimulus_action()` instead
+- Deprecate Twig function `stimulus_target()`, use `ux_stimulus_target()` instead
+- Deprecate Twig filter `stimulus_controller`, use `ux_stimulus_controller` instead
+- Deprecate Twig filter `stimulus_action`, use `ux_stimulus_action` instead
+- Deprecate Twig filter `stimulus_target`, use `ux_stimulus_target` instead
 
 ## 3.0.0
 

--- a/src/StimulusBundle/src/Twig/StimulusTwigExtension.php
+++ b/src/StimulusBundle/src/Twig/StimulusTwigExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\StimulusBundle\Twig;
 
 use Symfony\UX\StimulusBundle\Dto\StimulusAttributes;
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -29,18 +30,54 @@ final class StimulusTwigExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('stimulus_controller', [$this, 'renderStimulusController'], ['is_safe' => ['html_attr']]),
-            new TwigFunction('stimulus_action', [$this, 'renderStimulusAction'], ['is_safe' => ['html_attr']]),
-            new TwigFunction('stimulus_target', [$this, 'renderStimulusTarget'], ['is_safe' => ['html_attr']]),
+            new TwigFunction('stimulus_controller', [$this, 'renderStimulusController'], [
+                'is_safe' => ['html_attr'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-stimulus-bundle', '3.1', 'ux_stimulus_controller')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-stimulus-bundle', 'alternative' => 'ux_stimulus_controller']),
+            ]),
+            new TwigFunction('ux_stimulus_controller', [$this, 'renderStimulusController'], ['is_safe' => ['html_attr']]),
+            new TwigFunction('stimulus_action', [$this, 'renderStimulusAction'], [
+                'is_safe' => ['html_attr'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-stimulus-bundle', '3.1', 'ux_stimulus_action')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-stimulus-bundle', 'alternative' => 'ux_stimulus_action']),
+            ]),
+            new TwigFunction('ux_stimulus_action', [$this, 'renderStimulusAction'], ['is_safe' => ['html_attr']]),
+            new TwigFunction('stimulus_target', [$this, 'renderStimulusTarget'], [
+                'is_safe' => ['html_attr'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-stimulus-bundle', '3.1', 'ux_stimulus_target')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-stimulus-bundle', 'alternative' => 'ux_stimulus_target']),
+            ]),
+            new TwigFunction('ux_stimulus_target', [$this, 'renderStimulusTarget'], ['is_safe' => ['html_attr']]),
         ];
     }
 
     public function getFilters(): array
     {
         return [
-            new TwigFilter('stimulus_controller', [$this, 'appendStimulusController'], ['is_safe' => ['html_attr']]),
-            new TwigFilter('stimulus_action', [$this, 'appendStimulusAction'], ['is_safe' => ['html_attr']]),
-            new TwigFilter('stimulus_target', [$this, 'appendStimulusTarget'], ['is_safe' => ['html_attr']]),
+            new TwigFilter('stimulus_controller', [$this, 'appendStimulusController'], [
+                'is_safe' => ['html_attr'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-stimulus-bundle', '3.1', 'ux_stimulus_controller')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-stimulus-bundle', 'alternative' => 'ux_stimulus_controller']),
+            ]),
+            new TwigFilter('ux_stimulus_controller', [$this, 'appendStimulusController'], ['is_safe' => ['html_attr']]),
+            new TwigFilter('stimulus_action', [$this, 'appendStimulusAction'], [
+                'is_safe' => ['html_attr'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-stimulus-bundle', '3.1', 'ux_stimulus_action')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-stimulus-bundle', 'alternative' => 'ux_stimulus_action']),
+            ]),
+            new TwigFilter('ux_stimulus_action', [$this, 'appendStimulusAction'], ['is_safe' => ['html_attr']]),
+            new TwigFilter('stimulus_target', [$this, 'appendStimulusTarget'], [
+                'is_safe' => ['html_attr'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-stimulus-bundle', '3.1', 'ux_stimulus_target')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-stimulus-bundle', 'alternative' => 'ux_stimulus_target']),
+            ]),
+            new TwigFilter('ux_stimulus_target', [$this, 'appendStimulusTarget'], ['is_safe' => ['html_attr']]),
         ];
     }
 

--- a/src/Turbo/CHANGELOG.md
+++ b/src/Turbo/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 3.3.0
+
+- Deprecate Twig function `turbo_is_frame_request()`, use `ux_turbo_is_frame_request()` instead
+- Deprecate Twig function `turbo_frame_request_id()`, use `ux_turbo_frame_request_id()` instead
+- Deprecate Twig function `turbo_stream_from()`, use `ux_turbo_stream_from()` instead
+- Deprecate Twig function `turbo_exempts_page_from_cache()`, use `ux_turbo_exempts_page_from_cache()` instead
+- Deprecate Twig function `turbo_exempts_page_from_preview()`, use `ux_turbo_exempts_page_from_preview()` instead
+- Deprecate Twig function `turbo_page_requires_reload()`, use `ux_turbo_page_requires_reload()` instead
+- Deprecate Twig function `turbo_refreshes_with()`, use `ux_turbo_refreshes_with()` instead
+- Deprecate Twig function `turbo_refresh_method()`, use `ux_turbo_refresh_method()` instead
+- Deprecate Twig function `turbo_refresh_scroll()`, use `ux_turbo_refresh_scroll()` instead
+
 ## 3.2.0
 
 - Prevent installation alongside `symfony/mercure` 0.7.0 and 0.7.1, which are incompatible

--- a/src/Turbo/src/Twig/TwigExtension.php
+++ b/src/Turbo/src/Twig/TwigExtension.php
@@ -29,22 +29,75 @@ final class TwigExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('turbo_is_frame_request', [TurboRuntime::class, 'isTurboFrameRequest']),
-            new TwigFunction('turbo_frame_request_id', [TurboRuntime::class, 'getTurboFrameRequestId']),
-            new TwigFunction('turbo_stream_from', [TurboRuntime::class, 'renderTurboStreamFrom'], ['needs_environment' => true, 'is_safe' => ['html']]),
+            new TwigFunction('turbo_is_frame_request', [TurboRuntime::class, 'isTurboFrameRequest'], [
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_is_frame_request')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_is_frame_request']),
+            ]),
+            new TwigFunction('ux_turbo_is_frame_request', [TurboRuntime::class, 'isTurboFrameRequest']),
+            new TwigFunction('turbo_frame_request_id', [TurboRuntime::class, 'getTurboFrameRequestId'], [
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_frame_request_id')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_frame_request_id']),
+            ]),
+            new TwigFunction('ux_turbo_frame_request_id', [TurboRuntime::class, 'getTurboFrameRequestId']),
+            new TwigFunction('turbo_stream_from', [TurboRuntime::class, 'renderTurboStreamFrom'], [
+                'needs_environment' => true,
+                'is_safe' => ['html'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_stream_from')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_stream_from']),
+            ]),
+            new TwigFunction('ux_turbo_stream_from', [TurboRuntime::class, 'renderTurboStreamFrom'], ['needs_environment' => true, 'is_safe' => ['html']]),
             new TwigFunction('turbo_stream_listen', [TurboRuntime::class, 'renderTurboStreamListen'], [
                 'needs_environment' => true,
                 'is_safe' => ['html'],
                 ...(class_exists(DeprecatedCallableInfo::class)
-                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'turbo_stream_from')]
-                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'turbo_stream_from']),
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_stream_from')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_stream_from']),
             ]),
-            new TwigFunction('turbo_exempts_page_from_cache', $this->turboExemptsPageFromCache(...), ['is_safe' => ['html']]),
-            new TwigFunction('turbo_exempts_page_from_preview', $this->turboExemptsPageFromPreview(...), ['is_safe' => ['html']]),
-            new TwigFunction('turbo_page_requires_reload', $this->turboPageRequiresReload(...), ['is_safe' => ['html']]),
-            new TwigFunction('turbo_refreshes_with', $this->turboRefreshesWith(...), ['is_safe' => ['html']]),
-            new TwigFunction('turbo_refresh_method', $this->turboRefreshMethod(...), ['is_safe' => ['html']]),
-            new TwigFunction('turbo_refresh_scroll', $this->turboRefreshScroll(...), ['is_safe' => ['html']]),
+            new TwigFunction('turbo_exempts_page_from_cache', $this->turboExemptsPageFromCache(...), [
+                'is_safe' => ['html'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_exempts_page_from_cache')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_exempts_page_from_cache']),
+            ]),
+            new TwigFunction('ux_turbo_exempts_page_from_cache', $this->turboExemptsPageFromCache(...), ['is_safe' => ['html']]),
+            new TwigFunction('turbo_exempts_page_from_preview', $this->turboExemptsPageFromPreview(...), [
+                'is_safe' => ['html'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_exempts_page_from_preview')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_exempts_page_from_preview']),
+            ]),
+            new TwigFunction('ux_turbo_exempts_page_from_preview', $this->turboExemptsPageFromPreview(...), ['is_safe' => ['html']]),
+            new TwigFunction('turbo_page_requires_reload', $this->turboPageRequiresReload(...), [
+                'is_safe' => ['html'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_page_requires_reload')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_page_requires_reload']),
+            ]),
+            new TwigFunction('ux_turbo_page_requires_reload', $this->turboPageRequiresReload(...), ['is_safe' => ['html']]),
+            new TwigFunction('turbo_refreshes_with', $this->turboRefreshesWith(...), [
+                'is_safe' => ['html'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_refreshes_with')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_refreshes_with']),
+            ]),
+            new TwigFunction('ux_turbo_refreshes_with', $this->turboRefreshesWith(...), ['is_safe' => ['html']]),
+            new TwigFunction('turbo_refresh_method', $this->turboRefreshMethod(...), [
+                'is_safe' => ['html'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_refresh_method')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_refresh_method']),
+            ]),
+            new TwigFunction('ux_turbo_refresh_method', $this->turboRefreshMethod(...), ['is_safe' => ['html']]),
+            new TwigFunction('turbo_refresh_scroll', $this->turboRefreshScroll(...), [
+                'is_safe' => ['html'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-turbo', '3.1', 'ux_turbo_refresh_scroll')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-turbo', 'alternative' => 'ux_turbo_refresh_scroll']),
+            ]),
+            new TwigFunction('ux_turbo_refresh_scroll', $this->turboRefreshScroll(...), ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Turbo/tests/Bridge/Mercure/MercureStreamSourceRendererTest.php
+++ b/src/Turbo/tests/Bridge/Mercure/MercureStreamSourceRendererTest.php
@@ -38,39 +38,39 @@ final class MercureStreamSourceRendererTest extends KernelTestCase
         $book->id = 123;
 
         yield 'string topic — public' => [
-            "{{ turbo_stream_from('a_topic') }}",
+            "{{ ux_turbo_stream_from('a_topic') }}",
             [],
             '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=a_topic"></turbo-mercure-stream-source>',
         ];
 
         yield 'string topic — private' => [
-            "{{ turbo_stream_from('a_topic', private=true) }}",
+            "{{ ux_turbo_stream_from('a_topic', private=true) }}",
             [],
             '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=a_topic" private></turbo-mercure-stream-source>',
         ];
 
         yield 'class name — single backslash (Twig drops \\X)' => [
-            "{{ turbo_stream_from('Symfony\\UX\\Turbo\\Tests\\Fixtures\\Book') }}",
+            "{{ ux_turbo_stream_from('Symfony\\UX\\Turbo\\Tests\\Fixtures\\Book') }}",
             [],
             // single-quoted Twig string: \X drops the backslash → 'SymfonyUXTurboTestsFixturesBook'
             '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=SymfonyUXTurboTestsFixturesBook"></turbo-mercure-stream-source>',
         ];
 
         yield 'class name — double backslash (correct usage)' => [
-            "{{ turbo_stream_from('Symfony\\\\UX\\\\Turbo\\\\Tests\\\\Fixtures\\\\Book') }}",
+            "{{ ux_turbo_stream_from('Symfony\\\\UX\\\\Turbo\\\\Tests\\\\Fixtures\\\\Book') }}",
             [],
             // \\\\ in PHP string → \\ in Twig source → \ in Twig output → 'Symfony\UX\Turbo\Tests\Fixtures\Book' → class_exists → URL pattern
             '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=https%3A%2F%2Fsymfony.com%2Fux-turbo%2FSymfony%255CUX%255CTurbo%255CTests%255CFixtures%255CBook%2F%7Bid%7D"></turbo-mercure-stream-source>',
         ];
 
         yield 'entity topic' => [
-            '{{ turbo_stream_from(book) }}',
+            '{{ ux_turbo_stream_from(book) }}',
             ['book' => $book],
             '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=https%3A%2F%2Fsymfony.com%2Fux-turbo%2FSymfony%255CUX%255CTurbo%255CTests%255CFixtures%255CBook%2F123"></turbo-mercure-stream-source>',
         ];
 
         yield 'array of topics' => [
-            "{{ turbo_stream_from(['topic_a', 'topic_b']) }}",
+            "{{ ux_turbo_stream_from(['topic_a', 'topic_b']) }}",
             [],
             '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=topic_a&amp;topic=topic_b"></turbo-mercure-stream-source>',
         ];

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 3.3.0
+
+- Deprecate Twig function `component()`, use `ux_twig_component()` instead
+- Deprecate Twig function `provide()`, use `ux_twig_provide()` instead
+- Deprecate Twig function `inject()`, use `ux_twig_inject()` instead
+
 ## 3.2.0
 
 - Add `ComponentRendererInterface::preCreateForRender()`, `ComponentRendererInterface::startEmbeddedComponentRender()`, and `ComponentRendererInterface::finishEmbeddedComponentRender()` methods

--- a/src/TwigComponent/src/Twig/ComponentExtension.php
+++ b/src/TwigComponent/src/Twig/ComponentExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\TwigComponent\Twig;
 
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -24,9 +25,25 @@ final class ComponentExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('component', [ComponentRuntime::class, 'render'], ['is_safe' => ['all']]),
-            new TwigFunction('provide', [ComponentRuntime::class, 'provide']),
-            new TwigFunction('inject', [ComponentRuntime::class, 'inject']),
+            new TwigFunction('component', [ComponentRuntime::class, 'render'], [
+                'is_safe' => ['all'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-twig-component', '3.1', 'ux_twig_component')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-twig-component', 'alternative' => 'ux_twig_component']),
+            ]),
+            new TwigFunction('ux_twig_component', [ComponentRuntime::class, 'render'], ['is_safe' => ['all']]),
+            new TwigFunction('provide', [ComponentRuntime::class, 'provide'], [
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-twig-component', '3.1', 'ux_twig_provide')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-twig-component', 'alternative' => 'ux_twig_provide']),
+            ]),
+            new TwigFunction('ux_twig_provide', [ComponentRuntime::class, 'provide']),
+            new TwigFunction('inject', [ComponentRuntime::class, 'inject'], [
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-twig-component', '3.1', 'ux_twig_inject')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-twig-component', 'alternative' => 'ux_twig_inject']),
+            ]),
+            new TwigFunction('ux_twig_inject', [ComponentRuntime::class, 'inject']),
         ];
     }
 

--- a/src/TwigComponent/tests/Fixtures/templates/components/ComplexValueProvider.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/ComplexValueProvider.html.twig
@@ -1,5 +1,5 @@
-{% do provide('list', ['a', 'b', 'c']) %}
-{% do provide('config', { 'key': 'value', 'count': 42 }) %}
+{% do ux_twig_provide('list', ['a', 'b', 'c']) %}
+{% do ux_twig_provide('config', { 'key': 'value', 'count': 42 }) %}
 
 <div class="complex-provider">
     {% block content %}{% endblock %}

--- a/src/TwigComponent/tests/Fixtures/templates/components/ComplexValueReader.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/ComplexValueReader.html.twig
@@ -1,4 +1,4 @@
-{% set list = inject('list', []) %}
-{% set config = inject('config', {}) %}
+{% set list = ux_twig_inject('list', []) %}
+{% set config = ux_twig_inject('config', {}) %}
 
 <span class="reader">list:{{ list|join('+') }};config:{{ config.key }}/{{ config.count }}</span>

--- a/src/TwigComponent/tests/Fixtures/templates/components/InputOtp.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/InputOtp.html.twig
@@ -1,7 +1,7 @@
 {% props maxLength = 6, name = 'otp' %}
 
-{% do provide('inputOtp.maxLength', maxLength) %}
-{% do provide('inputOtp.name', name) %}
+{% do ux_twig_provide('inputOtp.maxLength', maxLength) %}
+{% do ux_twig_provide('inputOtp.name', name) %}
 
 <div class="input-otp">
     {% block content %}{% endblock %}

--- a/src/TwigComponent/tests/Fixtures/templates/components/InputOtp/Slot.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/InputOtp/Slot.html.twig
@@ -1,5 +1,5 @@
 {% props input %}
-{% set maxLength = inject('inputOtp.maxLength', 4) %}
-{% set name = inject('inputOtp.name', 'otp') %}
+{% set maxLength = ux_twig_inject('inputOtp.maxLength', 4) %}
+{% set name = ux_twig_inject('inputOtp.name', 'otp') %}
 
 <input type="text" name="{{ name }}[{{ input - 1 }}]" maxlength="1" data-index="{{ input }}" data-max-length="{{ maxLength }}" />

--- a/src/TwigComponent/tests/Fixtures/templates/components/NestedAttributes.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/NestedAttributes.html.twig
@@ -1,7 +1,7 @@
 <main{{ attributes }}>
     <div{{ attributes.nested('title') }}>
         <span{{ attributes.nested('title').nested('span') }}>
-            {{ component('JustAttributes', [...attributes.nested('inner')]) }}
+            {{ ux_twig_component('JustAttributes', [...attributes.nested('inner')]) }}
         </span>
     </div>
 </main>

--- a/src/TwigComponent/tests/Fixtures/templates/components/OverwritingTabs.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/OverwritingTabs.html.twig
@@ -1,5 +1,5 @@
-{% do provide('tabs.active', 'first') %}
-{% do provide('tabs.active', 'second') %}
+{% do ux_twig_provide('tabs.active', 'first') %}
+{% do ux_twig_provide('tabs.active', 'second') %}
 
 <div class="tabs">
     {% block content %}{% endblock %}

--- a/src/TwigComponent/tests/Fixtures/templates/components/ProvidesNull.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/ProvidesNull.html.twig
@@ -1,3 +1,3 @@
-{% do provide('inputOtp.name', null) %}
+{% do ux_twig_provide('inputOtp.name', null) %}
 
 <twig:InputOtp:Slot input="1" />

--- a/src/TwigComponent/tests/Fixtures/templates/components/Tabs.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/Tabs.html.twig
@@ -1,6 +1,6 @@
 {% props activeTab %}
 
-{% do provide('tabs.active', activeTab) %}
+{% do ux_twig_provide('tabs.active', activeTab) %}
 
 <div class="tabs">
     {% block content %}{% endblock %}

--- a/src/TwigComponent/tests/Fixtures/templates/components/Tabs/Trigger.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/Tabs/Trigger.html.twig
@@ -1,5 +1,5 @@
 {% props value %}
-{% set active = inject('tabs.active') %}
+{% set active = ux_twig_inject('tabs.active') %}
 
 <button type="button" role="tab" data-value="{{ value }}" aria-selected="{{ active == value ? 'true' : 'false' }}">
     {{ value }}

--- a/src/TwigComponent/tests/Fixtures/templates/flexible_component_attributes.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/flexible_component_attributes.html.twig
@@ -1,7 +1,7 @@
 {% set attributes1 = {propA: 'A1', propB: 'B1' } %}
 {% set attributes3 = {propA: 'A3', propB: 'B3' } %}
 
-{{ component('component_a', attributes1) }}
-{{ component('component_a', {propA: 'A2', propB: 'B0' }|merge({propB: 'B2'})) }}
+{{ ux_twig_component('component_a', attributes1) }}
+{{ ux_twig_component('component_a', {propA: 'A2', propB: 'B0' }|merge({propB: 'B2'})) }}
 {% component 'component_a' with attributes3 %}{% endcomponent %}
 {% component 'component_a' with ({propA: 'A4', propB: 'B0' })|merge({propB: 'B4'}) %}{% endcomponent %}

--- a/src/TwigComponent/tests/Fixtures/templates/invalid_flexible_component.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/invalid_flexible_component.html.twig
@@ -1,2 +1,2 @@
 {% set attributes = 'wrong' %}
-{{ component('component_a', attributes) }}
+{{ ux_twig_component('component_a', attributes) }}

--- a/src/TwigComponent/tests/Fixtures/templates/multi_render.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/multi_render.html.twig
@@ -1,3 +1,3 @@
-{{ component('component_a', {propA: 'prop a value 1', propB: 'prop b value 1'}) }}
-{{ component('component_a', {propA: 'prop a value 2', propB: 'prop b value 2'}) }}
-{{ component('component_b', {value: 'b value 1', extra: 'value'}) }}
+{{ ux_twig_component('component_a', {propA: 'prop a value 1', propB: 'prop b value 1'}) }}
+{{ ux_twig_component('component_a', {propA: 'prop a value 2', propB: 'prop b value 2'}) }}
+{{ ux_twig_component('component_b', {value: 'b value 1', extra: 'value'}) }}

--- a/src/TwigComponent/tests/Fixtures/templates/provide_inject_inject_outside_component.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/provide_inject_inject_outside_component.html.twig
@@ -1,1 +1,1 @@
-fallback={{ inject('missing.key', 'fallback-value') }}
+fallback={{ ux_twig_inject('missing.key', 'fallback-value') }}

--- a/src/TwigComponent/tests/Fixtures/templates/provide_inject_outside_component.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/provide_inject_outside_component.html.twig
@@ -1,1 +1,1 @@
-{% do provide('foo', 'bar') %}
+{% do ux_twig_provide('foo', 'bar') %}

--- a/src/TwigComponent/tests/Fixtures/templates/provide_inject_passed_content_skips_self.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/provide_inject_passed_content_skips_self.html.twig
@@ -1,3 +1,3 @@
 <twig:Tabs activeTab="A">
-    inline:{{ inject('tabs.active', 'NONE') }}
+    inline:{{ ux_twig_inject('tabs.active', 'NONE') }}
 </twig:Tabs>

--- a/src/TwigComponent/tests/Fixtures/templates/render_component.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/render_component.html.twig
@@ -1,1 +1,1 @@
-{{ component(name, data) }}
+{{ ux_twig_component(name, data) }}

--- a/src/Vue/CHANGELOG.md
+++ b/src/Vue/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.3.0
+
+- Deprecate Twig function `vue_component()`, use `ux_vue_component()` instead
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/Vue/src/Twig/VueComponentExtension.php
+++ b/src/Vue/src/Twig/VueComponentExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\Vue\Twig;
 
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -30,7 +31,13 @@ class VueComponentExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('vue_component', [$this, 'renderVueComponent'], ['is_safe' => ['html_attr']]),
+            new TwigFunction('vue_component', [$this, 'renderVueComponent'], [
+                'is_safe' => ['html_attr'],
+                ...(class_exists(DeprecatedCallableInfo::class)
+                    ? ['deprecation_info' => new DeprecatedCallableInfo('symfony/ux-vue', '3.1', 'ux_vue_component')]
+                    : ['deprecated' => '3.1', 'deprecating_package' => 'symfony/ux-vue', 'alternative' => 'ux_vue_component']),
+            ]),
+            new TwigFunction('ux_vue_component', [$this, 'renderVueComponent'], ['is_safe' => ['html_attr']]),
         ];
     }
 


### PR DESCRIPTION
Introduce `ux_<package>` prefixed aliases for all Twig functions and filters across Symfony UX packages, and deprecate the old names to establish a consistent naming convention (following the pattern already used by `ux_icon`, `ux_map`, `ux_is_native`).

| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | yes <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
