### PR TITLE
[Toolkit][Shadcn] Use `attributes.defaults()` in `resizable` component templates

### DIFF
--- a/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable/Handle.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable/Handle.html.twig
@@ -2,9 +2,9 @@
 {%- props withHandle = false -%}
 <div
     class="{{ ('relative flex w-px items-center justify-center bg-border ring-offset-background after:absolute after:inset-y-0 ltr:after:left-1/2 rtl:after:start-1/2 after:w-1 after:-translate-x-1/2 rtl:after:translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden group-data-[orientation=horizontal]/resizable:h-full group-data-[orientation=horizontal]/resizable:cursor-col-resize group-data-[orientation=vertical]/resizable:h-px group-data-[orientation=vertical]/resizable:w-full group-data-[orientation=vertical]/resizable:cursor-row-resize ltr:group-data-[orientation=vertical]/resizable:after:left-0 rtl:group-data-[orientation=vertical]/resizable:after:start-0 group-data-[orientation=vertical]/resizable:after:h-1 group-data-[orientation=vertical]/resizable:after:w-full group-data-[orientation=vertical]/resizable:after:translate-x-0 group-data-[orientation=vertical]/resizable:after:-translate-y-1/2 rtl:group-data-[orientation=vertical]/resizable:after:-translate-x-0 group-data-[orientation=vertical]/resizable:[&>div]:rotate-90 ' ~ attributes.render('class'))|tailwind_merge }}"
-    tabindex="0"
-    role="separator"
     {{ attributes.defaults({
+        tabindex: '0',
+        role: 'separator',
         'data-slot': 'resizable-handle',
         'data-resizable-target': 'handle',
     }) }}

--- a/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable/Panel.html.twig
+++ b/src/Toolkit/kits/shadcn/resizable/templates/components/Resizable/Panel.html.twig
@@ -3,8 +3,8 @@
 {%- props size = null -%}
 <div
     class="{{ ('overflow-auto ' ~ attributes.render('class'))|tailwind_merge }}"
-    style="flex: {{ size ?? 1 }} 1 0%;"
     {{ attributes.defaults({
+        style: 'flex: ' ~ (size ?? 1) ~ ' 1 0%;',
         'data-slot': 'resizable-panel',
         'data-resizable-target': 'panel',
     }) }}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Part of https://github.com/symfony/ux/issues/3233
| License        | MIT