### PR TITLE
[LiveComponent] Avoid 500 errors on malformed hydration payloads

### DIFF
--- a/src/LiveComponent/src/LiveComponentHydrator.php
+++ b/src/LiveComponent/src/LiveComponentHydrator.php
@@ -619,6 +619,10 @@ final class LiveComponentHydrator
                 return null;
             }
 
+            if (!\is_int($value) && !\is_string($value)) {
+                throw new HydrationException(\sprintf('Invalid value sent for enum "%s".', $className));
+            }
+
             return $className::tryFrom($value);
         }
 
@@ -657,8 +661,11 @@ final class LiveComponentHydrator
 
         if (\is_array($value)) {
             $object = new $className();
+            $reflectionClass = new \ReflectionClass($className);
             foreach ($value as $propertyName => $propertyValue) {
-                $reflectionClass = new \ReflectionClass($className);
+                if (!\is_string($propertyName) || !$reflectionClass->hasProperty($propertyName)) {
+                    throw new HydrationException(\sprintf('The property "%s" does not exist on the object "%s".', $propertyName, $className));
+                }
                 $property = $reflectionClass->getProperty($propertyName);
                 $propMetadata = $this->liveComponentMetadataFactory->createLivePropMetadata($className, $propertyName, $property, new LiveProp());
                 $this->propertyAccessor->setValue($object, $propertyName, $this->hydrateValue($propertyValue, $propMetadata, $component));

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -863,6 +863,21 @@ final class LiveComponentHydratorTest extends KernelTestCase
             ;
         }];
 
+        yield 'Enum: a non-scalar updated value is ignored gracefully (not a 500)' => [static function () {
+            return HydrationTest::create(new class {
+                #[LiveProp(writable: true)]
+                public IntEnum $int = IntEnum::HIGH;
+            })
+                ->mountWith(['int' => IntEnum::HIGH])
+                // a tampered payload sending an array instead of a scalar used to trigger
+                // a TypeError (500) in BackedEnum::tryFrom() instead of being ignored
+                ->userUpdatesProps(['int' => ['not-a-scalar']])
+                ->assertObjectAfterHydration(static function (object $object) {
+                    self::assertSame(IntEnum::HIGH, $object->int);
+                })
+            ;
+        }];
+
         yield 'Enum: null-like enum values are handled correctly' => [static function () {
             return HydrationTest::create(new class {
                 #[LiveProp(writable: true)]
@@ -930,6 +945,29 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 ->assertObjectAfterHydration(static function (object $object) {
                     self::assertSame($object->address->address, '4 rue des lilas');
                     self::assertSame($object->address->city, 'Asnieres');
+                })
+            ;
+        }];
+
+        yield 'Object: an unknown property in an updated object is ignored gracefully (not a 500)' => [static function () {
+            return HydrationTest::create(new class {
+                #[LiveProp(writable: true)]
+                public ?Address $address = null;
+
+                public function mount()
+                {
+                    $this->address = new Address();
+                    $this->address->address = '1 rue du Bac';
+                    $this->address->city = 'Paris';
+                }
+            })
+                ->mountWith([])
+                // a tampered payload sending an unknown property used to trigger a
+                // ReflectionException (500) instead of being ignored
+                ->userUpdatesProps(['address' => ['address' => '4 rue des lilas', 'unknownProperty' => 'x']])
+                ->assertObjectAfterHydration(static function (object $object) {
+                    self::assertSame('1 rue du Bac', $object->address->address);
+                    self::assertSame('Paris', $object->address->city);
                 })
             ;
         }];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | -
| License       | MIT

Hydrating a LiveComponent from a tampered `updated` payload could raise an uncaught native exception and surface as a 500 instead of being ignored:

- an array sent for a writable backed-enum prop → `TypeError` in `BackedEnum::tryFrom()`
- an unknown property sent for a writable object prop → `ReflectionException`

These are only reachable by manually crafting the payload (a regular user never hits them). Each case is now turned into a `HydrationException`, so the malformed writable value is ignored like any other bad data and the original value is kept.

Discussed with @Kocal.