### PR TITLE
[LiveComponent] Add push history state support to LiveComponent

### DIFF
--- a/src/LiveComponent/CHANGELOG.md
+++ b/src/LiveComponent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1
 
 - Use `aria-busy` attribute during component re-render
+- Add a new `pushHistoryState` parameter to the `AsLiveComponent` attribute, which allows pushing a new history state on URL change after a re-render.
 
 ## 3.0.0
 

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -3,9 +3,11 @@ declare class export_default$2 {
   response: Response;
   private body;
   private liveUrl;
+  private pushHistoryState;
   constructor(response: Response);
   getBody(): Promise<string>;
   getLiveUrl(): string | null;
+  hasPushHistoryStateEnabled(): boolean;
 }
 declare class export_default$1 {
   promise: Promise<Response>;

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -97,6 +97,10 @@ var BackendResponse_default = class {
 		if (void 0 === this.liveUrl) this.liveUrl = this.response.headers.get("X-Live-Url");
 		return this.liveUrl;
 	}
+	hasPushHistoryStateEnabled() {
+		if (void 0 === this.pushHistoryState) this.pushHistoryState = this.response.headers.get("X-Live-Url-Push-History-State") === "1";
+		return this.pushHistoryState;
+	}
 };
 function getElementAsTagText(element) {
 	return element.innerHTML ? element.outerHTML.slice(0, element.outerHTML.indexOf(element.innerHTML)) : element.outerHTML;
@@ -1519,7 +1523,7 @@ var Component = class {
 				return response;
 			}
 			const liveUrl = backendResponse.getLiveUrl();
-			if (liveUrl) history.replaceState(history.state, "", new URL(liveUrl + window.location.hash, window.location.origin));
+			if (liveUrl) (backendResponse.hasPushHistoryStateEnabled() ? history.pushState : history.replaceState).call(history, history.state, "", new URL(liveUrl + window.location.hash, window.location.origin));
 			this.processRerender(html, backendResponse);
 			this.backendRequest = null;
 			thisPromiseResolve(backendResponse);

--- a/src/LiveComponent/assets/src/Backend/BackendResponse.ts
+++ b/src/LiveComponent/assets/src/Backend/BackendResponse.ts
@@ -2,6 +2,7 @@ export default class {
     response: Response;
     private body: string;
     private liveUrl: string | null;
+    private pushHistoryState: boolean;
 
     constructor(response: Response) {
         this.response = response;
@@ -21,5 +22,13 @@ export default class {
         }
 
         return this.liveUrl;
+    }
+
+    hasPushHistoryStateEnabled(): boolean {
+        if (undefined === this.pushHistoryState) {
+            this.pushHistoryState = this.response.headers.get('X-Live-Url-Push-History-State') === '1';
+        }
+
+        return this.pushHistoryState;
     }
 }

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -329,7 +329,12 @@ export default class Component {
 
             const liveUrl = backendResponse.getLiveUrl();
             if (liveUrl) {
-                history.replaceState(
+                const historyMethod = backendResponse.hasPushHistoryStateEnabled()
+                    ? history.pushState
+                    : history.replaceState;
+
+                historyMethod.call(
+                    history,
                     history.state,
                     '',
                     new URL(liveUrl + window.location.hash, window.location.origin)

--- a/src/LiveComponent/assets/test/tools.ts
+++ b/src/LiveComponent/assets/test/tools.ts
@@ -175,6 +175,7 @@ class MockedAjaxCall {
     private changePropsCallback?: (props: any) => void;
     private template?: (props: any) => string;
     private liveUrl?: string;
+    private pushHistoryState?: string;
     private delayResponseTime?: number = 0;
     private customResponseStatusCode?: number;
     private customResponseHTML?: string;
@@ -273,12 +274,14 @@ class MockedAjaxCall {
                 const headers = {
                     'Content-Type': 'application/vnd.live-component+html',
                     'X-Live-Url': '',
+                    'X-Live-Url-Push-History-State': '0',
                 };
                 if (this.customResponseHTML) {
                     headers['Content-Type'] = 'text/html';
                 }
                 if (this.liveUrl) {
                     headers['X-Live-Url'] = this.liveUrl;
+                    headers['X-Live-Url-Push-History-State'] = this.pushHistoryState ? '1' : '0';
                 }
 
                 const response = new Response(html, {
@@ -351,6 +354,12 @@ class MockedAjaxCall {
 
     willReturnLiveUrl(liveUrl: string): MockedAjaxCall {
         this.liveUrl = liveUrl;
+
+        return this;
+    }
+
+    willReturnPushHistoryState(pushHistoryState: string): MockedAjaxCall {
+        this.pushHistoryState = pushHistoryState;
 
         return this;
     }

--- a/src/LiveComponent/assets/test/unit/controller/query-binding.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/query-binding.test.ts
@@ -50,14 +50,20 @@ describe('LiveController query string binding', () => {
         // String
 
         // Set value
-        test.expectsAjaxCall().expectUpdatedData({ prop1: 'foo' }).willReturnLiveUrl('?prop1=foo&prop2=');
+        test.expectsAjaxCall()
+            .expectUpdatedData({ prop1: 'foo' })
+            .willReturnLiveUrl('?prop1=foo&prop2=')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop1', 'foo', true);
 
         expectCurrentSearch().toEqual('?prop1=foo&prop2=');
 
         // Remove value
-        test.expectsAjaxCall().expectUpdatedData({ prop1: '' }).willReturnLiveUrl('?prop1=&prop2=');
+        test.expectsAjaxCall()
+            .expectUpdatedData({ prop1: '' })
+            .willReturnLiveUrl('?prop1=&prop2=')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop1', '', true);
 
@@ -66,14 +72,20 @@ describe('LiveController query string binding', () => {
         // Number
 
         // Set value
-        test.expectsAjaxCall().expectUpdatedData({ prop2: 42 }).willReturnLiveUrl('?prop1=&prop2=42');
+        test.expectsAjaxCall()
+            .expectUpdatedData({ prop2: 42 })
+            .willReturnLiveUrl('?prop1=&prop2=42')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop2', 42, true);
 
         expectCurrentSearch().toEqual('?prop1=&prop2=42');
 
         // Remove value
-        test.expectsAjaxCall().expectUpdatedData({ prop2: null }).willReturnLiveUrl('?prop1=&prop2=');
+        test.expectsAjaxCall()
+            .expectUpdatedData({ prop2: null })
+            .willReturnLiveUrl('?prop1=&prop2=')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop2', null, true);
 
@@ -91,7 +103,8 @@ describe('LiveController query string binding', () => {
         // Set value
         test.expectsAjaxCall()
             .expectUpdatedData({ prop: ['foo', 'bar'] })
-            .willReturnLiveUrl('?prop[0]=foo&prop[1]=bar');
+            .willReturnLiveUrl('?prop[0]=foo&prop[1]=bar')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop', ['foo', 'bar'], true);
 
@@ -100,14 +113,18 @@ describe('LiveController query string binding', () => {
         // Remove one value
         test.expectsAjaxCall()
             .expectUpdatedData({ prop: ['foo'] })
-            .willReturnLiveUrl('?prop[0]=foo');
+            .willReturnLiveUrl('?prop[0]=foo')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop', ['foo'], true);
 
         expectCurrentSearch().toEqual('?prop[0]=foo');
 
         // Remove all remaining values
-        test.expectsAjaxCall().expectUpdatedData({ prop: [] }).willReturnLiveUrl('?prop=');
+        test.expectsAjaxCall()
+            .expectUpdatedData({ prop: [] })
+            .willReturnLiveUrl('?prop=')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop', [], true);
 
@@ -123,7 +140,10 @@ describe('LiveController query string binding', () => {
         );
 
         // Set single nested prop
-        test.expectsAjaxCall().expectUpdatedData({ 'prop.foo': 'dummy' }).willReturnLiveUrl('?prop[foo]=dummy');
+        test.expectsAjaxCall()
+            .expectUpdatedData({ 'prop.foo': 'dummy' })
+            .willReturnLiveUrl('?prop[foo]=dummy')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop.foo', 'dummy', true);
 
@@ -132,7 +152,8 @@ describe('LiveController query string binding', () => {
         // Set multiple values
         test.expectsAjaxCall()
             .expectUpdatedData({ prop: { foo: 'other', bar: 42 } })
-            .willReturnLiveUrl('?prop[foo]=other&prop[bar]=42');
+            .willReturnLiveUrl('?prop[foo]=other&prop[bar]=42')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop', { foo: 'other', bar: 42 }, true);
 
@@ -141,7 +162,8 @@ describe('LiveController query string binding', () => {
         // Remove one value
         test.expectsAjaxCall()
             .expectUpdatedData({ prop: { foo: 'other', bar: null } })
-            .willReturnLiveUrl('?prop[foo]=other');
+            .willReturnLiveUrl('?prop[foo]=other')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop', { foo: 'other', bar: null }, true);
 
@@ -150,7 +172,8 @@ describe('LiveController query string binding', () => {
         // Remove all values
         test.expectsAjaxCall()
             .expectUpdatedData({ prop: { foo: null, bar: null } })
-            .willReturnLiveUrl('?prop=');
+            .willReturnLiveUrl('?prop=')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop', { foo: null, bar: null }, true);
 
@@ -173,7 +196,8 @@ describe('LiveController query string binding', () => {
             .serverWillChangeProps((data: any) => {
                 data.prop = 'foo';
             })
-            .willReturnLiveUrl('?prop=foo');
+            .willReturnLiveUrl('?prop=foo')
+            .willReturnPushHistoryState('0');
 
         getByText(test.element, 'Change prop').click();
 
@@ -192,14 +216,20 @@ describe('LiveController query string binding', () => {
         );
 
         // Set value
-        test.expectsAjaxCall().expectUpdatedData({ prop1: 'foo' }).willReturnLiveUrl('?alias1=foo');
+        test.expectsAjaxCall()
+            .expectUpdatedData({ prop1: 'foo' })
+            .willReturnLiveUrl('?alias1=foo')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop1', 'foo', true);
 
         expectCurrentSearch().toEqual('?alias1=foo');
 
         // Remove value
-        test.expectsAjaxCall().expectUpdatedData({ prop1: '' }).willReturnLiveUrl('?alias1=');
+        test.expectsAjaxCall()
+            .expectUpdatedData({ prop1: '' })
+            .willReturnLiveUrl('?alias1=')
+            .willReturnPushHistoryState('0');
 
         await test.component.set('prop1', '', true);
 

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -2590,9 +2590,33 @@ new state of your component, for example: ``https://my.domain/search?query=my+se
 If you load this URL in your browser, the ``LiveProp`` value will be initialized using the query string
 (e.g. ``my search string``).
 
-.. note::
+When a ``LiveProp`` that is bound to the URL changes, the URL is updated via ``history.replaceState()``,
+so no new entry is added to the browser's history. This means that if the user clicks the back button, they will not go
+back to the previous state of the component, but to the previous page.
 
-    The URL is changed via ``history.replaceState()``. So no new entry is added.
+.. versionadded:: 3.1
+
+    The ``pushHistoryState`` option was added in LiveComponents 3.1.
+
+If you want to add a new entry to the browser's history via ``history.pushState()`` each time the URL is updated,
+you can set the ``pushHistoryState`` option to ``true``::
+
+.. code-block:: diff
+
+      // src/Twig/Components/SearchModule.php
+      use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+      use Symfony\UX\LiveComponent\Attribute\LiveProp;
+      use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+    - #[AsLiveComponent]
+    + #[AsLiveComponent(pushHistoryState: true)]
+      class SearchModule
+      {
+          use DefaultActionTrait;
+
+          #[LiveProp(writable: true, url: true)]
+          public string $query = '';
+      }
 
 Supported Data Types
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -29,6 +29,7 @@ final class AsLiveComponent extends AsTwigComponent
     public string $method;
     public int $urlReferenceType;
     public ?string $fetchCredentials;
+    public bool $pushHistoryState;
 
     private ?string $defaultAction;
 
@@ -42,6 +43,7 @@ final class AsLiveComponent extends AsTwigComponent
      * @param string                   $method            The HTTP method to use
      * @param UrlGeneratorInterface::* $urlReferenceType  Which type of URL should be generated for the given route
      * @param string|null              $fetchCredentials  The fetch credentials mode to use ('same-origin', 'include', 'omit'), null to use the global default
+     * @param bool                     $pushHistoryState  Whether to push or replace the history state when the URL is updated. If true, a new history entry will be added. If false the current history entry will be replaced.
      */
     public function __construct(
         ?string $name = null,
@@ -53,6 +55,7 @@ final class AsLiveComponent extends AsTwigComponent
         string $method = 'post',
         int $urlReferenceType = UrlGeneratorInterface::ABSOLUTE_PATH,
         ?string $fetchCredentials = null,
+        bool $pushHistoryState = false,
     ) {
         parent::__construct($name, $template, $exposePublicProps, $attributesVar);
 
@@ -61,6 +64,7 @@ final class AsLiveComponent extends AsTwigComponent
         $this->method = strtolower($method);
         $this->urlReferenceType = $urlReferenceType;
         $this->fetchCredentials = $fetchCredentials;
+        $this->pushHistoryState = $pushHistoryState;
 
         if (!\in_array($this->method, ['get', 'post'], true)) {
             throw new \UnexpectedValueException('$method must be either \'get\' or \'post\'.');
@@ -83,6 +87,7 @@ final class AsLiveComponent extends AsTwigComponent
             'method' => $this->method,
             'url_reference_type' => $this->urlReferenceType,
             'fetch_credentials' => $this->fetchCredentials,
+            'push_history_state' => $this->pushHistoryState,
         ]);
     }
 

--- a/src/LiveComponent/src/EventListener/LiveUrlSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveUrlSubscriber.php
@@ -28,6 +28,7 @@ use Symfony\UX\TwigComponent\MountedComponent;
 class LiveUrlSubscriber implements EventSubscriberInterface, ServiceSubscriberInterface
 {
     private const URL_HEADER = 'X-Live-Url';
+    private const URL_PUSH_STATE_HEADER = 'X-Live-Url-Push-History-State';
 
     public function __construct(
         private ContainerInterface $container,
@@ -58,9 +59,10 @@ class LiveUrlSubscriber implements EventSubscriberInterface, ServiceSubscriberIn
         /** @var MountedComponent $mounted */
         $mounted = $request->attributes->get('_mounted_component');
 
-        [$pathProps, $queryProps] = $this->extractUrlLiveProps($mounted);
+        [$pathProps, $queryProps, $pushHistoryState] = $this->extractUrlLiveProps($mounted);
 
         $event->getResponse()->headers->set(self::URL_HEADER, $this->generateNewLiveUrl($previousLiveUrl, $pathProps, $queryProps));
+        $event->getResponse()->headers->set(self::URL_PUSH_STATE_HEADER, $pushHistoryState ? '1' : '0');
     }
 
     public static function getSubscribedEvents(): array
@@ -71,7 +73,7 @@ class LiveUrlSubscriber implements EventSubscriberInterface, ServiceSubscriberIn
     }
 
     /**
-     * @return array{ array<string, mixed>, array<string, mixed> }
+     * @return array{ array<string, mixed>, array<string, mixed>, bool }
      */
     private function extractUrlLiveProps(MountedComponent $mounted): array
     {
@@ -94,7 +96,7 @@ class LiveUrlSubscriber implements EventSubscriberInterface, ServiceSubscriberIn
             }
         }
 
-        return [$pathProps, $queryProps];
+        return [$pathProps, $queryProps, $mountedMetadata->hasPushHistoryStateEnabled()];
     }
 
     private function generateNewLiveUrl(string $previousUrl, array $pathProps, array $queryProps): string

--- a/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadata.php
@@ -92,4 +92,9 @@ class LiveComponentMetadata
 
         return false;
     }
+
+    public function hasPushHistoryStateEnabled(): bool
+    {
+        return $this->componentMetadata->get('push_history_state', false);
+    }
 }

--- a/src/LiveComponent/tests/Fixtures/Component/ComponentWithPushHistoryState.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ComponentWithPushHistoryState.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * @author Antonio J. García Lagar <aj@garcialagar.es>
+ */
+#[AsLiveComponent('component_with_push_history_state', pushHistoryState: true)]
+final class ComponentWithPushHistoryState
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true, url: true)]
+    public int $count = 0;
+
+    #[LiveAction]
+    public function setCount(#[LiveArg] int $count): void
+    {
+        $this->count = $count;
+    }
+}

--- a/src/LiveComponent/tests/Fixtures/templates/components/component_with_push_history_state.html.twig
+++ b/src/LiveComponent/tests/Fixtures/templates/components/component_with_push_history_state.html.twig
@@ -1,0 +1,3 @@
+<div {{ attributes }}>
+    Count: {{ count }}
+</div>

--- a/src/LiveComponent/tests/Functional/EventListener/LiveUrlSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveUrlSubscriberTest.php
@@ -27,6 +27,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Missing header' => [
             'previousLocation' => null,
             'expectedLocation' => null,
+            'expectedPushHistoryState' => null,
             'initialComponentData' => [],
             'args' => [],
         ];
@@ -34,6 +35,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Unknown previous location' => [
             'previousLocation' => 'foo/bar',
             'expectedLocation' => 'foo/bar',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [],
             'args' => [],
         ];
@@ -41,6 +43,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'No props change' => [
             'previousLocation' => '/route_with_prop/foo',
             'expectedLocation' => '/route_with_prop/foo',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
             ],
@@ -50,6 +53,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Changes in prop' => [
             'previousLocation' => '/route_with_prop/foo',
             'expectedLocation' => '/route_with_prop/bar',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
             ],
@@ -62,6 +66,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Change in query' => [
             'previousLocation' => '/route_with_prop/foo',
             'expectedLocation' => '/route_with_prop/foo?stringProp=hello',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
             ],
@@ -74,6 +79,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Change in query (with an existing query that is not a LiveProp)' => [
             'previousLocation' => '/route_with_prop/foo?not-a-prop=value',
             'expectedLocation' => '/route_with_prop/foo?not-a-prop=value&stringProp=hello',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
             ],
@@ -85,6 +91,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Change in query (with two existing query, one LiveProp, one non-LiveProp)' => [
             'previousLocation' => '/route_with_prop/foo?not-a-prop=value&stringProp=hello',
             'expectedLocation' => '/route_with_prop/foo?not-a-prop=value&stringProp=bye',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
                 'stringProp' => 'hello',
@@ -98,6 +105,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Changes in prop (alias)' => [
             'previousLocation' => '/route_with_alias_prop/foo',
             'expectedLocation' => '/route_with_alias_prop/bar',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathPropWithAlias' => 'foo',
             ],
@@ -110,6 +118,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Changes in prop, with two props' => [
             'previousLocation' => '/route_with_two_props/foo/alias',
             'expectedLocation' => '/route_with_two_props/bar/alias',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
                 'pathPropWithAlias' => 'alias',
@@ -123,6 +132,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Changes in prop, with two path params but only one prop' => [
             'previousLocation' => '/route_with_two_path_params_but_one_prop/foo/30',
             'expectedLocation' => '/route_with_two_path_params_but_one_prop/bar/30',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
             ],
@@ -135,6 +145,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Changes in query (alias)' => [
             'previousLocation' => '/',
             'expectedLocation' => '/?q=search+term',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [],
             'args' => [
                 'propName' => 'boundPropWithAlias',
@@ -145,6 +156,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Change in query (array)' => [
             'previousLocation' => '/route_with_prop/foo',
             'expectedLocation' => '/route_with_prop/foo?arrayProp%5B0%5D=hello&arrayProp%5B1%5D=world',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
             ],
@@ -157,6 +169,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Change in query (array & alias)' => [
             'previousLocation' => '/route_with_prop/foo',
             'expectedLocation' => '/route_with_prop/foo?arr_alias%5B0%5D=hello&arr_alias%5B1%5D=world',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
             ],
@@ -169,6 +182,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Change in query (array & field name)' => [
             'previousLocation' => '/route_with_prop/foo',
             'expectedLocation' => '/route_with_prop/foo?arr_field_name%5B0%5D=hello&arr_field_name%5B1%5D=world',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'foo',
             ],
@@ -181,6 +195,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'Changes in props and query' => [
             'previousLocation' => '/route_with_prop/foo',
             'expectedLocation' => '/route_with_prop/baz?q=foo+bar',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'pathProp' => 'baz',
             ],
@@ -196,6 +211,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'with an object in query, keys "address" and "city" must be present' => [
             'previousLocation' => '/',
             'expectedLocation' => '/?objectProp%5Baddress%5D=123+Main+St&objectProp%5Bcity%5D=Anytown&q=search',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'objectProp' => $address,
             ],
@@ -211,6 +227,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'with an object in query, with "useSerializerForHydration: true", keys "address" and "c" must be present' => [
             'previousLocation' => '/',
             'expectedLocation' => '/?intProp=3&objectPropWithSerializerForHydration%5Baddress%5D=123+Main+St&objectPropWithSerializerForHydration%5Bc%5D=Anytown',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'objectPropWithSerializerForHydration' => $address,
             ],
@@ -223,6 +240,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
         yield 'query with alias ("p") and modifier (prefix by "alias_")' => [
             'previousLocation' => '/',
             'expectedLocation' => '/?alias_p=test',
+            'expectedPushHistoryState' => '0',
             'initialComponentData' => [
                 'propertyWithModifierAndAlias' => 'test',
             ],
@@ -234,6 +252,7 @@ class LiveUrlSubscriberTest extends KernelTestCase
     public function testNewLiveUrlAfterLiveAction(
         ?string $previousLocation,
         ?string $expectedLocation,
+        ?string $expectedPushHistoryState,
         array $initialComponentData,
         array $args,
     ): void {
@@ -259,6 +278,34 @@ class LiveUrlSubscriberTest extends KernelTestCase
                 ]
             )
             ->assertSuccessful()
-            ->assertHeaderEquals('X-Live-Url', $expectedLocation);
+            ->assertHeaderEquals('X-Live-Url', $expectedLocation)
+            ->assertHeaderEquals('X-Live-Url-Push-History-State', $expectedPushHistoryState);
+    }
+
+    public function testPushHistoryStateEnabledLiveAction()
+    {
+        $component = $this->mountComponent('component_with_push_history_state', []);
+        $dehydrated = $this->dehydrateComponent($component);
+        $this->browser()
+            ->throwExceptions()
+            ->post(
+                '/_components/component_with_push_history_state/setCount',
+                [
+                    'body' => [
+                        'data' => json_encode([
+                            'props' => $dehydrated->getProps(),
+                            'args' => [
+                                'count' => 5,
+                            ],
+                        ]),
+                    ],
+                    'headers' => [
+                        'X-Live-Url' => '/',
+                    ],
+                ]
+            )
+            ->assertSuccessful()
+            ->assertHeaderEquals('X-Live-Url', '/?count=5')
+            ->assertHeaderEquals('X-Live-Url-Push-History-State', '1');
     }
 }

--- a/src/LiveComponent/tests/Unit/Metadata/LiveComponentMetadataTest.php
+++ b/src/LiveComponent/tests/Unit/Metadata/LiveComponentMetadataTest.php
@@ -53,4 +53,13 @@ class LiveComponentMetadataTest extends TestCase
         $this->assertInstanceOf(UrlMapping::class, $urlMappings['basicUrlMapping']);
         $this->assertEquals($aliasUrlMapping, $urlMappings['aliasUrlMapping']);
     }
+
+    public function testHasPushHistoryStateEnabled()
+    {
+        $liveComponentMetadata = new LiveComponentMetadata(new ComponentMetadata([]), []);
+        $this->assertFalse($liveComponentMetadata->hasPushHistoryStateEnabled());
+
+        $liveComponentMetadataWithPushHistoryStateEnabled = new LiveComponentMetadata(new ComponentMetadata(['push_history_state' => true]), []);
+        $this->assertTrue($liveComponentMetadataWithPushHistoryStateEnabled->hasPushHistoryStateEnabled());
+    }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes 
| Deprecations?  | no 
| Documentation? | yes
| Issues         | Fix #3149
| License        | MIT

This PR adds support for pushing browser history entries when a LiveComponent updates URL-bound LiveProp values.

Until now, URL updates were always done with `history.replaceState()`, which overwrote the current entry. With this change, components can opt in to `history.pushState()` so users can navigate previous component states via the browser back button (for example, previous pages in pagination or prior filter states in search UIs).

Included changes:
- Added a new `pushHistoryState` parameter to `#[AsLiveComponent(...)]` (default: false).
- Exposed this option in component metadata as `push_history_state`.
- Added `LiveComponentMetadata::hasPushHistoryStateEnabled()` to read the flag.
- Updated LiveUrlSubscriber to include a new response header:
  - `X-Live-Url-Push-History-State: 1|0`
- Updated frontend `BackendResponse` to parse the new header.
- Updated frontend URL update logic to choose:
  - `history.pushState(...)` when enabled
  - `history.replaceState(...)` otherwise (current behavior preserved)