### PR TITLE
[CI] Harden the release-on-npm workflow

### DIFF
--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -53,5 +53,18 @@ jobs:
             - name: Install root JS dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Build JS assets
+              run: pnpm run build
+
+            - name: Verify dist files match committed sources
+              run: |
+                  if ! git diff --quiet; then
+                      echo "::error::Built dist files differ from the committed ones at tag ${GITHUB_REF_NAME}. Refusing to publish."
+                      git status --porcelain
+                      git diff
+                      exit 1
+                  fi
+                  echo "Built dist files match the committed ones."
+
             - name: Publish on NPM
               run: pnpm publish --recursive --access public --no-git-checks --provenance

--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -9,6 +9,10 @@ permissions:
     id-token: write # Required for OIDC
     contents: read
 
+concurrency:
+    group: release-on-npm-${{ github.ref_name }}
+    cancel-in-progress: false
+
 jobs:
     release:
         runs-on: ubuntu-latest

--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -7,7 +7,7 @@ on:
 
 permissions:
     id-token: write # Required for OIDC
-    contents: write # Required to push changes to the repository
+    contents: read
 
 jobs:
     release:
@@ -31,14 +31,6 @@ jobs:
                   fi
                   echo "Tag ${GITHUB_REF_NAME} verified as ancestor of ${BRANCH}."
 
-            - name: Configure Git
-              run: |
-                  git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                  git config --global user.name "github-actions[bot]"
-
-            - name: Extract version from tag
-              run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-
             - run: npm i -g corepack && corepack enable
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
               with:
@@ -56,18 +48,5 @@ jobs:
             - name: Install root JS dependencies
               run: pnpm install --frozen-lockfile
 
-            - name: Update version of JS packages
-              run: pnpm version ${{ env.VERSION }} --no-git-tag-version --workspaces --no-workspaces-update
-
-            - name: Commit changes
-              run: |
-                  git add .
-                  git commit -m "Update versions to ${{ env.VERSION }}"
-
             - name: Publish on NPM
               run: pnpm publish --recursive --access public --no-git-checks
-
-            - name: Push changes
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: git push origin 2.x

--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -15,7 +15,21 @@ jobs:
         steps:
             - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
               with:
-                  ref: 2.x
+                  ref: ${{ github.ref }}
+                  fetch-depth: 0
+
+            - name: Verify tag is on the matching release branch
+              run: |
+                  set -euo pipefail
+                  MAJOR="${GITHUB_REF_NAME#v}"
+                  MAJOR="${MAJOR%%.*}"
+                  BRANCH="${MAJOR}.x"
+                  git fetch --no-tags origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+                  if ! git merge-base --is-ancestor "${GITHUB_SHA}" "refs/remotes/origin/${BRANCH}"; then
+                      echo "::error::Tag ${GITHUB_REF_NAME} (${GITHUB_SHA}) is not an ancestor of branch ${BRANCH}. Refusing to publish."
+                      exit 1
+                  fi
+                  echo "Tag ${GITHUB_REF_NAME} verified as ancestor of ${BRANCH}."
 
             - name: Configure Git
               run: |

--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -50,4 +50,4 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Publish on NPM
-              run: pnpm publish --recursive --access public --no-git-checks
+              run: pnpm publish --recursive --access public --no-git-checks --provenance

--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -42,8 +42,9 @@ jobs:
                       package.json
                       src/**/package.json
 
-              # npm 11.5.1 or later is required for OIDC
-            - run: npm install -g npm@latest
+              # npm 11.5.1 or later is required for OIDC. Pinned explicitly to avoid
+              # pulling a compromised "latest" at release time; bump via dedicated PR.
+            - run: npm install -g npm@11.16.0
 
             - name: Install root JS dependencies
               run: pnpm install --frozen-lockfile

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,26 @@
+# Maintainers' guide
+
+This document is for Symfony UX maintainers. It collects procedures that are not
+needed by regular contributors.
+
+## Releasing UX packages on NPM
+
+The Git tag is the source of truth for the released version. The
+`release-on-npm.yaml` workflow refuses to publish if any workspace
+`package.json` does not match the tag — bump and commit **before** tagging.
+
+From the release branch (`2.x` or `3.x`), with `upstream` pointing to `symfony/ux`:
+
+```shell
+$ git checkout 2.x # or 3.x
+$ VERSION=2.36.0 && \
+  pnpm install --frozen-lockfile && \
+  pnpm build && \
+  pnpm version $VERSION --no-git-tag-version --workspaces --no-workspaces-update && \
+  git add . && \
+  git commit -m "Bump npm packages to v$VERSION"
+$ git push upstream HEAD
+```
+
+The tag is created and pushed afterwards by following the Symfony's release process.
+The `release-on-npm.yaml` workflow then publishes via OIDC trusted publisher.


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Following #3604

## Summary

Following an audit of `.github/workflows/release-on-npm.yaml` with my super friend Claude, 
this PR tightens several aspects of the npm release pipeline. 
OIDC trusted publisher protects authentication on the npm side, but says nothing about the integrity of the code being published. 
The changes below close that gap.

Each commit addresses one finding from the audit, tagged `(F<n>)` in its title.

## Commits

- **[CI] Publish from the tagged commit, not the branch HEAD (F1)** — checkout `${{ github.ref }}` (the tag) instead
of the hardcoded `2.x` branch, and verify the tagged commit is an ancestor of the matching release branch
(`2.x` for `v2.*.*`, `3.x` for `v3.*.*`). Closes a TOCTOU where `2.x` HEAD could drift between tag creation and job execution.

- **[CI] Stop touching package.json versions during release (F8)** — drop the `pnpm version` + commit + push back to
`2.x` block. The Git tag is the single source of truth; version bumps are now done manually before tagging. The workflow token is downgraded from `contents: write` to `contents: read`, and **the new `MAINTAINERS.md` documents the bump procedure.** 
Code can not be commited/pushed to the repo anymore ✨ 

- **[CI] Pin npm version used by the release workflow (F6)** — replace `npm@latest` with `npm@11.16.0` so a compromised npm release cannot ship through the release path without an explicit, reviewable bump PR.

- **[CI] Generate npm provenance attestations on publish (F7)** — add `--provenance` to `pnpm publish`. Each tarball now carries a signed SLSA attestation pointing to the repo, commit and workflow run, verifiable via `npm audit signatures`.

- **[CI] Serialize release runs per tag (F9)** — add a concurrency group keyed on `github.ref_name`, so two runs on the same tag queue instead of overlapping. Distinct tags (`v2.x.y` vs `v3.0.0`) still run in parallel.

- **[CI] Build assets and refuse to publish if dist files drift (F2)** — run `pnpm build` on the tagged commit and fail if `git diff --quiet` reports anything. Mirrors the existing `dist-files-unbuilt.yaml` PR check, brought into the release path so tampered dist/source pairs cannot publish even if the branch CI was bypassed.