### PR TITLE
[Toolkit] Add lint kit command and CI lint workflow

### DIFF
--- a/.github/workflows/toolkit-lint-kits.yaml
+++ b/.github/workflows/toolkit-lint-kits.yaml
@@ -1,0 +1,71 @@
+name: Toolkit Lint Kits
+
+defaults:
+    run:
+        shell: bash
+
+on:
+    push:
+        branches-ignore:
+            - 'dependabot/**'
+        paths:
+            - 'src/Toolkit/**'
+            - '.github/workflows/toolkit-lint-kits.yaml'
+    pull_request:
+        paths:
+            - 'src/Toolkit/**'
+            - '.github/workflows/toolkit-lint-kits.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+    discover:
+        name: Discover kits
+        runs-on: ubuntu-latest
+        outputs:
+            kits: ${{ steps.set.outputs.kits }}
+        steps:
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+              with:
+                  persist-credentials: false
+
+            - id: set
+              name: Build matrix from src/Toolkit/kits/*
+              run: |
+                  KITS=$(find src/Toolkit/kits -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort | jq -R . | jq -sc .)
+                  echo "Kits: $KITS"
+                  echo "kits=$KITS" >> "$GITHUB_OUTPUT"
+
+    lint:
+        name: Lint ${{ matrix.kit }}
+        needs: discover
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                kit: ${{ fromJson(needs.discover.outputs.kits) }}
+        steps:
+            - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+              with:
+                  persist-credentials: false
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@083d5237d9340d541bf95e2a6eceaf3529b85892
+              with:
+                  php-version: '8.4'
+
+            - name: Install Toolkit dependencies
+              uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27
+              with:
+                  working-directory: src/Toolkit
+
+            - name: Lint kit
+              working-directory: src/Toolkit
+              env:
+                  COLUMNS: 120
+                  KIT: ${{ matrix.kit }}
+              run: php bin/ux-toolkit-kit-lint --ansi --fail-on-warning "kits/$KIT"

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -14,6 +14,7 @@
         "src/**/dist",
         "src/**/var",
         "src/**/tests/**/fixtures/**",
+        "src/**/tests/**/Fixtures/**",
         "src/**/tests/**/__snapshots__/**"
     ],
     "printWidth": 120,

--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.2.0
+
+- Add lint kit command `bin/ux-toolkit-kit-lint` to check for issues in local kits
+
 ## 3.1
 
 - [Flowbite] Add `avatar` recipe

