### PR TITLE
[Turbo] Conflict with Mercure >=0.7.0 <0.7.2

### DIFF
--- a/src/Turbo/composer.json
+++ b/src/Turbo/composer.json
@@ -57,7 +57,8 @@
         "symfony/expression-language": "^7.4|^8.0"
     },
     "conflict": {
-        "symfony/flex": "<1.13"
+        "symfony/flex": "<1.13",
+        "symfony/mercure": ">=0.7.0 <0.7.2"
     },
     "extra": {
         "thanks": {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Fix https://github.com/symfony/ux/actions/runs/26723428765/job/78754475199

```
1) Symfony\UX\Turbo\Tests\Bridge\Mercure\MercureStreamSourceRendererTest::testRenderTurboStreamFrom with data set "string topic — public" ('{{ turbo_stream_from('a_topic') }}', [], '<turbo-mercure-stream-source ...ource>')
Twig\Error\RuntimeError: Unable to load the "Symfony\Component\Mercure\Twig\MercureExtension" runtime in "__string_template__99d0892f0ab319d56791b4f8d3f0ecca" at line 1.

/home/runner/work/ux/ux/src/Turbo/vendor/twig/twig/src/Environment.php:681
/home/runner/work/ux/ux/src/Turbo/src/Bridge/Mercure/MercureStreamSourceRenderer.php:56
/home/runner/work/ux/ux/src/Turbo/src/Twig/TurboRuntime.php:47
/tmp/ux_turbo/cache/test/twig/ff/ff27dce2fa029d54bfa6c1e850f34dad.php:45
/home/runner/work/ux/ux/src/Turbo/vendor/twig/twig/src/Template.php:411
/home/runner/work/ux/ux/src/Turbo/vendor/twig/twig/src/Template.php:366
/home/runner/work/ux/ux/src/Turbo/vendor/twig/twig/src/Template.php:381
/home/runner/work/ux/ux/src/Turbo/vendor/twig/twig/src/TemplateWrapper.php:51
/home/runner/work/ux/ux/src/Turbo/tests/Bridge/Mercure/MercureStreamSourceRendererTest.php:29
```