### PR TITLE
[LiveComponent] Fix stale unit test after X-Requested-With CSRF gate

### DIFF
--- a/src/LiveComponent/tests/Unit/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Unit/EventListener/LiveComponentSubscriberTest.php
@@ -39,6 +39,7 @@ class LiveComponentSubscriberTest extends TestCase
         $request = new Request();
         $request->attributes->set('_live_component', 'some_component');
         $request->headers->set('Accept', 'application/vnd.live-component+html');
+        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
         $this->assertTrue($this->callIsLiveComponentRequest($subscriber, $request));
     }
@@ -64,7 +65,7 @@ class LiveComponentSubscriberTest extends TestCase
     }
 
     #[DataProvider('provideProductionGateScenarios')]
-    public function testProductionGateRequiresNonSafelistedHeader(array $headers, bool $expected): void
+    public function testProductionGateRequiresNonSafelistedHeader(array $headers, bool $expected)
     {
         $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class), testMode: false);
 
@@ -108,7 +109,7 @@ class LiveComponentSubscriberTest extends TestCase
         ];
     }
 
-    public function testRequestWithoutLiveComponentAttributeIsRejected(): void
+    public function testRequestWithoutLiveComponentAttributeIsRejected()
     {
         $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class), testMode: false);
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Spotted in https://github.com/symfony/ux/pull/3609.

Looks like something was forgotten in the security-fixes PRs, or during the merge. 🤷