### PR TITLE
 Add Symfony UX Image component (Slim v1)

### DIFF
--- a/src/Image/.gitattributes
+++ b/src/Image/.gitattributes
@@ -1,0 +1,6 @@
+* export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.dist.php export-ignore
+phpunit.dist.xml export-ignore
+tests/ export-ignore

--- a/src/Image/.gitignore
+++ b/src/Image/.gitignore
@@ -1,0 +1,6 @@
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.result.cache
+.phpunit.cache
+/var/

--- a/src/Image/.php-cs-fixer.dist.php
+++ b/src/Image/.php-cs-fixer.dist.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
+return (new PhpCsFixer\Config())
+    ->setParallelConfig(ParallelConfigFactory::detect())
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        (new Finder())
+            ->in(__DIR__.'/src')
+            ->in(__DIR__.'/tests')
+    )
+;

--- a/src/Image/.symfony.bundle.yaml
+++ b/src/Image/.symfony.bundle.yaml
@@ -1,0 +1,3 @@
+branches: ['2.x', '3.x']
+maintained_branches: ['3.x']
+doc_dir: 'doc'

--- a/src/Image/CHANGELOG.md
+++ b/src/Image/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 2.32.0
+
+- Add Symfony UX Image component

--- a/src/Image/README.md
+++ b/src/Image/README.md
@@ -1,0 +1,81 @@
+# Symfony UX Image
+
+Optimized responsive image components with automatic format conversion and Core Web Vitals optimization.
+
+## Installation
+
+```bash
+composer require symfony/ux-image
+```
+
+## Quick Start
+
+### Basic Usage
+
+```twig
+{# Simple responsive image #}
+<twig:ux:img
+    src="/images/hero.jpg"
+    alt="Hero image"
+    width="100vw md:80vw"
+/>
+```
+
+### Art Direction
+
+```twig
+{# Different aspect ratios per breakpoint #}
+<twig:ux:picture
+    src="/images/banner.jpg"
+    alt="Banner"
+    width="100vw md:80vw"
+    ratio="sm:1:1 md:16:9"
+/>
+```
+
+### Without Twig Components
+
+```twig
+{{ ux_image('/images/hero.jpg', 'Hero image', { width: '100vw md:80vw' }) }}
+```
+
+## Features
+
+- **Automatic WebP conversion** — via configurable providers
+- **Responsive srcset/sizes** — viewport-based width syntax (`100vw md:80vw`)
+- **Density support** — Retina displays (`densities="x1 x2"`)
+- **Art direction** — different crops per breakpoint with `<twig:ux:picture>`
+- **Provider-based** — works with local files, CDN, or any image service
+- **No hard dependencies** — no image processing library required
+
+## Configuration
+
+```yaml
+# config/packages/ux_image.yaml
+ux_image:
+    default_provider: passthrough
+    breakpoints:
+        sm: 640
+        md: 768
+        lg: 1024
+        xl: 1280
+        2xl: 1536
+    defaults:
+        format: webp
+        quality: 80
+        loading: lazy
+        fit: cover
+```
+
+### Using a CDN
+
+```yaml
+ux_image:
+    providers:
+        cloudflare:
+            pattern: '/cdn-cgi/image/w={width},f={format},q={quality}/{src}'
+```
+
+## License
+
+MIT License — see [LICENSE](LICENSE) for details.

