### PR TITLE
[Encore] Pin vue to <3.5.36 to workaround broken upstream publish

### DIFF
--- a/apps/encore/package.json
+++ b/apps/encore/package.json
@@ -30,7 +30,7 @@
         "react-dom": "^18.0",
         "regenerator-runtime": "^0.13.9",
         "tom-select": "^2.2.2",
-        "vue": "^3.0",
+        "vue": "^3.0 <3.5.36",
         "vue-loader": "^17.0.0",
         "webpack": "^5.74.0",
         "webpack-cli": "^5.1.0"


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

vue@3.5.36 shipped ~1h ago, ships with `workspace:*` in constrain version, making our Encore (based on npm) jobs fail.

To revert when https://github.com/vuejs/core/issues/14952 is fixed
