### PR TITLE
[Mercure][Test] Implement Mercure v1 to MercureStreamSourceRendererTest

### DIFF
--- a/src/Turbo/tests/Bridge/Mercure/MercureStreamSourceRendererTest.php
+++ b/src/Turbo/tests/Bridge/Mercure/MercureStreamSourceRendererTest.php
@@ -40,39 +40,39 @@ final class MercureStreamSourceRendererTest extends KernelTestCase
         yield 'string topic — public' => [
             "{{ turbo_stream_from('a_topic') }}",
             [],
-            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=a_topic"></turbo-mercure-stream-source>',
+            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?match=a_topic"></turbo-mercure-stream-source>',
         ];
 
         yield 'string topic — private' => [
             "{{ turbo_stream_from('a_topic', private=true) }}",
             [],
-            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=a_topic" private></turbo-mercure-stream-source>',
+            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?match=a_topic" private></turbo-mercure-stream-source>',
         ];
 
         yield 'class name — single backslash (Twig drops \\X)' => [
             "{{ turbo_stream_from('Symfony\\UX\\Turbo\\Tests\\Fixtures\\Book') }}",
             [],
             // single-quoted Twig string: \X drops the backslash → 'SymfonyUXTurboTestsFixturesBook'
-            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=SymfonyUXTurboTestsFixturesBook"></turbo-mercure-stream-source>',
+            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?match=SymfonyUXTurboTestsFixturesBook"></turbo-mercure-stream-source>',
         ];
 
         yield 'class name — double backslash (correct usage)' => [
             "{{ turbo_stream_from('Symfony\\\\UX\\\\Turbo\\\\Tests\\\\Fixtures\\\\Book') }}",
             [],
             // \\\\ in PHP string → \\ in Twig source → \ in Twig output → 'Symfony\UX\Turbo\Tests\Fixtures\Book' → class_exists → URL pattern
-            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=https%3A%2F%2Fsymfony.com%2Fux-turbo%2FSymfony%255CUX%255CTurbo%255CTests%255CFixtures%255CBook%2F%7Bid%7D"></turbo-mercure-stream-source>',
+            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?match=https%3A%2F%2Fsymfony.com%2Fux-turbo%2FSymfony%255CUX%255CTurbo%255CTests%255CFixtures%255CBook%2F%7Bid%7D"></turbo-mercure-stream-source>',
         ];
 
         yield 'entity topic' => [
             '{{ turbo_stream_from(book) }}',
             ['book' => $book],
-            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=https%3A%2F%2Fsymfony.com%2Fux-turbo%2FSymfony%255CUX%255CTurbo%255CTests%255CFixtures%255CBook%2F123"></turbo-mercure-stream-source>',
+            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?match=https%3A%2F%2Fsymfony.com%2Fux-turbo%2FSymfony%255CUX%255CTurbo%255CTests%255CFixtures%255CBook%2F123"></turbo-mercure-stream-source>',
         ];
 
         yield 'array of topics' => [
             "{{ turbo_stream_from(['topic_a', 'topic_b']) }}",
             [],
-            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?topic=topic_a&amp;topic=topic_b"></turbo-mercure-stream-source>',
+            '<turbo-mercure-stream-source src="http://127.0.0.1:3000/.well-known/mercure?match=topic_a&amp;match=topic_b"></turbo-mercure-stream-source>',
         ];
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | None
| License        | MIT

> [!IMPORTANT]
> This pull request relies on unmerged versions of the Symfony Mercure Component and Mercure Bundle. As a result, test failures are expected.

I have updated the tests for `MercureStreamSourceRenderer` to implement Mercure version 1. Before reviewing, please refer to the following PRs for context on the underlying changes :
- Mercure V1: https://github.com/dunglas/mercure/pull/1207
- Mercure V1 Docs: https://github.com/dunglas/mercure/pull/1238
- Mercure Component: https://github.com/symfony/mercure/pull/137
- Mercure Bundle: https://github.com/symfony/mercure-bundle/pull/119
