### PR TITLE
[LiveComponent] Fix support for nullable collection properties on component

### DIFF
--- a/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
+++ b/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php
@@ -86,7 +86,7 @@ class LiveComponentMetadataFactory implements ResetInterface
 
         $infoType = $this->propertyTypeExtractor->getType($className, $property->getName());
 
-        if ($infoType instanceof CollectionType) {
+        if ($infoType?->isSatisfiedBy(static fn ($t): bool => $t instanceof CollectionType)) {
             // If it's an "advanced" type (like CollectionType), let's use the PropertyTypeExtractor to get the Type
             $type = $infoType;
         } elseif (null !== $reflectionType) {

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -1316,6 +1316,38 @@ final class LiveComponentHydratorTest extends KernelTestCase
             ;
         }];
 
+        yield 'Nullable collection: using serializer (de)hydrates correctly' => [static function () {
+            return HydrationTest::create(new class {
+                /** @var \Symfony\UX\LiveComponent\Tests\Fixtures\Dto\Temperature[]|null */
+                #[LiveProp(useSerializerForHydration: true)]
+                public ?array $temperatures = [];
+
+                /**
+                 * @var string[]|null
+                 */
+                #[LiveProp(useSerializerForHydration: true)]
+                public ?array $tags = null;
+            })
+                ->mountWith([
+                    'temperatures' => [
+                        new Temperature(10, 'C'),
+                    ],
+                    'tags' => null,
+                ])
+                ->assertDehydratesTo([
+                    'temperatures' => [
+                        ['degrees' => 10, 'uom' => 'C'],
+                    ],
+                    'tags' => null,
+                ])
+                ->assertObjectAfterHydration(static function (object $object) {
+                    self::assertSame(10, $object->temperatures[0]->degrees);
+                    self::assertSame('C', $object->temperatures[0]->uom);
+                    self::assertNull($object->tags);
+                })
+            ;
+        }];
+
         yield 'Updating non-writable path is rejected' => [static function () {
             $product = new ProductFixtureEntity();
             $product->name = 'original name';


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

Currently it is not possible to have a nullable array liveprop on a live component. During dehydration it fails because it doesn't inspect the inner type, e.g. the following component:

```php
class Foo {
    /**
     * @var null|list<string>
     */
    #[LiveProp(useSerializerForHydration: true)]
    public ?array $items = null;
}
```

This is because in the [LiveComponentMetadataFactory](https://github.com/symfony/ux/blob/3.x/src/LiveComponent/src/Metadata/LiveComponentMetadataFactory.php#L89) the if-statement falls through and starts using the reflection type. This resolves in a `mixed[]` instead of `null|list<string>`. This PR fixes that by checking if the inner type of a nullable type might be a collection type.
