### PR TITLE
[TwigComponent] Add #[ComponentCache] attribute for persistent computed properties

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.2.1
+
+- Add `#[ComponentCache]` attribute to persistently cache heavy computed properties via Symfony Cache
+
 ## 3.2.0
 
 - Add `ComponentRendererInterface::preCreateForRender()`, `ComponentRendererInterface::startEmbeddedComponentRender()`, and `ComponentRendererInterface::finishEmbeddedComponentRender()` methods

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1640,6 +1640,44 @@ are called additional times, the cached value is used.
     otherwise the method will be called twice instead of only once, leading to
     unnecessary overhead and potential performance issues.
 
+Persistent Component Caching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+While ``computed`` properties memoize results during a single request, you can
+use the ``#[ComponentCache]`` attribute to persistently cache heavy method calls
+(e.g., database queries) across multiple requests using Symfony Cache.::
+
+    use Symfony\UX\TwigComponent\Attribute\ComponentCache;
+    #[AsTwigComponent]
+    class DashboardStats
+    {
+        #[ComponentCache(expiresAfter: 3600, tags: ['stats'])]
+        public function getHeavyMetrics(): array
+        {
+            // executed only once per hour across all requests
+            return $this->heavyQuery();
+        }
+    }
+
+In your template, call it via the ``computed`` proxy as usual:
+
+.. code-block:: html+twig
+
+    {# templates/components/Dashboard.html.twig #}
+    <div>
+        {{ computed.heavyMetrics }}
+    </div>
+
+By default, an automatic cache key is generated. You can customize the behavior
+by passing ``key``, ``expiresAfter``, ``tags``, or the cache ``pool`` name to
+the attribute.
+
+.. warning::
+
+    Since Symfony Cache serializes the returned value, you **must not** return objects
+    that contain database connections or closures (e.g., Doctrine's ``EntityManager``,
+    ``QueryBuilder``, or complex pagination objects directly).
+    Always return raw data structures like ``array``, ``string``, or simple DTOs.
+
 Events
 ------
 

--- a/src/TwigComponent/src/Attribute/ComponentCache.php
+++ b/src/TwigComponent/src/Attribute/ComponentCache.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Attribute;
+
+/**
+ * Marks a method as being cached persistently across requests.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class ComponentCache
+{
+    /**
+     * @param string|null     $key          The cache key. If null, an automatic key will be generated.
+     * @param int|string|null $expiresAfter the TTL (time to live) in seconds or a DateInterval string
+     * @param array<string>   $tags         an array of cache tags (if using TagAwareCacheInterface)
+     * @param string|null     $pool         the cache pool service name to use
+     */
+    public function __construct(
+        public readonly ?string $key = null,
+        public readonly int|string|null $expiresAfter = null,
+        public readonly array $tags = [],
+        public readonly ?string $pool = null,
+    ) {
+    }
+}

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\TwigComponent;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\UX\TwigComponent\Event\PostRenderEvent;
@@ -33,6 +34,7 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
         private ComponentFactory $factory,
         private ComponentProperties $componentProperties,
         private ComponentStack $componentStack,
+        private ?ContainerInterface $container = null,
     ) {
     }
 
@@ -128,7 +130,7 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
             ...$event->getVariables(),
             // add the component as "this"
             'this' => $component,
-            'computed' => new ComputedPropertiesProxy($component),
+            'computed' => new ComputedPropertiesProxy($component, $this->container),
             'outerScope' => $context,
             // keep this line for BC break reasons
             '__props' => $classProps,

--- a/src/TwigComponent/src/ComputedPropertiesProxy.php
+++ b/src/TwigComponent/src/ComputedPropertiesProxy.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\UX\TwigComponent;
 
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\UX\TwigComponent\Attribute\ComponentCache;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -21,8 +25,10 @@ final class ComputedPropertiesProxy
     /**
      * @internal
      */
-    public function __construct(private object $component)
-    {
+    public function __construct(
+        private object $component,
+        private ?ContainerInterface $container = null,
+    ) {
     }
 
     public function __call(string $name, array $arguments): mixed
@@ -46,8 +52,44 @@ final class ComputedPropertiesProxy
             return $this->cache[$method];
         }
 
