### PR TITLE
[LiveComponent] Add robust support for async action confirmations (Turbo, SweetAlert2, Native)

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -142,6 +142,10 @@ interface LiveEvent extends CustomEvent {
     component: Component;
   };
 }
+interface LiveConfirmEventDetail {
+  message: string;
+  promise: Promise<boolean> | null;
+}
 interface LiveController {
   element: HTMLElement;
   component: Component;
@@ -221,7 +225,7 @@ declare class LiveControllerDefault extends Controller<HTMLElement> implements L
   connect(): void;
   disconnect(): void;
   update(event: any): void;
-  action(event: any): void;
+  action(event: any): Promise<void>;
   $render(): Promise<export_default$2>;
   emit(event: any): void;
   emitUp(event: any): void;
@@ -239,4 +243,4 @@ declare class LiveControllerDefault extends Controller<HTMLElement> implements L
   private dispatchEvent;
   private onMutations;
 }
-export { Component, LiveController, LiveEvent, LiveControllerDefault as default, getComponent };
+export { Component, LiveConfirmEventDetail, LiveController, LiveEvent, LiveControllerDefault as default, getComponent };

--- a/src/LiveComponent/assets/dist/live_controller.d.ts
+++ b/src/LiveComponent/assets/dist/live_controller.d.ts
@@ -225,7 +225,8 @@ declare class LiveControllerDefault extends Controller<HTMLElement> implements L
   connect(): void;
   disconnect(): void;
   update(event: any): void;
-  action(event: any): Promise<void>;
+  action(event: any): void;
+  confirmAction(event: any): Promise<void>;
   $render(): Promise<export_default$2>;
   emit(event: any): void;
   emitUp(event: any): void;

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2105,39 +2105,9 @@ var LiveControllerDefault = class LiveControllerDefault extends Controller {
 		if (event.type === "input" || event.type === "change") throw new Error(`Since LiveComponents 2.3, you no longer need data-action="live#update" on form elements. Found on element: ${getElementAsTagText(event.currentTarget)}`);
 		this.updateModelFromElementEvent(event.currentTarget, null);
 	}