--- a/src/Image/composer.json
+++ b/src/Image/composer.json
@@ -1,0 +1,72 @@
+{
+    "name": "symfony/ux-image",
+    "type": "symfony-bundle",
+    "description": "Optimized responsive image components with automatic format conversion and Core Web Vitals optimization.",
+    "keywords": [
+        "symfony-ux",
+        "symfony",
+        "image",
+        "responsive",
+        "webp",
+        "optimization",
+        "core web vitals"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Aleksey Razbakov",
+            "email": "aleksey@razbakov.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Symfony\\UX\\Image\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\UX\\Image\\Tests\\": "tests/"
+        }
+    },
+    "require": {
+        "php": ">=8.4",
+        "symfony/framework-bundle": "^7.4|^8.0",
+        "symfony/twig-bundle": "^7.4|^8.0",
+        "symfony/config": "^7.4|^8.0",
+        "symfony/dependency-injection": "^7.4|^8.0",
+        "symfony/http-kernel": "^7.4|^8.0",
+        "symfony/options-resolver": "^7.4|^8.0",
+        "twig/twig": "^3.0"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.65",
+        "phpunit/phpunit": "^11.1|^12.0",
+        "symfony/browser-kit": "^7.4|^8.0",
+        "symfony/css-selector": "^7.4|^8.0",
+        "symfony/debug-bundle": "^7.4|^8.0",
+        "symfony/phpunit-bridge": "^7.4|^8.0",
+        "symfony/yaml": "^7.4|^8.0",
+        "symfony/ux-twig-component": "^2.21|^3.0"
+    },
+    "suggest": {
+        "symfony/ux-twig-component": "For using the Twig component syntax (<twig:ux:img>)"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "conflict": {
+        "symfony/flex": "<1.13"
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Image/config/services.yaml
+++ b/src/Image/config/services.yaml
@@ -1,0 +1,25 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Symfony\UX\Image\Provider\ProviderRegistry:
+        public: true
+
+    Symfony\UX\Image\Service\Transformer:
+        arguments:
+            $breakpoints: '%ux_image.breakpoints%'
+
+    Symfony\UX\Image\Twig\Img:
+        tags:
+            - { name: 'twig.component' }
+
+    Symfony\UX\Image\Twig\Picture:
+        tags:
+            - { name: 'twig.component' }
+
+    # Auto-register providers
+    Symfony\UX\Image\Provider\ProviderInterface:
+        abstract: true
+        tags:
+            - { name: 'ux_image.provider' }

--- a/src/Image/phpunit.dist.xml
+++ b/src/Image/phpunit.dist.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="Symfony UX Image Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Image/src/DependencyInjection/Compiler/ProviderPass.php
+++ b/src/Image/src/DependencyInjection/Compiler/ProviderPass.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\UX\Image\Provider\ProviderRegistry;
+
+/**
+ * Registers all tagged providers into the ProviderRegistry.
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+class ProviderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(ProviderRegistry::class)) {
+            return;
+        }
+
+        $registry = $container->getDefinition(ProviderRegistry::class);
+        $taggedServices = $container->findTaggedServiceIds('ux_image.provider');
+
+        foreach ($taggedServices as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $name = $attributes['name'] ?? $id;
+                $registry->addMethodCall('addProvider', [new Reference($id)]);
+            }
+        }
+    }
+}

--- a/src/Image/src/DependencyInjection/Configuration.php
+++ b/src/Image/src/DependencyInjection/Configuration.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('ux_image');
+        $rootNode = $treeBuilder->getRootNode();
+
+        $rootNode
+            ->children()
+                ->scalarNode('default_provider')
+                    ->defaultValue('passthrough')
+                    ->info('The default provider to use when none is specified.')
+                ->end()
+                ->arrayNode('providers')
+                    ->useAttributeAsKey('name')
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('pattern')->end()
+                            ->scalarNode('assets_path')->end()
+                            ->arrayNode('config')
+                                ->useAttributeAsKey('key')
+                                ->scalarPrototype()->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('breakpoints')
+                    ->useAttributeAsKey('name')
+                    ->integerPrototype()->end()
+                    ->defaultValue([
+                        'sm' => 640,
+                        'md' => 768,
+                        'lg' => 1024,
+                        'xl' => 1280,
+                        '2xl' => 1536,
+                    ])
+                ->end()
+                ->arrayNode('defaults')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('format')->defaultValue('webp')->end()
+                        ->integerNode('quality')->defaultValue(80)->end()
+                        ->scalarNode('loading')->defaultValue('lazy')->end()
+                        ->scalarNode('fit')->defaultValue('cover')->end()
+                        ->scalarNode('focal')->defaultValue('center')->end()
+                        ->scalarNode('fallback')->defaultValue('lg')->end()
+                        ->scalarNode('fallback_format')->defaultValue('auto')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/Image/src/DependencyInjection/ImageExtension.php
+++ b/src/Image/src/DependencyInjection/ImageExtension.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\UX\Image\Provider\PassThroughProvider;
+use Symfony\UX\Image\Provider\ProviderInterface;
+use Symfony\UX\Image\Provider\ProviderRegistry;
+use Symfony\UX\Image\Provider\UrlPatternProvider;
+use Symfony\UX\Image\Service\Transformer;
+use Symfony\UX\Image\Twig\ImageRuntime;
+
+/**
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+class ImageExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../../config'));
+        $loader->load('services.yaml');
+
+        // Register breakpoints
+        $container->setParameter('ux_image.breakpoints', $config['breakpoints']);
+
+        // Register defaults
+        $container->setParameter('ux_image.defaults', $config['defaults']);
+
+        // Configure Transformer with breakpoints
+        $container->getDefinition(Transformer::class)
+            ->setArgument('$breakpoints', $config['breakpoints']);
+
+        // Register PassThroughProvider as default
+        $container->register(PassThroughProvider::class, PassThroughProvider::class)
+            ->addTag('ux_image.provider', ['name' => 'passthrough']);
+
+        // Register UrlPatternProvider if configured
+        if (isset($config['providers']['url_pattern'])) {
+            $container->register(UrlPatternProvider::class, UrlPatternProvider::class)
+                ->addTag('ux_image.provider', ['name' => 'url_pattern'])
+                ->addMethodCall('configure', [$config['providers']['url_pattern']]);
+        }
+
+        // Register custom providers from config
+        foreach ($config['providers'] as $name => $providerConfig) {
+            if ('url_pattern' === $name) {
+                continue; // Already handled above
+            }
+
+            if (isset($providerConfig['pattern'])) {
+                $container->register('ux_image.provider.'.$name, UrlPatternProvider::class)
+                    ->addTag('ux_image.provider', ['name' => $name])
+                    ->addMethodCall('configure', [$providerConfig]);
+            }
+        }
+
+        // Set default provider
+        $container->getDefinition(ProviderRegistry::class)
+            ->addMethodCall('setDefaultProvider', [$config['default_provider']]);
+
+        // Register ImageRuntime as a Twig extension
+        $container->register(ImageRuntime::class, ImageRuntime::class)
+            ->addArgument($container->getDefinition(ProviderRegistry::class))
+            ->addArgument($container->getDefinition(Transformer::class))
+            ->addArgument($config['defaults'])
+            ->addTag('twig.extension');
+    }
+
+    public function getAlias(): string
+    {
+        return 'ux_image';
+    }
+}

--- a/src/Image/src/ImageBundle.php
+++ b/src/Image/src/ImageBundle.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\UX\Image\DependencyInjection\Compiler\ProviderPass;
+
+/**
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+class ImageBundle extends Bundle
+{
+    public function getPath(): string
+    {
+        return \dirname(__DIR__);
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+        $container->addCompilerPass(new ProviderPass());
+    }
+}

--- a/src/Image/src/Provider/PassThroughProvider.php
+++ b/src/Image/src/Provider/PassThroughProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+/**
+ * Default provider that returns the original image path without transformations.
+ *
+ * Works with local files out of the box — no CDN or image processing library required.
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+class PassThroughProvider implements ProviderInterface
+{
+    private string $assetsPath = '';
+
+    public function getName(): string
+    {
+        return 'passthrough';
+    }
+
+    public function configure(array $config): void
+    {
+        $this->assetsPath = $config['assets_path'] ?? '';
+    }
+
+    public function getImage(string $src, array $modifiers): string
+    {
+        // Return the original path — no transformations
+        if ('' !== $this->assetsPath && !str_starts_with($src, '/')) {
+            return rtrim($this->assetsPath, '/').'/'.$src;
+        }
+
+        return $src;
+    }
+}

--- a/src/Image/src/Provider/ProviderInterface.php
+++ b/src/Image/src/Provider/ProviderInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+/**
+ * Contract for image transformation providers.
+ *
+ * Providers generate URLs for transformed images (resized, cropped, converted).
+ * Implement this interface to add support for any image CDN or processing library.
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+interface ProviderInterface
+{
+    /**
+     * Returns the unique name of this provider.
+     */
+    public function getName(): string;
+
+    /**
+     * Configures the provider with the given options.
+     */
+    public function configure(array $config): void;
+
+    /**
+     * Generates the URL for a transformed image.
+     *
+     * @param string $src       The source image path (e.g. "/images/hero.jpg")
+     * @param array  $modifiers Transformation options (width, height, format, quality, etc.)
+     *
+     * @return string The URL of the transformed image
+     */
+    public function getImage(string $src, array $modifiers): string;
+}

--- a/src/Image/src/Provider/ProviderRegistry.php
+++ b/src/Image/src/Provider/ProviderRegistry.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+/**
+ * Registry that holds and provides access to image providers.
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+class ProviderRegistry
+{
+    /**
+     * @var array<string, ProviderInterface>
+     */
+    private array $providers = [];
+    private ?string $defaultProvider = null;
+
+    public function addProvider(ProviderInterface $provider): void
+    {
+        $this->providers[$provider->getName()] = $provider;
+    }
+
+    public function setDefaultProvider(string $name): void
+    {
+        $this->defaultProvider = $name;
+    }
+
+    public function getProvider(?string $name = null): ProviderInterface
+    {
+        $name ??= $this->defaultProvider;
+
+        if (null === $name) {
+            throw new \InvalidArgumentException('No default provider configured and no provider name specified.');
+        }
+
+        if (!isset($this->providers[$name])) {
+            throw new \InvalidArgumentException(\sprintf('Provider "%s" not found. Available providers: %s', $name, implode(', ', array_keys($this->providers))));
+        }
+
+        return $this->providers[$name];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getProviderNames(): array
+    {
+        return array_keys($this->providers);
+    }
+}

--- a/src/Image/src/Provider/UrlPatternProvider.php
+++ b/src/Image/src/Provider/UrlPatternProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+/**
+ * Provider that generates URLs using a configurable pattern template.
+ *
+ * Example pattern: "/img/{src}?w={width}&h={height}&f={format}&q={quality}"
+ *
+ * This allows integration with any CDN that supports URL-based transformations
+ * (Cloudflare, imgix, Cloudinary, etc.) without writing custom code.
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+class UrlPatternProvider implements ProviderInterface
+{
+    private string $pattern;
+
+    public function getName(): string
+    {
+        return 'url_pattern';
+    }
+
+    public function configure(array $config): void
+    {
+        if (empty($config['pattern'])) {
+            throw new \InvalidArgumentException('The "pattern" option is required for UrlPatternProvider.');
+        }
+
+        $this->pattern = $config['pattern'];
+    }
+
+    public function getImage(string $src, array $modifiers): string
+    {
+        $url = $this->pattern;
+
+        $replacements = [
+            '{src}' => ltrim($src, '/'),
+            '{width}' => $modifiers['width'] ?? '',
+            '{height}' => $modifiers['height'] ?? '',
+            '{format}' => $modifiers['format'] ?? '',
+            '{quality}' => $modifiers['quality'] ?? '',
+            '{fit}' => $modifiers['fit'] ?? '',
+            '{focal}' => $modifiers['focal'] ?? '',
+            '{ratio}' => $modifiers['ratio'] ?? '',
+        ];
+
+        $url = str_replace(array_keys($replacements), array_values($replacements), $url);
+
+        // Remove empty query parameters
+        $url = preg_replace('/[?&]\w*=[&]?/', '', $url);
+        $url = rtrim($url, '?');
+
+        return $url;
+    }
+}

--- a/src/Image/src/Service/ImageConfig.php
+++ b/src/Image/src/Service/ImageConfig.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Service;
+
+/**
+ * Value object representing image transformation configuration.
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+final class ImageConfig
+{
+    public function __construct(
+        public readonly string $src,
+        public readonly ?string $alt = null,
+        public readonly ?string $width = null,
+        public readonly ?int $height = null,
+        public readonly ?string $ratio = null,
+        public readonly ?string $fit = 'cover',
+        public readonly ?string $focal = 'center',
+        public readonly ?int $quality = 80,
+        public readonly ?string $format = 'webp',
+        public readonly ?string $loading = 'lazy',
+        public readonly ?string $fetchpriority = 'low',
+        public readonly ?string $background = null,
+        public readonly ?string $fallback = 'lg',
+        public readonly ?string $fallbackFormat = 'auto',
+        public readonly ?string $densities = null,
+        public readonly ?string $provider = null,
+        public readonly ?array $modifiers = null,
+    ) {
+    }
+
+    /**
+     * Returns modifiers array for the provider.
+     */
+    public function toModifiers(?int $widthOverride = null): array
+    {
+        $modifiers = [];
+
+        if (null !== $widthOverride) {
+            $modifiers['width'] = $widthOverride;
+        } elseif (null !== $this->width && is_numeric($this->width)) {
+            $modifiers['width'] = (int) $this->width;
+        }
+
+        if (null !== $this->height) {
+            $modifiers['height'] = $this->height;
+        }
+
+        if (null !== $this->format) {
+            $modifiers['format'] = $this->format;
+        }
+
+        if (null !== $this->quality) {
+            $modifiers['quality'] = $this->quality;
+        }
+
+        if (null !== $this->fit) {
+            $modifiers['fit'] = $this->fit;
+        }
+
+        if (null !== $this->focal) {
+            $modifiers['focal'] = $this->focal;
+        }
+
+        if (null !== $this->background) {
+            $modifiers['background'] = $this->background;
+        }
+
+        if (null !== $this->ratio) {
+            $modifiers['ratio'] = $this->ratio;
+        }
+
+        if (null !== $this->modifiers) {
+            $modifiers = array_merge($modifiers, $this->modifiers);
+        }
+
+        return $modifiers;
+    }
+}

