### PR TITLE
[Autocomplete] Fix LIKE ESCAPE clause breaking search on PostgreSQL

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.37
+
+- Fix the autocomplete search query throwing an exception on PostgreSQL because of
+  the `ESCAPE '\'` clause introduced in 2.36; a backslash-free LIKE escape character is now used.
+
 ## 2.36
 
 - Escape LIKE wildcards (`%` and `_`) in the autocomplete search query so user

--- a/src/Autocomplete/src/Doctrine/EntitySearchUtil.php
+++ b/src/Autocomplete/src/Doctrine/EntitySearchUtil.php
@@ -20,6 +20,13 @@ use Symfony\Component\Uid\Uuid;
  */
 class EntitySearchUtil
 {
+    /**
+     * Custom LIKE escape character. A backslash cannot be used here: the
+     * resulting "ESCAPE '\'" clause produces invalid SQL on PostgreSQL, while
+     * "!" is safe to embed in the ESCAPE clause on every supported platform.
+     */
+    private const LIKE_ESCAPE_CHARACTER = '!';
+
     public function __construct(private EntityMetadataFactory $metadataFactory)
     {
     }
@@ -38,14 +45,16 @@ class EntitySearchUtil
         $isUuidQuery = class_exists(Uuid::class) && Uuid::isValid($query);
         $isUlidQuery = class_exists(Ulid::class) && Ulid::isValid($query);
 
+        $databasePlatform = $queryBuilder->getEntityManager()->getConnection()->getDatabasePlatform();
+
         $dqlParameters = [
             // adding '0' turns the string into a numeric value
             'numeric_query' => is_numeric($query) ? 0 + $query : $query,
             'uuid_query' => $query,
-            // escape the LIKE wildcards "%" and "_" (and the escape char "\")
-            // so a user-supplied wildcard cannot broaden the search; paired
-            // with the "ESCAPE '\'" clause on the LIKE expression below
-            'text_query' => '%'.addcslashes($lowercaseQuery, '\\%_').'%',
+            // escape the LIKE wildcards "%" and "_" (and the escape char itself)
+            // so a user-supplied wildcard cannot broaden the search; paired with
+            // the "ESCAPE '!'" clause on the LIKE expression below
+            'text_query' => '%'.$databasePlatform->escapeStringForLike($lowercaseQuery, self::LIKE_ESCAPE_CHARACTER).'%',
             'words_query' => explode(' ', $lowercaseQuery),
         ];
 
@@ -123,8 +132,8 @@ class EntitySearchUtil
                 $expressions[] = $queryBuilder->expr()->eq(\sprintf('%s.%s', $entityName, $propertyName), ':query_for_uuids');
                 $queryBuilder->setParameter('query_for_uuids', $dqlParameters['uuid_query'], 'ulid');
             } elseif ($isTextProperty) {
-                // ESCAPE '\' so the backslash-escaped wildcards in :query_for_text are treated literally
-                $expressions[] = \sprintf("LOWER(%s.%s) LIKE :query_for_text ESCAPE '\\'", $entityName, $propertyName);
+                // ESCAPE '!' so the escaped wildcards in :query_for_text are treated literally
+                $expressions[] = \sprintf("LOWER(%s.%s) LIKE :query_for_text ESCAPE '%s'", $entityName, $propertyName, self::LIKE_ESCAPE_CHARACTER);
                 $queryBuilder->setParameter('query_for_text', $dqlParameters['text_query']);
 
                 $expressions[] = $queryBuilder->expr()->in(\sprintf('LOWER(%s.%s)', $entityName, $propertyName), ':query_as_words');

--- a/src/Autocomplete/tests/Integration/Doctrine/EntitySearchUtilTest.php
+++ b/src/Autocomplete/tests/Integration/Doctrine/EntitySearchUtilTest.php
@@ -63,6 +63,7 @@ class EntitySearchUtilTest extends KernelTestCase
         $percent = ProductFactory::createOne(['name' => '100% legit']);
         $underscore = ProductFactory::createOne(['name' => 'foo_bar']);
         $backslash = ProductFactory::createOne(['name' => 'a\\b literal']);
+        $bang = ProductFactory::createOne(['name' => 'wow! deal']);
         ProductFactory::createOne(['name' => 'unrelated thing']);
 
         // a literal "%" must match only the row that actually contains "%",
@@ -74,6 +75,9 @@ class EntitySearchUtilTest extends KernelTestCase
 
         // a literal "\" must be treated as data, not as the LIKE escape char
         $this->assertSame([$backslash], $this->callAddSearchClass('a\\b'));
+
+        // the LIKE escape char itself ("!") must be treated as data
+        $this->assertSame([$bang], $this->callAddSearchClass('wow!'));
 
         // a normal substring search still works
         $this->assertSame([$percent], $this->callAddSearchClass('legit'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tickets       | Fix #3668
| License       | MIT

Since 2.36, `EntitySearchUtil` escapes the LIKE wildcards (`%`, `_`) in the
autocomplete search query and pairs that with an `ESCAPE '\'` clause so the
escaped wildcards are treated literally.

That backslash breaks on **PostgreSQL**: with `standard_conforming_strings = off`
(older setups / some PDO driver versions) the backslash escapes the closing
quote of the SQL string literal, producing invalid SQL. It surfaces as
`SQLSTATE[HY093] Invalid parameter number` or
`SQLSTATE[22025] invalid escape string` and makes every text search throw.

### Fix

Use a **backslash-free** LIKE escape character (`!`) via the platform's
`escapeStringForLike()`. The explicit `ESCAPE` clause is kept on purpose:
SQLite has **no default** LIKE escape character, so dropping it would silently
re-open the wildcard-injection the 2.36 hardening closed.

> Note: the workaround suggested in the issue (`escapeStringForLike($q, '\')` +
> removing the `ESCAPE` clause) wouldn't fully work — `escapeStringForLike($q, '\')`
> produces byte-identical output to the current `addcslashes($q, '\\%_')`, so the
> only effective change there is dropping `ESCAPE`, which regresses wildcard
> escaping on SQLite. Switching the escape *character* is what actually fixes
> PostgreSQL without that regression.

### Tests

- SQLite (CI): the existing `testItEscapesLikeWildcardsInTheQuery` is extended
  with a literal `!` case and stays green — it can only pass if the `ESCAPE`
  clause works.
- PostgreSQL (verified locally against a real server): the old `ESCAPE '\'`
  errors with `standard_conforming_strings=off`; the new `ESCAPE '!'` works
  under both settings and correctly matches literal `%`, `_` and `!`.
