### PR TITLE
[LiveComponent] Fix data-loading scanner ignoring data-live-ignore subtrees

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1895,6 +1895,7 @@ var LoadingPlugin_default = class {
 		const loadingDirectives = [];
 		let matchingElements = Array.from(element.querySelectorAll("[data-loading]"));
 		matchingElements = matchingElements.filter((elt) => elementBelongsToThisComponent(elt, component));
+		matchingElements = matchingElements.filter((elt) => !elt.closest("[data-live-ignore]"));
 		if (element.hasAttribute("data-loading")) matchingElements = [element, ...matchingElements];
 		matchingElements.forEach((element) => {
 			if (!(element instanceof HTMLElement) && !(element instanceof SVGElement)) throw new Error("Invalid Element Type");

--- a/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
+++ b/src/LiveComponent/assets/src/Component/plugins/LoadingPlugin.ts
@@ -178,6 +178,10 @@ export default class implements PluginInterface {
         // ignore elements which are inside a nested "live" component
         matchingElements = matchingElements.filter((elt) => elementBelongsToThisComponent(elt, component));
 
+        // ignore elements inside a "data-live-ignore" subtree: those are managed
+        // outside of Live (e.g. third-party widgets) and may set their own "data-loading"
+        matchingElements = matchingElements.filter((elt) => !elt.closest('[data-live-ignore]'));
+
         // querySelectorAll doesn't include the element itself
         if (element.hasAttribute('data-loading')) {
             matchingElements = [element, ...matchingElements];

--- a/src/LiveComponent/assets/test/unit/controller/loading.test.ts
+++ b/src/LiveComponent/assets/test/unit/controller/loading.test.ts
@@ -297,4 +297,42 @@ describe('LiveController data-loading Tests', () => {
         expect(getByTestId(test.element, 'child-loading-element-showing')).not.toBeVisible();
         expect(getByTestId(test.element, 'child-loading-element-hiding')).toBeVisible();
     });
+
+    it('ignores "data-loading" inside a "data-live-ignore" subtree', async () => {
+        const test = await createTest(
+            { food: 'pizza' },
+            (data: any) => `
+            <div ${initComponent(data)}>
+                <span>I like: ${data.food}</span>
+                <span data-loading="show" data-testid="loading-element">Loading...</span>
+
+                <div data-live-ignore data-testid="ignored">
+                    <!-- third-party widget managing its own, non-directive "data-loading" -->
+                    <span data-loading="false" data-testid="ignored-loading-element">widget internals</span>
+                </div>
+            </div>
+        `
+        );
+
+        test.expectsAjaxCall()
+            .serverWillChangeProps((data: any) => {
+                data.food = 'popcorn';
+            })
+            // delay so we can check loading
+            .delayResponse(50);
+
+        // the component initializes without throwing on the "false" value
+        // held by the "data-loading" attribute inside the "data-live-ignore" subtree
+        await waitFor(() => expect(getByTestId(test.element, 'loading-element')).not.toBeVisible());
+
+        test.component.render();
+        // the real loading element still behaves as usual
+        expect(getByTestId(test.element, 'loading-element')).toBeVisible();
+        // the ignored element is never picked up by the loading scanner
+        expect(getByTestId(test.element, 'ignored-loading-element')).not.toHaveAttribute('data-live-is-loading');
+
+        // wait for loading to finish
+        await waitFor(() => expect(test.element).toHaveTextContent('I like: popcorn'));
+        expect(getByTestId(test.element, 'loading-element')).not.toBeVisible();
+    });
 });


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3665
| License        | MIT

The `data-loading` scanner walks a component's entire subtree, including `data-live-ignore` regions. A third-party widget placed inside such a region (e.g. Altcha) that manages its own non-directive `data-loading` value crashes the component on mount with `Unknown data-loading action "..."`.

Since the scan runs in `attachToComponent()` (`finishLoading(component, component.element)`), the component fails to initialise on page load and every subsequent live request is broken too.

This skips `data-loading` elements living inside a `data-live-ignore` subtree, the same way nested live-component elements are already skipped just above.
