### PR TITLE
[Toolkit][Shadcn] Use `attributes.defaults()` in `table` component templates

### DIFF
--- a/src/Toolkit/kits/shadcn/table/templates/components/Table.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table.html.twig
@@ -2,7 +2,7 @@
 <div class="relative w-full overflow-x-auto" data-slot="table-container">
     <table
         class="{{ ('w-full caption-bottom text-sm ' ~ attributes.render('class'))|tailwind_merge }}"
-        {{ attributes }}
+        {{ attributes.defaults({'data-slot': 'table'}) }}
     >
         {%- block content %}{% endblock -%}
     </table>

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Body.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Body.html.twig
@@ -1,8 +1,7 @@
 {# @block content The table body rows, typically `Table:Row` components #}
 <tbody
     class="{{ ('[&_tr:last-child]:border-0 ' ~ attributes.render('class'))|tailwind_merge }}"
-    data-slot="table-body"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'table-body'}) }}
 >
     {%- block content %}{% endblock -%}
 </tbody>

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Caption.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Caption.html.twig
@@ -1,8 +1,7 @@
 {# @block content The table caption text #}
 <caption
     class="{{ ('text-muted-foreground mt-4 text-sm ' ~ attributes.render('class'))|tailwind_merge }}"
-    data-slot="table-caption"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'table-caption'}) }}
 >
     {%- block content %}{% endblock -%}
 </caption>

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Cell.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Cell.html.twig
@@ -1,8 +1,7 @@
 {# @block content The cell content #}
 <td
     class="{{ ('p-2 align-middle whitespace-nowrap ltr:[&:has([role=checkbox])]:pr-0 rtl:[&:has([role=checkbox])]:pe-0' ~ attributes.render('class'))|tailwind_merge }}"
-    data-slot="table-cell"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'table-cell'}) }}
 >
     {%- block content %}{% endblock -%}
 </td>

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Footer.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Footer.html.twig
@@ -1,8 +1,7 @@
 {# @block content The table footer rows, typically `Table:Row` components #}
 <tfoot
     class="{{ ('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0 ' ~ attributes.render('class'))|tailwind_merge }}"
-    data-slot="table-footer"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'table-footer'}) }}
 >
     {%- block content %}{% endblock -%}
 </tfoot>

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Head.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Head.html.twig
@@ -1,8 +1,7 @@
 {# @block content The header cell content #}
 <th
     class="{{ ('h-10 px-2 text-left rtl:text-start align-middle font-medium whitespace-nowrap text-foreground ltr:[&:has([role=checkbox])]:pr-0 rtl:[&:has([role=checkbox])]:pe-0' ~ attributes.render('class'))|tailwind_merge }}"
-    data-slot="table-head"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'table-head'}) }}
 >
     {%- block content %}{% endblock -%}
 </th>

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Header.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Header.html.twig
@@ -1,8 +1,7 @@
 {# @block content The header row(s), typically a `Table:Row` with `Table:Head` cells #}
 <thead
     class="{{ ('[&_tr]:border-b ' ~ attributes.render('class'))|tailwind_merge }}"
-    data-slot="table-header"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'table-header'}) }}
 >
     {%- block content %}{% endblock -%}
 </thead>

