### PR TITLE
[TwigComponent] Expose pre/embedded render methods on `ComponentRendererInterface`

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.2.0
+
+- Add `ComponentRendererInterface::preCreateForRender()`, `ComponentRendererInterface::startEmbeddedComponentRender()`, and `ComponentRendererInterface::finishEmbeddedComponentRender()` methods
+
 ## 3.1.0
 
 - Add `provide()` and `inject()` Twig functions to share state from a parent

--- a/src/TwigComponent/src/ComponentRendererInterface.php
+++ b/src/TwigComponent/src/ComponentRendererInterface.php
@@ -11,6 +11,13 @@
 
 namespace Symfony\UX\TwigComponent;
 
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
+
+/**
+ * @method ?string        preCreateForRender(string $name, array $props = [])
+ * @method PreRenderEvent startEmbeddedComponentRender(string $name, array $props, array $context, string $hostTemplateName, int $index)
+ * @method void           finishEmbeddedComponentRender()
+ */
 interface ComponentRendererInterface
 {
     /**

--- a/src/TwigComponent/src/Twig/ComponentRuntime.php
+++ b/src/TwigComponent/src/Twig/ComponentRuntime.php
@@ -12,7 +12,7 @@
 namespace Symfony\UX\TwigComponent\Twig;
 
 use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\UX\TwigComponent\ComponentRenderer;
+use Symfony\UX\TwigComponent\ComponentRendererInterface;
 use Symfony\UX\TwigComponent\ComponentStack;
 use Symfony\UX\TwigComponent\Event\PreRenderEvent;
 
@@ -25,7 +25,7 @@ use Symfony\UX\TwigComponent\Event\PreRenderEvent;
 final class ComponentRuntime
 {
     public function __construct(
-        private readonly ComponentRenderer $renderer,
+        private readonly ComponentRendererInterface $renderer,
         private readonly ServiceLocator $renderers,
         private readonly ComponentStack $componentStack,
     ) {


### PR DESCRIPTION
| Q              | A   |
|----------------|-----|
| Bug fix?       | yes |
| New feature?   | yes |
| Deprecations?  | no  |
| Documentation? | no  |
| Issues         | n/a |
| License        | MIT |

## Problem

`ComponentRuntime` depends on the concrete `ComponentRenderer` class (which is `final`):

```php
public function __construct(
    private readonly ComponentRenderer $renderer,
    // ...
) {}
```

`ComponentRendererInterface` exists and is already aliased to the renderer service in the DI container, but it only declares `createAndRender()`. The three other methods actually called by `ComponentRuntime` — `preCreateForRender()`, `startEmbeddedComponentRender()`, and `finishEmbeddedComponentRender()` — are missing from the interface.

Projects that need to intercept or augment the render pipeline (e.g. for server-side pre-loading of component instances) currently have to either fork `ComponentRuntime` and replace the service via a compiler pass, or use `\ReflectionProperty` to access private state on `ComponentRenderer`. Neither is acceptable for production code that needs to survive upstream upgrades.

## Solution

- Add the three missing methods to `ComponentRendererInterface`
- Switch `ComponentRuntime::$renderer` from `ComponentRenderer` to `ComponentRendererInterface`

No DI change is needed: the container already injects the renderer via its interface alias (`ComponentRendererInterface::class → ux.twig_component.component_renderer`).