### PR TITLE
 Revert "[Encore] Pin vue to <3.5.36 to workaround broken upstream publish"

### DIFF
--- a/apps/encore/package.json
+++ b/apps/encore/package.json
@@ -30,7 +30,7 @@
         "react-dom": "^18.0",
         "regenerator-runtime": "^0.13.9",
         "tom-select": "^2.2.2",
-        "vue": "^3.0 <3.5.36",
+        "vue": "^3.0",
         "vue-loader": "^17.0.0",
         "webpack": "^5.74.0",
         "webpack-cli": "^5.1.0"


### PR DESCRIPTION
Reverts symfony/ux#3673, https://github.com/vuejs/core/issues/14952#issuecomment-4677482782 should have fixed the issue.