### PR TITLE
[CalendarLink] Fix rendering issue

### DIFF
--- a/src/CalendarLink/doc/index.rst
+++ b/src/CalendarLink/doc/index.rst
@@ -76,8 +76,8 @@ start / end               yes         yes        yes           yes
 description               yes         yes        yes           yes
 location                  yes         yes        yes           yes
 all-day                   yes         yes        yes           yes
-reminders (VALARM)        -           -          -             yes
-recurrence (RRULE)        yes         -          -             yes
+reminders (VALARM)        ``-``       ``-``      ``-``         yes
+recurrence (RRULE)        yes         ``-``      ``-``         yes
 ========================= =========== ========== ============= =========
 
 Fields marked ``-`` are silently ignored when generating a link for that


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | 
| License        | MIT

In documentation, - in rendered as a list item :

<img width="1618" height="1038" alt="image" src="https://github.com/user-attachments/assets/1631e773-bb61-460b-b0e1-a470b362e631" />

Minor fix to wrap it as code for rendering
