### PR TITLE
[Toolkit] Allow declaring kit-global dependencies in kit manifest

### DIFF
--- a/src/Toolkit/kits/flowbite-4/manifest.json
+++ b/src/Toolkit/kits/flowbite-4/manifest.json
@@ -3,5 +3,9 @@
     "name": "Flowbite v4",
     "description": "Component based on the Flowbite (v4) library, popular open-source library of interactive UI components built with the utility classes from Tailwind CSS.",
     "license": "MIT",
-    "homepage": "https://ux.symfony.com/toolkit/kits/flowbite"
+    "homepage": "https://ux.symfony.com/toolkit/kits/flowbite",
+    "dependencies": {
+        "npm": ["flowbite"],
+        "importmap": ["flowbite"]
+    }
 }

--- a/src/Toolkit/schema-kit-v1.json
+++ b/src/Toolkit/schema-kit-v1.json
@@ -21,6 +21,36 @@
             "type": "string",
             "format": "uri",
             "description": "The homepage URL for the kit, typically where users can find more information or documentation."
+        },
+        "dependencies": {
+            "description": "List of kit-global dependencies, available to every recipe of the kit (e.g. a library installed once during the kit setup).",
+            "type": "object",
+            "properties": {
+                "composer": {
+                    "description": "List of Composer package dependencies",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "A dependency on a Composer package, e.g., 'twig/extra-bundle' or 'twig/html-extra:^3.12.0'"
+                    }
+                },
+                "npm": {
+                    "description": "List of NPM package dependencies",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "A dependency on an NPM package, e.g., 'flowbite' or '@tailwindplus/elements@1'"
+                    }
+                },
+                "importmap": {
+                    "description": "List of Importmap package dependencies",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "A dependency on an Importmap package, e.g., 'flowbite' or 'bootstrap/dist/css/bootstrap.min.css'"
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Toolkit/src/Dependency/DependencyParser.php
+++ b/src/Toolkit/src/Dependency/DependencyParser.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Dependency;
+
+/**
+ * Parses the `dependencies` object of a Kit or Recipe manifest into typed dependencies.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class DependencyParser
+{
+    /**
+     * @param array<string, mixed>|null $dependencies The raw `dependencies` object, or null when absent
+     * @param bool                      $allowRecipe  Whether the `recipe` dependency type is allowed (Recipes only)
+     *
+     * @return list<DependencyInterface>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function parse(?array $dependencies, bool $allowRecipe): array
+    {
+        if (null === $dependencies) {
+            return [];
+        }
+
+        if ([] !== $dependencies && array_values($dependencies) === $dependencies) {
+            throw new \InvalidArgumentException('The "dependencies" property must be an object.');
+        }
+
+        $parsed = [];
+
+        if ($allowRecipe) {
+            foreach ($dependencies['recipe'] ?? [] as $i => $name) {
+                if (!\is_string($name) || '' === $name) {
+                    throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "recipe" must be a non-empty string.', $i));
+                }
+
+                $parsed[] = new RecipeDependency($name);
+            }
+            unset($dependencies['recipe']);
+        }
+
+        foreach ($dependencies['composer'] ?? [] as $i => $package) {
+            if (!\is_string($package) || '' === $package) {
+                throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "composer" must be a non-empty string.', $i));
+            }
+
+            // format: "package:version"
+            if (str_contains($package, ':')) {
+                [$name, $version] = explode(':', $package, 2);
+                $parsed[] = new PhpPackageDependency($name, new ConstraintVersion($version));
+            } else {
+                $parsed[] = new PhpPackageDependency($package);
+            }
+        }
+
+        foreach ($dependencies['npm'] ?? [] as $i => $package) {
+            if (!\is_string($package) || '' === $package) {
+                throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "npm" must be a non-empty string.', $i));
+            }
+
+            // format: "package@version", "@scope/package", "@scope/package@version"
+            $name = $package;
+            $version = null;
+            $versionPos = strrpos($package, '@');
+            if (false !== $versionPos && 0 !== $versionPos) {
+                $name = substr($package, 0, $versionPos);
+                $version = substr($package, $versionPos + 1);
+            }
+
+            if (null !== $version) {
+                $parsed[] = new NpmPackageDependency($name, new ConstraintVersion($version));
+            } else {
+                $parsed[] = new NpmPackageDependency($name);
+            }
+        }
+
+        foreach ($dependencies['importmap'] ?? [] as $i => $package) {
+            if (!\is_string($package) || '' === $package) {
+                throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "importmap" must be a non-empty string.', $i));
+            }
+
+            $parsed[] = new ImportmapPackageDependency($package);
+        }
+
+        unset($dependencies['composer'], $dependencies['npm'], $dependencies['importmap']);
+
+        if ([] !== $dependencies) {
+            throw new \InvalidArgumentException(\sprintf('The dependency types "%s" are not supported.', implode('", "', array_keys($dependencies))));
+        }
+
+        return $parsed;
+    }
+}

--- a/src/Toolkit/src/Kit/KitManifest.php
+++ b/src/Toolkit/src/Kit/KitManifest.php
@@ -12,18 +12,24 @@
 namespace Symfony\UX\Toolkit\Kit;
 
 use Symfony\UX\Toolkit\Assert;
+use Symfony\UX\Toolkit\Dependency\DependencyInterface;
+use Symfony\UX\Toolkit\Dependency\DependencyParser;
 
 /**
  * @author Hugo Alliaume <hugo@alliau.me>
  */
 final class KitManifest
 {
+    /**
+     * @param list<DependencyInterface> $dependencies Kit-global dependencies, available to every recipe
+     */
     public function __construct(
         public readonly string $name,
         public readonly string $description,
         public readonly string $license,
         public readonly string $homepage,
         public ?string $installAsMarkdown = null,
+        public readonly array $dependencies = [],
     ) {
         Assert::kitName($this->name);
 
@@ -44,7 +50,8 @@ final class KitManifest
             name: $data['name'] ?? throw new \InvalidArgumentException('Property "name" is required.'),
             description: $data['description'] ?? throw new \InvalidArgumentException('Property "description" is required.'),
             license: $data['license'] ?? throw new \InvalidArgumentException('Property "license" is required.'),
-            homepage: $data['homepage'] ?? throw new \InvalidArgumentException('Property "homepage" is required.')
+            homepage: $data['homepage'] ?? throw new \InvalidArgumentException('Property "homepage" is required.'),
+            dependencies: DependencyParser::parse($data['dependencies'] ?? null, allowRecipe: false),
         );
     }
 }

