### PR TITLE
[LiveComponent] Fix incorrect emit() usage in docs

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -3420,12 +3420,14 @@ it emits a ``lineItem:created`` event to the parent::
         #[LiveAction]
         public function save(EntityManagerInterface $entityManager)
         {
-            if (!$this->lineItem->getId()) {
-                $this->emit('lineItem:created', $this->lineItem);
-            }
+            $isNew = null === $this->lineItem->getId();
 
             $entityManager->persist($this->lineItem);
             $entityManager->flush();
+
+            if ($isNew) {
+                $this->emit('lineItem:created');
+            }
         }
     }
 
@@ -3491,13 +3493,14 @@ To fix this, you have two options:
 
             if ($isNew) {
                 // reset the state of this component
-                $this->emit('lineItem:created', $this->lineItem);
+                $this->emit('lineItem:created');
                 $this->lineItem = new InvoiceLineItem();
                 // if you're using ValidatableComponentTrait
                 $this->clearValidation();
             }
         }
     }
+
 
 .. _passing-blocks:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | -
| License       | MIT

### Problem

In the LiveComponent documentation under the "Emitting Events" / "Resetting Form After Save" section, two examples pass an entity object as the second argument to `emit()`:

```
$this->emit('lineItem:created', $this->lineItem);
```

However, ComponentToolsTrait::emit() is typed to require an array:

```
// src/LiveComponent/src/ComponentToolsTrait.php
public function emit(string $eventName, array $data = [], ?string $componentName = null): void
{
    $this->liveResponder->emit($eventName, $data, $componentName);
}
```
Following the docs as-written results in a TypeError at runtime

### Fix
Removed the second argument from the emit() calls entirely, since the existing #[LiveListener('lineItem:created')] example shown later in the same document does not consume any payload:
```
#[LiveListener('lineItem:created')]
public function addLineItem()
{
    // no need to do anything here: the component will re-render
}
```
Passing an empty array or the lineitemId would also be valid, but omitting the argument is cleaner and keeps the example consistent with how the event is actually used.