### PR TITLE
[Toolkit] Consider recipe deps in `StimulusControllerChecker`

### DIFF
--- a/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerChecker.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
 
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
+use Symfony\UX\Toolkit\Dependency\RecipeDependency;
 use Symfony\UX\Toolkit\Kit\Kit;
 
 use function Symfony\Component\String\u;
@@ -45,6 +46,15 @@ final class StimulusControllerChecker implements KitCheckerInterface
             }
 
             $shippedControllers = $this->listShippedControllers($recipe);
+            foreach ($recipe->manifest->dependencies as $dependency) {
+                if (!$dependency instanceof RecipeDependency) {
+                    continue;
+                }
+                if (null === $dependencyRecipe = $kit->getRecipe($dependency->name)) {
+                    continue;
+                }
+                $shippedControllers = array_merge($shippedControllers, $this->listShippedControllers($dependencyRecipe));
+            }
 
             foreach ($controllerNames as $controllerName => $file) {
                 if (\in_array($controllerName, $shippedControllers, true)) {

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/from-dep/assets/controllers/via_dep_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/from-dep/assets/controllers/via_dep_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/from-dep/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/from-dep/manifest.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "From Dep",
+    "description": "Recipe shipping a controller consumed by other recipes via dependencies.recipe.",
+    "copy-files": {
+        "assets/": "assets/"
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/missing-dep/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/missing-dep/manifest.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Missing Dep",
+    "description": "Declares a recipe dependency that does NOT ship the referenced controller.",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "recipe": ["from-dep"]
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/missing-dep/templates/components/MissingDep.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/missing-dep/templates/components/MissingDep.html.twig
@@ -1,0 +1,1 @@
+<div data-controller="not-shipped-anywhere">missing dep</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/uses-dep/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/uses-dep/manifest.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Uses Dep",
+    "description": "Consumes a Stimulus controller shipped by a recipe declared in dependencies.recipe.",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "recipe": ["from-dep"]
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus/uses-dep/templates/components/UsesDep.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus/uses-dep/templates/components/UsesDep.html.twig
@@ -1,0 +1,1 @@
+<div data-controller="via-dep">uses dep</div>

--- a/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
+++ b/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
@@ -146,6 +146,26 @@ class KitLinterTest extends TestCase
         $this->assertStringContainsString($expectedFile, $matching[0]->file);
     }
 
+    public function testStimulusControllerSatisfiedByRecipeDependency()
+    {
+        $kit = $this->loadFixtureKit('lint-stimulus');
+
+        $issues = new KitLinter([new StimulusControllerChecker()])->lint($kit)->getIssues();
+
+        $usesDepIssues = array_values(array_filter(
+            $issues,
+            static fn (LintIssue $i) => 'stimulus.controller.missing' === $i->category && 'uses-dep' === $i->recipe,
+        ));
+        $this->assertSame([], $usesDepIssues, 'Controller shipped by a recipe declared in dependencies.recipe must not be reported.');
+
+        $missingDepIssues = array_values(array_filter(
+            $issues,
+            static fn (LintIssue $i) => 'stimulus.controller.missing' === $i->category && 'missing-dep' === $i->recipe,
+        ));
+        $this->assertCount(1, $missingDepIssues, 'A controller not shipped by any declared recipe dependency must still be reported.');
+        $this->assertStringContainsString('not-shipped-anywhere', $missingDepIssues[0]->message);
+    }
+
     /**
      * @return iterable<string, array{string, ?string, ?string}>
      */


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

`StimulusControllerChecker` warned `stimulus.controller.missing` even when the referenced controller was provided by a recipe declared in `dependencies.recipe`. Spotted on `kits/shadcn/toggle-group`, which already depends on `toggle`.