### PR TITLE
[Cropperjs] Upgrade to Intervention Image v4 and make the image driver configurable

### DIFF
--- a/src/Cropperjs/CHANGELOG.md
+++ b/src/Cropperjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 3.3
+
+- Upgrade the `intervention/image` dependency to `^4.0` (drops support for v2,
+  which fixes the indirect deprecations triggered by v2).
+- Add a configurable image driver: the new `cropperjs.driver` option accepts
+  `gd` (default), `imagick` or `vips`. A custom driver service can be provided
+  through the `cropperjs.driver_service` option.
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/Cropperjs/CHANGELOG.md
+++ b/src/Cropperjs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 3.5.0
+
+- Add support for `intervention/image` 3 and 4, which fixes the deprecations triggered by version 2. Version 2 keeps working and stays the lowest supported version
+- Add a configurable image driver through the new `cropperjs.driver` option, accepting `gd` (default), `imagick` or `vips`. A custom driver service can be given through `cropperjs.driver_service`. Both require `intervention/image` 3 or higher
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": ">=8.4",
-        "intervention/image": "^2.5",
+        "intervention/image": "^4.0",
         "symfony/config": "^7.4|^8.0",
         "symfony/dependency-injection": "^7.4|^8.0",
         "symfony/deprecation-contracts": "^2.5|^3",
