### PR TITLE
[LiveComponent] Sync auto-selected <select> value in forms

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -623,9 +623,12 @@ var Idiomorph = (function() {
 			} else if (ctx.head.shouldRemove(currentHeadElt) !== false) removed.push(currentHeadElt);
 		}
 		nodesToAppend.push(...srcToNewHeadNodes.values());
+		log("to append: ", nodesToAppend);
 		let promises = [];
 		for (const newNode of nodesToAppend) {
+			log("adding: ", newNode);
 			let newElt = document.createRange().createContextualFragment(newNode.outerHTML).firstChild;
+			log(newElt);
 			if (ctx.callbacks.beforeNodeAdded(newElt) !== false) {
 				if (newElt.href || newElt.src) {
 					let resolve = null;
@@ -653,6 +656,7 @@ var Idiomorph = (function() {
 		});
 		return promises;
 	}
+	function log() {}
 	function noOp() {}
 	function mergeDefaults(config) {
 		let finalConfig = {};
@@ -1748,8 +1752,7 @@ var ChildComponentPlugin_default = class {
 	constructor(component) {
 		this.parentModelBindings = [];
 		this.component = component;
-		const modelDirectives = getAllModelDirectiveFromElements(this.component.element);
-		this.parentModelBindings = modelDirectives.map(get_model_binding_default);
+		this.parentModelBindings = getAllModelDirectiveFromElements(this.component.element).map(get_model_binding_default);
 	}
 	attachToComponent(component) {
 		component.on("request:started", (requestData) => {
@@ -2049,11 +2052,11 @@ var SetValueOntoModelFieldsPlugin_default = class {
 		});
 	}
 	synchronizeValueOfModelFields(component) {
-		component.element.querySelectorAll("[data-model]").forEach((element) => {
+		component.element.querySelectorAll("[data-model], select[name]").forEach((element) => {
 			if (!(element instanceof HTMLElement)) throw new Error("Invalid element using data-model.");
 			if (element instanceof HTMLFormElement) return;
 			if (!elementBelongsToThisComponent(element, component)) return;
-			const modelDirective = getModelDirectiveFromElement(element);
+			const modelDirective = getModelDirectiveFromElement(element, false);
 			if (!modelDirective) return;
 			const modelName = modelDirective.action;
 			if (component.getUnsyncedModels().includes(modelName)) return;

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -623,12 +623,9 @@ var Idiomorph = (function() {
 			} else if (ctx.head.shouldRemove(currentHeadElt) !== false) removed.push(currentHeadElt);
 		}
 		nodesToAppend.push(...srcToNewHeadNodes.values());
-		log("to append: ", nodesToAppend);
 		let promises = [];
 		for (const newNode of nodesToAppend) {
-			log("adding: ", newNode);
 			let newElt = document.createRange().createContextualFragment(newNode.outerHTML).firstChild;
-			log(newElt);
 			if (ctx.callbacks.beforeNodeAdded(newElt) !== false) {
 				if (newElt.href || newElt.src) {
 					let resolve = null;
@@ -656,7 +653,6 @@ var Idiomorph = (function() {
 		});
 		return promises;
 	}
-	function log() {}
 	function noOp() {}
 	function mergeDefaults(config) {
 		let finalConfig = {};
@@ -1752,7 +1748,8 @@ var ChildComponentPlugin_default = class {
 	constructor(component) {
 		this.parentModelBindings = [];
 		this.component = component;
-		this.parentModelBindings = getAllModelDirectiveFromElements(this.component.element).map(get_model_binding_default);
+		const modelDirectives = getAllModelDirectiveFromElements(this.component.element);
+		this.parentModelBindings = modelDirectives.map(get_model_binding_default);
 	}
 	attachToComponent(component) {
 		component.on("request:started", (requestData) => {

--- a/src/LiveComponent/assets/src/Component/plugins/SetValueOntoModelFieldsPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/SetValueOntoModelFieldsPlugin.ts
@@ -30,7 +30,11 @@ export default class implements PluginInterface {
      * the "firstName" model.
      */
     private synchronizeValueOfModelFields(component: Component): void {
-        component.element.querySelectorAll('[data-model]').forEach((element: Element) => {
+        // Also target `select[name]` elements: inside a `<form data-model="*">`, fields
+        // are bound through their `name` attribute and carry no `data-model` of their own.
+        // They must still be synchronized so an auto-selected <option> is reflected in the model.
+        // https://github.com/symfony/ux/issues/767
+        component.element.querySelectorAll('[data-model], select[name]').forEach((element: Element) => {
             if (!(element instanceof HTMLElement)) {
                 throw new Error('Invalid element using data-model.');
             }
@@ -43,7 +47,7 @@ export default class implements PluginInterface {
                 return;
             }
 
-            const modelDirective = getModelDirectiveFromElement(element);
+            const modelDirective = getModelDirectiveFromElement(element, false);
             if (!modelDirective) {
                 return;
             }

--- a/src/LiveComponent/assets/test/unit/controller/model.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/model.test.ts
@@ -660,6 +660,36 @@ describe('LiveController data-model Tests', () => {
         await waitFor(() => expect(test.element).toHaveTextContent('Food: carrot'));
     });
 
+    it('notices the "real" value of a select without an empty value inside a form', async () => {
+        // https://github.com/symfony/ux/issues/767
+        const test = await createTest(
+            { form: { food: null } },
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <form data-model="*">
+                    <label>
+                        Food:
+                        <select name="form[food]">
+                            <option value="carrot">🥕</option>
+                            <option value="brocolli">🥦</option>
+                        </select>
+                    </label>
+                </form>
+
+                Food: ${data.form.food}
+
+                <button data-action="live#$render">Reload</button>
+            </div>
+        `
+        );
+
+        // "carrot" is sent because, in practice, that's what's selected
+        test.expectsAjaxCall().expectUpdatedData({ 'form.food': 'carrot' });
+
+        getByText(test.element, 'Reload').click();
+        await waitFor(() => expect(test.element).toHaveTextContent('Food: carrot'));
+    });
+
     it('allows model fields to be set manually and rolled into a single request', async () => {
         const test = await createTest(
             { food: '', dessert: '' },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #767
| License       | MIT

A single `<select>` without a placeholder/empty option is auto-selected by the browser on its first `<option>`. In a native form POST, that first option is submitted as if picked. Inside a LiveComponent form, however, the model stayed `null` until the user actually interacted with the field, so a `NotBlank()` constraint failed even though the option appeared selected.

`SetValueOntoModelFieldsPlugin` already handles this for selects carrying a `data-model` (#469), but it only iterated over `[data-model]` elements. Form fields inside `<form data-model="*">` are bound through their `name` attribute and have no `data-model` of their own, so they were skipped.

This widens the selector to also pick up `select[name]` elements and resolves their model through the existing `getModelDirectiveFromElement()` (which already knows how to derive the model name from `name` within a `data-model` form). The existing single-select sync logic then reflects the auto-selected option into the model — matching native browser behavior.

Added a unit test mirroring the existing `#469` one, but for a select living inside a `<form data-model="*">`.