### PR TITLE
[Native] Rename `ux-native:dump` command to `ux:native:build-configs`

### DIFF
--- a/src/Native/CHANGELOG.md
+++ b/src/Native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 3.2
+
+- **[BC BREAK]** Rename the `ux-native:dump` command to `ux:native:build-configs`
+  to follow the `ux:<...>` naming convention and clarify its purpose.
+
+    **Note:** This is a breaking change, but the UX Native component is still experimental.
+
 ## 2.35
 
 - Add `assets/` to ease the installation of `@hotwired/stimulus` and `@hotwired/hotwire-native-bridge` JavaScript dependencies.

--- a/src/Native/config/services.php
+++ b/src/Native/config/services.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\UX\Native\EventListener\NativeListener;
 use Symfony\UX\Native\Twig\NativeExtension;
-use Symfony\UX\Native\Command\ConfigurationDumper;
+use Symfony\UX\Native\Command\BuildConfigurationsCommand;
 use Symfony\UX\Native\ConfigurationBuilder;
 
 return static function (ContainerConfigurator $container): void {
@@ -35,8 +35,8 @@ return static function (ContainerConfigurator $container): void {
             '%ux_native.output_dir%',
         ])
     ;
-    $services->set('.ux_native.command.configuration_dumper', ConfigurationDumper::class)
+    $services->set('.ux_native.command.build_configurations', BuildConfigurationsCommand::class)
         ->args([service('.ux_native.configuration_builder')])
-        ->tag('console.command', ['command' => 'ux-native:dump'])
+        ->tag('console.command')
     ;
 };

--- a/src/Native/doc/index.rst
+++ b/src/Native/doc/index.rst
@@ -47,7 +47,7 @@ The bundle exposes a single configuration option:
         output_dir: '%kernel.project_dir%/public' # default
 
 The ``output_dir`` option defines the directory where JSON configuration files
-are written when you run the ``ux-native:dump`` command (see
+are written when you run the ``ux:native:build-configs`` command (see
 `Dumping Configurations for Production`_).
 
 Usage
@@ -280,7 +280,7 @@ Run the following command:
 
 .. code-block:: terminal
 
-    $ php bin/console ux-native:dump
+    $ php bin/console ux:native:build-configs
 
 This writes all registered configurations as JSON files into the ``output_dir``
 directory (defaults to ``public/``). For example, a configuration registered at

--- a/src/Native/src/Command/BuildConfigurationsCommand.php
+++ b/src/Native/src/Command/BuildConfigurationsCommand.php
@@ -18,8 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\UX\Native\ConfigurationBuilder;
 
-#[AsCommand('ux-native:dump')]
-final class ConfigurationDumper extends Command
+#[AsCommand(
+    name: 'ux:native:build-configs',
+    description: 'Build Hotwire Native configuration files (iOS, Android)',
+)]
+final class BuildConfigurationsCommand extends Command
 {
     public function __construct(
         private readonly ConfigurationBuilder $configurationBuilder,
@@ -30,10 +33,10 @@ final class ConfigurationDumper extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $io->comment('Dumping UX Native configuration files...');
+        $io->comment('Building UX Native configuration files...');
 
         $this->configurationBuilder->build();
-        $io->success('UX Native configuration files dumped successfully.');
+        $io->success('UX Native configuration files built successfully.');
 
         return Command::SUCCESS;
     }

--- a/src/Native/tests/Command/BuildConfigurationsCommandTest.php
+++ b/src/Native/tests/Command/BuildConfigurationsCommandTest.php
@@ -14,18 +14,18 @@ namespace Symfony\UX\Native\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\UX\Native\Command\ConfigurationDumper;
+use Symfony\UX\Native\Command\BuildConfigurationsCommand;
 use Symfony\UX\Native\Configuration\Configuration;
 use Symfony\UX\Native\Configuration\Rule;
 use Symfony\UX\Native\ConfigurationBuilder;
 
-final class ConfigurationDumperTest extends TestCase
+final class BuildConfigurationsCommandTest extends TestCase
 {
     private string $outputDir;
 
     protected function setUp(): void
     {
-        $this->outputDir = sys_get_temp_dir().'/ux_native_dumper_test_'.bin2hex(random_bytes(4));
+        $this->outputDir = sys_get_temp_dir().'/ux_native_build_test_'.bin2hex(random_bytes(4));
     }
 
     protected function tearDown(): void
@@ -41,26 +41,26 @@ final class ConfigurationDumperTest extends TestCase
             rules: [new Rule(['.*'], ['context' => 'default'])],
         ));
 
-        $command = new ConfigurationDumper($builder);
+        $command = new BuildConfigurationsCommand($builder);
         $commandTester = new CommandTester($command);
 
         $commandTester->execute([]);
 
         $commandTester->assertCommandIsSuccessful();
         self::assertFileExists($this->outputDir.'/config/test.json');
-        self::assertStringContainsString('dumped successfully', $commandTester->getDisplay());
+        self::assertStringContainsString('built successfully', $commandTester->getDisplay());
     }
 
     public function testExecuteWithNoConfigurations()
     {
         $builder = new ConfigurationBuilder($this->outputDir);
 
-        $command = new ConfigurationDumper($builder);
+        $command = new BuildConfigurationsCommand($builder);
         $commandTester = new CommandTester($command);
 
         $commandTester->execute([]);
 
         $commandTester->assertCommandIsSuccessful();
-        self::assertStringContainsString('dumped successfully', $commandTester->getDisplay());
+        self::assertStringContainsString('built successfully', $commandTester->getDisplay());
     }
 }

--- a/src/Native/tests/Functional/BuildConfigurationsCommandTest.php
+++ b/src/Native/tests/Functional/BuildConfigurationsCommandTest.php
@@ -17,14 +17,14 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 
-final class CompileCommandTest extends WebTestCase
+final class BuildConfigurationsCommandTest extends WebTestCase
 {
     public static function testTheFilesAreCompiledWithTheCommand(): void
     {
         // Given
         static::cleanup();
         $application = new Application(self::bootKernel());
-        $command = $application->find('ux-native:dump');
+        $command = $application->find('ux:native:build-configs');
         $commandTester = new CommandTester($command);
 
         // When
@@ -41,7 +41,7 @@ final class CompileCommandTest extends WebTestCase
         // Given
         static::cleanup();
         $application = new Application(self::bootKernel());
-        $command = $application->find('ux-native:dump');
+        $command = $application->find('ux:native:build-configs');
         $commandTester = new CommandTester($command);
 
         // When
@@ -63,7 +63,7 @@ final class CompileCommandTest extends WebTestCase
         $client = self::createClient();
         static::cleanup();
         $application = new Application($client->getKernel());
-        $command = $application->find('ux-native:dump');
+        $command = $application->find('ux:native:build-configs');
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3597 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

The previous name did not follow the `ux:<...>` convention and the verb
`dump` carries debug semantics in Symfony, while this command actually
produces JSON configs for the iOS / Android Hotwire Native shells.
Rename to `ux:native:build-configs` (mirrors `ConfigurationBuilder::build()`),
rename `ConfigurationDumper` → `BuildConfigurationsCommand`, add a
description to `#[AsCommand]`.