--- a/src/Toolkit/src/Kit/Lint/Checker/JsImportChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/JsImportChecker.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
 
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
+use Symfony\UX\Toolkit\Dependency\DependencyInterface;
 use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
 use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
 use Symfony\UX\Toolkit\Kit\Kit;
@@ -41,20 +42,16 @@ final class JsImportChecker implements KitCheckerInterface
 
     public function check(Kit $kit): iterable
     {
+        // Kit-global dependencies are available to every recipe (e.g. a library installed once during the kit setup).
+        $kitDeclared = $this->collectDeclaredNames($kit->manifest->dependencies);
+
         foreach ($kit->getRecipes() as $recipe) {
             $assetsDir = Path::join($recipe->absolutePath, 'assets');
             if (!is_dir($assetsDir)) {
                 continue;
             }
 
-            $declared = [];
-            foreach ($recipe->manifest->dependencies as $dependency) {
-                if ($dependency instanceof NpmPackageDependency) {
-                    $declared[] = $dependency->name;
-                } elseif ($dependency instanceof ImportmapPackageDependency) {
-                    $declared[] = $dependency->package;
-                }
-            }
+            $declared = [...$kitDeclared, ...$this->collectDeclaredNames($recipe->manifest->dependencies)];
 
             $finder = new Finder()->in($assetsDir)->files()->name(['*.js', '*.ts', '*.mjs']);
             foreach ($finder as $file) {
@@ -77,6 +74,25 @@ final class JsImportChecker implements KitCheckerInterface
                 }
             }
         }