--- a/src/Toolkit/bin/ux-toolkit-kit-create
+++ b/src/Toolkit/bin/ux-toolkit-kit-create
@@ -38,7 +38,7 @@ if (!class_exists(Application::class)) {
 
 $filesystem = new Filesystem();
 
-(new Application())->add($command = new CreateKitCommand($filesystem))
+(new Application())->{method_exists(Application::class, 'addCommand') ? 'addCommand' : 'add'}($command = new CreateKitCommand($filesystem))
     ->getApplication()
     ->setDefaultCommand($command->getName(), true)
     ->run()

--- a/src/Toolkit/bin/ux-toolkit-kit-debug
+++ b/src/Toolkit/bin/ux-toolkit-kit-debug
@@ -50,7 +50,7 @@ $filesystem = new Filesystem();
 $kitSynchronizer = new KitSynchronizer($filesystem, new RecipeSynchronizer());
 $kitFactory = new KitFactory($filesystem, $kitSynchronizer);
 
-(new Application())->add($command = new DebugKitCommand($kitFactory))
+(new Application())->{method_exists(Application::class, 'addCommand') ? 'addCommand' : 'add'}($command = new DebugKitCommand($kitFactory))
     ->getApplication()
     ->setDefaultCommand($command->getName(), true)
     ->run()

--- a/src/Toolkit/bin/ux-toolkit-kit-lint
+++ b/src/Toolkit/bin/ux-toolkit-kit-lint
@@ -1,0 +1,51 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\UX\Toolkit\Command\LintKitCommand;
+use Symfony\UX\Toolkit\Kit\KitFactory;
+use Symfony\UX\Toolkit\Kit\KitSynchronizer;
+use Symfony\UX\Toolkit\Kit\Lint\KitLinter;
+use Symfony\UX\Toolkit\Recipe\RecipeSynchronizer;
+
+function includeIfExists(string $file): bool
+{
+    return file_exists($file) && include $file;
+}
+
+if (
+    !includeIfExists(__DIR__ . '/../../../autoload.php') &&
+    !includeIfExists(__DIR__ . '/../vendor/autoload.php')
+) {
+    fwrite(STDERR, 'Install dependencies using Composer.'.PHP_EOL);
+    exit(1);
+}
+
+if (!class_exists(Application::class)) {
+    fwrite(STDERR, 'You need the "symfony/console" component in order to run the UX Toolkit kit linter.'.PHP_EOL);
+    exit(1);
+}
+
+$filesystem = new Filesystem();
+$kitSynchronizer = new KitSynchronizer($filesystem, new RecipeSynchronizer());
+$kitFactory = new KitFactory($filesystem, $kitSynchronizer);
+
+(new Application())->{method_exists(Application::class, 'addCommand') ? 'addCommand' : 'add'}($command = new LintKitCommand($kitFactory, new KitLinter()))
+    ->getApplication()
+    ->setDefaultCommand($command->getName(), true)
+    ->run()
+;

--- a/src/Toolkit/composer.json
+++ b/src/Toolkit/composer.json
@@ -35,6 +35,7 @@
         "symfony/console": "^7.4|^8.0",
         "symfony/filesystem": "^7.4|^8.0",
         "symfony/framework-bundle": "^7.4|^8.0",
+        "symfony/string": "^7.4|^8.0",
         "symfony/twig-bundle": "^7.4|^8.0",
         "symfony/ux-twig-component": "^3.1",
         "symfony/yaml": "^7.4|^8.0"
@@ -53,7 +54,8 @@
     },
     "bin": [
         "bin/ux-toolkit-kit-create",
-        "bin/ux-toolkit-kit-debug"
+        "bin/ux-toolkit-kit-debug",
+        "bin/ux-toolkit-kit-lint"
     ],
     "autoload": {
         "psr-4": {

--- a/src/Toolkit/src/Command/LintKitCommand.php
+++ b/src/Toolkit/src/Command/LintKitCommand.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Path;
+use Symfony\UX\Toolkit\Kit\KitFactory;
+use Symfony\UX\Toolkit\Kit\Lint\KitLinter;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintReport;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+
+/**
+ * Lint a Kit: structure, manifests, and declared-vs-used dependencies.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+#[AsCommand(
+    name: 'ux:toolkit:lint-kit',
+    description: 'Lint a local Kit (structure, manifests, dependencies).',
+)]
+class LintKitCommand extends Command
+{
+    public function __construct(
+        private readonly KitFactory $kitFactory,
+        private readonly KitLinter $kitLinter,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('kit-path', InputArgument::OPTIONAL, 'The path to the kit to lint', '.')
+            ->addOption('fail-on-warning', null, InputOption::VALUE_NONE, 'Exit 1 when at least one warning is reported (errors always exit 1)')
+            ->setHelp(
+                <<<'EOF'
+                    To lint a Kit in the current directory:
+                        <info>php %command.full_name%</info>
+
+                    Or in another directory:
+                        <info>php %command.full_name% ./kits/shadcn</info>
+                        <info>php %command.full_name% /path/to/my-kit</info>
+
+                    Exits 0 when no errors are found (warnings are allowed by default), 1 otherwise.
+                    Pass <info>--fail-on-warning</info> to also fail on warnings.
+                    EOF
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $kitPath = Path::makeAbsolute($input->getArgument('kit-path'), getcwd());
+
+        try {
+            $kit = $this->kitFactory->createKitFromAbsolutePath($kitPath);
+        } catch (\InvalidArgumentException|\RuntimeException $e) {
+            $io->title(\sprintf('Linting kit "%s"', $kitPath));
+            $io->error(\sprintf('Unable to load kit: %s', $e->getMessage()));
+
+            return 1;
+        }
+
+        $io->title(\sprintf('Linting kit "%s"', $kit->manifest->name));
+
+        $report = $this->kitLinter->lint($kit);
+
+        $this->renderIssues($io, $report);
+
+        $errors = $report->getErrorCount();
+        $warnings = $report->getWarningCount();
+
+        if (0 === $errors && 0 === $warnings) {
+            $io->success('No issues found.');
+
+            return Command::SUCCESS;
+        }
+
+        if ($errors > 0) {
+            $io->error(\sprintf('%d error(s), %d warning(s).', $errors, $warnings));
+
+            return Command::FAILURE;
+        }
+
+        if ($input->getOption('fail-on-warning')) {
+            $io->error(\sprintf('%d warning(s).', $warnings));
+
+            return Command::FAILURE;
+        }
+
+        $io->warning(\sprintf('%d warning(s).', $warnings));
+
+        return Command::SUCCESS;
+    }
+
+    private function renderIssues(SymfonyStyle $io, LintReport $report): void
+    {
+        $issues = $report->getIssues();
+        if ([] === $issues) {
+            return;
+        }
+
+        usort($issues, static function (LintIssue $a, LintIssue $b) {
+            return [$a->recipe ?? '', $a->severity->value, $a->category]
+                <=> [$b->recipe ?? '', $b->severity->value, $b->category];
+        });
+
+        $byRecipe = [];
+        foreach ($issues as $issue) {
+            $byRecipe[$issue->recipe ?? '(kit)'][] = $issue;
+        }
+
+        foreach ($byRecipe as $recipeName => $list) {
+            $io->section($recipeName);
+            foreach ($list as $issue) {
+                $badge = LintSeverity::Error === $issue->severity ? '❌' : '⚠️';
+                $head = \sprintf('%s <fg=cyan>%s</>', $badge, $issue->category);
+                if (null !== $issue->file) {
+                    $head .= \sprintf(' <fg=gray>(%s)</>', $issue->file);
+                }
+                $io->writeln($head);
+                $io->writeln('    '.$issue->message);
+                $io->newLine();
+            }
+        }
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/Checker/ComposerSymbolChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/ComposerSymbolChecker.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
+
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Finder\Finder;
+use Symfony\UX\Toolkit\Dependency\ConstraintVersion;
+use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+
+/**
+ * Heuristic, warning-only consistency check between declared Composer dependencies and
+ * Twig symbols they are known to provide.
+ *
+ * The mapping is curated and intentionally incomplete: false positives are reported as
+ * warnings, never errors, because maintaining a complete mapping is fragile.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class ComposerSymbolChecker implements KitCheckerInterface
+{
+    /**
+     * Composer package => symbol => minimum version that ships the symbol (null = always shipped).
+     *
+     * Symbols are literal substrings searched in template contents (no regex).
+     *
+     * @var array<string, array<string, ?string>>
+     */
+    private const PROVIDES = [
+        'twig/extra-bundle' => [
+            'html_cva' => '3.12',
+            'html_classes' => null,
+            'html_attr_type' => '3.24',
+            'html_attr_merge' => '3.24',
+        ],
+        'twig/html-extra' => [
+            'html_cva' => '3.12',
+            'html_classes' => null,
+            'html_attr_type' => '3.24',
+            'html_attr_merge' => '3.24',
+        ],
+        'tales-from-a-dev/twig-tailwind-extra' => [
+            'tailwind_merge' => null,
+        ],
+        'symfony/ux-icons' => [
+            'ux_icon' => null,
+            '<twig:ux:icon' => null,
+        ],
+        'symfony/ux-map' => [
+            '<twig:ux:map' => null,
+        ],
+        'symfony/ux-twig-component' => [
+            'provide(' => '3.1',
+            'inject(' => '3.1',
+        ],
+    ];
+
+    public function check(Kit $kit): iterable
+    {
+        foreach ($kit->getRecipes() as $recipe) {
+            $templatesDir = Path::join($recipe->absolutePath, 'templates');
+            $usedSymbols = is_dir($templatesDir) ? $this->extractUsedSymbols($templatesDir) : [];
+
+            /** @var array<string, PhpPackageDependency> $declared */
+            $declared = [];
+            foreach ($recipe->manifest->dependencies as $dependency) {
+                if ($dependency instanceof PhpPackageDependency) {
+                    $declared[$dependency->name] = $dependency;
+                }
+            }
+
+            foreach ($declared as $package => $_dep) {
+                if (!isset(self::PROVIDES[$package])) {
+                    continue;
+                }
+                $knownSymbols = array_keys(self::PROVIDES[$package]);
+                if ([] === array_intersect($knownSymbols, array_keys($usedSymbols))) {
+                    yield new LintIssue(
+                        severity: LintSeverity::Warning,
+                        category: 'composer.declared-but-unused',
+                        message: \sprintf(
+                            'Composer dependency "%s" is declared but none of its known symbols (%s) appear in templates.',
+                            $package,
+                            implode(', ', $knownSymbols),
+                        ),
+                        recipe: $recipe->name,
+                    );
+                }
+            }
+
+            foreach ($usedSymbols as $symbol => $file) {
+                $providers = $this->providersOf($symbol);
+                if ([] === $providers) {
+                    continue;
+                }
+
+                $declaredProviders = array_values(array_intersect($providers, array_keys($declared)));
+                if ([] === $declaredProviders) {
+                    yield new LintIssue(
+                        severity: LintSeverity::Warning,
+                        category: 'composer.symbol-undeclared',
+                        message: \sprintf(
+                            'Template uses Twig symbol "%s" but none of its known providers (%s) is declared as a Composer dependency.',
+                            $symbol,
+                            implode(', ', $providers),
+                        ),
+                        recipe: $recipe->name,
+                        file: $file,
+                    );
+                    continue;
+                }
+
+                // A symbol is satisfied if at least one declared provider ships it at a version
+                // compatible with the recipe's declared constraint (or has no minimum requirement).
+                $offending = [];
+                foreach ($declaredProviders as $package) {
+                    $since = self::PROVIDES[$package][$symbol];
+                    if (null === $since) {
+                        $offending = [];
+                        break;
+                    }
+                    $declaredMin = self::constraintMinVersion($declared[$package]->constraintVersion);
+                    if (null === $declaredMin || version_compare($declaredMin, $since, '>=')) {
+                        $offending = [];
+                        break;
+                    }
+                    $offending[] = \sprintf('"%s:%s" (need >=%s)', $package, (string) $declared[$package]->constraintVersion, $since);
+                }
+
+                if ([] !== $offending) {
+                    yield new LintIssue(
+                        severity: LintSeverity::Warning,
+                        category: 'composer.symbol-version-insufficient',
+                        message: \sprintf(
+                            'Template uses Twig symbol "%s" but no declared provider meets its minimum version: %s.',
+                            $symbol,
+                            implode('; ', $offending),
+                        ),
+                        recipe: $recipe->name,
+                        file: $file,
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string> symbol => first file where it was found
+     */
+    private function extractUsedSymbols(string $templatesDir): array
+    {
+        $allSymbols = [];
+        foreach (self::PROVIDES as $symbols) {
+            foreach (array_keys($symbols) as $symbol) {
+                $allSymbols[$symbol] = true;
+            }
+        }
+
+        $used = [];
+        $finder = new Finder()->in($templatesDir)->files()->name('*.html.twig');
+        foreach ($finder as $file) {
+            $contents = $file->getContents();
+            foreach ($allSymbols as $symbol => $_) {
+                if (isset($used[$symbol])) {
+                    continue;
+                }
+                if (str_contains($contents, $symbol)) {
+                    $used[$symbol] = $file->getRelativePathname();
+                }
+            }
+        }
+
+        return $used;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function providersOf(string $symbol): array
+    {
+        $providers = [];
+        foreach (self::PROVIDES as $package => $symbols) {
+            if (\array_key_exists($symbol, $symbols)) {
+                $providers[] = $package;
+            }
+        }
+
+        return $providers;
+    }
+
+    /**
+     * Extract the lowest version a Composer constraint can accept. Best-effort: takes the
+     * first version-looking token from the constraint string. Handles "^X.Y", "~X.Y.Z",
+     * ">=X.Y", "X.Y.*", "X.Y.Z", "X.Y || X.Z". Returns null when no version is found.
+     */
+    private static function constraintMinVersion(?ConstraintVersion $constraint): ?string
+    {
+        if (null === $constraint) {
+            return null;
+        }
+        if (!preg_match('/\d+(?:\.\d+)*/', (string) $constraint, $matches)) {
+            return null;
+        }
+
+        return $matches[0];
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/Checker/CopyFilesExistenceChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/CopyFilesExistenceChecker.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
+
+use Symfony\Component\Filesystem\Path;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+
+/**
+ * Verifies every `copy-files` source path exists on disk and is non-empty.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class CopyFilesExistenceChecker implements KitCheckerInterface
+{
+    public function check(Kit $kit): iterable
+    {
+        foreach ($kit->getRecipes() as $recipe) {
+            foreach ($recipe->manifest->copyFiles as $source => $destination) {
+                $sourcePath = Path::join($recipe->absolutePath, $source);
+
+                if (!file_exists($sourcePath)) {
+                    yield new LintIssue(
+                        severity: LintSeverity::Error,
+                        category: 'copy-files.missing',
+                        message: \sprintf('copy-files source "%s" does not exist.', $source),
+                        recipe: $recipe->name,
+                        file: $source,
+                    );
+                    continue;
+                }
+
+                if (is_dir($sourcePath) && [] === array_diff(scandir($sourcePath) ?: [], ['.', '..'])) {
+                    yield new LintIssue(
+                        severity: LintSeverity::Warning,
+                        category: 'copy-files.empty',
+                        message: \sprintf('copy-files source directory "%s" is empty.', $source),
+                        recipe: $recipe->name,
+                        file: $source,
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/Checker/JsImportChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/JsImportChecker.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
+
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Finder\Finder;
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+
+/**
+ * Scans recipe JS files for ES `import` statements and verifies each non-relative package
+ * is declared as `npm` or `importmap` dependency.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class JsImportChecker implements KitCheckerInterface
+{
+    /**
+     * Implicit packages always available in a Symfony UX app — never warn for these.
+     */
+    private const IMPLICIT_PACKAGES = [
+        '@hotwired/stimulus',
+        '@hotwired/turbo',
+        '@symfony/stimulus-bundle',
+    ];
+
+    public function check(Kit $kit): iterable
+    {
+        foreach ($kit->getRecipes() as $recipe) {
+            $assetsDir = Path::join($recipe->absolutePath, 'assets');
+            if (!is_dir($assetsDir)) {
+                continue;
+            }
+
+            $declared = [];
+            foreach ($recipe->manifest->dependencies as $dependency) {
+                if ($dependency instanceof NpmPackageDependency) {
+                    $declared[] = $dependency->name;
+                } elseif ($dependency instanceof ImportmapPackageDependency) {
+                    $declared[] = $dependency->package;
+                }
+            }
+
+            $finder = new Finder()->in($assetsDir)->files()->name(['*.js', '*.ts', '*.mjs']);
+            foreach ($finder as $file) {
+                $contents = $file->getContents();
+                foreach ($this->extractImports($contents) as $packageName) {
+                    if (\in_array($packageName, self::IMPLICIT_PACKAGES, true)) {
+                        continue;
+                    }
+                    if ($this->isDeclared($packageName, $declared)) {
+                        continue;
+                    }
+
+                    yield new LintIssue(
+                        severity: LintSeverity::Warning,
+                        category: 'js.import.undeclared',
+                        message: \sprintf('JS import "%s" is not declared in dependencies.npm or dependencies.importmap.', $packageName),
+                        recipe: $recipe->name,
+                        file: 'assets/'.$file->getRelativePathname(),
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Inspired by Symfony AssetMapper's JavaScriptImportPathCompiler::IMPORT_PATTERN: the first
+     * two alternation arms swallow line comments and string literals so the import arms cannot
+     * match inside them. Captures the raw spec; relative/absolute filtering happens in PHP.
+     */
+    private const IMPORT_PATTERN = '#
+        ^\h*//.*$
+    |
+        \'(?:[^\'\\\\\n]|\\\\.)*+\' | "(?:[^"\\\\\n]|\\\\.)*+"
+    |
+        (?:
+            import\s*
+                (?:
+                    (?:\*\s*as\s+\w+|[\w\s{},*]+)\s*from\s*
+                )?
+        |
+            export\s*
+                (?:
+                    \*(?:\s*as\s+\w+)?
+                |
+                    \{[^}]*+\}
+                )
+                \s*from\s*
+        |
+            \bimport\(
+        |
+            \brequire\(
+        )
+        \s*[\'"`]([^\'"`\n]+)[\'"`]
+    #mxu';
+
+    /**
+     * @return iterable<string>
+     */
+    private function extractImports(string $contents): iterable
+    {
+        if (!preg_match_all(self::IMPORT_PATTERN, $contents, $matches)) {
+            return;
+        }
+
+        $seen = [];
+        foreach ($matches[1] as $spec) {
+            if ('' === $spec || '.' === $spec[0] || '/' === $spec[0]) {
+                continue;
+            }
+            $package = $this->toPackageName($spec);
+            if (isset($seen[$package])) {
+                continue;
+            }
+            $seen[$package] = true;
+            yield $package;
+        }
+    }
+
+    private function toPackageName(string $spec): string
+    {
+        if ('@' === $spec[0]) {
+            $parts = explode('/', $spec, 3);
+
+            return implode('/', \array_slice($parts, 0, 2));
+        }
+
+        return explode('/', $spec, 2)[0];
+    }
+
+    /**
+     * @param list<string> $declared
+     */
+    private function isDeclared(string $packageName, array $declared): bool
+    {
+        foreach ($declared as $entry) {
+            if ($entry === $packageName) {
+                return true;
+            }
+            if (str_starts_with($entry, $packageName.'/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/Checker/MissingRecipeManifestChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/MissingRecipeManifestChecker.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
+
+use Symfony\Component\Filesystem\Path;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+
+/**
+ * Detects directories at the kit root that look like a recipe but have no manifest.json.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class MissingRecipeManifestChecker implements KitCheckerInterface
+{
+    public function check(Kit $kit): iterable
+    {
+        $entries = scandir($kit->absolutePath);
+        if (false === $entries) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+
+            $dir = Path::join($kit->absolutePath, $entry);
+            if (!is_dir($dir)) {
+                continue;
+            }
+
+            if (!file_exists(Path::join($dir, 'manifest.json'))) {
+                yield new LintIssue(
+                    severity: LintSeverity::Error,
+                    category: 'manifest.missing',
+                    message: \sprintf('Directory "%s/" looks like a recipe but contains no "manifest.json".', $entry),
+                    recipe: $entry,
+                );
+            }
+        }
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/Checker/RecipeReferenceChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/RecipeReferenceChecker.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
+
+use Symfony\UX\Toolkit\Dependency\RecipeDependency;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+
+/**
+ * Verifies every `dependencies.recipe[]` entry points to a recipe that exists in the same kit.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class RecipeReferenceChecker implements KitCheckerInterface
+{
+    public function check(Kit $kit): iterable
+    {
+        foreach ($kit->getRecipes() as $recipe) {
+            foreach ($recipe->manifest->dependencies as $dependency) {
+                if (!$dependency instanceof RecipeDependency) {
+                    continue;
+                }
+
+                if (null === $kit->getRecipe($dependency->name)) {
+                    yield new LintIssue(
+                        severity: LintSeverity::Error,
+                        category: 'dependencies.recipe.unknown',
+                        message: \sprintf('Recipe dependency "%s" does not exist in this kit.', $dependency->name),
+                        recipe: $recipe->name,
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerChecker.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
+
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Finder\Finder;
+use Symfony\UX\Toolkit\Kit\Kit;
+
+use function Symfony\Component\String\u;
+use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+use Symfony\UX\Toolkit\Recipe\Recipe;
+
+/**
+ * Detects `data-controller="..."` usages in Twig templates and verifies that a matching
+ * Stimulus controller file is shipped with the recipe.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class StimulusControllerChecker implements KitCheckerInterface
+{
+    public function check(Kit $kit): iterable
+    {
+        foreach ($kit->getRecipes() as $recipe) {
+            $templatesDir = Path::join($recipe->absolutePath, 'templates');
+            if (!is_dir($templatesDir)) {
+                continue;
+            }
+
+            $controllerNames = $this->extractControllerNames($templatesDir);
+            if ([] === $controllerNames) {
+                continue;
+            }
+
+            $shippedControllers = $this->listShippedControllers($recipe);
+
+            foreach ($controllerNames as $controllerName => $file) {
+                if (\in_array($controllerName, $shippedControllers, true)) {
+                    continue;
+                }
+
+                yield new LintIssue(
+                    severity: LintSeverity::Warning,
+                    category: 'stimulus.controller.missing',
+                    message: \sprintf(
+                        'Template references Stimulus controller "%s" but no matching file "assets/controllers/%s_controller.js" was found in the recipe.',
+                        $controllerName,
+                        // Stimulus convention: kebab-case identifier <-> snake_case filename.
+                        u($controllerName)->snake(),
+                    ),
+                    recipe: $recipe->name,
+                    file: $file,
+                );
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string> controller name => first file where it was found
+     */
+    private function extractControllerNames(string $templatesDir): array
+    {
+        $names = [];
+        $patterns = [
+            // Twig hash form: {'data-controller': 'foo'} or {"data-controller": "foo"}
+            '/[\'"]data-controller[\'"]\s*[:=]\s*[\'"]([^\'"]+)[\'"]/',
+            // HTML attribute form: data-controller="foo"
+            '/data-controller\s*=\s*[\'"]([^\'"]+)[\'"]/',
+        ];
+
+        $finder = new Finder()->in($templatesDir)->files()->name('*.html.twig');
+        foreach ($finder as $file) {
+            $contents = $file->getContents();
+            foreach ($patterns as $pattern) {
+                if (!preg_match_all($pattern, $contents, $matches)) {
+                    continue;
+                }
+                foreach ($matches[1] as $value) {
+                    foreach (preg_split('/\s+/', trim($value)) as $name) {
+                        if ('' === $name) {
+                            continue;
+                        }
+                        $names[$name] ??= $file->getRelativePathname();
+                    }
+                }
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listShippedControllers(Recipe $recipe): array
+    {
+        $dir = Path::join($recipe->absolutePath, 'assets/controllers');
+        if (!is_dir($dir)) {
+            return [];
+        }
+
+        $controllers = [];
+        $finder = new Finder()->in($dir)->files()->name('*_controller.js');
+        foreach ($finder as $file) {
+            $basename = substr($file->getFilename(), 0, -\strlen('_controller.js'));
+            // Stimulus convention: snake_case in filename, kebab-case in identifier.
+            $controllers[] = (string) u($basename)->kebab();
+        }
+
+        return $controllers;
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/KitCheckerInterface.php
+++ b/src/Toolkit/src/Kit/Lint/KitCheckerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint;
+
+use Symfony\UX\Toolkit\Kit\Kit;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+interface KitCheckerInterface
+{
+    /**
+     * @return iterable<LintIssue>
+     */
+    public function check(Kit $kit): iterable;
+}

--- a/src/Toolkit/src/Kit/Lint/KitLinter.php
+++ b/src/Toolkit/src/Kit/Lint/KitLinter.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint;
+
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\ComposerSymbolChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\CopyFilesExistenceChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\JsImportChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\MissingRecipeManifestChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\RecipeReferenceChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerChecker;
+
+/**
+ * Runs every registered {@see KitCheckerInterface} against a kit and aggregates issues.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class KitLinter
+{
+    /**
+     * @var array<KitCheckerInterface>
+     */
+    private readonly array $checkers;
+
+    /**
+     * @param array<KitCheckerInterface> $checkers when empty, every built-in checker is used
+     */
+    public function __construct(array $checkers = [])
+    {
+        $this->checkers = [] !== $checkers ? $checkers : [
+            new MissingRecipeManifestChecker(),
+            new CopyFilesExistenceChecker(),
+            new RecipeReferenceChecker(),
+            new StimulusControllerChecker(),
+            new JsImportChecker(),
+            new ComposerSymbolChecker(),
+        ];
+    }
+
+    public function lint(Kit $kit): LintReport
+    {
+        $report = new LintReport();
+
+        foreach ($this->checkers as $checker) {
+            foreach ($checker->check($kit) as $issue) {
+                $report->add($issue);
+            }
+        }
+
+        return $report;
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/LintIssue.php
+++ b/src/Toolkit/src/Kit/Lint/LintIssue.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class LintIssue
+{
+    public readonly ?string $file;
+
+    public function __construct(
+        public readonly LintSeverity $severity,
+        public readonly string $category,
+        public readonly string $message,
+        public readonly ?string $recipe = null,
+        ?string $file = null,
+    ) {
+        // Normalize to forward slashes so reports are identical on Windows and Unix.
+        $this->file = null !== $file ? strtr($file, '\\', '/') : null;
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/LintReport.php
+++ b/src/Toolkit/src/Kit/Lint/LintReport.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class LintReport
+{
+    /**
+     * @var list<LintIssue>
+     */
+    private array $issues = [];
+
+    public function add(LintIssue $issue): void
+    {
+        $this->issues[] = $issue;
+    }
+
+    /**
+     * @return list<LintIssue>
+     */
+    public function getIssues(): array
+    {
+        return $this->issues;
+    }
+
+    /**
+     * @return list<LintIssue>
+     */
+    public function getErrors(): array
+    {
+        return array_values(array_filter($this->issues, static fn (LintIssue $i) => LintSeverity::Error === $i->severity));
+    }
+
+    /**
+     * @return list<LintIssue>
+     */
+    public function getWarnings(): array
+    {
+        return array_values(array_filter($this->issues, static fn (LintIssue $i) => LintSeverity::Warning === $i->severity));
+    }
+
+    public function getErrorCount(): int
+    {
+        return \count($this->getErrors());
+    }
+
+    public function getWarningCount(): int
+    {
+        return \count($this->getWarnings());
+    }
+
+    public function hasErrors(): bool
+    {
+        return $this->getErrorCount() > 0;
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/LintSeverity.php
+++ b/src/Toolkit/src/Kit/Lint/LintSeverity.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+enum LintSeverity: string
+{
+    case Error = 'error';
+    case Warning = 'warning';
+}

--- a/src/Toolkit/tests/Command/LintKitCommandTest.php
+++ b/src/Toolkit/tests/Command/LintKitCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\UX\Toolkit\Command\LintKitCommand;
+use Symfony\UX\Toolkit\Kit\KitFactory;
+use Symfony\UX\Toolkit\Kit\KitSynchronizer;
+use Symfony\UX\Toolkit\Kit\Lint\KitLinter;
+use Symfony\UX\Toolkit\Recipe\RecipeSynchronizer;
+use Symfony\UX\Toolkit\Tests\TestHelperTrait;
+use Zenstruck\Console\Test\TestCommand;
+
+class LintKitCommandTest extends TestCase
+{
+    use TestHelperTrait;
+
+    private function createCommand(): LintKitCommand
+    {
+        $filesystem = new Filesystem();
+        $kitFactory = new KitFactory($filesystem, new KitSynchronizer($filesystem, new RecipeSynchronizer()));
+
+        return new LintKitCommand($kitFactory, new KitLinter());
+    }
+
+    public function testLintBrokenFixtureReportsErrors()
+    {
+        $result = TestCommand::for($this->createCommand())
+            ->addArgument(self::getFixtureKitPath('lint-broken'))
+            ->execute()
+            ->assertFaulty()
+        ;
+
+        $output = str_replace("\r\n", "\n", $result->output());
+
+        self::assertStringContainsString(<<<TXT
+            button
+            ------
+
+            ❌ copy-files.missing (missing-dir/)
+                copy-files source "missing-dir/" does not exist.
+
+            ❌ dependencies.recipe.unknown
+                Recipe dependency "does-not-exist" does not exist in this kit.
+            TXT, $output);
+
+        self::assertStringContainsString(<<<TXT
+            orphan
+            ------
+
+            ❌ manifest.missing
+                Directory "orphan/" looks like a recipe but contains no "manifest.json".
+            TXT, $output);
+
+        self::assertStringContainsString(<<<TXT
+            widget
+            ------
+
+            ⚠️ js.import.undeclared (assets/controllers/widget_controller.js)
+                JS import "lodash" is not declared in dependencies.npm or dependencies.importmap.
+
+            ⚠️ stimulus.controller.missing (components/Widget.html.twig)
+                Template references Stimulus controller "undeclared-widget" but no matching file "assets/controllers/undeclared_widget_controller.js" was found in the recipe.
+            TXT, $output);
+
+        self::assertStringContainsString('[ERROR] 3 error(s), 3 warning(s).', $output);
+    }
+
+    public function testWarningsOnlyExitsSuccessfullyByDefault()
+    {
+        TestCommand::for($this->createCommand())
+            ->addArgument(self::getFixtureKitPath('lint-stimulus'))
+            ->execute()
+            ->assertSuccessful()
+            ->assertOutputContains('[WARNING]')
+            ->assertOutputNotContains('[ERROR]')
+        ;
+    }
+
+    public function testFailOnWarningExitsAsFailure()
+    {
+        TestCommand::for($this->createCommand())
+            ->addArgument(self::getFixtureKitPath('lint-stimulus'))
+            ->addOption('--fail-on-warning')
+            ->execute()
+            ->assertFaulty()
+            ->assertOutputContains('[ERROR]')
+        ;
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-broken/button/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-broken/button/manifest.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Button",
+    "description": "Button with broken copy-files entry and a recipe dep that does not exist.",
+    "copy-files": {
+        "templates/": "templates/",
+        "missing-dir/": "missing-dir/"
+    },
+    "dependencies": {
+        "recipe": ["does-not-exist"],
+        "composer": ["tales-from-a-dev/twig-tailwind-extra:^1.0.0"]
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-broken/button/templates/components/Button.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-broken/button/templates/components/Button.html.twig
@@ -1,0 +1,1 @@
+<button {{ attributes }}>Click me</button>

--- a/src/Toolkit/tests/Fixtures/kits/lint-broken/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-broken/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "Lint Broken",
+    "description": "Kit with intentional issues for lint tests.",
+    "license": "MIT",
+    "homepage": "https://example.com/lint-broken"
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-broken/widget/assets/controllers/widget_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-broken/widget/assets/controllers/widget_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from '@hotwired/stimulus';
+import _ from 'lodash';
+
+export default class extends Controller {
+    connect() {
+        _.noop();
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-broken/widget/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-broken/widget/manifest.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Widget",
+    "description": "Widget uses an undeclared JS package and references a missing Stimulus controller.",
+    "copy-files": {
+        "templates/": "templates/",
+        "assets/": "assets/"
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-broken/widget/templates/components/Widget.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-broken/widget/templates/components/Widget.html.twig
@@ -1,0 +1,3 @@
+<div {{ attributes.defaults({'data-controller': 'undeclared-widget'}) }}>
+    Hello
+</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/attr-type-version-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/attr-type-version-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "AttrTypeVersionOk",
+    "description": "twig/extra-bundle:^3.24.0 declared + html_attr_type used -> no warning (since=3.24).",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["twig/extra-bundle:^3.24.0"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/attr-type-version-ok/templates/components/AttrTypeVersionOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/attr-type-version-ok/templates/components/AttrTypeVersionOk.html.twig
@@ -1,0 +1,1 @@
+<div class="{{ {type: 'button'}|html_attr_type }}">ok</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/attr-type-version-too-low/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/attr-type-version-too-low/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "AttrTypeVersionTooLow",
+    "description": "twig/extra-bundle:^3.12.0 declared + html_attr_type used -> warning (since=3.24).",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["twig/extra-bundle:^3.12.0"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/attr-type-version-too-low/templates/components/AttrTypeVersionTooLow.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/attr-type-version-too-low/templates/components/AttrTypeVersionTooLow.html.twig
@@ -1,0 +1,1 @@
+<div class="{{ {type: 'button'}|html_attr_type }}">x</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/classes-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/classes-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ClassesOk",
+    "description": "twig/html-extra declared + html_classes used -> no warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["twig/html-extra"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/classes-ok/templates/components/ClassesOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/classes-ok/templates/components/ClassesOk.html.twig
@@ -1,0 +1,1 @@
+<div class="{{ html_classes('a', 'b') }}">ok</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "CvaOk",
+    "description": "twig/extra-bundle declared + html_cva used -> no warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["twig/extra-bundle"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-ok/templates/components/CvaOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-ok/templates/components/CvaOk.html.twig
@@ -1,0 +1,2 @@
+{% set classes = html_cva({}) %}
+<div>{{ classes }}</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-undeclared/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-undeclared/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "CvaUndeclared",
+    "description": "html_cva used but no provider declared -> warning.",
+    "copy-files": {"templates/": "templates/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-undeclared/templates/components/CvaUndeclared.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-undeclared/templates/components/CvaUndeclared.html.twig
@@ -1,0 +1,2 @@
+{% set c = html_cva({}) %}
+<div>{{ c }}</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-version-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-version-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "CvaVersionOk",
+    "description": "twig/extra-bundle:^3.12.0 declared + html_cva used -> no warning (since=3.12).",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["twig/extra-bundle:^3.12.0"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-version-ok/templates/components/CvaVersionOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-version-ok/templates/components/CvaVersionOk.html.twig
@@ -1,0 +1,2 @@
+{% set c = html_cva({}) %}
+<div>{{ c }}</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-version-too-low/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-version-too-low/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "CvaVersionTooLow",
+    "description": "twig/extra-bundle:^3.0.0 declared + html_cva used -> warning (since=3.12).",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["twig/extra-bundle:^3.0.0"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-version-too-low/templates/components/CvaVersionTooLow.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/cva-version-too-low/templates/components/CvaVersionTooLow.html.twig
@@ -1,0 +1,2 @@
+{% set c = html_cva({}) %}
+<div>{{ c }}</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-declared-unused/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-declared-unused/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "IconDeclaredUnused",
+    "description": "symfony/ux-icons declared but no ux_icon/twig:ux:icon used -> warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["symfony/ux-icons"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-declared-unused/templates/components/IconDeclaredUnused.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-declared-unused/templates/components/IconDeclaredUnused.html.twig
@@ -1,0 +1,1 @@
+<div>no icon symbol</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-fn-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-fn-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "IconFnOk",
+    "description": "symfony/ux-icons declared + ux_icon() function used -> no warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["symfony/ux-icons"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-fn-ok/templates/components/IconFnOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-fn-ok/templates/components/IconFnOk.html.twig
@@ -1,0 +1,1 @@
+<div>{{ ux_icon('lucide:check') }}</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-tag-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-tag-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "IconTagOk",
+    "description": "symfony/ux-icons declared + <twig:ux:icon> tag used -> no warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["symfony/ux-icons"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-tag-ok/templates/components/IconTagOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-tag-ok/templates/components/IconTagOk.html.twig
@@ -1,0 +1,1 @@
+<div><twig:ux:icon name="lucide:check" /></div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-tag-undeclared/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-tag-undeclared/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "IconTagUndeclared",
+    "description": "<twig:ux:icon> used but symfony/ux-icons not declared -> warning.",
+    "copy-files": {"templates/": "templates/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-tag-undeclared/templates/components/IconTagUndeclared.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/icon-tag-undeclared/templates/components/IconTagUndeclared.html.twig
@@ -1,0 +1,1 @@
+<div><twig:ux:icon name="lucide:check" /></div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/inject-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/inject-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "InjectOk",
+    "description": "symfony/ux-twig-component declared + inject() used -> no warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["symfony/ux-twig-component"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/inject-ok/templates/components/InjectOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/inject-ok/templates/components/InjectOk.html.twig
@@ -1,0 +1,2 @@
+{% set answer = inject('answer') %}
+<div>{{ answer }}</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "Lint Composer Symbol",
+    "description": "Kit covering ComposerSymbolChecker scenarios (one recipe per case).",
+    "license": "MIT",
+    "homepage": "https://example.com/lint-composer-symbol"
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-declared-unused/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-declared-unused/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "MapDeclaredUnused",
+    "description": "symfony/ux-map declared but no <twig:ux:map> used -> warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["symfony/ux-map"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-declared-unused/templates/components/MapDeclaredUnused.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-declared-unused/templates/components/MapDeclaredUnused.html.twig
@@ -1,0 +1,1 @@
+<div>no map here</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "MapOk",
+    "description": "symfony/ux-map declared + <twig:ux:map> tag used -> no warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["symfony/ux-map"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-ok/templates/components/MapOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-ok/templates/components/MapOk.html.twig
@@ -1,0 +1,1 @@
+<div><twig:ux:map center="[0,0]" zoom="3" /></div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-undeclared/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-undeclared/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "MapUndeclared",
+    "description": "<twig:ux:map> used but symfony/ux-map not declared -> warning.",
+    "copy-files": {"templates/": "templates/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-undeclared/templates/components/MapUndeclared.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/map-undeclared/templates/components/MapUndeclared.html.twig
@@ -1,0 +1,1 @@
+<div><twig:ux:map center="[0,0]" zoom="3" /></div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-declared-unused/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-declared-unused/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "MergeDeclaredUnused",
+    "description": "tailwind-extra declared but tailwind_merge never used -> warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["tales-from-a-dev/twig-tailwind-extra"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-declared-unused/templates/components/MergeDeclaredUnused.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-declared-unused/templates/components/MergeDeclaredUnused.html.twig
@@ -1,0 +1,1 @@
+<div>no merge filter here</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "MergeOk",
+    "description": "tailwind-extra declared + tailwind_merge filter used -> no warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["tales-from-a-dev/twig-tailwind-extra"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-ok/templates/components/MergeOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-ok/templates/components/MergeOk.html.twig
@@ -1,0 +1,1 @@
+<div class="{{ 'a b'|tailwind_merge }}">ok</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-undeclared/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-undeclared/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "MergeUndeclared",
+    "description": "tailwind_merge used but tailwind-extra not declared -> warning.",
+    "copy-files": {"templates/": "templates/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-undeclared/templates/components/MergeUndeclared.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/merge-undeclared/templates/components/MergeUndeclared.html.twig
@@ -1,0 +1,1 @@
+<div class="{{ 'a b'|tailwind_merge }}">x</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/provide-ok/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/provide-ok/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ProvideOk",
+    "description": "symfony/ux-twig-component declared + provide() used -> no warning.",
+    "copy-files": {"templates/": "templates/"},
+    "dependencies": {"composer": ["symfony/ux-twig-component"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/provide-ok/templates/components/ProvideOk.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/provide-ok/templates/components/ProvideOk.html.twig
@@ -1,0 +1,2 @@
+{{ provide('answer', 42) }}
+<div>ok</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/provide-undeclared/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/provide-undeclared/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ProvideUndeclared",
+    "description": "provide() used but symfony/ux-twig-component not declared -> warning.",
+    "copy-files": {"templates/": "templates/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/provide-undeclared/templates/components/ProvideUndeclared.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-composer-symbol/provide-undeclared/templates/components/ProvideUndeclared.html.twig
@@ -1,0 +1,2 @@
+{{ provide('answer', 42) }}
+<div>x</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/dynamic-import/assets/controllers/dynamic_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/dynamic-import/assets/controllers/dynamic_controller.js
@@ -1,0 +1,3 @@
+export async function load() {
+    return await import('lodash');
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/dynamic-import/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/dynamic-import/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "DynamicImport",
+    "description": "Dynamic import('lodash') without declaration -> warning.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/export-re-export/assets/controllers/reexport_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/export-re-export/assets/controllers/reexport_controller.js
@@ -1,0 +1,1 @@
+export { default } from 'lodash';

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/export-re-export/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/export-re-export/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ExportReExport",
+    "description": "export { x } from 'lodash' without declaration -> warning.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-bundle/assets/controllers/bundle_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-bundle/assets/controllers/bundle_controller.js
@@ -1,0 +1,3 @@
+import { startStimulusApp } from '@symfony/stimulus-bundle';
+
+export default startStimulusApp;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-bundle/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-bundle/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ImplicitBundle",
+    "description": "@symfony/stimulus-bundle is implicit -> no warning.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-stimulus/assets/controllers/stimulus_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-stimulus/assets/controllers/stimulus_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-stimulus/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-stimulus/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ImplicitStimulus",
+    "description": "@hotwired/stimulus is implicit -> no warning even when not declared.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-turbo/assets/controllers/turbo_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-turbo/assets/controllers/turbo_controller.js
@@ -1,0 +1,3 @@
+import * as Turbo from '@hotwired/turbo';
+
+export default Turbo;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-turbo/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/implicit-turbo/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ImplicitTurbo",
+    "description": "@hotwired/turbo is implicit -> no warning.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/import-in-string-noise/assets/controllers/noise_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/import-in-string-noise/assets/controllers/noise_controller.js
@@ -1,0 +1,6 @@
+// import 'commented-out-pkg';
+// require('also-commented');
+const stringLiteral = "import 'string-literal-pkg';";
+const otherLiteral = 'require("another-string-pkg")';
+
+export default { stringLiteral, otherLiteral };

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/import-in-string-noise/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/import-in-string-noise/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ImportInStringNoise",
+    "description": "Strings and comments containing the word 'import' must not be detected.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/importmap-declared/assets/controllers/importmap_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/importmap-declared/assets/controllers/importmap_controller.js
@@ -1,0 +1,3 @@
+import _ from 'lodash';
+
+export default _;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/importmap-declared/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/importmap-declared/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ImportmapDeclared",
+    "description": "lodash declared as importmap + imported -> no warning.",
+    "copy-files": {"assets/": "assets/"},
+    "dependencies": {"importmap": ["lodash"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "Lint JS Import",
+    "description": "Kit covering JsImportChecker scenarios (one recipe per case).",
+    "license": "MIT",
+    "homepage": "https://example.com/lint-js-import"
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/mjs-file/assets/controllers/mjs_controller.mjs
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/mjs-file/assets/controllers/mjs_controller.mjs
@@ -1,0 +1,3 @@
+import _ from 'lodash';
+
+export default _;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/mjs-file/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/mjs-file/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "MjsFile",
+    "description": "Imports in *.mjs files must be scanned -> warning when undeclared.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/no-assets/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/no-assets/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "NoAssets",
+    "description": "No assets/ directory at all -> no warning (checker skips recipe).",
+    "copy-files": {"templates/": "templates/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/no-assets/templates/components/NoAssets.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/no-assets/templates/components/NoAssets.html.twig
@@ -1,0 +1,1 @@
+<div>no js</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/npm-declared/assets/controllers/npm_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/npm-declared/assets/controllers/npm_controller.js
@@ -1,0 +1,3 @@
+import _ from 'lodash';
+
+export default _;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/npm-declared/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/npm-declared/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "NpmDeclared",
+    "description": "lodash declared as npm + imported -> no warning.",
+    "copy-files": {"assets/": "assets/"},
+    "dependencies": {"npm": ["lodash"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/plain-subpath/assets/controllers/plain_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/plain-subpath/assets/controllers/plain_controller.js
@@ -1,0 +1,3 @@
+import x from 'pkg/sub';
+
+export default x;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/plain-subpath/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/plain-subpath/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "PlainSubpath",
+    "description": "pkg declared + pkg/sub imported -> no warning (subpath collapse).",
+    "copy-files": {"assets/": "assets/"},
+    "dependencies": {"npm": ["pkg"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/relative-ignored/assets/controllers/relative_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/relative-ignored/assets/controllers/relative_controller.js
@@ -1,0 +1,4 @@
+import sibling from './sibling.js';
+import other from '../shared/other.js';
+
+export default { sibling, other };

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/relative-ignored/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/relative-ignored/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "RelativeIgnored",
+    "description": "Relative imports must never be reported.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/require-import/assets/controllers/require_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/require-import/assets/controllers/require_controller.js
@@ -1,0 +1,3 @@
+const _ = require('lodash');
+
+module.exports = _;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/require-import/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/require-import/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "RequireImport",
+    "description": "require('lodash') without declaration -> warning.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/scoped-subpath/assets/controllers/scoped_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/scoped-subpath/assets/controllers/scoped_controller.js
@@ -1,0 +1,3 @@
+import x from '@scope/pkg/sub';
+
+export default x;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/scoped-subpath/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/scoped-subpath/manifest.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "ScopedSubpath",
+    "description": "@scope/pkg declared + @scope/pkg/sub imported -> no warning (subpath collapse).",
+    "copy-files": {"assets/": "assets/"},
+    "dependencies": {"npm": ["@scope/pkg"]}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/ts-file/assets/controllers/ts_controller.ts
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/ts-file/assets/controllers/ts_controller.ts
@@ -1,0 +1,3 @@
+import _ from 'lodash';
+
+export default _;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/ts-file/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/ts-file/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "TsFile",
+    "description": "Imports in *.ts files must be scanned -> warning when undeclared.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/undeclared/assets/controllers/undeclared_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/undeclared/assets/controllers/undeclared_controller.js
@@ -1,0 +1,3 @@
+import _ from 'lodash';
+
+export default _;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/undeclared/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/undeclared/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Undeclared",
+    "description": "lodash imported without declaration -> warning.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/assets/controllers/shipped_ctrl_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/assets/controllers/shipped_ctrl_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/manifest.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Cases",
+    "description": "One template per Stimulus detection scenario.",
+    "copy-files": {
+        "templates/": "templates/",
+        "assets/": "assets/"
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/HashForm.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/HashForm.html.twig
@@ -1,0 +1,1 @@
+<div {{ attributes.defaults({'data-controller': 'hash-form-ctrl'}) }}>hash form</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/HtmlForm.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/HtmlForm.html.twig
@@ -1,0 +1,1 @@
+<div data-controller="html-form-ctrl">html form</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/Mixed.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/Mixed.html.twig
@@ -1,0 +1,1 @@
+<div data-controller="mixed-html" {{ attributes.defaults({'data-controller': 'mixed-hash'}) }}>both forms in one template</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/Multi.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/Multi.html.twig
@@ -1,0 +1,1 @@
+<div data-controller="multi-a multi-b">two controllers in one attribute</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/Shipped.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/cases/templates/components/Shipped.html.twig
@@ -1,0 +1,1 @@
+<div data-controller="shipped-ctrl">controller is shipped, no warning expected</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "Lint Stimulus",
+    "description": "Kit covering StimulusControllerChecker scenarios.",
+    "license": "MIT",
+    "homepage": "https://example.com/lint-stimulus"
+}

--- a/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
+++ b/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Kit\Lint;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\KitFactory;
+use Symfony\UX\Toolkit\Kit\KitSynchronizer;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\ComposerSymbolChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\CopyFilesExistenceChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\JsImportChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\MissingRecipeManifestChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\RecipeReferenceChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerChecker;
+use Symfony\UX\Toolkit\Kit\Lint\KitLinter;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintReport;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+use Symfony\UX\Toolkit\Recipe\RecipeSynchronizer;
+use Symfony\UX\Toolkit\Tests\TestHelperTrait;
+
+class KitLinterTest extends TestCase
+{
+    use TestHelperTrait;
+
+    private function loadFixtureKit(string $name): Kit
+    {
+        $factory = new KitFactory(new Filesystem(), new KitSynchronizer(new Filesystem(), new RecipeSynchronizer()));
+
+        return $factory->createKitFromAbsolutePath(self::getFixtureKitPath($name));
+    }
+
+    private function loadBrokenKit(): Kit
+    {
+        return $this->loadFixtureKit('lint-broken');
+    }
+
+    private function findIssues(LintReport $report, string $category, ?string $recipe = null): array
+    {
+        return array_values(array_filter($report->getIssues(), static function (LintIssue $issue) use ($category, $recipe) {
+            if ($issue->category !== $category) {
+                return false;
+            }
+            if (null !== $recipe && $issue->recipe !== $recipe) {
+                return false;
+            }
+
+            return true;
+        }));
+    }
+
+    /**
+     * @return list<LintIssue>
+     */
+    private function findRecipeIssues(LintReport $report, string $recipe): array
+    {
+        return array_values(array_filter(
+            $report->getIssues(),
+            static fn (LintIssue $i) => $i->recipe === $recipe,
+        ));
+    }
+
+    public function testMissingRecipeManifestCheckerDetectsOrphanDirectory()
+    {
+        $kit = $this->loadBrokenKit();
+        $linter = new KitLinter([new MissingRecipeManifestChecker()]);
+
+        $issues = $this->findIssues($linter->lint($kit), 'manifest.missing');
+
+        $this->assertCount(1, $issues);
+        $this->assertSame('orphan', $issues[0]->recipe);
+        $this->assertSame(LintSeverity::Error, $issues[0]->severity);
+    }
+
+    public function testCopyFilesExistenceCheckerDetectsMissingDirectory()
+    {
+        $kit = $this->loadBrokenKit();
+        $linter = new KitLinter([new CopyFilesExistenceChecker()]);
+
+        $issues = $this->findIssues($linter->lint($kit), 'copy-files.missing', 'button');
+
+        $this->assertCount(1, $issues);
+        $this->assertSame('missing-dir/', $issues[0]->file);
+        $this->assertSame(LintSeverity::Error, $issues[0]->severity);
+    }
+
+    public function testRecipeReferenceCheckerDetectsUnknownRecipe()
+    {
+        $kit = $this->loadBrokenKit();
+        $linter = new KitLinter([new RecipeReferenceChecker()]);
+
+        $issues = $this->findIssues($linter->lint($kit), 'dependencies.recipe.unknown', 'button');
+
+        $this->assertCount(1, $issues);
+        $this->assertStringContainsString('does-not-exist', $issues[0]->message);
+    }
+
+    /**
+     * @return iterable<string, array{string, bool, ?string}>
+     */
+    public static function provideStimulusCases(): iterable
+    {
+        // controller name => [expected warning? , source template]
+        yield 'HTML attribute form' => ['html-form-ctrl', true, 'HtmlForm.html.twig'];
+        yield 'Twig hash form' => ['hash-form-ctrl', true, 'HashForm.html.twig'];
+        yield 'mixed forms (HTML)' => ['mixed-html', true, 'Mixed.html.twig'];
+        yield 'mixed forms (hash)' => ['mixed-hash', true, 'Mixed.html.twig'];
+        yield 'space-separated (1st)' => ['multi-a', true, 'Multi.html.twig'];
+        yield 'space-separated (2nd)' => ['multi-b', true, 'Multi.html.twig'];
+        yield 'shipped controller' => ['shipped-ctrl', false, null];
+    }
+
+    #[DataProvider('provideStimulusCases')]
+    public function testStimulusControllerChecker(string $controllerName, bool $expectWarning, ?string $expectedFile)
+    {
+        $kit = $this->loadFixtureKit('lint-stimulus');
+
+        $report = new KitLinter([new StimulusControllerChecker()])->lint($kit);
+
+        $matching = array_values(array_filter(
+            $report->getIssues(),
+            static fn (LintIssue $i) => 'stimulus.controller.missing' === $i->category
+                && str_contains($i->message, \sprintf('"%s"', $controllerName))
+        ));
+
+        if (!$expectWarning) {
+            $this->assertSame([], $matching, \sprintf('Controller "%s" must NOT be reported.', $controllerName));
+
+            return;
+        }
+
+        $this->assertCount(1, $matching, \sprintf('Controller "%s" must be reported exactly once.', $controllerName));
+        $this->assertSame(LintSeverity::Warning, $matching[0]->severity);
+        $this->assertSame('cases', $matching[0]->recipe);
+        $this->assertStringContainsString($expectedFile, $matching[0]->file);
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string, ?string}>
+     */
+    public static function provideComposerCases(): iterable
+    {
+        // recipe slug => [expected category | null, needle in message | null]
+        yield 'cva-ok declared+used' => ['cva-ok', null, null];
+        yield 'classes-ok declared+used' => ['classes-ok', null, null];
+        yield 'merge-ok declared+used (filter)' => ['merge-ok', null, null];
+        yield 'icon-fn-ok declared+used (fn)' => ['icon-fn-ok', null, null];
+        yield 'icon-tag-ok declared+used (tag)' => ['icon-tag-ok', null, null];
+        yield 'map-ok declared+used' => ['map-ok', null, null];
+        yield 'provide-ok declared+used' => ['provide-ok', null, null];
+        yield 'inject-ok declared+used' => ['inject-ok', null, null];
+        yield 'merge declared but unused' => ['merge-declared-unused', 'composer.declared-but-unused', 'tales-from-a-dev/twig-tailwind-extra'];
+        yield 'icon declared but unused' => ['icon-declared-unused', 'composer.declared-but-unused', 'symfony/ux-icons'];
+        yield 'map declared but unused' => ['map-declared-unused', 'composer.declared-but-unused', 'symfony/ux-map'];
+        yield 'html_cva used but undeclared' => ['cva-undeclared', 'composer.symbol-undeclared', 'html_cva'];
+        yield 'tailwind_merge used but undeclared' => ['merge-undeclared', 'composer.symbol-undeclared', 'tailwind_merge'];
+        yield '<twig:ux:icon used but undeclared' => ['icon-tag-undeclared', 'composer.symbol-undeclared', '<twig:ux:icon'];
+        yield '<twig:ux:map used but undeclared' => ['map-undeclared', 'composer.symbol-undeclared', '<twig:ux:map'];
+        yield 'provide() used but undeclared' => ['provide-undeclared', 'composer.symbol-undeclared', 'provide('];
+        yield 'html_cva with sufficient version' => ['cva-version-ok', null, null];
+        yield 'html_cva with version too low' => ['cva-version-too-low', 'composer.symbol-version-insufficient', 'need >=3.12'];
+        yield 'html_attr_type with sufficient version' => ['attr-type-version-ok', null, null];
+        yield 'html_attr_type with version too low' => ['attr-type-version-too-low', 'composer.symbol-version-insufficient', 'need >=3.24'];
+    }
+
+    #[DataProvider('provideComposerCases')]
+    public function testComposerSymbolChecker(string $recipe, ?string $category, ?string $needle)
+    {
+        $kit = $this->loadFixtureKit('lint-composer-symbol');
+        $issues = $this->findRecipeIssues(new KitLinter([new ComposerSymbolChecker()])->lint($kit), $recipe);
+
+        if (null === $category) {
+            $this->assertSame([], $issues, \sprintf('Recipe "%s" must produce no issue.', $recipe));
+
+            return;
+        }
+
+        $this->assertCount(1, $issues, \sprintf('Recipe "%s" must produce exactly one issue.', $recipe));
+        $this->assertSame($category, $issues[0]->category);
+        $this->assertSame(LintSeverity::Warning, $issues[0]->severity);
+        $this->assertStringContainsString($needle, $issues[0]->message);
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string, ?string}>
+     */
+    public static function provideJsImportCases(): iterable
+    {
+        // recipe slug => [expected category | null, expected package in message | null]
+        yield 'npm declared' => ['npm-declared', null, null];
+        yield 'importmap declared' => ['importmap-declared', null, null];
+        yield 'undeclared static import' => ['undeclared', 'js.import.undeclared', 'lodash'];
+        yield 'relative paths ignored' => ['relative-ignored', null, null];
+        yield 'implicit @hotwired/stimulus' => ['implicit-stimulus', null, null];
+        yield 'implicit @hotwired/turbo' => ['implicit-turbo', null, null];
+        yield 'implicit @symfony/stimulus-bundle' => ['implicit-bundle', null, null];
+        yield 'scoped subpath collapses' => ['scoped-subpath', null, null];
+        yield 'plain subpath collapses' => ['plain-subpath', null, null];
+        yield 'dynamic import detected' => ['dynamic-import', 'js.import.undeclared', 'lodash'];
+        yield 'require() detected' => ['require-import', 'js.import.undeclared', 'lodash'];
+        yield 'imports in *.ts scanned' => ['ts-file', 'js.import.undeclared', 'lodash'];
+        yield 'imports in *.mjs scanned' => ['mjs-file', 'js.import.undeclared', 'lodash'];
+        yield 'recipe without assets dir' => ['no-assets', null, null];
+        yield 'noise in strings and comments' => ['import-in-string-noise', null, null];
+        yield 'export ... from re-export' => ['export-re-export', 'js.import.undeclared', 'lodash'];
+    }
+
+    #[DataProvider('provideJsImportCases')]
+    public function testJsImportChecker(string $recipe, ?string $category, ?string $needle)
+    {
+        $kit = $this->loadFixtureKit('lint-js-import');
+        $issues = $this->findRecipeIssues(new KitLinter([new JsImportChecker()])->lint($kit), $recipe);
+
+        if (null === $category) {
+            $this->assertSame([], $issues, \sprintf('Recipe "%s" must produce no issue.', $recipe));
+
+            return;
+        }
+
+        $this->assertCount(1, $issues, \sprintf('Recipe "%s" must produce exactly one issue.', $recipe));
+        $this->assertSame($category, $issues[0]->category);
+        $this->assertSame(LintSeverity::Warning, $issues[0]->severity);
+        $this->assertStringContainsString($needle, $issues[0]->message);
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Add a quality-control layer for Toolkit kits, so structural and dependency-coherence regressions are caught before they ship.

A new `ux:toolkit:lint-kit <kit-path>` command runs a pipeline of small checkers against a kit and reports issues per recipe.
The command is exposed as a standalone `bin/ux-toolkit-kit-lint` only, no DI wiring, since it has no value inside a user's app: it's a tool for kit maintainers, used locally or from CI.

Checks performed:
- **structural**: missing recipe manifests, broken copy-files entries, unknown references in `dependencies.recipe[]` (errors);
- **coherence**: Stimulus controllers used in Twig without a matching JS file, bare JS imports not declared in `dependencies.npm` / `.importmap`, and a curated mapping between Composer packages and the Twig symbols they provide.

A dedicated GitHub Actions workflow runs the linter on every kit under`src/Toolkit/kits/*` via a dynamically built matrix, triggered only when`src/Toolkit/**` changes.
Each kit gets its own job (`fail-fast: false`) so output stays readable and failures are isolated; adding a new kit needs no workflow change.