--- a/src/Image/src/Service/Transformer.php
+++ b/src/Image/src/Service/Transformer.php
@@ -1,0 +1,319 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Service;
+
+/**
+ * Transforms responsive image configurations into HTML attributes.
+ *
+ * Handles width parsing, breakpoint calculations, srcset and sizes generation.
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+class Transformer
+{
+    private const BREAKPOINT_ORDER = ['default', 'sm', 'md', 'lg', 'xl', '2xl'];
+
+    /**
+     * @param array<string, int> $breakpoints
+     */
+    public function __construct(
+        private readonly array $breakpoints = [
+            'sm' => 640,
+            'md' => 768,
+            'lg' => 1024,
+            'xl' => 1280,
+            '2xl' => 1536,
+        ],
+    ) {
+    }
+
+    /**
+     * Parses a width string like "100vw sm:50vw md:400px" into structured data.
+     *
+     * Returns an array keyed by breakpoint name, each containing:
+     *   - 'value': pixel width
+     *   - 'vw': viewport width percentage (0 if fixed)
+     */
+    public function parseWidth(string $width): array
+    {
+        $parts = preg_split('/\s+/', trim($width));
+        $widths = [];
+        $smallestBreakpoint = null;
+
+        foreach ($parts as $part) {
+            if (str_contains($part, ':')) {
+                [$breakpoint, $value] = explode(':', $part, 2);
+                $normalized = $this->normalizeWidthValue($value, $breakpoint);
+                $widths[$breakpoint] = $normalized;
+
+                if (!$smallestBreakpoint
+                    || array_search($breakpoint, self::BREAKPOINT_ORDER, true) < array_search($smallestBreakpoint, self::BREAKPOINT_ORDER, true)) {
+                    $smallestBreakpoint = $breakpoint;
+                }
+            } else {
+                $widths['default'] = $this->normalizeWidthValue($part, 'default');
+            }
+        }
+
+        // If no default but we have breakpoints, use smallest as default
+        if (!isset($widths['default']) && $smallestBreakpoint) {
+            $widths['default'] = $widths[$smallestBreakpoint];
+        }
+
+        // Calculate viewport widths
+        if (isset($widths['default']) && '0' !== $widths['default']['vw']) {
+            $this->calculateViewportWidths($widths);
+        } else {
+            $this->propagateFixedWidths($widths);
+        }
+
+        return $widths;
+    }
+
+    /**
+     * Generates the sizes attribute from parsed widths.
+     */
+    public function getSizes(array $widths): string
+    {
+        if (isset($widths['default']) && '100' === $widths['default']['vw']) {
+            return '100vw';
+        }
+
+        $sizes = [];
+        $breakpointKeys = array_keys($this->breakpoints);
+
+        // Find largest explicit value for default
+        $largestValue = null;
+        foreach (array_reverse($breakpointKeys) as $key) {
+            if (isset($widths[$key])) {
+                $largestValue = $widths[$key];
+                break;
+            }
+        }
+
+        if ($largestValue) {
+            $sizes[] = $this->formatSizeValue($largestValue);
+        }
+
+        // Process breakpoints largest to smallest
+        foreach (array_reverse($breakpointKeys) as $i => $key) {
+            if (isset($widths[$key])) {
+                $nextValue = null;
+                for ($j = $i + 1; $j < \count($breakpointKeys); ++$j) {
+                    $nextKey = array_reverse($breakpointKeys)[$j];
+                    if (isset($widths[$nextKey])) {
+                        $nextValue = $widths[$nextKey];
+                        break;
+                    }
+                }
+
+                if (!$nextValue && isset($widths['default'])) {
+                    $nextValue = $widths['default'];
+                }
+
+                $sizes[] = \sprintf('(max-width: %dpx) %s',
+                    $this->breakpoints[$key],
+                    $this->formatSizeValue($widths[$key])
+                );
+
+                if ($nextValue && !$this->isSameValue($widths[$key], $nextValue)) {
+                    $sizes[] = \sprintf('(max-width: %dpx) %s',
+                        $this->breakpoints[$key],
+                        $this->formatSizeValue($nextValue)
+                    );
+                }
+            }
+        }
+
+        return implode(', ', array_unique($sizes));
+    }
+
+    /**
+     * Generates the srcset attribute from parsed widths.
+     *
+     * @param callable $imageCallback Function that takes modifiers and returns image URL
+     */
+    public function getSrcset(string $src, array $widths, callable $imageCallback): string
+    {
+        $srcset = [];
+        foreach ($widths as $width) {
+            if ($width['value'] > 0) {
+                $srcset[] = \sprintf('%s %sw',
+                    $imageCallback(['width' => $width['value']]),
+                    $width['value']
+                );
+            }
+        }
+
+        return implode(', ', $srcset);
+    }
+
+    /**
+     * Returns the initial width for the fallback/src image.
+     */
+    public function getInitialWidth(array $widths, string $pattern): int
+    {
+        if (preg_match('/^\d+vw/', $pattern)) {
+            $smallestWidth = \PHP_INT_MAX;
+            foreach ($widths as $width) {
+                if ($width['value'] < $smallestWidth && '0' !== $width['vw']) {
+                    $smallestWidth = $width['value'];
+                }
+            }
+
+            return $smallestWidth;
+        }
+
+        return $widths['default']['value'];
+    }
+
+    /**
+     * Calculates widths for density-based srcset (e.g., x1 x2).
+     */
+    public function getDensityBasedWidths(int $baseWidth, string $densities): array
+    {
+        $multipliers = array_map(
+            fn ($d) => (float) str_replace('x', '', trim($d)),
+            explode(' ', $densities)
+        );
+
+        $widths = [];
+        foreach ($multipliers as $multiplier) {
+            $widths[] = (int) ($baseWidth * $multiplier);
+        }
+
+        sort($widths);
+
+        return $widths;
+    }
+
+    /**
+     * Parses a ratio string like "sm:1:1 md:16:9" into breakpoint-ratio pairs.
+     */
+    public function parseRatio(string $ratio): array
+    {
+        $parts = preg_split('/\s+/', trim($ratio));
+        $ratios = [];
+
+        foreach ($parts as $part) {
+            if (str_contains($part, ':')) {
+                // Handle "sm:1:1" — split on first colon only
+                [$breakpoint, $value] = explode(':', $part, 2);
+                $ratios[$breakpoint] = $value;
+            } else {
+                $ratios['default'] = $part;
+            }
+        }
+
+        return $ratios;
+    }
+
+    /**
+     * Cascades ratios across breakpoints (CSS-like inheritance).
+     */
+    public function cascadeRatios(array $parsedRatios): array
+    {
+        if (empty($parsedRatios)) {
+            return [];
+        }
+
+        $breakpointOrder = ['sm', 'md', 'lg', 'xl', '2xl'];
+        $cascaded = [];
+        $currentRatio = $parsedRatios['default'] ?? null;
+
+        foreach ($breakpointOrder as $breakpoint) {
+            if (isset($parsedRatios[$breakpoint])) {
+                $currentRatio = $parsedRatios[$breakpoint];
+            }
+
+            if ($currentRatio) {
+                $cascaded[$breakpoint] = $currentRatio;
+            }
+        }
+
+        return $cascaded;
+    }
+
+    public function getBreakpoints(): array
+    {
+        return $this->breakpoints;
+    }
+
+    private function normalizeWidthValue(string $value, string $breakpoint = 'default'): array
+    {
+        $isVw = str_ends_with($value, 'vw');
+        $numericValue = (int) preg_replace('/[^0-9]/', '', $value);
+
+        if ($isVw) {
+            $breakpointWidth = 'default' === $breakpoint
+                ? $this->breakpoints['sm']
+                : $this->breakpoints[$breakpoint];
+
+            $pixelWidth = (int) ($breakpointWidth * ($numericValue / 100));
+
+            return [
+                'value' => $pixelWidth,
+                'vw' => (string) $numericValue,
+            ];
+        }
+
+        return [
+            'value' => $numericValue,
+            'vw' => '0',
+        ];
+    }
+
+    private function calculateViewportWidths(array &$widths): void
+    {
+        $vwPercentage = (int) $widths['default']['vw'];
+
+        foreach (self::BREAKPOINT_ORDER as $breakpoint) {
+            if (!isset($widths[$breakpoint])) {
+                $breakpointWidth = 'default' === $breakpoint
+                    ? $this->breakpoints['sm']
+                    : $this->breakpoints[$breakpoint];
+
+                $pixelWidth = (int) ($breakpointWidth * ($vwPercentage / 100));
+
+                $widths[$breakpoint] = [
+                    'value' => $pixelWidth,
+                    'vw' => (string) $vwPercentage,
+                ];
+            }
+        }
+    }
+
+    private function propagateFixedWidths(array &$widths): void
+    {
+        $lastValue = $widths['default'];
+
+        foreach (self::BREAKPOINT_ORDER as $breakpoint) {
+            if (!isset($widths[$breakpoint])) {
+                $widths[$breakpoint] = $lastValue;
+            } else {
+                $lastValue = $widths[$breakpoint];
+            }
+        }
+    }
+
+    private function isSameValue(array $a, array $b): bool
+    {
+        return $a['value'] === $b['value'] && $a['vw'] === $b['vw'];
+    }
+
+    private function formatSizeValue(array $width): string
+    {
+        return '0' !== $width['vw']
+            ? $width['vw'].'vw'
+            : $width['value'].'px';
+    }
+}

