### PR TITLE
[Toolkit][Shadcn] Use `attributes.defaults()` in `breadcrumb` component templates

### DIFF
--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb.html.twig
@@ -1,8 +1,9 @@
 {# @block content The breadcrumb structure, typically a `Breadcrumb:List` #}
 <nav
-    data-slot="breadcrumb"
-    aria-label="breadcrumb"
-    {{ attributes }}
+    {{ attributes.defaults({
+        'data-slot': 'breadcrumb',
+        'aria-label': 'breadcrumb',
+    }) }}
 >
     {%- block content %}{% endblock -%}
 </nav>

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Ellipsis.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Ellipsis.html.twig
@@ -1,10 +1,11 @@
 {# @block content Optional custom content replacing the ellipsis icon #}
 <span
-    data-slot="breadcrumb-ellipsis"
-    role="presentation"
-    aria-hidden="true"
     class="{{ ('flex size-5 items-center justify-center [&>svg]:size-4 ' ~ attributes.render('class'))|tailwind_merge }}"
-    {{ attributes }}
+    {{ attributes.defaults({
+        'data-slot': 'breadcrumb-ellipsis',
+        role: 'presentation',
+        'aria-hidden': 'true',
+    }) }}
 >
     <twig:ux:icon name="lucide:ellipsis" />
     <span class="sr-only">More</span>

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Item.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Item.html.twig
@@ -1,8 +1,7 @@
 {# @block content The breadcrumb item content, typically a `Breadcrumb:Link` or `Breadcrumb:Page` #}
 <li
-    data-slot="breadcrumb-item"
     class="{{ ('inline-flex items-center gap-1 ' ~ attributes.render('class'))|tailwind_merge }}"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'breadcrumb-item'}) }}
 >
     {%- block content %}{% endblock -%}
 </li>

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Link.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Link.html.twig
@@ -1,8 +1,7 @@
 {# @block content The clickable link text #}
 <a
-    data-slot="breadcrumb-link"
     class="{{ ('transition-colors hover:text-foreground ' ~ attributes.render('class'))|tailwind_merge }}"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'breadcrumb-link'}) }}
 >
     {%- block content %}{% endblock -%}
 </a>

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/List.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/List.html.twig
@@ -1,8 +1,7 @@
 {# @block content The list of breadcrumb items, typically multiple `Breadcrumb:Item` components #}
 <ol
-    data-slot="breadcrumb-list"
     class="{{ ('flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground ' ~ attributes.render('class'))|tailwind_merge }}"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'breadcrumb-list'}) }}
 >
     {%- block content %}{% endblock -%}
 </ol>

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Page.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Page.html.twig
@@ -1,11 +1,12 @@
 {# @block content The current page text (non-clickable) #}
 <span
-    data-slot="breadcrumb-page"
-    role="link"
-    aria-disabled="true"
-    aria-current="page"
     class="{{ ('font-normal text-foreground ' ~ attributes.render('class'))|tailwind_merge }}"
-    {{ attributes }}
+    {{ attributes.defaults({
+        'data-slot': 'breadcrumb-page',
+        role: 'link',
+        'aria-disabled': 'true',
+        'aria-current': 'page',
+    }) }}
 >
     {%- block content %}{% endblock -%}
 </span>

--- a/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Separator.html.twig
+++ b/src/Toolkit/kits/shadcn/breadcrumb/templates/components/Breadcrumb/Separator.html.twig
@@ -1,10 +1,11 @@
 {# @block content The separator icon between breadcrumb items, defaults to a chevron #}
 <li
-    data-slot="breadcrumb-separator"
-    role="presentation"
-    aria-hidden="true"
     class="{{ ('[&>svg]:size-3.5 ' ~ attributes.render('class'))|tailwind_merge }}"
-    {{ attributes }}
+    {{ attributes.defaults({
+        'data-slot': 'breadcrumb-separator',
+        role: 'presentation',
+        'aria-hidden': 'true',
+    }) }}
 >
     {%- block content -%}
         <twig:ux:icon name="lucide:chevron-right" class="rtl:rotate-180" />

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Basic.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Basic.html.twig__1.html
@@ -20,19 +20,19 @@
 </twig:Breadcrumb>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol data-slot="breadcrumb-list" class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground">
-<li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Home</a>
+<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground" data-slot="breadcrumb-list">
+<li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Home</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Components</a>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Components</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<span data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page" class="font-normal text-foreground">Breadcrumb</span>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<span class="font-normal text-foreground" data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page">Breadcrumb</span>
         </li>
     </ol>
 </nav>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Collapsed.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Collapsed.html.twig__1.html
@@ -24,28 +24,28 @@
 </twig:Breadcrumb>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol data-slot="breadcrumb-list" class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground">
-<li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Home</a>
+<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground" data-slot="breadcrumb-list">
+<li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Home</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<span data-slot="breadcrumb-ellipsis" role="presentation" aria-hidden="true" class="flex size-5 items-center justify-center [&amp;&gt;svg]:size-4">
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<span class="flex size-5 items-center justify-center [&amp;&gt;svg]:size-4" data-slot="breadcrumb-ellipsis" role="presentation" aria-hidden="true">
     <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></g></svg>
     <span class="sr-only">More</span>
 </span>
 
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Components</a>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Components</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<span data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page" class="font-normal text-foreground">Breadcrumb</span>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<span class="font-normal text-foreground" data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page">Breadcrumb</span>
         </li>
     </ol>
 </nav>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Custom Separator.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Custom Separator.html.twig__1.html
@@ -24,21 +24,21 @@
 </twig:Breadcrumb>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol data-slot="breadcrumb-list" class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground">
-<li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Home</a>
+<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground" data-slot="breadcrumb-list">
+<li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Home</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5">
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true">
 <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12.1" cy="12.1" r="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></circle></svg>
         </li>
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Components</a>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Components</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5">
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true">
 <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12.1" cy="12.1" r="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></circle></svg>
         </li>
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<span data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page" class="font-normal text-foreground">Breadcrumb</span>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<span class="font-normal text-foreground" data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page">Breadcrumb</span>
         </li>
     </ol>
 </nav>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Demo.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Demo.html.twig__1.html
@@ -24,28 +24,28 @@
 </twig:Breadcrumb>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol data-slot="breadcrumb-list" class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground">
-<li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Home</a>
+<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground" data-slot="breadcrumb-list">
+<li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Home</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<span data-slot="breadcrumb-ellipsis" role="presentation" aria-hidden="true" class="flex size-5 items-center justify-center [&amp;&gt;svg]:size-4">
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<span class="flex size-5 items-center justify-center [&amp;&gt;svg]:size-4" data-slot="breadcrumb-ellipsis" role="presentation" aria-hidden="true">
     <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></g></svg>
     <span class="sr-only">More</span>
 </span>
 
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Components</a>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Components</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<span data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page" class="font-normal text-foreground">Breadcrumb</span>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<span class="font-normal text-foreground" data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page">Breadcrumb</span>
         </li>
     </ol>
 </nav>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Link component.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file Link component.html.twig__1.html
@@ -20,19 +20,19 @@
 </twig:Breadcrumb>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol data-slot="breadcrumb-list" class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground">
-<li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Home</a>
+<nav data-slot="breadcrumb" aria-label="breadcrumb"><ol class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground" data-slot="breadcrumb-list">
+<li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Home</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">Components</a>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">Components</a>
         </li>
-        <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
+        <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg></li>
 
-        <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<span data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page" class="font-normal text-foreground">Breadcrumb</span>
+        <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<span class="font-normal text-foreground" data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page">Breadcrumb</span>
         </li>
     </ol>
 </nav>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file RTL.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component breadcrumb, code file RTL.html.twig__1.html
@@ -46,39 +46,39 @@
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex flex-col gap-6">
-    <nav data-slot="breadcrumb" aria-label="breadcrumb" dir="rtl"><ol data-slot="breadcrumb-list" class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground">
-<li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">&Oslash;&sect;&Ugrave;&#132;&Oslash;&plusmn;&Oslash;&brvbar;&Ugrave;&#138;&Oslash;&sup3;&Ugrave;&#138;&Oslash;&copy;</a>
+    <nav data-slot="breadcrumb" aria-label="breadcrumb" dir="rtl"><ol class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground" data-slot="breadcrumb-list">
+<li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">&Oslash;&sect;&Ugrave;&#132;&Oslash;&plusmn;&Oslash;&brvbar;&Ugrave;&#138;&Oslash;&sup3;&Ugrave;&#138;&Oslash;&copy;</a>
             </li>
-            <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5">
+            <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true">
 <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12.1" cy="12.1" r="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></circle></svg>
             </li>
-            <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">&Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#131;&Ugrave;&#136;&Ugrave;&#134;&Oslash;&sect;&Oslash;&ordf;</a>
+            <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">&Oslash;&sect;&Ugrave;&#132;&Ugrave;&#133;&Ugrave;&#131;&Ugrave;&#136;&Ugrave;&#134;&Oslash;&sect;&Oslash;&ordf;</a>
             </li>
-            <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5">
+            <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true">
 <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12.1" cy="12.1" r="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></circle></svg>
             </li>
-            <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<span data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page" class="font-normal text-foreground">&Ugrave;&#133;&Oslash;&sup3;&Oslash;&sect;&Oslash;&plusmn; &Oslash;&sect;&Ugrave;&#132;&Oslash;&ordf;&Ugrave;&#134;&Ugrave;&#130;&Ugrave;&#132;</span>
+            <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<span class="font-normal text-foreground" data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page">&Ugrave;&#133;&Oslash;&sup3;&Oslash;&sect;&Oslash;&plusmn; &Oslash;&sect;&Ugrave;&#132;&Oslash;&ordf;&Ugrave;&#134;&Ugrave;&#130;&Ugrave;&#132;</span>
             </li>
         </ol>
     </nav>
-    <nav data-slot="breadcrumb" aria-label="breadcrumb" dir="rtl"><ol data-slot="breadcrumb-list" class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground">
-<li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">&times;&#145;&times;&#153;&times;&ordf;</a>
+    <nav data-slot="breadcrumb" aria-label="breadcrumb" dir="rtl"><ol class="flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground" data-slot="breadcrumb-list">
+<li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">&times;&#145;&times;&#153;&times;&ordf;</a>
             </li>
-            <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5">
+            <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true">
 <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12.1" cy="12.1" r="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></circle></svg>
             </li>
-            <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<a data-slot="breadcrumb-link" class="transition-colors hover:text-foreground" href="#">&times;&uml;&times;&#155;&times;&#153;&times;&#145;&times;&#153;&times;&#157;</a>
+            <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<a class="transition-colors hover:text-foreground" data-slot="breadcrumb-link" href="#">&times;&uml;&times;&#155;&times;&#153;&times;&#145;&times;&#153;&times;&#157;</a>
             </li>
-            <li data-slot="breadcrumb-separator" role="presentation" aria-hidden="true" class="[&amp;&gt;svg]:size-3.5">
+            <li class="[&amp;&gt;svg]:size-3.5" data-slot="breadcrumb-separator" role="presentation" aria-hidden="true">
 <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12.1" cy="12.1" r="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></circle></svg>
             </li>
-            <li data-slot="breadcrumb-item" class="inline-flex items-center gap-1">
-<span data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page" class="font-normal text-foreground">&times;&nbsp;&times;&#153;&times;&#149;&times;&#149;&times;&#152;</span>
+            <li class="inline-flex items-center gap-1" data-slot="breadcrumb-item">
+<span class="font-normal text-foreground" data-slot="breadcrumb-page" role="link" aria-disabled="true" aria-current="page">&times;&nbsp;&times;&#153;&times;&#149;&times;&#149;&times;&#152;</span>
             </li>
         </ol>
     </nav>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Part of https://github.com/symfony/ux/issues/3233
| License        | MIT