### PR TITLE
[Toolkit][Shadcn] Use `attributes.defaults()` in `skeleton` component template

### DIFF
--- a/src/Toolkit/kits/shadcn/skeleton/templates/components/Skeleton.html.twig
+++ b/src/Toolkit/kits/shadcn/skeleton/templates/components/Skeleton.html.twig
@@ -1,5 +1,4 @@
 <div
-    data-slot="skeleton"
     class="{{ ('animate-pulse rounded-md bg-muted ' ~ attributes.render('class'))|tailwind_merge }}"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'skeleton'}) }}
 ></div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Avatar.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Avatar.html.twig__1.html
@@ -13,12 +13,12 @@
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex w-fit items-center gap-4">
-    <div data-slot="skeleton" class="animate-pulse bg-muted size-10 shrink-0 rounded-full"></div>
+    <div class="animate-pulse bg-muted size-10 shrink-0 rounded-full" data-slot="skeleton"></div>
 
     <div class="grid gap-2">
-        <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-[150px]"></div>
+        <div class="animate-pulse rounded-md bg-muted h-4 w-[150px]" data-slot="skeleton"></div>
 
-        <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-[100px]"></div>
+        <div class="animate-pulse rounded-md bg-muted h-4 w-[100px]" data-slot="skeleton"></div>
 
     </div>
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Card.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Card.html.twig__1.html
@@ -16,13 +16,13 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl w-full max-w-xs" data-slot="card" data-size="default">
 <div class="group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3" data-slot="card-header">
-<div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-2/3"></div>
+<div class="animate-pulse rounded-md bg-muted h-4 w-2/3" data-slot="skeleton"></div>
 
-        <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-1/2"></div>
+        <div class="animate-pulse rounded-md bg-muted h-4 w-1/2" data-slot="skeleton"></div>
 
     </div>
     <div class="px-4 group-data-[size=sm]/card:px-3" data-slot="card-content">
-<div data-slot="skeleton" class="animate-pulse rounded-md bg-muted aspect-video w-full"></div>
+<div class="animate-pulse rounded-md bg-muted aspect-video w-full" data-slot="skeleton"></div>
 
     </div>
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Demo.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Demo.html.twig__1.html
@@ -13,12 +13,12 @@
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex items-center gap-4">
-    <div data-slot="skeleton" class="animate-pulse bg-muted h-12 w-12 rounded-full"></div>
+    <div class="animate-pulse bg-muted h-12 w-12 rounded-full" data-slot="skeleton"></div>
 
     <div class="space-y-2">
-        <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-[250px]"></div>
+        <div class="animate-pulse rounded-md bg-muted h-4 w-[250px]" data-slot="skeleton"></div>
 
-        <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-[200px]"></div>
+        <div class="animate-pulse rounded-md bg-muted h-4 w-[200px]" data-slot="skeleton"></div>
 
     </div>
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Form.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Form.html.twig__1.html
@@ -18,17 +18,17 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex w-full max-w-xs flex-col gap-7">
     <div class="flex flex-col gap-3">
-        <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-20"></div>
+        <div class="animate-pulse rounded-md bg-muted h-4 w-20" data-slot="skeleton"></div>
 
-        <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-8 w-full"></div>
+        <div class="animate-pulse rounded-md bg-muted h-8 w-full" data-slot="skeleton"></div>
 
     </div>
     <div class="flex flex-col gap-3">
-        <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-24"></div>
+        <div class="animate-pulse rounded-md bg-muted h-4 w-24" data-slot="skeleton"></div>
 
-        <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-8 w-full"></div>
+        <div class="animate-pulse rounded-md bg-muted h-8 w-full" data-slot="skeleton"></div>
 
     </div>
-    <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-8 w-24"></div>
+    <div class="animate-pulse rounded-md bg-muted h-8 w-24" data-slot="skeleton"></div>
 
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file RTL.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file RTL.html.twig__1.html
@@ -26,23 +26,23 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex flex-col gap-8">
         <div class="flex items-center gap-4" dir="rtl">
-        <div data-slot="skeleton" class="animate-pulse bg-muted h-12 w-12 rounded-full"></div>
+        <div class="animate-pulse bg-muted h-12 w-12 rounded-full" data-slot="skeleton"></div>
 
         <div class="space-y-2">
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-[250px]"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-[250px]" data-slot="skeleton"></div>
 
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-[200px]"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-[200px]" data-slot="skeleton"></div>
 
         </div>
     </div>
 
         <div class="flex items-center gap-4" dir="rtl">
-        <div data-slot="skeleton" class="animate-pulse bg-muted h-12 w-12 rounded-full"></div>
+        <div class="animate-pulse bg-muted h-12 w-12 rounded-full" data-slot="skeleton"></div>
 
         <div class="space-y-2">
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-[250px]"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-[250px]" data-slot="skeleton"></div>
 
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-[200px]"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-[200px]" data-slot="skeleton"></div>
 
         </div>
     </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Table.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Table.html.twig__1.html
@@ -16,43 +16,43 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex w-full max-w-sm flex-col gap-2">
             <div class="flex gap-4">
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 flex-1"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 flex-1" data-slot="skeleton"></div>
 
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-24"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-24" data-slot="skeleton"></div>
 
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-20"></div>
-
-        </div>
-            <div class="flex gap-4">
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 flex-1"></div>
-
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-24"></div>
-
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-20"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-20" data-slot="skeleton"></div>
 
         </div>
             <div class="flex gap-4">
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 flex-1"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 flex-1" data-slot="skeleton"></div>
 
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-24"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-24" data-slot="skeleton"></div>
 
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-20"></div>
-
-        </div>
-            <div class="flex gap-4">
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 flex-1"></div>
-
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-24"></div>
-
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-20"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-20" data-slot="skeleton"></div>
 
         </div>
             <div class="flex gap-4">
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 flex-1"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 flex-1" data-slot="skeleton"></div>
 
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-24"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-24" data-slot="skeleton"></div>
 
-            <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-20"></div>
+            <div class="animate-pulse rounded-md bg-muted h-4 w-20" data-slot="skeleton"></div>
+
+        </div>
+            <div class="flex gap-4">
+            <div class="animate-pulse rounded-md bg-muted h-4 flex-1" data-slot="skeleton"></div>
+
+            <div class="animate-pulse rounded-md bg-muted h-4 w-24" data-slot="skeleton"></div>
+
+            <div class="animate-pulse rounded-md bg-muted h-4 w-20" data-slot="skeleton"></div>
+
+        </div>
+            <div class="flex gap-4">
+            <div class="animate-pulse rounded-md bg-muted h-4 flex-1" data-slot="skeleton"></div>
+
+            <div class="animate-pulse rounded-md bg-muted h-4 w-24" data-slot="skeleton"></div>
+
+            <div class="animate-pulse rounded-md bg-muted h-4 w-20" data-slot="skeleton"></div>
 
         </div>
     </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Text.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component skeleton, code file Text.html.twig__1.html
@@ -11,10 +11,10 @@
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex w-full max-w-xs flex-col gap-2">
-    <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-full"></div>
+    <div class="animate-pulse rounded-md bg-muted h-4 w-full" data-slot="skeleton"></div>
 
-    <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-full"></div>
+    <div class="animate-pulse rounded-md bg-muted h-4 w-full" data-slot="skeleton"></div>
 
-    <div data-slot="skeleton" class="animate-pulse rounded-md bg-muted h-4 w-3/4"></div>
+    <div class="animate-pulse rounded-md bg-muted h-4 w-3/4" data-slot="skeleton"></div>
 
 </div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Part of https://github.com/symfony/ux/issues/3233
| License        | MIT