@@ -48,6 +48,9 @@
     },
     "conflict": {
         "symfony/flex": "<1.13"
+    },
+    "suggest": {
+        "intervention/image-driver-vips": "To use the 'vips' cropping driver (also requires the libvips system library and the ext-ffi PHP extension)"
     },
     "extra": {
         "thanks": {

--- a/src/Cropperjs/composer.json
+++ b/src/Cropperjs/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": ">=8.4",
-        "intervention/image": "^2.5",
+        "intervention/image": "^2.5|^3.0|^4.0",
         "symfony/config": "^7.4|^8.0",
         "symfony/dependency-injection": "^7.4|^8.0",
         "symfony/deprecation-contracts": "^2.5|^3",

--- a/src/Cropperjs/doc/index.rst
+++ b/src/Cropperjs/doc/index.rst
@@ -30,6 +30,43 @@ needed if you're using AssetMapper):
 
     For more complex installation scenarios, you can install the JavaScript assets through the `@symfony/ux-cropperjs npm package`_
 
+Configuring the Image Driver
+----------------------------
+
+The server-side cropping (``Crop::getCroppedImage()`` and
+``Crop::getCroppedThumbnail()``) is powered by `Intervention Image`_. By
+default it uses the ``gd`` driver. You can switch to ``imagick`` or ``vips``
+through the bundle configuration:
+
+.. code-block:: yaml
+
+    # config/packages/cropperjs.yaml
+    cropperjs:
+        driver: gd # "gd" (default), "imagick" or "vips"
+
+The ``gd`` and ``imagick`` drivers ship with ``intervention/image`` (make sure
+the matching ``ext-gd`` or ``ext-imagick`` PHP extension is enabled). The
+``vips`` driver additionally requires the ``intervention/image-driver-vips``
+package, the libvips system library and the ``ext-ffi`` PHP extension:
+
+.. code-block:: terminal
+
+    $ composer require intervention/image-driver-vips
+
+Using a custom driver
+~~~~~~~~~~~~~~~~~~~~~
+
+If you need full control over the Intervention Image driver, register your own
+service implementing ``Intervention\Image\Interfaces\DriverInterface`` and
+reference it with the ``driver_service`` option. When set, it takes precedence
+over ``driver``:
+
+.. code-block:: yaml
+
+    # config/packages/cropperjs.yaml
+    cropperjs:
+        driver_service: App\Image\MyCustomDriver
+
 Usage
 -----
 
@@ -150,6 +187,7 @@ the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
 .. _`Cropper.js`: https://fengyuanchen.github.io/cropperjs/
+.. _`Intervention Image`: https://image.intervention.io/
 .. _`the Symfony UX initiative`: https://ux.symfony.com/
 .. _`the Cropper.js options`: https://github.com/fengyuanchen/cropperjs/blob/main/README.md#options
 .. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/Cropperjs/doc/index.rst
+++ b/src/Cropperjs/doc/index.rst
@@ -30,6 +30,56 @@ needed if you're using AssetMapper):
 
     For more complex installation scenarios, you can install the JavaScript assets through the `@symfony/ux-cropperjs npm package`_
 
+Configuring the Image Driver
+----------------------------
+
+The server-side cropping (``Crop::getCroppedImage()`` and
+``Crop::getCroppedThumbnail()``) is powered by `Intervention Image`_. By
+default it uses the ``gd`` driver. You can switch to ``imagick`` or ``vips``
+through the bundle configuration:
+
+.. code-block:: yaml
+
+    # config/packages/cropperjs.yaml
+    cropperjs:
+        driver: gd # "gd" (default), "imagick" or "vips"
+
+The ``gd`` and ``imagick`` drivers ship with ``intervention/image`` (make sure
+the matching ``ext-gd`` or ``ext-imagick`` PHP extension is enabled). The
+``vips`` driver additionally requires the ``intervention/image-driver-vips``
+package, the libvips system library and the ``ext-ffi`` PHP extension:
+
+.. code-block:: terminal
+
+    $ composer require intervention/image-driver-vips
+
+.. note::
+
+    The bundle supports ``intervention/image`` versions 2, 3 and 4. The
+    ``driver`` option requires version 3 or higher: on version 2, only
+    ``gd`` and ``imagick`` are available, and ``vips`` is rejected.
+    Upgrading to version 4 is recommended, as version 2 triggers PHP
+    deprecations.
+
+Using a custom driver
+~~~~~~~~~~~~~~~~~~~~~
+
+If you need full control over the Intervention Image driver, register your own
+service implementing ``Intervention\Image\Interfaces\DriverInterface`` and
+reference it with the ``driver_service`` option. When set, it takes precedence
+over ``driver``:
+
+.. code-block:: yaml
+
+    # config/packages/cropperjs.yaml
+    cropperjs:
+        driver_service: App\Image\MyCustomDriver
+
+.. note::
+
+    The ``driver_service`` option requires ``intervention/image``
+    version 3 or higher, as version 2 has no ``DriverInterface``.
+
 Usage
 -----
 
@@ -150,6 +200,7 @@ the Symfony framework:
 https://symfony.com/doc/current/contributing/code/bc.html
 
 .. _`Cropper.js`: https://fengyuanchen.github.io/cropperjs/
+.. _`Intervention Image`: https://image.intervention.io/
 .. _`the Symfony UX initiative`: https://ux.symfony.com/
 .. _`the Cropper.js options`: https://github.com/fengyuanchen/cropperjs/blob/main/README.md#options
 .. _StimulusBundle configured in your app: https://symfony.com/bundles/StimulusBundle/current/index.html

--- a/src/Cropperjs/src/DependencyInjection/Configuration.php
+++ b/src/Cropperjs/src/DependencyInjection/Configuration.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Cropperjs\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @internal
+ */
+final class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('cropperjs');
+
+        $treeBuilder->getRootNode()
+            ->children()
+                ->enumNode('driver')
+                    ->info('The Intervention Image driver used for server-side cropping.')
+                    ->values(['gd', 'imagick', 'vips'])
+                    ->defaultValue('gd')
+                ->end()
+                ->scalarNode('driver_service')
+                    ->info('Service id of a custom Intervention\Image\Interfaces\DriverInterface. When set, it takes precedence over "driver".')
+                    ->defaultNull()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/Cropperjs/src/DependencyInjection/CropperjsExtension.php
+++ b/src/Cropperjs/src/DependencyInjection/CropperjsExtension.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\UX\Cropperjs\DependencyInjection;
 
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Drivers\Vips\Driver as VipsDriver;
 use Intervention\Image\ImageManager;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -31,6 +34,8 @@ class CropperjsExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
         $container
             ->setDefinition('form.cropper', new Definition(CropperType::class))
             ->addTag('form.type')
@@ -39,6 +44,8 @@ class CropperjsExtension extends Extension implements PrependExtensionInterface
 
         $container
             ->setDefinition('cropper.image_manager', new Definition(ImageManager::class))
+            ->setFactory([ImageManager::class, 'usingDriver'])
+            ->setArguments([$this->resolveDriver($config)])
             ->setPublic(false)
         ;
 
@@ -49,6 +56,26 @@ class CropperjsExtension extends Extension implements PrependExtensionInterface
         ;
 
         $container->setAlias(CropperInterface::class, 'cropper')->setPublic(false);
+    }
+
+    /**
+     * @param array{driver: string, driver_service: string|null} $config
+     */
+    private function resolveDriver(array $config): Reference|string
+    {
+        if (null !== $config['driver_service']) {
+            return new Reference($config['driver_service']);
+        }
+
+        if ('vips' === $config['driver'] && !class_exists(VipsDriver::class)) {
+            throw new \LogicException('The "vips" cropperjs driver requires the "intervention/image-driver-vips" package. Try running "composer require intervention/image-driver-vips".');
+        }
+
+        return match ($config['driver']) {
+            'gd' => GdDriver::class,
+            'imagick' => ImagickDriver::class,
+            'vips' => VipsDriver::class,
+        };
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/src/Cropperjs/src/DependencyInjection/CropperjsExtension.php
+++ b/src/Cropperjs/src/DependencyInjection/CropperjsExtension.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\UX\Cropperjs\DependencyInjection;
 
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Drivers\Vips\Driver as VipsDriver;
 use Intervention\Image\ImageManager;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -21,6 +24,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\UX\Cropperjs\Factory\Cropper;
 use Symfony\UX\Cropperjs\Factory\CropperInterface;
 use Symfony\UX\Cropperjs\Form\CropperType;
+use Symfony\UX\Cropperjs\Intervention\InterventionImage;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
@@ -31,6 +35,8 @@ class CropperjsExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
         $container
             ->setDefinition('form.cropper', new Definition(CropperType::class))
             ->addTag('form.type')
@@ -38,7 +44,7 @@ class CropperjsExtension extends Extension implements PrependExtensionInterface
         ;
 
         $container
-            ->setDefinition('cropper.image_manager', new Definition(ImageManager::class))
+            ->setDefinition('cropper.image_manager', $this->createImageManagerDefinition($config))
             ->setPublic(false)
         ;
 
@@ -49,6 +55,51 @@ class CropperjsExtension extends Extension implements PrependExtensionInterface
         ;
 
         $container->setAlias(CropperInterface::class, 'cropper')->setPublic(false);
+    }
+
+    /**
+     * @param array{driver: string, driver_service: string|null} $config
+     */
+    private function createImageManagerDefinition(array $config): Definition
+    {
+        $definition = new Definition(ImageManager::class);
+
+        if (InterventionImage::V2 === InterventionImage::major()) {
+            if (null !== $config['driver_service']) {
+                throw new \LogicException('The "cropperjs.driver_service" option requires "intervention/image" 3.0 or higher. Try running "composer require intervention/image:^4.0".');
+            }
+
+            if ('vips' === $config['driver']) {
+                throw new \LogicException('The "vips" cropperjs driver requires "intervention/image" 3.0 or higher. Try running "composer require intervention/image:^4.0".');
+            }
+
+            return $definition->setArguments([['driver' => $config['driver']]]);
+        }
+
+        return $definition
+            ->setFactory([ImageManager::class, InterventionImage::V4 === InterventionImage::major() ? 'usingDriver' : 'withDriver'])
+            ->setArguments([$this->resolveDriver($config)])
+        ;
+    }
+
+    /**
+     * @param array{driver: string, driver_service: string|null} $config
+     */
+    private function resolveDriver(array $config): Reference|string
+    {
+        if (null !== $config['driver_service']) {
+            return new Reference($config['driver_service']);
+        }
+
+        if ('vips' === $config['driver'] && !class_exists(VipsDriver::class)) {
+            throw new \LogicException('The "vips" cropperjs driver requires the "intervention/image-driver-vips" package. Try running "composer require intervention/image-driver-vips".');
+        }
+
+        return match ($config['driver']) {
+            'gd' => GdDriver::class,
+            'imagick' => ImagickDriver::class,
+            'vips' => VipsDriver::class,
+        };
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/src/Cropperjs/src/Factory/Cropper.php
+++ b/src/Cropperjs/src/Factory/Cropper.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\UX\Cropperjs\Factory;
 
-use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\ImageManagerInterface;
 use Symfony\UX\Cropperjs\Model\Crop;
 
 /**
@@ -21,9 +21,9 @@ use Symfony\UX\Cropperjs\Model\Crop;
  */
 class Cropper implements CropperInterface
 {
-    private $imageManager;
+    private ImageManagerInterface $imageManager;
 
-    public function __construct(ImageManager $imageManager)
+    public function __construct(ImageManagerInterface $imageManager)
     {
         $this->imageManager = $imageManager;
     }

--- a/src/Cropperjs/src/Factory/Cropper.php
+++ b/src/Cropperjs/src/Factory/Cropper.php
@@ -21,7 +21,7 @@ use Symfony\UX\Cropperjs\Model\Crop;
  */
 class Cropper implements CropperInterface
 {
-    private $imageManager;
+    private ImageManager $imageManager;
 
     public function __construct(ImageManager $imageManager)
     {

--- a/src/Cropperjs/src/Intervention/InterventionImage.php
+++ b/src/Cropperjs/src/Intervention/InterventionImage.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Cropperjs\Intervention;
+
+use Intervention\Image\ImageManager;
+
+/**
+ * Tells which major of intervention/image is installed.
+ *
+ * The three majors this bundle supports differ in the manager factory, the
+ * decoding method, the downscaling method, the rotation direction and the
+ * encoding method, so callers branch on the result of {@see self::major()}.
+ *
+ * @author Thomas <thomas@sctr.net>
+ *
+ * @internal
+ */
+final class InterventionImage
+{
+    public const V2 = 2;
+    public const V3 = 3;
+    public const V4 = 4;
+
+    private static ?int $major = null;
+
+    public static function major(): int
+    {
+        return self::$major ??= match (true) {
+            method_exists(ImageManager::class, 'usingDriver') => self::V4,
+            method_exists(ImageManager::class, 'withDriver') => self::V3,
+            default => self::V2,
+        };
+    }
+
+    /**
+     * Drivers are passed as class names from v3 onwards, and as plain names in v2.
+     */
+    public static function supportsDriverClasses(): bool
+    {
+        return self::V2 !== self::major();
+    }
+}

--- a/src/Cropperjs/src/Model/Crop.php
+++ b/src/Cropperjs/src/Model/Crop.php
@@ -61,7 +61,7 @@ class Crop
         $image->scaleDown($maxWidth, $maxHeight);
 
         if (!empty($this->options['rotate'])) {
-            $image->rotate(-1 * $this->options['rotate'], 'ffffff');
+            $image->rotate($this->options['rotate'], 'ffffff');
         }
 
         return (string) $image->encodeUsingFileExtension($format, quality: $quality);
@@ -77,7 +77,7 @@ class Crop
         }
 
         if (!empty($this->options['rotate'])) {
-            $image->rotate(-1 * $this->options['rotate'], 'ffffff');
+            $image->rotate($this->options['rotate'], 'ffffff');
         }
 
         return (string) $image->encodeUsingFileExtension($format, quality: $quality);

--- a/src/Cropperjs/src/Model/Crop.php
+++ b/src/Cropperjs/src/Model/Crop.php
@@ -61,7 +61,7 @@ class Crop
         $image->scaleDown($maxWidth, $maxHeight);
 
         if (!empty($this->options['rotate'])) {
-            $image->rotate($this->options['rotate'], 'ffffff');
+            $image->rotate($this->options['rotate']);
         }
 
         return (string) $image->encodeUsingFileExtension($format, quality: $quality);
@@ -77,7 +77,7 @@ class Crop
         }
 
         if (!empty($this->options['rotate'])) {
-            $image->rotate($this->options['rotate'], 'ffffff');
+            $image->rotate($this->options['rotate']);
         }
 
         return (string) $image->encodeUsingFileExtension($format, quality: $quality);

--- a/src/Cropperjs/src/Model/Crop.php
+++ b/src/Cropperjs/src/Model/Crop.php
@@ -11,9 +11,8 @@
 
 namespace Symfony\UX\Cropperjs\Model;
 
-use Intervention\Image\Constraint;
-use Intervention\Image\Image;
-use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Interfaces\ImageManagerInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -23,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Crop
 {
-    private $imageManager;
+    private ImageManagerInterface $imageManager;
     private $filename;
 
     /**
@@ -49,7 +48,7 @@ class Crop
         'rotate' => 0,
     ];
 
-    public function __construct(ImageManager $imageManager, string $filename)
+    public function __construct(ImageManagerInterface $imageManager, string $filename)
     {
         $this->imageManager = $imageManager;
         $this->filename = $filename;
@@ -59,18 +58,13 @@ class Crop
     {
         $image = $this->createCroppedImage();
 
-        $image->resize($maxWidth, $maxHeight, static function ($constraint) {
-            $constraint->aspectRatio();
-            $constraint->upsize();
-        });
+        $image->scaleDown($maxWidth, $maxHeight);
 
         if (!empty($this->options['rotate'])) {
-            $image->rotate(-1 * $this->options['rotate']);
+            $image->rotate(-1 * $this->options['rotate'], 'ffffff');
         }
 
-        $image->encode($format, $quality);
-
-        return $image->getEncoded();
+        return (string) $image->encodeUsingFileExtension($format, quality: $quality);
     }
 
     public function getCroppedImage(string $format = 'jpg', int $quality = 80): string
@@ -79,24 +73,19 @@ class Crop
 
         // Max size
         if ($this->maxWidth && $this->maxHeight) {
-            $image->resize($this->maxWidth, $this->maxHeight, static function (Constraint $constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            });
+            $image->scaleDown($this->maxWidth, $this->maxHeight);
         }
 
         if (!empty($this->options['rotate'])) {
-            $image->rotate(-1 * $this->options['rotate']);
+            $image->rotate(-1 * $this->options['rotate'], 'ffffff');
         }
 
-        $image->encode($format, $quality);
-
-        return $image->getEncoded();
+        return (string) $image->encodeUsingFileExtension($format, quality: $quality);
     }
 
-    private function createCroppedImage(): Image
+    private function createCroppedImage(): ImageInterface
     {
-        $image = $this->imageManager->make(file_get_contents($this->filename));
+        $image = $this->imageManager->decodeBinary(file_get_contents($this->filename));
 
         // Crop
         if ($this->options['width'] && $this->options['height']) {

--- a/src/Cropperjs/src/Model/Crop.php
+++ b/src/Cropperjs/src/Model/Crop.php
@@ -11,10 +11,9 @@
 
 namespace Symfony\UX\Cropperjs\Model;
 
-use Intervention\Image\Constraint;
-use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\UX\Cropperjs\Intervention\InterventionImage;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
@@ -23,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Crop
 {
-    private $imageManager;
+    private ImageManager $imageManager;
     private $filename;
 
     /**
@@ -59,18 +58,10 @@ class Crop
     {
         $image = $this->createCroppedImage();
 
-        $image->resize($maxWidth, $maxHeight, static function ($constraint) {
-            $constraint->aspectRatio();
-            $constraint->upsize();
-        });
+        $this->scaleDown($image, $maxWidth, $maxHeight);
+        $this->rotate($image);
 
-        if (!empty($this->options['rotate'])) {
-            $image->rotate(-1 * $this->options['rotate']);
-        }
-
-        $image->encode($format, $quality);
-
-        return $image->getEncoded();
+        return $this->encode($image, $format, $quality);
     }
 
     public function getCroppedImage(string $format = 'jpg', int $quality = 80): string
@@ -79,24 +70,26 @@ class Crop
 
         // Max size
         if ($this->maxWidth && $this->maxHeight) {
-            $image->resize($this->maxWidth, $this->maxHeight, static function (Constraint $constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            });
+            $this->scaleDown($image, $this->maxWidth, $this->maxHeight);
         }
 
-        if (!empty($this->options['rotate'])) {
-            $image->rotate(-1 * $this->options['rotate']);
-        }
+        $this->rotate($image);
 
-        $image->encode($format, $quality);
-
-        return $image->getEncoded();
+        return $this->encode($image, $format, $quality);
     }
 
-    private function createCroppedImage(): Image
+    /**
+     * @return \Intervention\Image\Image|\Intervention\Image\Interfaces\ImageInterface
+     */
+    private function createCroppedImage(): object
     {
-        $image = $this->imageManager->make(file_get_contents($this->filename));
+        $binary = file_get_contents($this->filename);
+
+        $image = match (InterventionImage::major()) {
+            InterventionImage::V4 => $this->imageManager->decodeBinary($binary),
+            InterventionImage::V3 => $this->imageManager->read($binary),
+            default => $this->imageManager->make($binary),
+        };
 
         // Crop
         if ($this->options['width'] && $this->options['height']) {
@@ -109,6 +102,44 @@ class Crop
         }
 
         return $image;
+    }
+
+    private function scaleDown(object $image, int $maxWidth, int $maxHeight): void
+    {
+        if (InterventionImage::V2 === InterventionImage::major()) {
+            $image->resize($maxWidth, $maxHeight, static function ($constraint) {
+                $constraint->aspectRatio();
+                $constraint->upsize();
+            });
+
+            return;
+        }
+
+        $image->scaleDown($maxWidth, $maxHeight);
+    }
+
+    private function rotate(object $image): void
+    {
+        if (empty($this->options['rotate'])) {
+            return;
+        }
+
+        // v2 and v3 hand the angle straight to imagerotate(), which turns counter-clockwise, while v4
+        // negates it internally and so already turns clockwise like cropper.js does
+        $image->rotate(
+            InterventionImage::V4 === InterventionImage::major()
+                ? $this->options['rotate']
+                : -1 * $this->options['rotate']
+        );
+    }
+
+    private function encode(object $image, string $format, int $quality): string
+    {
+        return match (InterventionImage::major()) {
+            InterventionImage::V4 => (string) $image->encodeUsingFileExtension($format, quality: $quality),
+            InterventionImage::V3 => (string) $image->encodeByExtension($format, quality: $quality),
+            default => (string) $image->encode($format, $quality)->getEncoded(),
+        };
     }
 
     public function getOptions(): string

--- a/src/Cropperjs/tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Cropperjs/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Cropperjs\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\UX\Cropperjs\DependencyInjection\Configuration;
+
+/**
+ * @internal
+ */
+class ConfigurationTest extends TestCase
+{
+    private function process(array $config): array
+    {
+        $processor = new Processor();
+
+        return $processor->processConfiguration(new Configuration(), [$config]);
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $config = $this->process([]);
+
+        $this->assertSame('gd', $config['driver']);
+        $this->assertNull($config['driver_service']);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideValidDrivers(): iterable
+    {
+        yield 'gd' => ['gd'];
+        yield 'imagick' => ['imagick'];
+        yield 'vips' => ['vips'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideValidDrivers')]
+    public function testValidDriversAreAccepted(string $driver)
+    {
+        $config = $this->process(['driver' => $driver]);
+
+        $this->assertSame($driver, $config['driver']);
+    }
+
+    public function testInvalidDriverIsRejected()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->process(['driver' => 'bogus']);
+    }
+}

--- a/src/Cropperjs/tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Cropperjs/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Cropperjs\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\UX\Cropperjs\DependencyInjection\Configuration;
+
+/**
+ * @internal
+ */
+class ConfigurationTest extends TestCase
+{
+    private function process(array $config): array
+    {
+        $processor = new Processor();
+
+        return $processor->processConfiguration(new Configuration(), [$config]);
+    }
+
+    public function testDefaultConfiguration(): void
+    {
+        $config = $this->process([]);
+
+        $this->assertSame('gd', $config['driver']);
+        $this->assertNull($config['driver_service']);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideValidDrivers(): iterable
+    {
+        yield 'gd' => ['gd'];
+        yield 'imagick' => ['imagick'];
+        yield 'vips' => ['vips'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideValidDrivers')]
+    public function testValidDriversAreAccepted(string $driver): void
+    {
+        $config = $this->process(['driver' => $driver]);
+
+        $this->assertSame($driver, $config['driver']);
+    }
+
+    public function testInvalidDriverIsRejected(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->process(['driver' => 'bogus']);
+    }
+}

--- a/src/Cropperjs/tests/DependencyInjection/CropperjsExtensionTest.php
+++ b/src/Cropperjs/tests/DependencyInjection/CropperjsExtensionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Cropperjs\Tests\DependencyInjection;
+
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Drivers\Vips\Driver as VipsDriver;
+use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\ImageManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\UX\Cropperjs\DependencyInjection\CropperjsExtension;
+use Symfony\UX\Cropperjs\Factory\CropperInterface;
+
+/**
+ * @internal
+ */
+class CropperjsExtensionTest extends TestCase
+{
+    private function loadContainer(array $config = []): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $extension = new CropperjsExtension();
+        $extension->load([$config], $container);
+
+        return $container;
+    }
+
+    public function testImageManagerUsesGdDriverByDefault()
+    {
+        $definition = $this->loadContainer()->getDefinition('cropper.image_manager');
+
+        $this->assertSame([ImageManager::class, 'usingDriver'], $definition->getFactory());
+        $this->assertSame([GdDriver::class], $definition->getArguments());
+    }
+
+    public function testImageManagerUsesImagickDriver()
+    {
+        $definition = $this->loadContainer(['driver' => 'imagick'])->getDefinition('cropper.image_manager');
+
+        $this->assertSame([ImagickDriver::class], $definition->getArguments());
+    }
+
+    public function testCustomDriverServiceTakesPrecedenceOverDriver()
+    {
+        $definition = $this->loadContainer([
+            'driver' => 'imagick',
+            'driver_service' => 'app.custom_driver',
+        ])->getDefinition('cropper.image_manager');
+
+        $arguments = $definition->getArguments();
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
+        $this->assertSame('app.custom_driver', (string) $arguments[0]);
+    }
+
+    public function testVipsDriverThrowsWhenDriverPackageNotInstalled()
+    {
+        if (class_exists(VipsDriver::class)) {
+            $this->markTestSkipped('intervention/image-driver-vips is installed; cannot test the missing-package guard.');
+        }
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('intervention/image-driver-vips');
+
+        $this->loadContainer(['driver' => 'vips']);
+    }
+
+    public function testConfiguredImageManagerCanBeInstantiated()
+    {
+        $container = $this->loadContainer();
+        $container->getDefinition('cropper.image_manager')->setPublic(true);
+        $container->getAlias(CropperInterface::class)->setPublic(true);
+        $container->compile();
+
+        $this->assertInstanceOf(ImageManagerInterface::class, $container->get('cropper.image_manager'));
+        $this->assertInstanceOf(CropperInterface::class, $container->get(CropperInterface::class));
+    }
+}

--- a/src/Cropperjs/tests/DependencyInjection/CropperjsExtensionTest.php
+++ b/src/Cropperjs/tests/DependencyInjection/CropperjsExtensionTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Cropperjs\Tests\DependencyInjection;
+
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Drivers\Vips\Driver as VipsDriver;
+use Intervention\Image\ImageManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\UX\Cropperjs\DependencyInjection\CropperjsExtension;
+use Symfony\UX\Cropperjs\Factory\CropperInterface;
+use Symfony\UX\Cropperjs\Intervention\InterventionImage;
+
+/**
+ * @internal
+ */
+class CropperjsExtensionTest extends TestCase
+{
+    private function loadContainer(array $config = []): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $extension = new CropperjsExtension();
+        $extension->load([$config], $container);
+
+        return $container;
+    }
+
+    private function skipUnlessDriverClasses(): void
+    {
+        if (!InterventionImage::supportsDriverClasses()) {
+            $this->markTestSkipped('Driver classes require intervention/image 3.0 or higher.');
+        }
+    }
+
+    private function skipUnlessLegacy(): void
+    {
+        if (InterventionImage::V2 !== InterventionImage::major()) {
+            $this->markTestSkipped('This behavior is specific to intervention/image 2.');
+        }
+    }
+
+    public function testImageManagerUsesGdDriverByDefault(): void
+    {
+        $this->skipUnlessDriverClasses();
+
+        $definition = $this->loadContainer()->getDefinition('cropper.image_manager');
+
+        $factoryMethod = InterventionImage::V4 === InterventionImage::major() ? 'usingDriver' : 'withDriver';
+        $this->assertSame([ImageManager::class, $factoryMethod], $definition->getFactory());
+        $this->assertSame([GdDriver::class], $definition->getArguments());
+    }
+
+    public function testImageManagerUsesImagickDriver(): void
+    {
+        $this->skipUnlessDriverClasses();
+
+        $definition = $this->loadContainer(['driver' => 'imagick'])->getDefinition('cropper.image_manager');
+
+        $this->assertSame([ImagickDriver::class], $definition->getArguments());
+    }
+
+    public function testCustomDriverServiceTakesPrecedenceOverDriver(): void
+    {
+        $this->skipUnlessDriverClasses();
+
+        $definition = $this->loadContainer([
+            'driver' => 'imagick',
+            'driver_service' => 'app.custom_driver',
+        ])->getDefinition('cropper.image_manager');
+
+        $arguments = $definition->getArguments();
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
+        $this->assertSame('app.custom_driver', (string) $arguments[0]);
+    }
+
+    public function testVipsDriverThrowsWhenDriverPackageNotInstalled(): void
+    {
+        $this->skipUnlessDriverClasses();
+
+        if (class_exists(VipsDriver::class)) {
+            $this->markTestSkipped('intervention/image-driver-vips is installed; cannot test the missing-package guard.');
+        }
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('intervention/image-driver-vips');
+
+        $this->loadContainer(['driver' => 'vips']);
+    }
+
+    public function testLegacyImageManagerIsBuiltFromTheDriverName(): void
+    {
+        $this->skipUnlessLegacy();
+
+        $definition = $this->loadContainer(['driver' => 'imagick'])->getDefinition('cropper.image_manager');
+
+        $this->assertNull($definition->getFactory());
+        $this->assertSame([['driver' => 'imagick']], $definition->getArguments());
+    }
+
+    public function testLegacyRejectsTheVipsDriver(): void
+    {
+        $this->skipUnlessLegacy();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('3.0 or higher');
+
+        $this->loadContainer(['driver' => 'vips']);
+    }
+
+    public function testLegacyRejectsACustomDriverService(): void
+    {
+        $this->skipUnlessLegacy();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('3.0 or higher');
+
+        $this->loadContainer(['driver_service' => 'app.custom_driver']);
+    }
+
+    public function testConfiguredImageManagerCanBeInstantiated(): void
+    {
+        $container = $this->loadContainer();
+        $container->getDefinition('cropper.image_manager')->setPublic(true);
+        $container->getAlias(CropperInterface::class)->setPublic(true);
+        $container->compile();
+
+        $this->assertInstanceOf(ImageManager::class, $container->get('cropper.image_manager'));
+        $this->assertInstanceOf(CropperInterface::class, $container->get(CropperInterface::class));
+    }
+}

--- a/src/Cropperjs/tests/Model/CropTest.php
+++ b/src/Cropperjs/tests/Model/CropTest.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\UX\Cropperjs\Tests\Model;
 
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\Cropperjs\Model\Crop;
 
@@ -37,61 +40,143 @@ class CropTest extends TestCase
         }
     }
 
-    private function createCrop(int $rotate = 0): Crop
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideDrivers(): iterable
     {
-        $imageManager = new ImageManager();
-        $crop = new Crop($imageManager, $this->testImagePath);
+        yield 'gd' => [GdDriver::class];
 
-        $crop->setOptions(json_encode([
+        if (\extension_loaded('imagick')) {
+            yield 'imagick' => [ImagickDriver::class];
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function createCrop(string $driver, array $options = [], ?string $imagePath = null): Crop
+    {
+        $crop = new Crop(ImageManager::usingDriver($driver), $imagePath ?? $this->testImagePath);
+
+        $crop->setOptions(json_encode($options + [
+            'x' => 0,
+            'y' => 0,
             'width' => null,
             'height' => null,
-            'rotate' => $rotate,
+            'rotate' => 0,
         ]));
 
         return $crop;
     }
 
-    public function testGetCroppedImageWithRotation()
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageWithRotation(string $driver)
     {
-        $crop = $this->createCrop(rotate: 90);
-
-        $result = $crop->getCroppedImage();
+        $result = $this->createCrop($driver, ['rotate' => 90])->getCroppedImage();
 
         $image = imagecreatefromstring($result);
         $this->assertSame(100, imagesx($image));
         $this->assertSame(200, imagesy($image));
     }
 
-    public function testGetCroppedImageWithoutRotation()
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageWithoutRotation(string $driver)
     {
-        $crop = $this->createCrop(rotate: 0);
-
-        $result = $crop->getCroppedImage();
+        $result = $this->createCrop($driver)->getCroppedImage();
 
         $image = imagecreatefromstring($result);
         $this->assertSame(200, imagesx($image));
         $this->assertSame(100, imagesy($image));
     }
 
-    public function testGetCroppedThumbnailWithRotation()
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageCropsTheRequestedRegion(string $driver)
     {
-        $crop = $this->createCrop(rotate: 90);
+        // Source: left half red, right half blue (split at x = 100)
+        $source = $this->createTwoColorImage();
 
-        $result = $crop->getCroppedThumbnail(200, 200);
+        try {
+            // The 50x40 region at x=120 sits entirely in the blue (right) half
+            $result = $this->createCrop($driver, [
+                'x' => 120,
+                'y' => 10,
+                'width' => 50,
+                'height' => 40,
+            ], $source)->getCroppedImage('png');
+        } finally {
+            unlink($source);
+        }
+
+        $image = imagecreatefromstring($result);
+        $this->assertSame(50, imagesx($image), 'Cropped width should match the requested region width');
+        $this->assertSame(40, imagesy($image), 'Cropped height should match the requested region height');
+
+        // Locks the crop(width, height, x, y) argument order: a swapped x/y would land in the red half
+        $color = imagecolorat($image, 25, 20);
+        $this->assertLessThan(80, ($color >> 16) & 0xFF, 'Red channel should be low (region is in the blue half)');
+        $this->assertGreaterThan(200, $color & 0xFF, 'Blue channel should be high (region is in the blue half)');
+    }
+
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageRespectsMaxSize(string $driver)
+    {
+        $crop = $this->createCrop($driver);
+        $crop->setCroppedMaxSize(100, 100);
+
+        $image = imagecreatefromstring($crop->getCroppedImage());
+        $this->assertSame(100, imagesx($image));
+        $this->assertSame(50, imagesy($image));
+    }
+
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageEncodesTheRequestedFormat(string $driver)
+    {
+        $result = $this->createCrop($driver)->getCroppedImage('png');
+
+        $this->assertSame("\x89PNG", substr($result, 0, 4));
+        $this->assertNotFalse(imagecreatefromstring($result));
+    }
+
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedThumbnailWithRotation(string $driver)
+    {
+        $result = $this->createCrop($driver, ['rotate' => 90])->getCroppedThumbnail(200, 200);
 
         $image = imagecreatefromstring($result);
         $this->assertSame(100, imagesx($image));
         $this->assertSame(200, imagesy($image));
     }
 
-    public function testGetCroppedThumbnailWithoutRotation()
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedThumbnailWithoutRotation(string $driver)
     {
-        $crop = $this->createCrop(rotate: 0);
-
-        $result = $crop->getCroppedThumbnail(200, 200);
+        $result = $this->createCrop($driver)->getCroppedThumbnail(200, 200);
 
         $image = imagecreatefromstring($result);
         $this->assertSame(200, imagesx($image));
         $this->assertSame(100, imagesy($image));
+    }
+
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedThumbnailDownscales(string $driver)
+    {
+        $result = $this->createCrop($driver)->getCroppedThumbnail(50, 50);
+
+        $image = imagecreatefromstring($result);
+        $this->assertSame(50, imagesx($image));
+        $this->assertSame(25, imagesy($image));
+    }
+
+    private function createTwoColorImage(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'crop_test_two_color_').'.png';
+
+        $image = imagecreatetruecolor(200, 100);
+        imagefilledrectangle($image, 0, 0, 99, 99, imagecolorallocate($image, 255, 0, 0));
+        imagefilledrectangle($image, 100, 0, 199, 99, imagecolorallocate($image, 0, 0, 255));
+        imagepng($image, $path);
+
+        return $path;
     }
 }

--- a/src/Cropperjs/tests/Model/CropTest.php
+++ b/src/Cropperjs/tests/Model/CropTest.php
@@ -91,6 +91,33 @@ class CropTest extends TestCase
     }
 
     #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageRotatesClockwise(string $driver)
+    {
+        // Source: left half red, right half blue (split at x = 100).
+        // Cropper.js rotates clockwise for positive degrees, so a 90° rotation
+        // moves the left (red) edge to the top and the right (blue) edge to the bottom.
+        $source = $this->createTwoColorImage();
+
+        try {
+            $result = $this->createCrop($driver, ['rotate' => 90], $source)->getCroppedImage('png');
+        } finally {
+            unlink($source);
+        }
+
+        $image = imagecreatefromstring($result);
+        $this->assertSame(100, imagesx($image));
+        $this->assertSame(200, imagesy($image));
+
+        $top = imagecolorat($image, 50, 30);
+        $this->assertGreaterThan(200, ($top >> 16) & 0xFF, 'Top should be red (clockwise: left edge rotates to the top)');
+        $this->assertLessThan(80, $top & 0xFF, 'Top should not be blue');
+
+        $bottom = imagecolorat($image, 50, 170);
+        $this->assertGreaterThan(200, $bottom & 0xFF, 'Bottom should be blue (clockwise: right edge rotates to the bottom)');
+        $this->assertLessThan(80, ($bottom >> 16) & 0xFF, 'Bottom should not be red');
+    }
+
+    #[DataProvider('provideDrivers')]
     public function testGetCroppedImageCropsTheRequestedRegion(string $driver)
     {
         // Source: left half red, right half blue (split at x = 100)

--- a/src/Cropperjs/tests/Model/CropTest.php
+++ b/src/Cropperjs/tests/Model/CropTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\UX\Cropperjs\Tests\Model;
 
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\UX\Cropperjs\Intervention\InterventionImage;
 use Symfony\UX\Cropperjs\Model\Crop;
 
 /**
@@ -37,61 +41,183 @@ class CropTest extends TestCase
         }
     }
 
-    private function createCrop(int $rotate = 0): Crop
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideDrivers(): iterable
     {
-        $imageManager = new ImageManager();
-        $crop = new Crop($imageManager, $this->testImagePath);
+        $useClasses = InterventionImage::supportsDriverClasses();
 
-        $crop->setOptions(json_encode([
+        yield 'gd' => [$useClasses ? GdDriver::class : 'gd'];
+
+        // intervention/image 2 predates ImageMagick 7.1 and its imagick driver decodes images to black
+        // against it, so the driver is only exercised from v3 onwards
+        if (\extension_loaded('imagick') && $useClasses) {
+            yield 'imagick' => [ImagickDriver::class];
+        }
+    }
+
+    private static function createImageManager(string $driver): ImageManager
+    {
+        return match (InterventionImage::major()) {
+            InterventionImage::V4 => ImageManager::usingDriver($driver),
+            InterventionImage::V3 => ImageManager::withDriver($driver),
+            default => new ImageManager(['driver' => $driver]),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function createCrop(string $driver, array $options = [], ?string $imagePath = null): Crop
+    {
+        $crop = new Crop(self::createImageManager($driver), $imagePath ?? $this->testImagePath);
+
+        $crop->setOptions(json_encode($options + [
+            'x' => 0,
+            'y' => 0,
             'width' => null,
             'height' => null,
-            'rotate' => $rotate,
+            'rotate' => 0,
         ]));
 
         return $crop;
     }
 
-    public function testGetCroppedImageWithRotation(): void
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageWithRotation(string $driver): void
     {
-        $crop = $this->createCrop(rotate: 90);
-
-        $result = $crop->getCroppedImage();
+        $result = $this->createCrop($driver, ['rotate' => 90])->getCroppedImage();
 
         $image = imagecreatefromstring($result);
         $this->assertSame(100, imagesx($image));
         $this->assertSame(200, imagesy($image));
     }
 
-    public function testGetCroppedImageWithoutRotation(): void
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageWithoutRotation(string $driver): void
     {
-        $crop = $this->createCrop(rotate: 0);
-
-        $result = $crop->getCroppedImage();
+        $result = $this->createCrop($driver)->getCroppedImage();
 
         $image = imagecreatefromstring($result);
         $this->assertSame(200, imagesx($image));
         $this->assertSame(100, imagesy($image));
     }
 
-    public function testGetCroppedThumbnailWithRotation(): void
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageRotatesClockwise(string $driver): void
     {
-        $crop = $this->createCrop(rotate: 90);
+        // Source: left half red, right half blue (split at x = 100).
+        // Cropper.js rotates clockwise for positive degrees, so a 90° rotation
+        // moves the left (red) edge to the top and the right (blue) edge to the bottom.
+        $source = $this->createTwoColorImage();
 
-        $result = $crop->getCroppedThumbnail(200, 200);
+        try {
+            $result = $this->createCrop($driver, ['rotate' => 90], $source)->getCroppedImage('png');
+        } finally {
+            unlink($source);
+        }
+
+        $image = imagecreatefromstring($result);
+        $this->assertSame(100, imagesx($image));
+        $this->assertSame(200, imagesy($image));
+
+        $top = imagecolorat($image, 50, 30);
+        $this->assertGreaterThan(200, ($top >> 16) & 0xFF, 'Top should be red (clockwise: left edge rotates to the top)');
+        $this->assertLessThan(80, $top & 0xFF, 'Top should not be blue');
+
+        $bottom = imagecolorat($image, 50, 170);
+        $this->assertGreaterThan(200, $bottom & 0xFF, 'Bottom should be blue (clockwise: right edge rotates to the bottom)');
+        $this->assertLessThan(80, ($bottom >> 16) & 0xFF, 'Bottom should not be red');
+    }
+
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageCropsTheRequestedRegion(string $driver): void
+    {
+        // Source: left half red, right half blue (split at x = 100)
+        $source = $this->createTwoColorImage();
+
+        try {
+            // The 50x40 region at x=120 sits entirely in the blue (right) half
+            $result = $this->createCrop($driver, [
+                'x' => 120,
+                'y' => 10,
+                'width' => 50,
+                'height' => 40,
+            ], $source)->getCroppedImage('png');
+        } finally {
+            unlink($source);
+        }
+
+        $image = imagecreatefromstring($result);
+        $this->assertSame(50, imagesx($image), 'Cropped width should match the requested region width');
+        $this->assertSame(40, imagesy($image), 'Cropped height should match the requested region height');
+
+        // Locks the crop(width, height, x, y) argument order: a swapped x/y would land in the red half
+        $color = imagecolorat($image, 25, 20);
+        $this->assertLessThan(80, ($color >> 16) & 0xFF, 'Red channel should be low (region is in the blue half)');
+        $this->assertGreaterThan(200, $color & 0xFF, 'Blue channel should be high (region is in the blue half)');
+    }
+
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageRespectsMaxSize(string $driver): void
+    {
+        $crop = $this->createCrop($driver);
+        $crop->setCroppedMaxSize(100, 100);
+
+        $image = imagecreatefromstring($crop->getCroppedImage());
+        $this->assertSame(100, imagesx($image));
+        $this->assertSame(50, imagesy($image));
+    }
+
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedImageEncodesTheRequestedFormat(string $driver): void
+    {
+        $result = $this->createCrop($driver)->getCroppedImage('png');
+
+        $this->assertSame("\x89PNG", substr($result, 0, 4));
+        $this->assertNotFalse(imagecreatefromstring($result));
+    }
+
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedThumbnailWithRotation(string $driver): void
+    {
+        $result = $this->createCrop($driver, ['rotate' => 90])->getCroppedThumbnail(200, 200);
 
         $image = imagecreatefromstring($result);
         $this->assertSame(100, imagesx($image));
         $this->assertSame(200, imagesy($image));
     }
 
-    public function testGetCroppedThumbnailWithoutRotation(): void
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedThumbnailWithoutRotation(string $driver): void
     {
-        $crop = $this->createCrop(rotate: 0);
-
-        $result = $crop->getCroppedThumbnail(200, 200);
+        $result = $this->createCrop($driver)->getCroppedThumbnail(200, 200);
 
         $image = imagecreatefromstring($result);
         $this->assertSame(200, imagesx($image));
         $this->assertSame(100, imagesy($image));
+    }
+
+    #[DataProvider('provideDrivers')]
+    public function testGetCroppedThumbnailDownscales(string $driver): void
+    {
+        $result = $this->createCrop($driver)->getCroppedThumbnail(50, 50);
+
+        $image = imagecreatefromstring($result);
+        $this->assertSame(50, imagesx($image));
+        $this->assertSame(25, imagesy($image));
+    }
+
+    private function createTwoColorImage(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'crop_test_two_color_').'.png';
+
+        $image = imagecreatetruecolor(200, 100);
+        imagefilledrectangle($image, 0, 0, 99, 99, imagecolorallocate($image, 255, 0, 0));
+        imagefilledrectangle($image, 100, 0, 199, 99, imagecolorallocate($image, 0, 0, 255));
+        imagepng($image, $path);
+
+        return $path;
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | Fix #3394
| License        | MIT

Resolves the indirect `intervention/image` v2 deprecations reported in #3394 by upgrading the dependency to v4, and adds the ability to choose the image driver (proposal/discussion in #3678).

### What changes

- **`intervention/image`: `^2.5` → `^4.0`** (drops v2). The `Crop` model migrates to the v4 API: `make()` → `decodeBinary()`, the `resize(closure)` aspect-ratio + upsize calls → `scaleDown()`, `encode()` + `getEncoded()` → `encodeUsingFileExtension()`, and the type-hints move to `ImageManagerInterface` / `ImageInterface`.
- **Configurable image driver** via a new bundle configuration:

```yaml
# config/packages/cropperjs.yaml
cropperjs:
    driver: gd            # gd (default), imagick or vips
    driver_service: ~     # optional: a custom Intervention DriverInterface service (takes precedence)
```

  The `ImageManager` is built through `ImageManager::usingDriver()`. `gd` / `imagick` are bundled with `intervention/image`; `vips` uses the official `intervention/image-driver-vips` package, declared under composer `suggest` (it needs libvips + `ext-ffi`). Selecting `vips` without that package fails fast at container compile time with an actionable message. `driver_service` lets advanced users inject a fully custom / pre-configured `DriverInterface`.

### Backward compatibility

The bundle's public API is unchanged and **`gd` remains the zero-config default**, so existing apps behave exactly as before. The only requirement change is `intervention/image` v4 (PHP >= 8.3, already satisfied by the bundle's PHP >= 8.4 floor).

### Tests

`CropTest` is parameterized over the **gd and imagick** drivers and now covers the crop region (locking the `crop()` argument order), `setCroppedMaxSize()` downscaling, thumbnail downscaling and output format. New `ConfigurationTest` and `CropperjsExtensionTest` cover the driver configuration, the custom-driver precedence and the fail-fast `vips` guard.