-	async action(event) {
-		if (event.defaultPrevented) return;
-		const target = event.currentTarget;
+	action(event) {
 		const params = event.params;
-		if (!params.action) throw new Error(`No action name provided on element: ${getElementAsTagText(target)}. Did you forget to add the "data-live-action-param" attribute?`);
-		const confirmMessage = target.getAttribute("data-turbo-confirm") || target.getAttribute("data-live-confirm");
-		if (confirmMessage) {
-			event.preventDefault();
-			event.stopImmediatePropagation();
-			let isConfirmed = false;
-			const turbo = window.Turbo;
-			const turboConfirm = turbo?.config?.forms?.confirm || turbo?.navigator?.confirmMethod;
-			if (typeof turboConfirm === "function") isConfirmed = await turboConfirm(confirmMessage, target);
-			else {
-				const liveConfirmEvent = new CustomEvent("live:confirm", {
-					bubbles: true,
-					cancelable: true,
-					detail: {
-						message: confirmMessage,
-						promise: null
-					}
-				});
-				target.dispatchEvent(liveConfirmEvent);
-				if (liveConfirmEvent.defaultPrevented && liveConfirmEvent.detail.promise) try {
-					isConfirmed = await liveConfirmEvent.detail.promise;
-				} catch (e) {
-					isConfirmed = false;
-				}
-				else if (liveConfirmEvent.defaultPrevented) return;
-				else isConfirmed = window.confirm(confirmMessage);
-			}
-			if (!isConfirmed) return;
-		}
+		if (!params.action) throw new Error(`No action name provided on element: ${getElementAsTagText(event.currentTarget)}. Did you forget to add the "data-live-action-param" attribute?`);
 		const rawAction = params.action;
 		const actionArgs = { ...params };
 		delete actionArgs.action;
@@ -2150,7 +2120,7 @@ var LiveControllerDefault = class LiveControllerDefault extends Controller {
 				event.stopPropagation();
 			});
 			validModifiers.set("self", () => {
-				if (event.target !== target) return;
+				if (event.target !== event.currentTarget) return;
 			});
 			validModifiers.set("debounce", (modifier) => {
 				debounce = modifier.value ? Number.parseInt(modifier.value) : true;
@@ -2171,8 +2141,56 @@ var LiveControllerDefault = class LiveControllerDefault extends Controller {
 				delete this.pendingFiles[key];
 			}
 			this.component.action(directive.action, actionArgs, debounce);
-			if (getModelDirectiveFromElement(target, false)) this.pendingActionTriggerModelElement = target;
+			if (getModelDirectiveFromElement(event.currentTarget, false)) this.pendingActionTriggerModelElement = event.currentTarget;
 		});
+	}
+	async confirmAction(event) {
+		event.preventDefault();
+		const target = event.currentTarget;
+		const params = { ...event.params };
+		const confirmMessage = params.confirmMessage || target.dataset.confirmMessageParam || target.getAttribute("data-turbo-confirm");
+		if (!confirmMessage) {
+			console.warn("LiveComponent: live#confirmAction requires a confirm message.");
+			return;
+		}
+		const actionName = params.action || target.dataset.confirmActionParam;
+		if (!actionName) throw new Error("LiveComponent: No action provided. Please use data-live-action-param.");
+		let isConfirmed = false;
+		const liveConfirmEvent = new CustomEvent("live:confirmAction", {
+			bubbles: true,
+			cancelable: true,
+			detail: {
+				message: confirmMessage,
+				promise: null
+			}
+		});
+		target.dispatchEvent(liveConfirmEvent);
+		if (liveConfirmEvent.defaultPrevented) {
+			if (liveConfirmEvent.detail.promise) try {
+				isConfirmed = await liveConfirmEvent.detail.promise;
+			} catch {
+				isConfirmed = false;
+			}
+		} else {
+			const turbo = window.Turbo;
+			const turboConfirm = turbo?.config?.forms?.confirm || turbo?.navigator?.confirmMethod;
+			if (typeof turboConfirm === "function") isConfirmed = await turboConfirm(confirmMessage, target.closest("form"), target);
+			else isConfirmed = window.confirm(confirmMessage);
+		}
+		if (!isConfirmed) return;
+		params.action = actionName;
+		delete params.confirmMessage;
+		delete params.confirmAction;
+		const fakeEvent = {
+			type: event.type,
+			preventDefault: () => {},
+			stopPropagation: () => {},
+			currentTarget: target,
+			target: event.target,
+			params,
+			defaultPrevented: false
+		};
+		this.action(fakeEvent);
 	}
 	$render() {
 		return this.component.render();

--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -2105,9 +2105,39 @@ var LiveControllerDefault = class LiveControllerDefault extends Controller {
 		if (event.type === "input" || event.type === "change") throw new Error(`Since LiveComponents 2.3, you no longer need data-action="live#update" on form elements. Found on element: ${getElementAsTagText(event.currentTarget)}`);
 		this.updateModelFromElementEvent(event.currentTarget, null);
 	}
-	action(event) {
+	async action(event) {
+		if (event.defaultPrevented) return;
+		const target = event.currentTarget;
 		const params = event.params;
-		if (!params.action) throw new Error(`No action name provided on element: ${getElementAsTagText(event.currentTarget)}. Did you forget to add the "data-live-action-param" attribute?`);
+		if (!params.action) throw new Error(`No action name provided on element: ${getElementAsTagText(target)}. Did you forget to add the "data-live-action-param" attribute?`);
+		const confirmMessage = target.getAttribute("data-turbo-confirm") || target.getAttribute("data-live-confirm");
+		if (confirmMessage) {
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			let isConfirmed = false;
+			const turbo = window.Turbo;
+			const turboConfirm = turbo?.config?.forms?.confirm || turbo?.navigator?.confirmMethod;
+			if (typeof turboConfirm === "function") isConfirmed = await turboConfirm(confirmMessage, target);
+			else {
+				const liveConfirmEvent = new CustomEvent("live:confirm", {
+					bubbles: true,
+					cancelable: true,
+					detail: {
+						message: confirmMessage,
+						promise: null
+					}
+				});
+				target.dispatchEvent(liveConfirmEvent);
+				if (liveConfirmEvent.defaultPrevented && liveConfirmEvent.detail.promise) try {
+					isConfirmed = await liveConfirmEvent.detail.promise;
+				} catch (e) {
+					isConfirmed = false;
+				}
+				else if (liveConfirmEvent.defaultPrevented) return;
+				else isConfirmed = window.confirm(confirmMessage);
+			}
+			if (!isConfirmed) return;
+		}
 		const rawAction = params.action;
 		const actionArgs = { ...params };
 		delete actionArgs.action;
@@ -2120,7 +2150,7 @@ var LiveControllerDefault = class LiveControllerDefault extends Controller {
 				event.stopPropagation();
 			});
 			validModifiers.set("self", () => {
-				if (event.target !== event.currentTarget) return;
+				if (event.target !== target) return;
 			});
 			validModifiers.set("debounce", (modifier) => {
 				debounce = modifier.value ? Number.parseInt(modifier.value) : true;
@@ -2141,7 +2171,7 @@ var LiveControllerDefault = class LiveControllerDefault extends Controller {
 				delete this.pendingFiles[key];
 			}
 			this.component.action(directive.action, actionArgs, debounce);
-			if (getModelDirectiveFromElement(event.currentTarget, false)) this.pendingActionTriggerModelElement = event.currentTarget;
+			if (getModelDirectiveFromElement(target, false)) this.pendingActionTriggerModelElement = target;
 		});
 	}
 	$render() {

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -128,60 +128,15 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
         this.updateModelFromElementEvent(event.currentTarget, null);
     }
 
-    async action(event: any) {
-        if (event.defaultPrevented) {
-            return;
-        }
-        const target = event.currentTarget as HTMLElement;
+    action(event: any) {
         const params = event.params;
         if (!params.action) {
             throw new Error(
                 `No action name provided on element: ${getElementAsTagText(
-                    target
+                    event.currentTarget
                 )}. Did you forget to add the "data-live-action-param" attribute?`
             );
         }
-
-        const confirmMessage = target.getAttribute('data-turbo-confirm') || target.getAttribute('data-live-confirm');
-        if (confirmMessage) {
-            event.preventDefault();
-            event.stopImmediatePropagation();
-            let isConfirmed = false;
-
-            type TurboConfirmMethod = (message: string, element: HTMLElement) => Promise<boolean>;
-            interface TurboGlobal {
-                config?: { forms?: { confirm?: TurboConfirmMethod } };
-                navigator?: { confirmMethod?: TurboConfirmMethod };
-            }
-            const turbo = (window as any).Turbo as TurboGlobal | undefined;
-            const turboConfirm = turbo?.config?.forms?.confirm || turbo?.navigator?.confirmMethod;
-
-            if (typeof turboConfirm === 'function') {
-                isConfirmed = await turboConfirm(confirmMessage, target);
-            } else {
-                const liveConfirmEvent = new CustomEvent<LiveConfirmEventDetail>('live:confirm', {
-                    bubbles: true,
-                    cancelable: true,
-                    detail: { message: confirmMessage, promise: null },
-                });
-                target.dispatchEvent(liveConfirmEvent);
-                if (liveConfirmEvent.defaultPrevented && liveConfirmEvent.detail.promise) {
-                    try {
-                        isConfirmed = await liveConfirmEvent.detail.promise;
-                    } catch (e) {
-                        isConfirmed = false;
-                    }
-                } else if (liveConfirmEvent.defaultPrevented) {
-                    return; // Prevented but no promise, assume handled/cancelled
-                } else {
-                    isConfirmed = window.confirm(confirmMessage);
-                }
-            }
-            if (!isConfirmed) {
-                return;
-            }
-        }
-
         const rawAction = params.action;
         // all other params are considered action arguments
         const actionArgs = { ...params };
@@ -198,7 +153,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
                 event.stopPropagation();
             });
             validModifiers.set('self', () => {
-                if (event.target !== target) {
+                if (event.target !== event.currentTarget) {
                     return;
                 }
             });
@@ -241,10 +196,88 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
             // if so, to be safe, slightly delay the action so that the
             // change/input listener on LiveController can process the
             // model change *before* sending the action
-            if (getModelDirectiveFromElement(target, false)) {
-                this.pendingActionTriggerModelElement = target;
+            if (getModelDirectiveFromElement(event.currentTarget, false)) {
+                this.pendingActionTriggerModelElement = event.currentTarget;
             }
         });
+    }
+
+    async confirmAction(event: any) {
+        event.preventDefault();
+
+        const target = event.currentTarget as HTMLElement;
+        const params = { ...event.params };
+
+        // Read the message from Stimulus params or data attributes
+        const confirmMessage =
+            params.confirmMessage || target.dataset.confirmMessageParam || target.getAttribute('data-turbo-confirm');
+
+        if (!confirmMessage) {
+            console.warn('LiveComponent: live#confirmAction requires a confirm message.');
+            return;
+        }
+
+        // Read the action name to execute after confirmation
+        const actionName = params.action || target.dataset.confirmActionParam;
+
+        if (!actionName) {
+            throw new Error('LiveComponent: No action provided. Please use data-live-action-param.');
+        }
+
+        let isConfirmed = false;
+
+        // 1. Dispatch custom event for userland override (e.g., SweetAlert)
+        const liveConfirmEvent = new CustomEvent('live:confirmAction', {
+            bubbles: true,
+            cancelable: true,
+            detail: { message: confirmMessage, promise: null },
+        });
+
+        target.dispatchEvent(liveConfirmEvent);
+
+        if (liveConfirmEvent.defaultPrevented) {
+            // Wait for the user-provided promise if available
+            if (liveConfirmEvent.detail.promise) {
+                try {
+                    isConfirmed = await liveConfirmEvent.detail.promise;
+                } catch {
+                    isConfirmed = false;
+                }
+            }
+        } else {
+            // 2. Automatic Turbo Integration
+            const turbo = (window as any).Turbo;
+            const turboConfirm = turbo?.config?.forms?.confirm || turbo?.navigator?.confirmMethod;
+
+            if (typeof turboConfirm === 'function') {
+                const form = target.closest('form');
+                isConfirmed = await turboConfirm(confirmMessage, form, target);
+            } else {
+                // 3. Fallback to native window.confirm
+                isConfirmed = window.confirm(confirmMessage);
+            }
+        }
+
+        if (!isConfirmed) {
+            return;
+        }
+
+        // 3. Trigger the original action method safely with a mock event
+        params.action = actionName;
+        delete params.confirmMessage;
+        delete params.confirmAction;
+
+        const fakeEvent = {
+            type: event.type,
+            preventDefault: () => {},
+            stopPropagation: () => {},
+            currentTarget: target,
+            target: event.target,
+            params: params,
+            defaultPrevented: false,
+        };
+
+        this.action(fakeEvent);
     }
 
     $render() {

--- a/src/LiveComponent/assets/src/live_controller.ts
+++ b/src/LiveComponent/assets/src/live_controller.ts
@@ -32,6 +32,11 @@ export interface LiveEvent extends CustomEvent {
     };
 }
 