--- a/src/Toolkit/kits/shadcn/table/templates/components/Table/Row.html.twig
+++ b/src/Toolkit/kits/shadcn/table/templates/components/Table/Row.html.twig
@@ -1,8 +1,7 @@
 {# @block content The row cells, typically `Table:Cell` or `Table:Head` components #}
 <tr
     class="{{ ('border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted ' ~ attributes.render('class'))|tailwind_merge }}"
-    data-slot="table-row"
-    {{ attributes }}
+    {{ attributes.defaults({'data-slot': 'table-row'}) }}
 >
     {%- block content %}{% endblock -%}
 </tr>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component checkbox, code file Table.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component checkbox, code file Table.html.twig__1.html
@@ -52,7 +52,7 @@
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="relative w-full overflow-x-auto" data-slot="table-container">
-    <table class="w-full caption-bottom text-sm">
+    <table class="w-full caption-bottom text-sm" data-slot="table">
 <thead class="[&amp;_tr]:border-b" data-slot="table-header">
 <tr class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-slot="table-row">
 <th class="h-10 px-2 text-left rtl:text-start align-middle font-medium whitespace-nowrap text-foreground ltr:[&amp;:has([role=checkbox])]:pr-0 rtl:[&amp;:has([role=checkbox])]:pe-0w-8" data-slot="table-head">

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component table, code file Demo.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component table, code file Demo.html.twig__1.html
@@ -42,7 +42,7 @@
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="relative w-full overflow-x-auto" data-slot="table-container">
-    <table class="w-full caption-bottom text-sm">
+    <table class="w-full caption-bottom text-sm" data-slot="table">
 <caption class="text-muted-foreground mt-4 text-sm" data-slot="table-caption">A list of your recent invoices.</caption>
     <thead class="[&amp;_tr]:border-b" data-slot="table-header">
 <tr class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-slot="table-row">

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component table, code file Footer.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component table, code file Footer.html.twig__1.html
@@ -38,7 +38,7 @@
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="relative w-full overflow-x-auto" data-slot="table-container">
-    <table class="w-full caption-bottom text-sm">
+    <table class="w-full caption-bottom text-sm" data-slot="table">
 <caption class="text-muted-foreground mt-4 text-sm" data-slot="table-caption">A list of your recent invoices.</caption>
     <thead class="[&amp;_tr]:border-b" data-slot="table-header">
 <tr class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-slot="table-row">

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component table, code file RTL.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component table, code file RTL.html.twig__1.html
@@ -86,7 +86,7 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="flex flex-col gap-8 w-full items-center">
         <div class="relative w-full overflow-x-auto" data-slot="table-container">
-    <table class="w-full caption-bottom text-sm" dir="rtl">
+    <table class="w-full caption-bottom text-sm" data-slot="table" dir="rtl">
 <caption class="text-muted-foreground mt-4 text-sm" data-slot="table-caption">&Ugrave;&#130;&Oslash;&sect;&Oslash;&brvbar;&Ugrave;&#133;&Oslash;&copy; &Oslash;&uml;&Ugrave;&#129;&Ugrave;&#136;&Oslash;&sect;&Oslash;&ordf;&Ugrave;&#138;&Oslash;&plusmn;&Ugrave;&#131; &Oslash;&sect;&Ugrave;&#132;&Oslash;&pound;&Oslash;&reg;&Ugrave;&#138;&Oslash;&plusmn;&Oslash;&copy;.</caption>
         <thead class="[&amp;_tr]:border-b" data-slot="table-header">
 <tr class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-slot="table-row">
@@ -126,7 +126,7 @@
 </div>
 
         <div class="relative w-full overflow-x-auto" data-slot="table-container">
-    <table class="w-full caption-bottom text-sm" dir="rtl">
+    <table class="w-full caption-bottom text-sm" data-slot="table" dir="rtl">
 <caption class="text-muted-foreground mt-4 text-sm" data-slot="table-caption">&times;&uml;&times;&copy;&times;&#153;&times;&#158;&times;&ordf; &times;&#148;&times;&#151;&times;&copy;&times;&#145;&times;&#149;&times;&nbsp;&times;&#153;&times;&#149;&times;&ordf; &times;&#148;&times;&#144;&times;&#151;&times;&uml;&times;&#149;&times;&nbsp;&times;&#149;&times;&ordf; &times;&copy;&times;&#156;&times;&#154;.</caption>
         <thead class="[&amp;_tr]:border-b" data-slot="table-header">
 <tr class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-slot="table-row">


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Part of https://github.com/symfony/ux/issues/3233
| License        | MIT