### PR TITLE
 Rename native dump command

### DIFF
--- a/src/Native/config/services.php
+++ b/src/Native/config/services.php
@@ -37,6 +37,6 @@ return static function (ContainerConfigurator $container): void {
     ;
     $services->set('.ux_native.command.configuration_dumper', ConfigurationDumper::class)
         ->args([service('.ux_native.configuration_builder')])
-        ->tag('console.command', ['command' => 'ux-native:dump'])
+        ->tag('console.command', ['command' => 'ux:native:dump'])
     ;
 };

--- a/src/Native/doc/index.rst
+++ b/src/Native/doc/index.rst
@@ -47,7 +47,7 @@ The bundle exposes a single configuration option:
         output_dir: '%kernel.project_dir%/public' # default
 
 The ``output_dir`` option defines the directory where JSON configuration files
-are written when you run the ``ux-native:dump`` command (see
+are written when you run the ``ux:native:dump`` command (see
 `Dumping Configurations for Production`_).
 
 Usage
@@ -280,7 +280,7 @@ Run the following command:
 
 .. code-block:: terminal
 
-    $ php bin/console ux-native:dump
+    $ php bin/console ux:native:dump
 
 This writes all registered configurations as JSON files into the ``output_dir``
 directory (defaults to ``public/``). For example, a configuration registered at

--- a/src/Native/src/Command/ConfigurationDumper.php
+++ b/src/Native/src/Command/ConfigurationDumper.php
@@ -18,7 +18,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\UX\Native\ConfigurationBuilder;
 
-#[AsCommand('ux-native:dump')]
+#[AsCommand(
+    name: 'ux:native:dump',
+    description: 'Dump UX Native configuration files',
+)]
 final class ConfigurationDumper extends Command
 {
     public function __construct(

--- a/src/Native/tests/Functional/CompileCommandTest.php
+++ b/src/Native/tests/Functional/CompileCommandTest.php
@@ -24,7 +24,7 @@ final class CompileCommandTest extends WebTestCase
         // Given
         static::cleanup();
         $application = new Application(self::bootKernel());
-        $command = $application->find('ux-native:dump');
+        $command = $application->find('ux:native:dump');
         $commandTester = new CommandTester($command);
 
         // When
@@ -41,7 +41,7 @@ final class CompileCommandTest extends WebTestCase
         // Given
         static::cleanup();
         $application = new Application(self::bootKernel());
-        $command = $application->find('ux-native:dump');
+        $command = $application->find('ux:native:dump');
         $commandTester = new CommandTester($command);
 
         // When
@@ -63,7 +63,7 @@ final class CompileCommandTest extends WebTestCase
         $client = self::createClient();
         static::cleanup();
         $application = new Application($client->getKernel());
-        $command = $application->find('ux-native:dump');
+        $command = $application->find('ux:native:dump');
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
 
@@ -92,6 +92,15 @@ final class CompileCommandTest extends WebTestCase
         static::assertSame('application/json', $response->headers->get('Content-Type'));
         static::assertStringContainsString('"use_local_db":false', $response->getContent());
         static::assertStringContainsString('pull_to_refresh_enabled', $response->getContent());
+    }
+
+    public static function testTheCommandUsesUxNamespaceAndHasDescription(): void
+    {
+        $application = new Application(self::bootKernel());
+        $command = $application->find('ux:native:dump');
+
+        static::assertSame('ux:native:dump', $command->getName());
+        static::assertSame('Dump UX Native configuration files', $command->getDescription());
     }
 
     private static function cleanup(): void


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | related to FIX #3597
| License        | MIT

Renames the Native dump command from `ux-native:dump` to `ux:native:dump` and updates the related service configuration, documentation, and functional tests.