### PR TITLE
[TwigComponent] Fix test helper failing to render blocks in scoped templates

### DIFF
--- a/src/TwigComponent/src/Test/InteractsWithTwigComponents.php
+++ b/src/TwigComponent/src/Test/InteractsWithTwigComponents.php
@@ -51,8 +51,15 @@ trait InteractsWithTwigComponents
 
         $template = \sprintf('{%% component "%s" with data %%}', addslashes($name));
 
-        foreach (array_keys($blocks) as $blockName) {
-            $template .= \sprintf('{%% block %1$s %%}{{ blocks.%1$s|raw }}{%% endblock %%}', $blockName);
+        foreach ($blocks as $blockName => $blockContent) {
+            // Inline the content as a Twig string literal instead of passing it
+            // through a context variable: a variable would be filtered out when
+            // the component template restricts the scope with `{% with ... only %}`.
+            $template .= \sprintf(
+                '{%% block %s %%}{{ \'%s\'|raw }}{%% endblock %%}',
+                $blockName,
+                strtr((string) $blockContent, ['\\' => '\\\\', '\'' => '\\\'']),
+            );
         }
 
         $template .= '{% endcomponent %}';
@@ -62,7 +69,6 @@ trait InteractsWithTwigComponents
             ->createTemplate($template)
             ->render([
                 'data' => $data,
-                'blocks' => $blocks,
             ])
         );
     }

--- a/src/TwigComponent/tests/Fixtures/Component/WithSlotsScoped.php
+++ b/src/TwigComponent/tests/Fixtures/Component/WithSlotsScoped.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent]
+final class WithSlotsScoped
+{
+}

--- a/src/TwigComponent/tests/Fixtures/templates/components/WithSlotsScoped.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/WithSlotsScoped.html.twig
@@ -1,0 +1,6 @@
+<div>
+    {% with {} only %}
+        {% block content %}{% endblock %}
+        {% block slot1 %}{% endblock %}
+    {% endwith %}
+</div>

--- a/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
@@ -258,7 +258,7 @@ final class ComponentFactoryTest extends KernelTestCase
     #[TestWith(['tabler', 'Unknown component "tabler". Did you mean this: "table"?'])]
     #[TestWith(['Basic', 'Unknown component "Basic". Did you mean this: "BasicComponent"?'])]
     #[TestWith(['basic', 'Unknown component "basic". Did you mean this: "BasicComponent"?'])]
-    #[TestWith(['with', 'Unknown component "with". Did you mean one of these: "with_attributes", "WithExposedTraitChild", "WithExposedTraitParent", "with_exposed_variables", "WithSlots"?'])]
+    #[TestWith(['with', 'Unknown component "with". Did you mean one of these: "with_attributes", "WithExposedTraitChild", "WithExposedTraitParent", "with_exposed_variables", "WithSlots", "WithSlotsScoped"?'])]
     #[TestWith(['anonAnon', 'Unknown component "anonAnon". And no matching anonymous component template was found.'])]
     public function testCannotGetInvalidComponent(string $name, string $expectedExceptionMessage)
     {

--- a/src/TwigComponent/tests/Integration/Test/InteractsWithTwigComponentsTest.php
+++ b/src/TwigComponent/tests/Integration/Test/InteractsWithTwigComponentsTest.php
@@ -72,6 +72,22 @@ final class InteractsWithTwigComponentsTest extends KernelTestCase
         $this->assertStringContainsString('service: service a value', $rendered);
     }
 
+    public function testCanRenderComponentWithBlocksInScopedTemplate()
+    {
+        $rendered = $this->renderTwigComponent(
+            name: 'WithSlotsScoped',
+            content: '<p>some content</p>',
+            blocks: [
+                // content mixing quotes, a backslash and Twig-like syntax to
+                // make sure it is rendered verbatim and not re-parsed/evaluated.
+                'slot1' => '<p>it\'s a "slot1" \\ {{ not_evaluated }}</p>',
+            ],
+        );
+
+        $this->assertStringContainsString('<p>some content</p>', $rendered);
+        $this->assertStringContainsString('<p>it\'s a "slot1" \\ {{ not_evaluated }}</p>', $rendered);
+    }
+
     public static function componentANameProvider(): iterable
     {
         yield ['component_a'];


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3210
| License        | MIT

When a component template restricts its scope with `{% with ... only %}`, `renderTwigComponent()` from `InteractsWithTwigComponents` fails with:

```
Twig\Error\RuntimeError: Variable "blocks" does not exist
```

The helper builds a wrapper template that injects the mock block content through a context variable:

```twig
{% component "My:Component" with data %}{% block slot1 %}{{ blocks.slot1|raw }}{% endblock %}{% endcomponent %}
```

But `{% with ... only %}` resets the context (`$context = $vars + [] + globals`, see `WithNode`), so the `blocks` variable is filtered out before the overridden block is rendered.

This PR inlines the mock content as a Twig string literal instead of passing it through a context variable, so it no longer depends on the rendering context and survives the scope reset. Single-quoted Twig strings don't interpolate `{{ ... }}` or `#{...}`, and `\` / `'` are escaped, so the content is rendered verbatim.

A reproducer was provided by the reporter: https://github.com/janopae/reproduce-symfony-ux-blocks-cant-be-rendered-in-tests