+export interface LiveConfirmEventDetail {
+    message: string;
+    promise: Promise<boolean> | null;
+}
+
 export interface LiveController {
     element: HTMLElement;
     component: Component;
@@ -123,15 +128,60 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
         this.updateModelFromElementEvent(event.currentTarget, null);
     }
 
-    action(event: any) {
+    async action(event: any) {
+        if (event.defaultPrevented) {
+            return;
+        }
+        const target = event.currentTarget as HTMLElement;
         const params = event.params;
         if (!params.action) {
             throw new Error(
                 `No action name provided on element: ${getElementAsTagText(
-                    event.currentTarget
+                    target
                 )}. Did you forget to add the "data-live-action-param" attribute?`
             );
         }
+
+        const confirmMessage = target.getAttribute('data-turbo-confirm') || target.getAttribute('data-live-confirm');
+        if (confirmMessage) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            let isConfirmed = false;
+
+            type TurboConfirmMethod = (message: string, element: HTMLElement) => Promise<boolean>;
+            interface TurboGlobal {
+                config?: { forms?: { confirm?: TurboConfirmMethod } };
+                navigator?: { confirmMethod?: TurboConfirmMethod };
+            }
+            const turbo = (window as any).Turbo as TurboGlobal | undefined;
+            const turboConfirm = turbo?.config?.forms?.confirm || turbo?.navigator?.confirmMethod;
+
+            if (typeof turboConfirm === 'function') {
+                isConfirmed = await turboConfirm(confirmMessage, target);
+            } else {
+                const liveConfirmEvent = new CustomEvent<LiveConfirmEventDetail>('live:confirm', {
+                    bubbles: true,
+                    cancelable: true,
+                    detail: { message: confirmMessage, promise: null },
+                });
+                target.dispatchEvent(liveConfirmEvent);
+                if (liveConfirmEvent.defaultPrevented && liveConfirmEvent.detail.promise) {
+                    try {
+                        isConfirmed = await liveConfirmEvent.detail.promise;
+                    } catch (e) {
+                        isConfirmed = false;
+                    }
+                } else if (liveConfirmEvent.defaultPrevented) {
+                    return; // Prevented but no promise, assume handled/cancelled
+                } else {
+                    isConfirmed = window.confirm(confirmMessage);
+                }
+            }
+            if (!isConfirmed) {
+                return;
+            }
+        }
+
         const rawAction = params.action;
         // all other params are considered action arguments
         const actionArgs = { ...params };
@@ -148,7 +198,7 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
                 event.stopPropagation();
             });
             validModifiers.set('self', () => {
-                if (event.target !== event.currentTarget) {
+                if (event.target !== target) {
                     return;
                 }
             });
@@ -191,8 +241,8 @@ export default class LiveControllerDefault extends Controller<HTMLElement> imple
             // if so, to be safe, slightly delay the action so that the
             // change/input listener on LiveController can process the
             // model change *before* sending the action
-            if (getModelDirectiveFromElement(event.currentTarget, false)) {
-                this.pendingActionTriggerModelElement = event.currentTarget;
+            if (getModelDirectiveFromElement(target, false)) {
+                this.pendingActionTriggerModelElement = target;
             }
         });
     }

