### PR TITLE
[TwigComponent] Allow standalone usage with any PSR-11 container

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 3.2.0
 
 - Add `ComponentRendererInterface::preCreateForRender()`, `ComponentRendererInterface::startEmbeddedComponentRender()`, and `ComponentRendererInterface::finishEmbeddedComponentRender()` methods
+- Allow using `ComponentFactory` and `ComponentRuntime` with any PSR-11
+  container, making `symfony/dependency-injection` optional for standalone usage
 
 ## 3.1.0
 

--- a/src/TwigComponent/composer.json
+++ b/src/TwigComponent/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": ">=8.4",
-        "symfony/dependency-injection": "^7.4|^8.0",
+        "psr/container": "^1.1|^2.0",
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/event-dispatcher": "^7.4|^8.0",
         "symfony/property-access": "^7.4|^8.0",
@@ -37,6 +37,7 @@
         "phpunit/phpunit": "^11.1|^12.0",
         "symfony/console": "^7.4|^8.0",
         "symfony/css-selector": "^7.4|^8.0",
+        "symfony/dependency-injection": "^7.4|^8.0",
         "symfony/dom-crawler": "^7.4|^8.0",
         "symfony/framework-bundle": "^7.4|^8.0",
         "symfony/stimulus-bundle": "^2.9.1|^3.0",

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\UX\TwigComponent;
 
+use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\UX\TwigComponent\Event\PostMountEvent;
@@ -36,7 +36,7 @@ final class ComponentFactory implements ResetInterface
      */
     public function __construct(
         private ComponentTemplateFinderInterface $componentTemplateFinder,
-        private ServiceLocator $components,
+        private ContainerInterface $components,
         private PropertyAccessorInterface $propertyAccessor,
         private EventDispatcherInterface $eventDispatcher,
         private array $config,

--- a/src/TwigComponent/src/Twig/ComponentRuntime.php
+++ b/src/TwigComponent/src/Twig/ComponentRuntime.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\UX\TwigComponent\Twig;
 
-use Symfony\Component\DependencyInjection\ServiceLocator;
+use Psr\Container\ContainerInterface;
 use Symfony\UX\TwigComponent\ComponentRendererInterface;
 use Symfony\UX\TwigComponent\ComponentStack;
 use Symfony\UX\TwigComponent\Event\PreRenderEvent;
@@ -26,7 +26,7 @@ final class ComponentRuntime
 {
     public function __construct(
         private readonly ComponentRendererInterface $renderer,
-        private readonly ServiceLocator $renderers,
+        private readonly ContainerInterface $renderers,
         private readonly ComponentStack $componentStack,
     ) {
     }

--- a/src/TwigComponent/tests/Unit/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\UX\TwigComponent\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ServiceLocator;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\UX\TwigComponent\ComponentFactory;
@@ -28,7 +28,7 @@ class ComponentFactoryTest extends TestCase
     {
         $factory = new ComponentFactory(
             $this->createMock(ComponentTemplateFinderInterface::class),
-            $this->createMock(ServiceLocator::class),
+            $this->createMock(ContainerInterface::class),
             $this->createMock(PropertyAccessorInterface::class),
             $this->createMock(EventDispatcherInterface::class),
             ['foo' => ['key' => 'foo', 'template' => 'bar.html.twig']],
@@ -46,7 +46,7 @@ class ComponentFactoryTest extends TestCase
     {
         $factory = new ComponentFactory(
             $this->createMock(ComponentTemplateFinderInterface::class),
-            $this->createMock(ServiceLocator::class),
+            $this->createMock(ContainerInterface::class),
             $this->createMock(PropertyAccessorInterface::class),
             $this->createMock(EventDispatcherInterface::class),
             [
@@ -73,7 +73,7 @@ class ComponentFactoryTest extends TestCase
 
         $factory = new ComponentFactory(
             $templateFinder,
-            $this->createMock(ServiceLocator::class),
+            $this->createMock(ContainerInterface::class),
             $this->createMock(PropertyAccessorInterface::class),
             $this->createMock(EventDispatcherInterface::class),
             [],


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

Allow TwigComponent's runtime to work without `symfony/dependency-injection`.

`ComponentFactory` and `ComponentRuntime` only ever call `get()`/`has()` on
their injected service locator. Both methods are defined by PSR-11
`Psr\Container\ContainerInterface`, which Symfony's `ServiceLocator` already
implements — so the injection points can be typehinted against the interface
instead of the concrete class.

This decouples the runtime classes from the DI component: they can now be
wired with any PSR-11 container, enabling standalone (non-Symfony) usage with
just Twig. `symfony/dependency-injection` moves to `require-dev` (still pulled
transitively via `symfony/framework-bundle` in a full Symfony app, and only
needed at runtime for the bundle's extension/compiler-pass classes).

```php
// Standalone wiring, no symfony/dependency-injection required
$factory = new ComponentFactory(
    $templateFinder,
    $myPsr11Container, // any Psr\Container\ContainerInterface
    $propertyAccessor,
    $eventDispatcher,
    $config,
    $classMap,
    $twig,
);