### PR TITLE
[Autocomplete] Use `hash_equals()` to compare the `extra_options` checksum

### DIFF
--- a/src/Autocomplete/src/Controller/EntityAutocompleteController.php
+++ b/src/Autocomplete/src/Controller/EntityAutocompleteController.php
@@ -110,7 +110,7 @@ final class EntityAutocompleteController
             \ARRAY_FILTER_USE_KEY,
         );
 
-        if ($checksum !== $this->checksumCalculator->calculateForArray($extraOptionsWithoutChecksum)) {
+        if (!hash_equals($this->checksumCalculator->calculateForArray($extraOptionsWithoutChecksum), $checksum)) {
             throw new BadRequestHttpException('The extra options have been tampered with.');
         }
     }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

`validateChecksum() `compared the client-supplied checksum against the
server-computed HMAC with `!==`, which short-circuits on the first
differing byte and is therefore not constant-time (CWE-208).

The checksum guards the integrity of `extra_options`, which the
controller feeds into the autocompleter as form-creation options, so the
comparison should be timing-safe. Switch to hash_equals() with the
known value as the first argument. LiveComponent already does this in
LiveComponentHydrator::verifyChecksum() — this aligns Autocomplete with
it.