### PR TITLE
[CI] Add Zizmor, a static analysis tool for GitHub Actions

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches: ['3.x']
+    pull_request:
+        branches: ['**']
+
+permissions: {}
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        permissions:
+            security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+            contents: read # Only needed for private repos. Needed to clone the repo.
+            actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Due to all the recent events in the GitHub / npm ecosystem, adding a static analyzer for GitHub Actions - to ensure our workflows are well written and secure - is IMHO mandatory.

See https://docs.zizmor.sh/