+    }
+
+    /**
+     * @param iterable<DependencyInterface> $dependencies
+     *
+     * @return list<string>
+     */
+    private function collectDeclaredNames(iterable $dependencies): array
+    {
+        $declared = [];
+        foreach ($dependencies as $dependency) {
+            if ($dependency instanceof NpmPackageDependency) {
+                $declared[] = $dependency->name;
+            } elseif ($dependency instanceof ImportmapPackageDependency) {
+                $declared[] = $dependency->package;
+            }
+        }
+
+        return $declared;
     }
 
     /**

--- a/src/Toolkit/src/Recipe/RecipeManifest.php
+++ b/src/Toolkit/src/Recipe/RecipeManifest.php
@@ -12,12 +12,8 @@
 namespace Symfony\UX\Toolkit\Recipe;
 
 use Symfony\Component\Filesystem\Path;
-use Symfony\UX\Toolkit\Dependency\ConstraintVersion;
 use Symfony\UX\Toolkit\Dependency\DependencyInterface;
-use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
-use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
-use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
-use Symfony\UX\Toolkit\Dependency\RecipeDependency;
+use Symfony\UX\Toolkit\Dependency\DependencyParser;
 
 /**
  * @author Hugo Alliaume <hugo@alliau.me>
@@ -64,68 +60,7 @@ final class RecipeManifest
             throw new \InvalidArgumentException(\sprintf('The recipe type "%s" is not supported, valid types are "%s".', $data['type'], implode('", "', array_map(static fn (RecipeType $type) => $type->value, RecipeType::cases()))));
         }
 
-        $dependencies = [];
-        if (isset($data['dependencies'])) {
-            if (!\is_array($data['dependencies']) || array_values($data['dependencies']) === $data['dependencies']) {
-                throw new \InvalidArgumentException('The "dependencies" property must be an object.');
-            }
-
-            foreach ($data['dependencies']['recipe'] ?? [] as $i => $name) {
-                if (!\is_string($name) || '' === $name) {
-                    throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "recipe" must be a non-empty string.', $i));
-                }
-
-                $dependencies[] = new RecipeDependency($name);
-            }
-            foreach ($data['dependencies']['composer'] ?? [] as $i => $package) {
-                if (!\is_string($package) || '' === $package) {
-                    throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "composer" must be a non-empty string.', $i));
-                }
-
-                // format: "package:version"
-                if (str_contains($package, ':')) {
-                    [$name, $version] = explode(':', $package, 2);
-                    $dependencies[] = new PhpPackageDependency($name, new ConstraintVersion($version));
-                } else {
-                    $dependencies[] = new PhpPackageDependency($package);
-                }
-            }
-
-            foreach ($data['dependencies']['npm'] ?? [] as $i => $package) {
-                if (!\is_string($package) || '' === $package) {
-                    throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "npm" must be a non-empty string.', $i));
-                }
-
-                // format: "package@version", "@scope/package", "@scope/package@version"
-                $name = $package;
-                $version = null;
-                $versionPos = strrpos($package, '@');
-                if (false !== $versionPos && 0 !== $versionPos) {
-                    $name = substr($package, 0, $versionPos);
-                    $version = substr($package, $versionPos + 1);
-                }
-
-                if (null !== $version) {
-                    $dependencies[] = new NpmPackageDependency($name, new ConstraintVersion($version));
-                } else {
-                    $dependencies[] = new NpmPackageDependency($name);
-                }
-            }
-
-            foreach ($data['dependencies']['importmap'] ?? [] as $i => $package) {
-                if (!\is_string($package) || '' === $package) {
-                    throw new \InvalidArgumentException(\sprintf('The dependency #%d of type "importmap" must be a non-empty string.', $i));
-                }
-
-                $dependencies[] = new ImportmapPackageDependency($package);
-            }
-
-            unset($data['dependencies']['recipe'], $data['dependencies']['composer'], $data['dependencies']['npm'], $data['dependencies']['importmap']);
-
-            if ([] !== $data['dependencies'] ?? []) {
-                throw new \InvalidArgumentException(\sprintf('The dependency types "%s" are not supported.', implode('", "', array_keys($data['dependencies']))));
-            }
-        }
+        $dependencies = DependencyParser::parse($data['dependencies'] ?? null, allowRecipe: true);
 
         $versionAdded = $data['version-added'] ?? null;
         if (null !== $versionAdded && (!\is_string($versionAdded) || '' === $versionAdded)) {

--- a/src/Toolkit/tests/Dependency/DependencyParserTest.php
+++ b/src/Toolkit/tests/Dependency/DependencyParserTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Dependency;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Dependency\ConstraintVersion;
+use Symfony\UX\Toolkit\Dependency\DependencyParser;
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
+use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
+use Symfony\UX\Toolkit\Dependency\RecipeDependency;
+
+final class DependencyParserTest extends TestCase
+{
+    public function testParseNullReturnsEmptyList()
+    {
+        $this->assertSame([], DependencyParser::parse(null, allowRecipe: true));
+        $this->assertSame([], DependencyParser::parse(null, allowRecipe: false));
+    }
+
+    public function testParseTypedDependencies()
+    {
+        $dependencies = DependencyParser::parse([
+            'composer' => ['tales-from-a-dev/twig-tailwind-extra:^1.0.0'],
+            'npm' => ['tailwindcss@^4.0.0', '@tailwindplus/elements'],
+            'importmap' => ['flowbite'],
+        ], allowRecipe: false);
+
+        $this->assertEquals([
+            new PhpPackageDependency('tales-from-a-dev/twig-tailwind-extra', new ConstraintVersion('^1.0.0')),
+            new NpmPackageDependency('tailwindcss', new ConstraintVersion('^4.0.0')),
+            new NpmPackageDependency('@tailwindplus/elements'),
+            new ImportmapPackageDependency('flowbite'),
+        ], $dependencies);
+    }
+
+    public function testParseRecipeWhenAllowed()
+    {
+        $dependencies = DependencyParser::parse(['recipe' => ['Button']], allowRecipe: true);
+
+        $this->assertEquals([new RecipeDependency('Button')], $dependencies);
+    }
+
+    public function testParseRecipeWhenNotAllowedThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The dependency types "recipe" are not supported.');
+
+        DependencyParser::parse(['recipe' => ['Button']], allowRecipe: false);
+    }
+
+    public function testParseRejectsNonObject()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "dependencies" property must be an object.');
+
+        DependencyParser::parse(['foo'], allowRecipe: true);
+    }
+
+    public function testParseRejectsUnsupportedType()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The dependency types "unknown" are not supported.');
+
+        DependencyParser::parse(['unknown' => ['foo']], allowRecipe: true);
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/kit-level-declared/assets/controllers/kit_level_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/kit-level-declared/assets/controllers/kit_level_controller.js
@@ -1,0 +1,3 @@
+import { Dismiss } from 'flowbite';
+
+export default Dismiss;

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/kit-level-declared/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/kit-level-declared/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "KitLevelDeclared",
+    "description": "flowbite declared at kit level + imported -> no warning.",
+    "copy-files": {"assets/": "assets/"}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-js-import/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-js-import/manifest.json
@@ -3,5 +3,8 @@
     "name": "Lint JS Import",
     "description": "Kit covering JsImportChecker scenarios (one recipe per case).",
     "license": "MIT",
-    "homepage": "https://example.com/lint-js-import"
+    "homepage": "https://example.com/lint-js-import",
+    "dependencies": {
+        "npm": ["flowbite"]
+    }
 }

--- a/src/Toolkit/tests/Kit/KitManifestTest.php
+++ b/src/Toolkit/tests/Kit/KitManifestTest.php
@@ -12,6 +12,9 @@
 namespace Symfony\UX\Toolkit\Tests\Kit;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
+use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
+use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 use Symfony\UX\Toolkit\Kit\KitManifest;
 
 final class KitManifestTest extends TestCase
@@ -101,5 +104,46 @@ final class KitManifestTest extends TestCase
         $this->assertSame('A kit', $manifest->description);
         $this->assertSame('MIT', $manifest->license);
         $this->assertSame('https://example.com', $manifest->homepage);
+        $this->assertSame([], $manifest->dependencies);
+    }
+
+    public function testFromJsonWithDependencies()
+    {
+        $manifest = KitManifest::fromJson(<<<JSON
+                {
+                    "name": "kit",
+                    "description": "A kit",
+                    "license": "MIT",
+                    "homepage": "https://example.com",
+                    "dependencies": {
+                        "composer": ["twig/extra-bundle"],
+                        "npm": ["flowbite"],
+                        "importmap": ["flowbite"]
+                    }
+                }
+            JSON);
+
+        $this->assertCount(3, $manifest->dependencies);
+        $this->assertInstanceOf(PhpPackageDependency::class, $manifest->dependencies[0]);
+        $this->assertInstanceOf(NpmPackageDependency::class, $manifest->dependencies[1]);
+        $this->assertInstanceOf(ImportmapPackageDependency::class, $manifest->dependencies[2]);
+    }
+
+    public function testFromJsonRejectsRecipeDependency()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The dependency types "recipe" are not supported.');
+
+        KitManifest::fromJson(<<<JSON
+                {
+                    "name": "kit",
+                    "description": "A kit",
+                    "license": "MIT",
+                    "homepage": "https://example.com",
+                    "dependencies": {
+                        "recipe": ["Button"]
+                    }
+                }
+            JSON);
     }
 }

--- a/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
+++ b/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
@@ -220,6 +220,7 @@ class KitLinterTest extends TestCase
         // recipe slug => [expected category | null, expected package in message | null]
         yield 'npm declared' => ['npm-declared', null, null];
         yield 'importmap declared' => ['importmap-declared', null, null];
+        yield 'kit-level dependency declared' => ['kit-level-declared', null, null];
         yield 'undeclared static import' => ['undeclared', 'js.import.undeclared', 'lodash'];
         yield 'relative paths ignored' => ['relative-ignored', null, null];
         yield 'implicit @hotwired/stimulus' => ['implicit-stimulus', null, null];


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

The `JsImportChecker` only matched JS imports against per-recipe npm/importmap
dependencies, so kit-global libraries (e.g. flowbite, installed once via the
kit's ` INSTALL.md) were reported as `js.import.undeclared` on every recipe.

Add a `dependencies` object (composer/npm/importmap) to the kit manifest and
have JsImportChecker treat kit-level npm/importmap packages as available for
all recipes. Extract the shared parsing into DependencyParser.