--- a/src/Image/src/Twig/ImageRuntime.php
+++ b/src/Image/src/Twig/ImageRuntime.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+use Symfony\UX\Image\Provider\ProviderRegistry;
+use Symfony\UX\Image\Service\Transformer;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Twig extension providing the {{ ux_image() }} function.
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+class ImageRuntime extends AbstractExtension
+{
+    public function __construct(
+        private readonly ProviderRegistry $providerRegistry,
+        private readonly Transformer $transformer,
+        private readonly array $defaults = [],
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('ux_image', [$this, 'renderImage']),
+        ];
+    }
+
+    /**
+     * Renders a responsive image tag.
+     *
+     * @param string      $src       Image source path
+     * @param string|null $alt       Alt text
+     * @param array       $options   Additional options (width, ratio, format, etc.)
+     */
+    public function renderImage(string $src, ?string $alt = null, array $options = []): string
+    {
+        $provider = $this->providerRegistry->getProvider($options['provider'] ?? null);
+        $modifiers = [];
+
+        if (isset($options['width'])) {
+            $widths = $this->transformer->parseWidth($options['width']);
+            $initialWidth = $this->transformer->getInitialWidth($widths, $options['width']);
+            $modifiers['width'] = $initialWidth;
+        }
+
+        if (isset($options['format'])) {
+            $modifiers['format'] = $options['format'];
+        }
+        if (isset($options['quality'])) {
+            $modifiers['quality'] = $options['quality'];
+        }
+        if (isset($options['fit'])) {
+            $modifiers['fit'] = $options['fit'];
+        }
+        if (isset($options['focal'])) {
+            $modifiers['focal'] = $options['focal'];
+        }
+        if (isset($options['ratio'])) {
+            $modifiers['ratio'] = $options['ratio'];
+        }
+        if (isset($options['background'])) {
+            $modifiers['background'] = $options['background'];
+        }
+
+        $imageUrl = $provider->getImage($src, $modifiers);
+
+        $attributes = [
+            'src' => htmlspecialchars($imageUrl, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'),
+        ];
+
+        if (null !== $alt) {
+            $attributes['alt'] = htmlspecialchars($alt, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+        }
+
+        // Generate srcset if width is responsive
+        if (isset($options['width']) && (str_contains($options['width'], 'vw') || str_contains($options['width'], ':'))) {
+            $widths = $this->transformer->parseWidth($options['width']);
+            $srcset = $this->transformer->getSrcset($src, $widths,
+                fn ($m) => $provider->getImage($src, array_merge($modifiers, $m))
+            );
+            $attributes['srcset'] = htmlspecialchars($srcset, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+            $attributes['sizes'] = htmlspecialchars($this->transformer->getSizes($widths), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+        }
+
+        if (isset($options['loading'])) {
+            $attributes['loading'] = htmlspecialchars($options['loading'], \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+        }
+        if (isset($options['class'])) {
+            $attributes['class'] = htmlspecialchars($options['class'], \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+        }
+
+        $attrString = '';
+        foreach ($attributes as $key => $value) {
+            $attrString .= \sprintf(' %s="%s"', $key, $value);
+        }
+
+        return \sprintf('<img%s>', $attrString);
+    }
+}

--- a/src/Image/src/Twig/Img.php
+++ b/src/Image/src/Twig/Img.php
@@ -1,0 +1,258 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+use Symfony\UX\Image\Provider\ProviderRegistry;
+use Symfony\UX\Image\Service\Transformer;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+
+/**
+ * Responsive image Twig component.
+ *
+ * Usage:
+ *   <twig:ux:img src="/images/hero.jpg" alt="Hero" width="100vw md:80vw" />
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+#[AsTwigComponent('ux:img', template: '@Image/components/img.html.twig')]
+class Img
+{
+    public const EMPTY_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
+
+    public string $src;
+    public ?string $alt = null;
+    public ?string $width = null;
+    public ?int $height = null;
+    public ?string $ratio = null;
+    public ?string $fit = null;
+    public ?string $focal = null;
+    public ?int $quality = null;
+    public ?string $format = null;
+    public ?string $loading = null;
+    public ?string $fetchpriority = null;
+    public ?string $background = null;
+    public ?string $fallback = null;
+    public ?string $fallbackFormat = null;
+    public ?string $class = null;
+    public ?string $sizes = null;
+    public ?string $srcset = null;
+    public ?string $densities = null;
+    public ?array $modifiers = null;
+    public ?string $provider = null;
+    public ?string $fallbackImage = null;
+
+    /** @var array<string, mixed> */
+    public array $extraAttributes = [];
+
+    protected array $widths = [];
+    public ?int $widthComputed = null;
+
+    public function __construct(
+        protected ProviderRegistry $providerRegistry,
+        protected Transformer $transformer,
+    ) {
+    }
+
+    public function mount(
+        string $src,
+        ?string $alt = null,
+        ?string $width = null,
+        ?int $height = null,
+        ?string $ratio = null,
+        ?string $fit = null,
+        ?string $focal = null,
+        ?int $quality = null,
+        ?string $format = null,
+        ?string $loading = 'lazy',
+        ?string $fetchpriority = null,
+        ?string $background = null,
+        ?string $fallback = 'lg',
+        ?string $fallbackFormat = 'auto',
+        ?string $densities = null,
+        ?array $modifiers = null,
+        ?string $provider = null,
+        ?string $class = null,
+    ): void {
+        $this->src = $src;
+        $this->alt = $alt;
+        $this->width = $width;
+        $this->height = $height;
+        $this->ratio = $ratio;
+        $this->fit = $fit;
+        $this->focal = $focal;
+        $this->quality = $quality;
+        $this->format = $format;
+        $this->loading = $loading;
+        $this->fetchpriority = $fetchpriority;
+        $this->background = $background;
+        $this->fallback = $fallback;
+        $this->fallbackFormat = $fallbackFormat;
+        $this->densities = $densities;
+        $this->modifiers = $modifiers;
+        $this->provider = $provider;
+        $this->class = $class;
+
+        if ($this->width) {
+            $this->widths = $this->transformer->parseWidth($this->width);
+            $this->widthComputed = $this->transformer->getInitialWidth($this->widths, $this->width);
+
+            // Build fallback image (with fallback format)
+            $this->fallbackImage = $this->getImage(['width' => $this->widthComputed], true);
+
+            // Generate srcset
+            if ($this->densities) {
+                $this->handleDensities();
+            } elseif (str_contains($this->width, 'vw') || str_contains($this->width, ':')) {
+                $this->srcset = $this->transformer->getSrcset(
+                    $this->src,
+                    $this->widths,
+                    fn ($m) => $this->getImage($m, false)
+                );
+                $this->sizes = $this->transformer->getSizes($this->widths);
+            }
+        } else {
+            $this->fallbackImage = $this->getImage([], true);
+        }
+    }
+
+    /**
+     * Collects any data-* and aria-* attributes passed to the component.
+     */
+    public function preMount(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (str_starts_with($key, 'data-') || str_starts_with($key, 'aria-')) {
+                $this->extraAttributes[$key] = $value;
+                unset($data[$key]);
+            }
+        }
+
+        return $data;
+    }
+
+    protected function getImage(array $modifiers = [], bool $applyFallback = false): string
+    {
+        if ($this->modifiers) {
+            $modifiers = array_merge($modifiers, $this->modifiers);
+        }
+
+        if ($this->format && !$applyFallback) {
+            $modifiers['format'] = $this->format;
+        } elseif ($applyFallback) {
+            if ('empty' === $this->fallbackFormat) {
+                return self::EMPTY_GIF;
+            } elseif ('auto' === $this->fallbackFormat) {
+                $ext = strtolower(pathinfo($this->src, \PATHINFO_EXTENSION));
+                $modifiers['format'] = \in_array($ext, ['png', 'webp', 'gif'], true) ? 'png' : 'jpg';
+            } elseif ($this->fallbackFormat) {
+                $modifiers['format'] = $this->fallbackFormat;
+            }
+        }
+
+        if (null !== $this->quality) {
+            $modifiers['quality'] = $this->quality;
+        }
+        if (null !== $this->fit) {
+            $modifiers['fit'] = $this->fit;
+        }
+        if (null !== $this->focal) {
+            $modifiers['focal'] = $this->focal;
+        }
+        if (null !== $this->background) {
+            $modifiers['background'] = $this->background;
+        }
+        if (null !== $this->ratio) {
+            $modifiers['ratio'] = $this->ratio;
+        }
+        if (isset($modifiers['width'])) {
+            $modifiers['width'] = (int) $modifiers['width'];
+        }
+
+        return $this->providerRegistry->getProvider($this->provider)->getImage($this->src, $modifiers);
+    }
+
+    protected function handleDensities(): void
+    {
+        if (!str_contains($this->width, 'vw') && !str_contains($this->width, ':')) {
+            $densityWidths = $this->transformer->getDensityBasedWidths($this->widthComputed, $this->densities);
+            $parts = [];
+            foreach ($densityWidths as $w) {
+                $parts[] = $this->getImage(['width' => $w], false).' '.$w.'w';
+            }
+            $this->srcset = implode(', ', $parts);
+        } else {
+            $densityWidths = $this->transformer->getDensityBasedWidths($this->widthComputed, $this->densities);
+            $this->widths = array_unique(array_merge($this->widths, $densityWidths));
+            sort($this->widths);
+            $this->srcset = $this->transformer->getSrcset(
+                $this->src,
+                $this->widths,
+                fn ($m) => $this->getImage($m, false)
+            );
+        }
+    }
+
+    /**
+     * Returns the src attribute for the img element (fallback format).
+     */
+    public function getSrc(): string
+    {
+        if ($this->width && str_contains($this->width, 'vw')) {
+            $bps = $this->transformer->getBreakpoints();
+            return $this->getImage(['width' => $bps[$this->fallback]], true);
+        }
+
+        if ($this->width) {
+            $widths = $this->transformer->parseWidth($this->width);
+            $w = $widths['default'] ?? array_shift($widths);
+            return $this->getImage(['width' => $w['value']], true);
+        }
+
+        return $this->getImage([], true);
+    }
+
+    /**
+     * Returns the computed src (for the template).
+     */
+    public function getSrcComputed(): string
+    {
+        if ('empty' === $this->fallbackFormat) {
+            return self::EMPTY_GIF;
+        }
+
+        if ($this->width) {
+            $getFallback = str_contains($this->width, 'w');
+            return $this->getImage(['width' => $this->widthComputed], $getFallback);
+        }
+
+        return $this->getImage([], false);
+    }
+
+    public function getHtmlWidth(): ?string
+    {
+        if ($this->width && preg_match('/^\d+$/', $this->width)) {
+            return $this->width;
+        }
+
+        return null;
+    }
+
+    public function getHtmlHeight(): ?string
+    {
+        if (null !== $this->height) {
+            return (string) $this->height;
+        }
+
+        return null;
+    }
+}

--- a/src/Image/src/Twig/Picture.php
+++ b/src/Image/src/Twig/Picture.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * Art direction Twig component for different crops per breakpoint.
+ *
+ * Usage:
+ *   <twig:ux:picture src="/images/hero.jpg" alt="Hero" width="100vw md:80vw" ratio="sm:1:1 md:16:9" />
+ *
+ * @author Aleksey Razbakov <aleksey@razbakov.com>
+ */
+#[AsTwigComponent('ux:picture', template: '@Image/components/picture.html.twig')]
+final class Picture extends Img
+{
+    protected function getImage(array $modifiers = [], bool $applyFallback = false): string
+    {
+        // Don't auto-apply ratio — it may be breakpoint-specific
+        $originalRatio = $this->ratio;
+        $this->ratio = null;
+
+        $result = parent::getImage($modifiers, $applyFallback);
+
+        $this->ratio = $originalRatio;
+
+        return $result;
+    }
+
+    public function getBreakpoints(): array
+    {
+        if (!$this->width) {
+            return [];
+        }
+
+        $parsedRatios = $this->ratio ? $this->transformer->parseRatio($this->ratio) : [];
+        $cascadedRatios = $this->transformer->cascadeRatios($parsedRatios);
+        $hasArtDirection = !empty($cascadedRatios) && \count(array_unique($cascadedRatios)) > 1;
+
+        if (str_contains($this->width, 'vw')) {
+            $breakpoints = [];
+            $parsedWidths = $this->transformer->parseWidth($this->width);
+            $sizesAttribute = $this->transformer->getSizes($parsedWidths);
+            $configuredBreakpoints = $this->transformer->getBreakpoints();
+            $breakpointKeys = array_keys($configuredBreakpoints);
+            $index = 0;
+
+            foreach ($configuredBreakpoints as $breakpoint => $size) {
+                $modifiers = ['width' => $size];
+
+                if (isset($cascadedRatios[$breakpoint])) {
+                    $modifiers['ratio'] = $cascadedRatios[$breakpoint];
+                }
+
+                if ($hasArtDirection) {
+                    if ($index === \count($breakpointKeys) - 1) {
+                        $breakpoints[] = [
+                            'media' => "(min-width: {$size}px)",
+                            'srcset' => $this->getImage($modifiers, false)." {$size}w",
+                            'sizes' => $sizesAttribute,
+                        ];
+                    } else {
+                        $nextSize = $configuredBreakpoints[$breakpointKeys[$index + 1]];
+                        $breakpoints[] = [
+                            'media' => "(min-width: {$size}px) and (max-width: ".($nextSize - 1)."px)",
+                            'srcset' => $this->getImage($modifiers, false)." {$size}w",
+                            'sizes' => $sizesAttribute,
+                        ];
+                    }
+                } else {
+                    $breakpoints[] = [
+                        'media' => "(min-width: {$size}px)",
+                        'srcset' => $this->getImage($modifiers, false)." {$size}w",
+                        'sizes' => $sizesAttribute,
+                    ];
+                }
+
+                ++$index;
+            }
+
+            return $breakpoints;
+        }
+
+        if (!str_contains($this->width, ':')) {
+            return [];
+        }
+
+        $breakpoints = [];
+        $widths = $this->transformer->parseWidth($this->width);
+        $configuredBreakpoints = $this->transformer->getBreakpoints();
+
+        foreach ($widths as $breakpoint => $width) {
+            if ('default' === $breakpoint) {
+                continue;
+            }
+
+            if (isset($configuredBreakpoints[$breakpoint])) {
+                $modifiers = ['width' => $width['value']];
+
+                if (isset($cascadedRatios[$breakpoint])) {
+                    $modifiers['ratio'] = $cascadedRatios[$breakpoint];
+                }
+
+                $breakpoints[] = [
+                    'media' => "(max-width: {$configuredBreakpoints[$breakpoint]}px)",
+                    'srcset' => $this->getImage($modifiers, false),
+                ];
+            }
+        }
+
+        return $breakpoints;
+    }
+
+    public function getSizes(): ?string
+    {
+        if (str_contains($this->width, 'vw')) {
+            return $this->width;
+        }
+
+        return null;
+    }
+}

--- a/src/Image/templates/components/img.html.twig
+++ b/src/Image/templates/components/img.html.twig
@@ -1,0 +1,12 @@
+<img
+    src="{{ component.srcComputed }}"
+    {% if component.alt %}alt="{{ component.alt }}"{% endif %}
+    {% if component.srcset %}srcset="{{ component.srcset }}"{% endif %}
+    {% if component.sizes %}sizes="{{ component.sizes }}"{% endif %}
+    {% if component.getHtmlWidth %}width="{{ component.getHtmlWidth }}"{% endif %}
+    {% if component.getHtmlHeight %}height="{{ component.getHtmlHeight }}"{% endif %}
+    {% if component.loading %}loading="{{ component.loading }}"{% endif %}
+    {% if component.fetchpriority %}fetchpriority="{{ component.fetchpriority }}"{% endif %}
+    {% if component.class %}class="{{ component.class }}"{% endif %}
+    {% for attr, value in component.extraAttributes %}{{ attr }}="{{ value }}" {% endfor %}
+/>

--- a/src/Image/templates/components/picture.html.twig
+++ b/src/Image/templates/components/picture.html.twig
@@ -1,0 +1,19 @@
+<picture>
+    {% for bp in component.getBreakpoints() %}
+        <source
+            {% if bp.media is defined and bp.media %}media="{{ bp.media }}"{% endif %}
+            srcset="{{ bp.srcset }}"
+            {% if bp.sizes is defined and bp.sizes %}sizes="{{ bp.sizes }}"{% endif %}
+        />
+    {% endfor %}
+    <img
+        src="{{ component.srcComputed }}"
+        {% if component.alt %}alt="{{ component.alt }}"{% endif %}
+        {% if component.getSizes %}sizes="{{ component.getSizes }}"{% endif %}
+        {% if component.getHtmlWidth %}width="{{ component.getHtmlWidth }}"{% endif %}
+        {% if component.getHtmlHeight %}height="{{ component.getHtmlHeight }}"{% endif %}
+        {% if component.loading %}loading="{{ component.loading }}"{% endif %}
+        {% if component.fetchpriority %}fetchpriority="{{ component.fetchpriority }}"{% endif %}
+        {% if component.class %}class="{{ component.class }}"{% endif %}
+    />
+</picture>

--- a/src/Image/tests/Provider/ProviderTest.php
+++ b/src/Image/tests/Provider/ProviderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Provider\PassThroughProvider;
+use Symfony\UX\Image\Provider\UrlPatternProvider;
+
+class PassThroughProviderTest extends TestCase
+{
+    public function testReturnsOriginalPath(): void
+    {
+        $provider = new PassThroughProvider();
+        $this->assertEquals('/images/hero.jpg', $provider->getImage('/images/hero.jpg', []));
+    }
+
+    public function testPrependsAssetsPath(): void
+    {
+        $provider = new PassThroughProvider();
+        $provider->configure(['assets_path' => '/assets']);
+        $this->assertEquals('/assets/hero.jpg', $provider->getImage('hero.jpg', []));
+    }
+
+    public function testGetName(): void
+    {
+        $provider = new PassThroughProvider();
+        $this->assertEquals('passthrough', $provider->getName());
+    }
+}
+
+class UrlPatternProviderTest extends TestCase
+{
+    public function testGeneratesUrlFromPattern(): void
+    {
+        $provider = new UrlPatternProvider();
+        $provider->configure(['pattern' => '/img/{src}?w={width}&f={format}']);
+
+        $url = $provider->getImage('/images/hero.jpg', ['width' => 800, 'format' => 'webp']);
+        $this->assertEquals('/img/images/hero.jpg?w=800&f=webp', $url);
+    }
+
+    public function testRequiresPattern(): void
+    {
+        $provider = new UrlPatternProvider();
+        $this->expectException(\InvalidArgumentException::class);
+        $provider->configure([]);
+    }
+
+    public function testGetName(): void
+    {
+        $provider = new UrlPatternProvider();
+        $this->assertEquals('url_pattern', $provider->getName());
+    }
+}

--- a/src/Image/tests/Service/TransformerTest.php
+++ b/src/Image/tests/Service/TransformerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Service;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Service\Transformer;
+
+class TransformerTest extends TestCase
+{
+    private Transformer $transformer;
+
+    protected function setUp(): void
+    {
+        $this->transformer = new Transformer([
+            'sm' => 640,
+            'md' => 768,
+            'lg' => 1024,
+            'xl' => 1280,
+            '2xl' => 1536,
+        ]);
+    }
+
+    #[DataProvider('provideWidthParsing')]
+    public function testParseWidth(string $input, array $expected): void
+    {
+        $result = $this->transformer->parseWidth($input);
+
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $result);
+            $this->assertEquals($value['value'], $result[$key]['value'], "Value mismatch for key: $key");
+            $this->assertEquals($value['vw'], $result[$key]['vw'], "VW mismatch for key: $key");
+        }
+    }
+
+    public static function provideWidthParsing(): array
+    {
+        return [
+            'simple fixed' => [
+                '800',
+                ['default' => ['value' => 800, 'vw' => '0']],
+            ],
+            'viewport width' => [
+                '100vw',
+                ['default' => ['value' => 640, 'vw' => '100']],
+            ],
+            'responsive with breakpoints' => [
+                '100vw sm:50vw md:400',
+                [
+                    'default' => ['value' => 640, 'vw' => '100'],
+                    'sm' => ['value' => 640, 'vw' => '100'],
+                    'md' => ['value' => 400, 'vw' => '0'],
+                ],
+            ],
+        ];
+    }
+
+    public function testGetSizesReturns100vw(): void
+    {
+        $widths = $this->transformer->parseWidth('100vw');
+        $this->assertEquals('100vw', $this->transformer->getSizes($widths));
+    }
+
+    public function testGetDensityBasedWidths(): void
+    {
+        $result = $this->transformer->getDensityBasedWidths(200, 'x1 x2');
+        $this->assertEquals([200, 400], $result);
+    }
+
+    public function testParseRatio(): void
+    {
+        $result = $this->transformer->parseRatio('sm:1:1 md:16:9');
+        $this->assertEquals(['sm' => '1:1', 'md' => '16:9'], $result);
+    }
+
+    public function testCascadeRatios(): void
+    {
+        $parsed = ['sm' => '1:1', 'md' => '16:9'];
+        $result = $this->transformer->cascadeRatios($parsed);
+        $this->assertEquals([
+            'sm' => '1:1',
+            'md' => '16:9',
+            'lg' => '16:9',
+            'xl' => '16:9',
+            '2xl' => '16:9',
+        ], $result);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

## Summary

Slim v1 of `symfony/ux-image` — responsive image components addressing all feedback from the original PR #3188.

### What's Included

**`<twig:ux:img>`** — Simple responsive images
- Viewport-based width syntax (`100vw md:80vw`)
- Automatic srcset/sizes generation
- Density support (`densities="x1 x2"`)
- Fallback format for older browsers

**`<twig:ux:picture>`** — Art direction
- Breakpoint-specific aspect ratios (`sm:1:1 md:16:9`)
- Ratio cascading (CSS-like inheritance)
- Exclusive media queries for correct aspect ratio

### Key Changes from Original PR

| Original Issue | Resolution |
|---|---|
| `liip/imagine-bundle` in `require` | Removed — no hard dependencies |
| No local file support | `PassThroughProvider` works out of the box |
| PreloadManager controversy | Removed entirely |
| Arrays instead of objects | `ImageConfig` value object |
| Component name conflicts | `ux:img` / `ux:picture` |
| Only TwigComponent syntax | Also supports `{{ ux_image() }}` |
| Too many features | Slim scope — iterate on v1 |

### Provider Architecture

- **PassThroughProvider** (default) — works with local files, no CDN required
- **UrlPatternProvider** — generic CDN via URL template (Cloudflare, imgix, etc.)
- **Custom providers** — implement `ProviderInterface` and tag with `ux_image.provider`

### Usage

```twig
{# Simple responsive image #}
<twig:ux:img src="/images/hero.jpg" alt="Hero" width="100vw md:80vw" />

{# Art direction #}
<twig:ux:picture src="/images/banner.jpg" alt="Banner" width="100vw md:80vw" ratio="sm:1:1 md:16:9" />

{# Without Twig components #}
{{ ux_image('/images/hero.jpg', 'Hero', { width: '100vw md:80vw' }) }}
```

### Configuration

```yaml
# config/packages/ux_image.yaml
ux_image:
    default_provider: passthrough
    providers:
        cloudflare:
            pattern: '/cdn-cgi/image/w={width},f={format},q={quality}/{src}'
```

This addresses feedback from @WebMamba, @smnandre, and @Kocal on the original PR. Happy to iterate further!