-        if (new \ReflectionMethod($this->component, $method)->getNumberOfRequiredParameters()) {
+        $reflectionMethod = new \ReflectionMethod($this->component, $method);
+
+        if ($reflectionMethod->getNumberOfRequiredParameters()) {
             throw new \LogicException('Cannot use computed methods for methods with required parameters.');
+        }
+
+        if ($attributes = $reflectionMethod->getAttributes(ComponentCache::class)) {
+            $attribute = $attributes[0]->newInstance();
+            $poolName = $attribute->pool ?? 'cache.app';
+
+            if ($this->container && $this->container->has($poolName)) {
+                $pool = $this->container->get($poolName);
+
+                if ($pool instanceof CacheItemPoolInterface) {
+                    // Generate an automatic key if none is provided
+                    $key = $attribute->key ?? \sprintf('%s_%s_%s', str_replace('\\', '_', $this->component::class), $method, md5(serialize(get_object_vars($this->component))));
+
+                    $item = $pool->getItem($key);
+                    if ($item->isHit()) {
+                        return $this->cache[$method] = $item->get();
+                    }
+
+                    $value = $this->component->$method();
+                    $item->set($value);
+
+                    if (null !== $attribute->expiresAfter) {
+                        $item->expiresAfter($attribute->expiresAfter instanceof \DateInterval ? $attribute->expiresAfter : (int) $attribute->expiresAfter);
+                    }
+
+                    if ($attribute->tags && method_exists($item, 'tag')) {
+                        $item->tag($attribute->tags);
+                    }
+
+                    $pool->save($item);
+
+                    return $this->cache[$method] = $value;
+                }
+            }
         }
 
         return $this->cache[$method] = $this->component->$method();

--- a/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
+++ b/src/TwigComponent/src/DependencyInjection/TwigComponentExtension.php
@@ -108,6 +108,7 @@ final class TwigComponentExtension extends Extension implements ConfigurationInt
                 new Reference('ux.twig_component.component_factory'),
                 new Reference('ux.twig_component.component_properties'),
                 new Reference('ux.twig_component.component_stack'),
+                new Reference('service_container'),
             ])
             ->addTag('kernel.reset', ['method' => 'reset'])
         ;

--- a/src/TwigComponent/tests/Unit/ComputedPropertiesProxyTest.php
+++ b/src/TwigComponent/tests/Unit/ComputedPropertiesProxyTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\TwigComponent\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\UX\TwigComponent\Attribute\ComponentCache;
 use Symfony\UX\TwigComponent\ComputedPropertiesProxy;
 
 /**
@@ -133,5 +134,41 @@ final class ComputedPropertiesProxyTest extends TestCase
         $this->expectException(\LogicException::class);
 
         $proxy->getValue();
+    }
+
+    public function testComponentCacheAttributeUsesSymfonyCache()
+    {
+        $container = new \Symfony\Component\DependencyInjection\Container();
+        $cache = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
+        $container->set('cache.app', $cache);
+
+        $component = new class {
+            public int $count = 0;
+
+            #[ComponentCache(key: 'my_test_key')]
+            public function getHeavyData(): int
+            {
+                return ++$this->count;
+            }
+        };
+
+        $proxy = new ComputedPropertiesProxy($component, $container);
+
+        // First call hits the real method, returns 1, caches it
+        $this->assertSame(1, $proxy->heavyData());
+
+        // Second call hits the proxy in-memory cache, returns 1
+        $this->assertSame(1, $proxy->heavyData());
+
+        // New proxy, representing a new request
+        $proxy2 = new ComputedPropertiesProxy($component, $container);
+
+        // Hits the symfony cache pool, returns 1, DOES NOT increment count
+        $this->assertSame(1, $proxy2->heavyData());
+
+        // Check cache item directly
+        $item = $cache->getItem('my_test_key');
+        $this->assertTrue($item->isHit());
+        $this->assertSame(1, $item->get());
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | #
| License        | MIT
### Description

This PR introduces the `#[ComponentCache]` attribute, which supercharges the existing `computed` properties system by adding **persistent cross-request caching** using Symfony Cache.

While the current `computed` proxy memoizes results during a single request, there was no native way to persistently cache heavy component methods (like complex database queries or API calls) without polluting the component with manual CachePool injections.

With this feature, developers can easily cache the return value of any component method across requests directly from the component class, while keeping the Twig syntax (`{{ computed.method }}`) exactly the same.

### Usage Example

```php
use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
use Symfony\UX\TwigComponent\Attribute\ComponentCache;

#[AsTwigComponent]
class DashboardStats
{
    // Caches the return value in the 'cache.app' pool for 1 hour.
    #[ComponentCache(expiresAfter: 3600, tags: ['dashboard_stats'])]
    public function getHeavyMetrics(): array
    {
        return $this->repository->calculateComplexMetrics();
    }
}
```

In the template, it is accessed seamlessly via the existing proxy:
```twig
{# The first visitor triggers the DB query. For the next hour, it's served from the persistent cache in 0ms. #}
Total Users: {{ computed.heavyMetrics.totalUsers }}
```

### Key Features
- **Auto-Key Generation:** If no `key` is provided, a unique cache key is automatically generated using the component's class name, method name, and a hash of its public properties (`get_object_vars()`). This ensures the cache invalidates safely when LiveComponent props (e.g., page, filters) change!
- **Dynamic Pool Support:** Supports injecting specific cache pools (e.g. `pool: 'cache.redis'`). Falls back to `cache.app` by default.
- **Tags & Expiration:** Supports `tags` (for TagAware adapters) and `expiresAfter` (seconds or `DateInterval`).
- **LiveComponent Compatible:** Works flawlessly inside `LiveComponent`s since it hooks directly into `ComputedPropertiesProxy`.