--- a/src/LiveComponent/assets/test/unit/controller/action.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/action.test.ts
@@ -9,7 +9,7 @@
 
 import { getByText, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createTest, initComponent, shutdownTests } from '../../tools';
 
 describe('LiveController Action Tests', () => {
@@ -302,153 +302,135 @@ describe('LiveController Action Tests', () => {
         await waitFor(() => expect(test.element).toHaveTextContent('count: 61'));
     });
 
-    it('aborts action if event.defaultPrevented is true (e.g. from native confirm)', async () => {
-        const test = await createTest(
-            { isSaved: false },
-            (data: any) => `
-            <div ${initComponent(data)}>
-                <button id="prevent-btn" data-action="live#action" data-live-action-param="save">Save</button>
-            </div>
-        `
-        );
+    describe('confirmAction', () => {
+        it('integrates with Turbo.config.forms.confirm and executes action when confirmed', async () => {
+            const test = await createTest(
+                { isSaved: false },
+                (data: any) => `
+                <div ${initComponent(data)}>
+                    ${data.isSaved ? 'Saved!' : ''}
+                    <button data-action="live#confirmAction" data-live-action-param="save" data-turbo-confirm="Turbo?">Save</button>
+                </div>
+            `
+            );
 
-        const btn = test.element.querySelector('#prevent-btn') as HTMLElement;
-        btn.addEventListener('click', (e) => e.preventDefault(), { capture: true });
+            const confirmMock = vi.fn().mockResolvedValue(true);
+            (window as any).Turbo = { config: { forms: { confirm: confirmMock } } };
 
-        // No ajax call expected
-        getByText(test.element, 'Save').click();
+            test.expectsAjaxCall()
+                .expectActionCalled('save')
+                .serverWillChangeProps((data: any) => {
+                    data.isSaved = true;
+                });
 
-        // Wait a bit to ensure nothing happens
-        await new Promise((resolve) => setTimeout(resolve, 50));
-    });
+            getByText(test.element, 'Save').click();
 
-    it('integrates with Turbo.config.forms.confirm and executes action when confirmed', async () => {
-        const test = await createTest(
-            { isSaved: false },
-            (data: any) => `
-            <div ${initComponent(data)}>
-                ${data.isSaved ? 'Saved!' : ''}
-                <button data-action="live#action" data-live-action-param="save" data-turbo-confirm="Turbo?">Save</button>
-            </div>
-        `
-        );
+            await waitFor(() => expect(confirmMock).toHaveBeenCalledWith('Turbo?', null, expect.any(HTMLElement)));
+            await waitFor(() => expect(test.element).toHaveTextContent('Saved!'));
 
-        const confirmMock = vi.fn().mockResolvedValue(true);
-        (window as any).Turbo = { config: { forms: { confirm: confirmMock } } };
+            delete (window as any).Turbo;
+        });
 
-        test.expectsAjaxCall()
-            .expectActionCalled('save')
-            .serverWillChangeProps((data: any) => {
-                data.isSaved = true;
-            });
+        it('integrates with Turbo.config.forms.confirm and aborts when canceled', async () => {
+            const test = await createTest(
+                { isSaved: false },
+                (data: any) => `
+                <div ${initComponent(data)}>
+                    <button data-action="live#confirmAction" data-live-action-param="save" data-turbo-confirm="Turbo?">Save</button>
+                </div>
+            `
+            );
 
-        getByText(test.element, 'Save').click();
+            const confirmMock = vi.fn().mockResolvedValue(false);
+            (window as any).Turbo = { config: { forms: { confirm: confirmMock } } };
 
-        await waitFor(() => expect(confirmMock).toHaveBeenCalledWith('Turbo?', expect.any(HTMLElement)));
-        await waitFor(() => expect(test.element).toHaveTextContent('Saved!'));
+            getByText(test.element, 'Save').click();
 
-        delete (window as any).Turbo;
-    });
+            await waitFor(() => expect(confirmMock).toHaveBeenCalledWith('Turbo?', null, expect.any(HTMLElement)));
+            await new Promise((resolve) => setTimeout(resolve, 50));
 
-    it('integrates with Turbo.config.forms.confirm and aborts when canceled', async () => {
-        const test = await createTest(
-            { isSaved: false },
-            (data: any) => `
-            <div ${initComponent(data)}>
-                <button data-action="live#action" data-live-action-param="save" data-turbo-confirm="Turbo?">Save</button>
-            </div>
-        `
-        );
+            delete (window as any).Turbo;
+        });
 
-        const confirmMock = vi.fn().mockResolvedValue(false);
-        (window as any).Turbo = { config: { forms: { confirm: confirmMock } } };
+        it('dispatches live:confirmAction event and executes action when promise resolves to true', async () => {
+            const test = await createTest(
+                { isSaved: false },
+                (data: any) => `
+                <div ${initComponent(data)}>
+                    ${data.isSaved ? 'Saved!' : ''}
+                    <button data-action="live#confirmAction" data-live-action-param="save" data-live-confirm-message-param="Live?">Save</button>
+                </div>
+            `
+            );
 
-        getByText(test.element, 'Save').click();
+            document.addEventListener(
+                'live:confirmAction',
+                (event: any) => {
+                    event.preventDefault();
+                    event.detail.promise = Promise.resolve(true);
+                },
+                { once: true }
+            );
 
-        await waitFor(() => expect(confirmMock).toHaveBeenCalledWith('Turbo?', expect.any(HTMLElement)));
-        await new Promise((resolve) => setTimeout(resolve, 50));
+            test.expectsAjaxCall()
+                .expectActionCalled('save')
+                .serverWillChangeProps((data: any) => {
+                    data.isSaved = true;
+                });
 
-        delete (window as any).Turbo;
-    });
+            getByText(test.element, 'Save').click();
 
-    it('dispatches live:confirm event and executes action when promise resolves to true', async () => {
-        const test = await createTest(
-            { isSaved: false },
-            (data: any) => `
-            <div ${initComponent(data)}>
-                ${data.isSaved ? 'Saved!' : ''}
-                <button id="live-btn" data-action="live#action" data-live-action-param="save" data-live-confirm="Live?">Save</button>
-            </div>
-        `
-        );
+            await waitFor(() => expect(test.element).toHaveTextContent('Saved!'));
+        });
 
-        document.addEventListener(
-            'live:confirm',
-            (event: any) => {
-                event.preventDefault();
-                event.detail.promise = Promise.resolve(true);
-            },
-            { once: true }
-        );
+        it('dispatches live:confirmAction event and aborts when promise resolves to false', async () => {
+            const test = await createTest(
+                { isSaved: false },
+                (data: any) => `
+                <div ${initComponent(data)}>
+                    <button data-action="live#confirmAction" data-live-action-param="save" data-live-confirm-message-param="Live?">Save</button>
+                </div>
+            `
+            );
 
-        test.expectsAjaxCall()
-            .expectActionCalled('save')
-            .serverWillChangeProps((data: any) => {
-                data.isSaved = true;
-            });
+            document.addEventListener(
+                'live:confirmAction',
+                (event: any) => {
+                    event.preventDefault();
+                    event.detail.promise = Promise.resolve(false);
+                },
+                { once: true }
+            );
 
-        getByText(test.element, 'Save').click();
+            getByText(test.element, 'Save').click();
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        });
 
-        await waitFor(() => expect(test.element).toHaveTextContent('Saved!'));
-    });
+        it('falls back to window.confirm when no custom promise or Turbo is present', async () => {
+            const test = await createTest(
+                { isSaved: false },
+                (data: any) => `
+                <div ${initComponent(data)}>
+                    ${data.isSaved ? 'Saved!' : ''}
+                    <button data-action="live#confirmAction" data-live-action-param="save" data-live-confirm-message-param="Live Native?">Save</button>
+                </div>
+            `
+            );
 
-    it('dispatches live:confirm event and aborts when promise resolves to false', async () => {
-        const test = await createTest(
-            { isSaved: false },
-            (data: any) => `
-            <div ${initComponent(data)}>
-                <button data-action="live#action" data-live-action-param="save" data-live-confirm="Live?">Save</button>
-            </div>
-        `
-        );
+            const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
 
-        document.addEventListener(
-            'live:confirm',
-            (event: any) => {
-                event.preventDefault();
-                event.detail.promise = Promise.resolve(false);
-            },
-            { once: true }
-        );
+            test.expectsAjaxCall()
+                .expectActionCalled('save')
+                .serverWillChangeProps((data: any) => {
+                    data.isSaved = true;
+                });
 
-        getByText(test.element, 'Save').click();
-        await new Promise((resolve) => setTimeout(resolve, 50));
-    });
+            getByText(test.element, 'Save').click();
 
-    it('falls back to window.confirm when data-live-confirm is used without a custom promise', async () => {
-        const test = await createTest(
-            { isSaved: false },
-            (data: any) => `
-            <div ${initComponent(data)}>
-                ${data.isSaved ? 'Saved!' : ''}
-                <button data-action="live#action" data-live-action-param="save" data-live-confirm="Live Native?">Save</button>
-            </div>
-        `
-        );
+            await waitFor(() => expect(confirmSpy).toHaveBeenCalledWith('Live Native?'));
+            await waitFor(() => expect(test.element).toHaveTextContent('Saved!'));
 
-        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
-
-        test.expectsAjaxCall()
-            .expectActionCalled('save')
-            .serverWillChangeProps((data: any) => {
-                data.isSaved = true;
-            });
-
-        getByText(test.element, 'Save').click();
-
-        await waitFor(() => expect(confirmSpy).toHaveBeenCalledWith('Live Native?'));
-        await waitFor(() => expect(test.element).toHaveTextContent('Saved!'));
-
-        confirmSpy.mockRestore();
+            confirmSpy.mockRestore();
+        });
     });
 });

--- a/src/LiveComponent/assets/test/unit/controller/action.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/action.test.ts
@@ -301,4 +301,154 @@ describe('LiveController Action Tests', () => {
 
         await waitFor(() => expect(test.element).toHaveTextContent('count: 61'));
     });
+
+    it('aborts action if event.defaultPrevented is true (e.g. from native confirm)', async () => {
+        const test = await createTest(
+            { isSaved: false },
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <button id="prevent-btn" data-action="live#action" data-live-action-param="save">Save</button>
+            </div>
+        `
+        );
+
+        const btn = test.element.querySelector('#prevent-btn') as HTMLElement;
+        btn.addEventListener('click', (e) => e.preventDefault(), { capture: true });
+
+        // No ajax call expected
+        getByText(test.element, 'Save').click();
+
+        // Wait a bit to ensure nothing happens
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    it('integrates with Turbo.config.forms.confirm and executes action when confirmed', async () => {
+        const test = await createTest(
+            { isSaved: false },
+            (data: any) => `
+            <div ${initComponent(data)}>
+                ${data.isSaved ? 'Saved!' : ''}
+                <button data-action="live#action" data-live-action-param="save" data-turbo-confirm="Turbo?">Save</button>
+            </div>
+        `
+        );
+
+        const confirmMock = vi.fn().mockResolvedValue(true);
+        (window as any).Turbo = { config: { forms: { confirm: confirmMock } } };
+
+        test.expectsAjaxCall()
+            .expectActionCalled('save')
+            .serverWillChangeProps((data: any) => {
+                data.isSaved = true;
+            });
+
+        getByText(test.element, 'Save').click();
+
+        await waitFor(() => expect(confirmMock).toHaveBeenCalledWith('Turbo?', expect.any(HTMLElement)));
+        await waitFor(() => expect(test.element).toHaveTextContent('Saved!'));
+
+        delete (window as any).Turbo;
+    });
+
+    it('integrates with Turbo.config.forms.confirm and aborts when canceled', async () => {
+        const test = await createTest(
+            { isSaved: false },
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <button data-action="live#action" data-live-action-param="save" data-turbo-confirm="Turbo?">Save</button>
+            </div>
+        `
+        );
+
+        const confirmMock = vi.fn().mockResolvedValue(false);
+        (window as any).Turbo = { config: { forms: { confirm: confirmMock } } };
+
+        getByText(test.element, 'Save').click();
+
+        await waitFor(() => expect(confirmMock).toHaveBeenCalledWith('Turbo?', expect.any(HTMLElement)));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        delete (window as any).Turbo;
+    });
+
+    it('dispatches live:confirm event and executes action when promise resolves to true', async () => {
+        const test = await createTest(
+            { isSaved: false },
+            (data: any) => `
+            <div ${initComponent(data)}>
+                ${data.isSaved ? 'Saved!' : ''}
+                <button id="live-btn" data-action="live#action" data-live-action-param="save" data-live-confirm="Live?">Save</button>
+            </div>
+        `
+        );
+
+        document.addEventListener(
+            'live:confirm',
+            (event: any) => {
+                event.preventDefault();
+                event.detail.promise = Promise.resolve(true);
+            },
+            { once: true }
+        );
+
+        test.expectsAjaxCall()
+            .expectActionCalled('save')
+            .serverWillChangeProps((data: any) => {
+                data.isSaved = true;
+            });
+
+        getByText(test.element, 'Save').click();
+
+        await waitFor(() => expect(test.element).toHaveTextContent('Saved!'));
+    });
+
+    it('dispatches live:confirm event and aborts when promise resolves to false', async () => {
+        const test = await createTest(
+            { isSaved: false },
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <button data-action="live#action" data-live-action-param="save" data-live-confirm="Live?">Save</button>
+            </div>
+        `
+        );
+
+        document.addEventListener(
+            'live:confirm',
+            (event: any) => {
+                event.preventDefault();
+                event.detail.promise = Promise.resolve(false);
+            },
+            { once: true }
+        );
+
+        getByText(test.element, 'Save').click();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    it('falls back to window.confirm when data-live-confirm is used without a custom promise', async () => {
+        const test = await createTest(
+            { isSaved: false },
+            (data: any) => `
+            <div ${initComponent(data)}>
+                ${data.isSaved ? 'Saved!' : ''}
+                <button data-action="live#action" data-live-action-param="save" data-live-confirm="Live Native?">Save</button>
+            </div>
+        `
+        );
+
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+        test.expectsAjaxCall()
+            .expectActionCalled('save')
+            .serverWillChangeProps((data: any) => {
+                data.isSaved = true;
+            });
+
+        getByText(test.element, 'Save').click();
+
+        await waitFor(() => expect(confirmSpy).toHaveBeenCalledWith('Live Native?'));
+        await waitFor(() => expect(test.element).toHaveTextContent('Saved!'));
+
+        confirmSpy.mockRestore();
+    });
 });

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1282,26 +1282,69 @@ the ``#[LiveArg]`` attribute::
 Confirming Actions
 ~~~~~~~~~~~~~~~~~~
 
-If you want to ask the user for confirmation before executing a LiveComponent action,
-you have three ways to do it.
+To ask the user for confirmation before executing a LiveComponent action,
+use the ``live#confirmAction`` action instead of the standard ``live#action``.
 
-**1. Using standard Turbo Confirm (If Turbo is installed)**
+This dedicated action ensures your confirmations are handled asynchronously without disrupting
+the synchronous execution queue of standard actions.
 
-If you are already using ``@hotwired/turbo`` and have configured a custom confirm method
-(like SweetAlert) via ``Turbo.config.forms.confirm`` or ``Turbo.setConfirmMethod``,
-LiveComponent will automatically respect it. Just add the ``data-turbo-confirm`` attribute:
+**1. Basic Usage**
+
+Use ``data-action="live#confirmAction"`` and provide the action name and message:
 
 .. code-block:: html+twig
 
     <button
-        data-action="live#action"
+        data-action="live#confirmAction"
         data-live-action-param="delete"
-        data-turbo-confirm="Are you sure you want to delete this item?"
+        data-live-confirm-message-param="Are you sure you want to delete this item?"
     >Delete</button>
 
-Here is an example of how you might configure Turbo with SweetAlert2 in your JavaScript
+.. note::
+
+    If you are used to Turbo, you can also use the ``data-turbo-confirm`` attribute instead
+    of ``data-live-confirm-message-param``. Both will work seamlessly.
+
+By default, this triggers the browser's native ``window.confirm()``.
+
+**2. Passing Extra Parameters & Modifiers**
+
+Just like standard actions, you can pass additional parameters, use modifiers (like ``:prevent``),
+and pipe multiple actions together:
+
+.. code-block:: html+twig
+
+    <button
+        data-action="live#confirmAction"
+        data-live-action-param="debounce(500)|delete"
+        data-live-confirm-message-param="Are you sure?"
+        
+        data-live-id-param="{{ item.id }}"
+    >Delete</button>
+
+You can also use it on forms to intercept the ``submit`` event and prevent page reloads:
+
+.. code-block:: html+twig
+
+    <form data-action="live#confirmAction:prevent"
+          data-live-action-param="saveSettings"
+          data-live-confirm-message-param="This will reboot the system. Are you sure?">
+        
+        <!-- form fields... -->
+        
+        <button type="submit">Save Settings</button>
+    </form>
+
+**3. Automatic Turbo Integration**
+
+If your project uses ``@hotwired/turbo`` and you have a custom confirm method configured
+globally via ``Turbo.config.forms.confirm`` or ``Turbo.setConfirmMethod``,
+LiveComponent will automatically detect and use it! No extra configuration is needed.
+
+Here is an example of how you might configure Turbo in your JavaScript
 (e.g., in ``app.js``). While this example uses SweetAlert2, you can seamlessly integrate
-any other library or your own custom UI design as long as it returns a Promise:
+any other library (like Bootstrap Modals, Tailwind UI) or your own custom UI design
+as long as it returns a Promise:
 
 .. code-block:: javascript
 
@@ -1312,7 +1355,7 @@ any other library or your own custom UI design as long as it returns a Promise:
     // Turbo.setConfirmMethod((message, element) => { ... });
 
     // Turbo 8 usage:
-    Turbo.config.forms.confirm = (message, element) => {
+    Turbo.config.forms.confirm = (message, formElement, submitter) => {
         return Swal.fire({
             title: message,
             icon: 'warning',
@@ -1320,54 +1363,27 @@ any other library or your own custom UI design as long as it returns a Promise:
         }).then(result => result.isConfirmed);
     };
 
-**2. Using Custom Async Dialogs (Without Turbo)**
+**4. Customizing the Confirmation Dialog (Without Turbo)**
 
-If you are not using Turbo, or want to handle LiveComponent confirmations separately,
-use the ``data-live-confirm`` attribute:
-
-.. code-block:: html+twig
-
-    <button
-        data-action="live#action"
-        data-live-action-param="delete"
-        data-live-confirm="Are you sure you want to delete this item?"
-    >Delete</button>
-
-By default, this will trigger the browser's native ``window.confirm()``.
-However, you can intercept this to show your own asynchronous modal (like SweetAlert2,
-another library, or a completely custom UI design) by listening to the ``live:confirm``
-event in your JavaScript:
+If you are not using Turbo, or want a custom dialog specifically for LiveComponents,
+intercept the process by listening to the ``live:confirmAction`` event:
 
 .. code-block:: javascript
 
     // app.js
     import Swal from 'sweetalert2';
 
-    document.addEventListener('live:confirm', (event) => {
-        // Prevent the native browser confirm dialog
+    document.addEventListener('live:confirmAction', (event) => {
         event.preventDefault();
 
-        // Pass your Promise to event.detail.promise
+        // Pass your custom Promise to event.detail.promise.
+        // Again, SweetAlert2 is just an example, any library works!
         event.detail.promise = Swal.fire({
-            title: event.detail.message,
+            title: event.detail.message, // "Are you sure?"
             icon: 'warning',
             showCancelButton: true
         }).then(result => result.isConfirmed);
     });
-
-**3. Using Native Inline Confirm**
-
-If you prefer the native browser confirm, you can simply use the ``onclick``
-attribute and return its result. If the user clicks cancel, the LiveComponent
-action will automatically be aborted:
-
-.. code-block:: html+twig
-
-    <button
-        data-action="live#action"
-        data-live-action-param="delete"
-        onclick="return confirm('Are you sure you want to delete this item?')"
-    >Delete</button>
 
 Actions and CSRF Protection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -1279,6 +1279,96 @@ the ``#[LiveArg]`` attribute::
         }
     }
 
+Confirming Actions
+~~~~~~~~~~~~~~~~~~
+
+If you want to ask the user for confirmation before executing a LiveComponent action,
+you have three ways to do it.
+
+**1. Using standard Turbo Confirm (If Turbo is installed)**
+
+If you are already using ``@hotwired/turbo`` and have configured a custom confirm method
+(like SweetAlert) via ``Turbo.config.forms.confirm`` or ``Turbo.setConfirmMethod``,
+LiveComponent will automatically respect it. Just add the ``data-turbo-confirm`` attribute:
+
+.. code-block:: html+twig
+
+    <button
+        data-action="live#action"
+        data-live-action-param="delete"
+        data-turbo-confirm="Are you sure you want to delete this item?"
+    >Delete</button>
+
+Here is an example of how you might configure Turbo with SweetAlert2 in your JavaScript
+(e.g., in ``app.js``). While this example uses SweetAlert2, you can seamlessly integrate
+any other library or your own custom UI design as long as it returns a Promise:
+
+.. code-block:: javascript
+
+    import * as Turbo from '@hotwired/turbo';
+    import Swal from 'sweetalert2';
+
+    // Turbo 7 usage:
+    // Turbo.setConfirmMethod((message, element) => { ... });
+
+    // Turbo 8 usage:
+    Turbo.config.forms.confirm = (message, element) => {
+        return Swal.fire({
+            title: message,
+            icon: 'warning',
+            showCancelButton: true
+        }).then(result => result.isConfirmed);
+    };
+
+**2. Using Custom Async Dialogs (Without Turbo)**
+
+If you are not using Turbo, or want to handle LiveComponent confirmations separately,
+use the ``data-live-confirm`` attribute:
+
+.. code-block:: html+twig
+
+    <button
+        data-action="live#action"
+        data-live-action-param="delete"
+        data-live-confirm="Are you sure you want to delete this item?"
+    >Delete</button>
+
+By default, this will trigger the browser's native ``window.confirm()``.
+However, you can intercept this to show your own asynchronous modal (like SweetAlert2,
+another library, or a completely custom UI design) by listening to the ``live:confirm``
+event in your JavaScript:
+
+.. code-block:: javascript
+
+    // app.js
+    import Swal from 'sweetalert2';
+
+    document.addEventListener('live:confirm', (event) => {
+        // Prevent the native browser confirm dialog
+        event.preventDefault();
+
+        // Pass your Promise to event.detail.promise
+        event.detail.promise = Swal.fire({
+            title: event.detail.message,
+            icon: 'warning',
+            showCancelButton: true
+        }).then(result => result.isConfirmed);
+    });
+
+**3. Using Native Inline Confirm**
+
+If you prefer the native browser confirm, you can simply use the ``onclick``
+attribute and return its result. If the user clicks cancel, the LiveComponent
+action will automatically be aborted:
+
+.. code-block:: html+twig
+
+    <button
+        data-action="live#action"
+        data-live-action-param="delete"
+        onclick="return confirm('Are you sure you want to delete this item?')"
+    >Delete</button>
+
 Actions and CSRF Protection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | #
| License        | MIT

**Preview** **(This preview is outdated and is not valid for the new system.)**
<img width="1438" height="486" alt="Animation" src="https://github.com/user-attachments/assets/2606cd0c-35ce-4e36-aadc-a3649793dbb7" />

### Description

This PR introduces a robust and flexible way to add confirmation dialogs to LiveComponent actions using the new `live#confirmAction` mechanism. 

Previously, trying to intercept the core `live#action` asynchronously caused issues with `event.currentTarget` nullification and disrupted the synchronous action queue. By separating this into its own `live#confirmAction`, we ensure a flawless integration that safely resolves the confirmation before safely triggering the original action logic.

**Key Features:**
1. **Zero-Config Native Fallback**: Out of the box, it falls back to the browser's native `window.confirm()`.
2. **Automatic Turbo Support**: If the project uses `@hotwired/turbo` and has a globally configured confirm method (`Turbo.config.forms.confirm` or `Turbo.navigator.confirmMethod`), it detects and uses it automatically! No extra code needed.
3. **Promise-based Custom Modals**: Developers can easily hook into the `live:confirmAction` event to integrate any UI library (SweetAlert2, Bootstrap Modals, etc.) simply by passing a Promise.
4. **Form Interception**: Fully supports the `:prevent` modifier to stop native `<form>` submissions until confirmed.

### Examples

**Basic Usage:**
```html
<button
    data-action="live#confirmAction"
    data-live-action-param="delete"
    data-live-confirm-message-param="Are you sure?"
>Delete</button>
```

**Intercepting a Form:**
```html
<form data-action="live#confirmAction:prevent"
      data-live-action-param="save"
      data-live-confirm-message-param="Save all changes?">
    <button type="submit">Save Settings</button>
</form>
```

**Custom Modal Integration (e.g. SweetAlert2):**

```javascript
document.addEventListener('live:confirmAction', (event) => {
    event.preventDefault();
    event.detail.promise = Swal.fire({
        title: event.detail.message,
        icon: 'warning',
        showCancelButton: true
    }).then(result => result.isConfirmed);
});
```

**Customizing the Confirmation Dialog with Turbo (Optional)**

```javascript
import * as Turbo from '@hotwired/turbo';
    import Swal from 'sweetalert2';

    // Turbo 7 usage:
    // Turbo.setConfirmMethod((message, element) => { ... });

    // Turbo 8 usage:
    Turbo.config.forms.confirm = (message, formElement, submitter) => {
        return Swal.fire({
            title: message,
            icon: 'warning',
            showCancelButton: true
        }).then(result => result.isConfirmed);
    };
```