### PR TITLE
[Translator] Add `ux:translator:warm-cache` command

### DIFF
--- a/src/Translator/CHANGELOG.md
+++ b/src/Translator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.1.0
+
+- Add `ux:translator:warm-cache` console command to manually dump JS/TS translation files
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/Translator/config/services.php
+++ b/src/Translator/config/services.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\UX\Translator\CacheWarmer\TranslationsCacheWarmer;
+use Symfony\UX\Translator\Command\WarmCacheCommand;
 use Symfony\UX\Translator\MessageParameters\Extractor\IntlMessageParametersExtractor;
 use Symfony\UX\Translator\MessageParameters\Extractor\MessageParametersExtractor;
 use Symfony\UX\Translator\MessageParameters\Printer\TypeScriptMessageParametersPrinter;
@@ -47,5 +48,12 @@ return static function (ContainerConfigurator $container): void {
         ->set('ux.translator.message_parameters.extractor.intl_message_parameters_extractor', IntlMessageParametersExtractor::class)
 
         ->set('ux.translator.message_parameters.printer.typescript_message_parameters_printer', TypeScriptMessageParametersPrinter::class)
+
+        ->set('.ux_translator.command.warm_cache', WarmCacheCommand::class)
+            ->args([
+                service('ux.translator.cache_warmer.translations_cache_warmer'),
+                param('kernel.cache_dir'),
+            ])
+            ->tag('console.command')
     ;
 };

--- a/src/Translator/doc/index.rst
+++ b/src/Translator/doc/index.rst
@@ -112,6 +112,16 @@ You can also filter dumped translations by translation key patterns using wildca
 
 The wildcard ``*`` matches any characters. You can prefix a pattern with ``!`` to exclude keys matching that pattern.
 
+Manually warming the translations cache
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Translations are automatically dumped when warming up the Symfony cache. If you only need to refresh
+the JavaScript translations without warming up the whole cache, run:
+
+.. code-block:: terminal
+
+    $ php bin/console ux:translator:warm-cache
+
 Disabling TypeScript types dump
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Translator/src/Command/WarmCacheCommand.php
+++ b/src/Translator/src/Command/WarmCacheCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Translator\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\UX\Translator\CacheWarmer\TranslationsCacheWarmer;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+#[AsCommand(
+    name: 'ux:translator:warm-cache',
+    description: 'Warm the translations cache (dump JS/TS translation files)',
+)]
+final class WarmCacheCommand extends Command
+{
+    public function __construct(
+        private TranslationsCacheWarmer $cacheWarmer,
+        private string $cacheDir,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->comment('Warming the translations cache...');
+
+        $this->cacheWarmer->warmUp($this->cacheDir);
+
+        $io->success('Translations cache warmed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Translator/tests/Command/WarmCacheCommandTest.php
+++ b/src/Translator/tests/Command/WarmCacheCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Translator\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\UX\Translator\CacheWarmer\TranslationsCacheWarmer;
+use Symfony\UX\Translator\Command\WarmCacheCommand;
+
+final class WarmCacheCommandTest extends TestCase
+{
+    public function testWarmCache()
+    {
+        $cacheDir = '/tmp/cache';
+        $cacheWarmer = $this->createMock(TranslationsCacheWarmer::class);
+        $cacheWarmer
+            ->expects($this->once())
+            ->method('warmUp')
+            ->with($cacheDir);
+
+        $application = new Application();
+        $application->addCommand(new WarmCacheCommand($cacheWarmer, $cacheDir));
+
+        $tester = new CommandTester($application->find('ux:translator:warm-cache'));
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Warming the translations cache...', $tester->getDisplay());
+        $this->assertStringContainsString('Translations cache warmed.', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Adds a `ux:translator:warm-cache` console command to manually dump JS/TS
translation files without warming the whole Symfony cache.

Mirrors the existing `ux:icons:warm-cache` command from UX Icons. The
command wraps `TranslationsCacheWarmer::warmUp()`.

```shell
php bin/console ux:translator:warm-cache
```