### PR TITLE
[TwigComponent] Fix backslashes being stripped from literal component attribute values

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.2.0
 
+- Fix backslashes being stripped from literal component attribute values
 - Add `ComponentRendererInterface::preCreateForRender()`, `ComponentRendererInterface::startEmbeddedComponentRender()`, and `ComponentRendererInterface::finishEmbeddedComponentRender()` methods
 
 ## 3.1.0

--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -470,7 +470,7 @@ class TwigPreLexer
             if ($this->check('{{')) {
                 // mark any previous static text as complete: push into parts
                 if ('' !== $currentPart) {
-                    $parts[] = \sprintf("'%s'", str_replace("'", "\'", $currentPart));
+                    $parts[] = $this->toStringLiteral($currentPart);
                     $currentPart = '';
                 }
 
@@ -489,9 +489,21 @@ class TwigPreLexer
         }
 
         if ('' !== $currentPart) {
-            $parts[] = \sprintf("'%s'", str_replace("'", "\'", $currentPart));
+            $parts[] = $this->toStringLiteral($currentPart);
         }
 
         return implode('~', $parts);
+    }
+
+    /**
+     * Wraps a raw value into a single-quoted Twig string literal.
+     *
+     * Both the backslash and the single quote must be escaped: Twig processes
+     * backslash sequences inside single-quoted strings, so an unescaped
+     * backslash would corrupt the value.
+     */
+    private function toStringLiteral(string $value): string
+    {
+        return "'".strtr($value, ['\\' => '\\\\', "'" => "\\'"])."'";
     }
 }

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -60,6 +60,21 @@ final class TwigPreLexerTest extends TestCase
             '{{ component(\'foo\', { dynamic: (dynamicVar), otherDynamic: anotherVar }) }}',
         ];
 
+        yield 'attribute_value_with_backslashes_is_preserved' => [
+            '<twig:foo path="C:\Users\me" />',
+            "{{ component('foo', { path: 'C:\\\\Users\\\\me' }) }}",
+        ];
+
+        yield 'attribute_value_with_backslash_sequence_is_kept_literal' => [
+            '<twig:foo text="line\nbreak" />',
+            "{{ component('foo', { text: 'line\\\\nbreak' }) }}",
+        ];
+
+        yield 'attribute_value_mixing_backslash_and_expression' => [
+            '<twig:foo text="C:\dir {{ name }}" />',
+            "{{ component('foo', { text: 'C:\\\\dir '~(name) }) }}",
+        ];
+
         yield 'component_with_closing_tag' => [
             '<twig:foo></twig:foo>',
             '{% component \'foo\' %}{% endcomponent %}',


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | n/a
| License        | MIT

