### PR TITLE
[LiveComponent] Make `LiveComponentSubscriber` safe-by-default

### DIFF
--- a/src/LiveComponent/src/DependencyInjection/Compiler/OptionalDependencyPass.php
+++ b/src/LiveComponent/src/DependencyInjection/Compiler/OptionalDependencyPass.php
@@ -34,9 +34,9 @@ final class OptionalDependencyPass implements CompilerPassInterface
             ;
         }
 
-        if (!$container->hasDefinition('test.client')) {
+        if ($container->hasDefinition('test.client')) {
             $container->getDefinition('ux.live_component.event_subscriber')
-                ->setArgument(1, false);
+                ->setArgument(1, true);
         }
     }
 }

--- a/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
+++ b/src/LiveComponent/src/EventListener/LiveComponentSubscriber.php
@@ -47,7 +47,7 @@ class LiveComponentSubscriber implements EventSubscriberInterface, ServiceSubscr
 
     public function __construct(
         private ContainerInterface $container,
-        private bool $testMode = true,
+        private bool $testMode = false,
     ) {
     }
 

--- a/src/LiveComponent/tests/Unit/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Unit/EventListener/LiveComponentSubscriberTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\LiveComponent\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\UX\LiveComponent\EventListener\LiveComponentSubscriber;
+
+final class LiveComponentSubscriberTest extends TestCase
+{
+    public function testDefaultConstructedSubscriberRejectsRequestWithoutAcceptHeader()
+    {
+        $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class));
+
+        $request = new Request();
+        $request->attributes->set('_live_component', 'some_component');
+
+        $this->assertFalse(
+            $this->callIsLiveComponentRequest($subscriber, $request),
+            'Default-constructed subscriber must enforce the Accept-header CSRF check (testMode must default to false).'
+        );
+    }
+
+    public function testDefaultConstructedSubscriberAcceptsRequestWithProperAcceptHeader()
+    {
+        $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class));
+
+        $request = new Request();
+        $request->attributes->set('_live_component', 'some_component');
+        $request->headers->set('Accept', 'application/vnd.live-component+html');
+
+        $this->assertTrue($this->callIsLiveComponentRequest($subscriber, $request));
+    }
+
+    public function testTestModeBypassesAcceptHeaderCheck()
+    {
+        $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class), true);
+
+        $request = new Request();
+        $request->attributes->set('_live_component', 'some_component');
+
+        $this->assertTrue(
+            $this->callIsLiveComponentRequest($subscriber, $request),
+            'When testMode is explicitly true the Accept-header check is bypassed.'
+        );
+    }
+
+    private function callIsLiveComponentRequest(LiveComponentSubscriber $subscriber, Request $request): bool
+    {
+        $method = new \ReflectionMethod($subscriber, 'isLiveComponentRequest');
+
+        return $method->invoke($subscriber, $request);
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

A minor improvement, to make `LiveComponentSubscriber` "safe by default", by setting `$testMode` defaults to `false`. 

Note that `LiveComponentSubscriber` is an internal class. 