### PR TITLE
 [TwigComponent] Reduce per-render CPU cost of static components

### DIFF
--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\TwigComponent;
 
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface as IntrospectableEventDispatcherInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\UX\TwigComponent\Event\PostMountEvent;
@@ -34,6 +35,12 @@ final class ComponentFactory implements ResetInterface
     private array $metadata = [];
 
     /**
+     * Set when the dispatcher can be asked whether an event has listeners,
+     * allowing to skip creating and dispatching events nobody listens to.
+     */
+    private readonly ?IntrospectableEventDispatcherInterface $introspectableDispatcher;
+
+    /**
      * @param array<string, array>        $config
      * @param array<class-string, string> $classMap
      */
@@ -46,6 +53,7 @@ final class ComponentFactory implements ResetInterface
         private readonly array $classMap,
         private readonly Environment $twig,
     ) {
+        $this->introspectableDispatcher = $eventDispatcher instanceof IntrospectableEventDispatcherInterface ? $eventDispatcher : null;
     }
 
     public function metadataFor(string $name): ComponentMetadata
@@ -98,8 +106,7 @@ final class ComponentFactory implements ResetInterface
     public function mountFromObject(object $component, array $data, ComponentMetadata $componentMetadata): MountedComponent
     {
         $originalData = $data;
-        $event = $this->preMount($component, $data, $componentMetadata);
-        $data = $event->getData();
+        $data = $this->preMount($component, $data, $componentMetadata);
 
         $this->mount($component, $data, $componentMetadata);
 
@@ -113,8 +120,7 @@ final class ComponentFactory implements ResetInterface
             }
         }
 
-        $postMount = $this->postMount($component, $data, $componentMetadata);
-        $data = $postMount->getData();
+        [$data, $extraMetadata] = $this->postMount($component, $data, $componentMetadata);
 
         // create attributes from "attributes" key if exists
         $attributesVar = $componentMetadata->getAttributesVar();
@@ -132,7 +138,7 @@ final class ComponentFactory implements ResetInterface
             $component,
             new ComponentAttributes([...$attributes, ...$data], $this->twig->getRuntime(EscaperRuntime::class)),
             $originalData,
-            $postMount->getExtraMetadata(),
+            $extraMetadata,
         );
     }
 
@@ -182,34 +188,46 @@ final class ComponentFactory implements ResetInterface
         $mount->invoke($component, ...$parameters);
     }
 
-    private function preMount(object $component, array $data, ComponentMetadata $componentMetadata): PreMountEvent
+    /**
+     * @return array The (possibly modified) mount data
+     */
+    private function preMount(object $component, array $data, ComponentMetadata $componentMetadata): array
     {
-        $event = new PreMountEvent($component, $data, $componentMetadata);
-        $this->eventDispatcher->dispatch($event);
+        if (null === $this->introspectableDispatcher || $this->introspectableDispatcher->hasListeners(PreMountEvent::class)) {
+            $event = new PreMountEvent($component, $data, $componentMetadata);
+            $this->eventDispatcher->dispatch($event);
+            $data = $event->getData();
+        }
 
-        $data = $event->getData();
         foreach ($componentMetadata->getPreMounts() as $preMount) {
             if (null !== $newData = $component->$preMount($data)) {
-                $event->setData($data = $newData);
+                $data = $newData;
             }
         }
 
-        return $event;
+        return $data;
     }
 
-    private function postMount(object $component, array $data, ComponentMetadata $componentMetadata): PostMountEvent
+    /**
+     * @return array{0: array, 1: array} The (possibly modified) mount data and the extra metadata
+     */
+    private function postMount(object $component, array $data, ComponentMetadata $componentMetadata): array
     {
-        $event = new PostMountEvent($component, $data, $componentMetadata);
-        $this->eventDispatcher->dispatch($event);
+        $extraMetadata = [];
+        if (null === $this->introspectableDispatcher || $this->introspectableDispatcher->hasListeners(PostMountEvent::class)) {
+            $event = new PostMountEvent($component, $data, $componentMetadata);
+            $this->eventDispatcher->dispatch($event);
+            $data = $event->getData();
+            $extraMetadata = $event->getExtraMetadata();
+        }
 
-        $data = $event->getData();
         foreach ($componentMetadata->getPostMounts() as $postMount) {
             if (null !== $newData = $component->$postMount($data)) {
-                $event->setData($data = $newData);
+                $data = $newData;
             }
         }
 
-        return $event;
+        return [$data, $extraMetadata];
     }
 
     /**

--- a/src/TwigComponent/src/ComponentFactory.php
+++ b/src/TwigComponent/src/ComponentFactory.php
@@ -30,6 +30,9 @@ final class ComponentFactory implements ResetInterface
     private array $mountMethods = [];
     private array $writableProperties = [];
 
+    /** @var array<string, ComponentMetadata> */
+    private array $metadata = [];
+
     /**
      * @param array<string, array>        $config
      * @param array<class-string, string> $classMap
@@ -47,8 +50,12 @@ final class ComponentFactory implements ResetInterface
 
     public function metadataFor(string $name): ComponentMetadata
     {
+        if ($metadata = $this->metadata[$name] ?? null) {
+            return $metadata;
+        }
+
         if ($config = $this->config[$name] ?? null) {
-            return new ComponentMetadata($config);
+            return $this->metadata[$name] = new ComponentMetadata($config);
         }
 
         if ($template = $this->componentTemplateFinder->findAnonymousComponentTemplate($name)) {
@@ -57,12 +64,12 @@ final class ComponentFactory implements ResetInterface
                 'template' => $template,
             ];
 
-            return new ComponentMetadata($this->config[$name]);
+            return $this->metadata[$name] = new ComponentMetadata($this->config[$name]);
         }
 
         if ($mappedName = $this->classMap[$name] ?? null) {
             if ($config = $this->config[$mappedName] ?? null) {
-                return new ComponentMetadata($config);
+                return $this->metadata[$name] = new ComponentMetadata($config);
             }
 
             throw new \InvalidArgumentException(\sprintf('Unknown component "%s".', $name));
@@ -243,5 +250,6 @@ final class ComponentFactory implements ResetInterface
     {
         $this->mountMethods = [];
         $this->writableProperties = [];
+        $this->metadata = [];
     }
 }

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\TwigComponent;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface as IntrospectableEventDispatcherInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\UX\TwigComponent\Event\PostRenderEvent;
@@ -27,6 +28,12 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
 {
     private array $templateClasses = [];
 
+    /**
+     * Set when the dispatcher can be asked whether an event has listeners,
+     * allowing to skip creating and dispatching events nobody listens to.
+     */
+    private readonly ?IntrospectableEventDispatcherInterface $introspectableDispatcher;
+
     public function __construct(
         private Environment $twig,
         private EventDispatcherInterface $dispatcher,
@@ -34,6 +41,7 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
         private ComponentProperties $componentProperties,
         private ComponentStack $componentStack,
     ) {
+        $this->introspectableDispatcher = $dispatcher instanceof IntrospectableEventDispatcherInterface ? $dispatcher : null;
     }
 
     /**
@@ -41,6 +49,10 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
      */
     public function preCreateForRender(string $name, array $props = []): ?string
     {
+        if ($this->introspectableDispatcher && !$this->introspectableDispatcher->hasListeners(PreCreateForRenderEvent::class)) {
+            return null;
+        }
+
         $event = new PreCreateForRenderEvent($name, $props);
         $this->dispatcher->dispatch($event);
 
@@ -78,8 +90,9 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
         } finally {
             $mounted = $this->componentStack->pop();
 
-            $event = new PostRenderEvent($mounted);
-            $this->dispatcher->dispatch($event);
+            if (null === $this->introspectableDispatcher || $this->introspectableDispatcher->hasListeners(PostRenderEvent::class)) {
+                $this->dispatcher->dispatch(new PostRenderEvent($mounted));
+            }
         }
     }
 
@@ -100,8 +113,9 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
     {
         $mounted = $this->componentStack->pop();
 
-        $event = new PostRenderEvent($mounted);
-        $this->dispatcher->dispatch($event);
+        if (null === $this->introspectableDispatcher || $this->introspectableDispatcher->hasListeners(PostRenderEvent::class)) {
+            $this->dispatcher->dispatch(new PostRenderEvent($mounted));
+        }
     }
 
     private function preRender(MountedComponent $mounted, array $context = []): PreRenderEvent
@@ -122,7 +136,9 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
             $metadata->getAttributesVar() => $mounted->getAttributes(),
         ]);
 
-        $this->dispatcher->dispatch($event);
+        if (null === $this->introspectableDispatcher || $this->introspectableDispatcher->hasListeners(PreRenderEvent::class)) {
+            $this->dispatcher->dispatch($event);
+        }
 
         $event->setVariables([
             ...$event->getVariables(),

--- a/src/TwigComponent/src/ComponentRenderer.php
+++ b/src/TwigComponent/src/ComponentRenderer.php
@@ -129,30 +129,32 @@ final class ComponentRenderer implements ComponentRendererInterface, ResetInterf
         }
 
         // expose public properties and properties marked with ExposeInTemplate attribute
-        $props = [...$mounted->getInputProps(), ...$classProps];
-        $event = new PreRenderEvent($mounted, $metadata, [
+        $inputProps = $mounted->getInputProps();
+        $variables = [
             ...$context,
-            ...$props,
+            ...$inputProps,
+            ...$classProps,
             $metadata->getAttributesVar() => $mounted->getAttributes(),
-        ]);
+        ];
+        $event = new PreRenderEvent($mounted, $metadata, $variables);
 
         if (null === $this->introspectableDispatcher || $this->introspectableDispatcher->hasListeners(PreRenderEvent::class)) {
             $this->dispatcher->dispatch($event);
+            $variables = $event->getVariables();
         }
 
-        $event->setVariables([
-            ...$event->getVariables(),
-            // add the component as "this"
-            'this' => $component,
-            'computed' => new ComputedPropertiesProxy($component),
-            'outerScope' => $context,
-            // keep this line for BC break reasons
-            '__props' => $classProps,
-            // add the context in a separate variable to keep track
-            // of what is coming from outside the component, excluding props
-            // as they override initial context values
-            '__context' => array_diff_key($context, $props),
-        ]);
+        // add the component as "this"
+        $variables['this'] = $component;
+        $variables['computed'] = new ComputedPropertiesProxy($component);
+        $variables['outerScope'] = $context;
+        // keep this line for BC break reasons
+        $variables['__props'] = $classProps;
+        // add the context in a separate variable to keep track
+        // of what is coming from outside the component, excluding props
+        // as they override initial context values
+        $variables['__context'] = [] === $context ? [] : array_diff_key($context, $inputProps, $classProps);
+
+        $event->setVariables($variables);
 
         return $event;
     }

--- a/src/TwigComponent/tests/Integration/ComponentEventTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentEventTest.php
@@ -13,6 +13,11 @@ namespace Symfony\UX\TwigComponent\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\TwigComponent\Event\PostMountEvent;
+use Symfony\UX\TwigComponent\Event\PostRenderEvent;
+use Symfony\UX\TwigComponent\Event\PreCreateForRenderEvent;
+use Symfony\UX\TwigComponent\Event\PreMountEvent;
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 
@@ -37,6 +42,30 @@ final class ComponentEventTest extends KernelTestCase
         $result = $component->render();
 
         self::assertSame('updated', $result);
+    }
+
+    public function testEventsAreDispatchedForAnonymousComponentsWhenListenersExist(): void
+    {
+        $dispatched = [];
+        $listener = static function (object $event) use (&$dispatched) {
+            $dispatched[] = $event::class;
+        };
+        $dispatcher = self::getContainer()->get('event_dispatcher');
+        foreach ([PreCreateForRenderEvent::class, PreMountEvent::class, PostMountEvent::class, PreRenderEvent::class, PostRenderEvent::class] as $eventClass) {
+            $dispatcher->addListener($eventClass, $listener);
+        }
+
+        self::getContainer()->get(Environment::class)
+            ->createTemplate('{{ component("BasicComponent") }}')
+            ->render();
+
+        self::assertSame([
+            PreCreateForRenderEvent::class,
+            PreMountEvent::class,
+            PostMountEvent::class,
+            PreRenderEvent::class,
+            PostRenderEvent::class,
+        ], $dispatched);
     }
 
     public static function provideFooBarSyntaxes(): iterable


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

Pages that render hundreds of small components (e.g. an EasyAdmin index page renders ~630 components of 15 types: icons, table cells, action-menu items, ...) spend a significant share of their CPU time inside TwigComponent's own render pipeline rather than in the templates. Profiling such a workload showed three recurring per-render costs that this PR removes, without changing any observable behavior: the rendered HTML is byte-identical before/after each commit.

This PR contains three independent commits:

**1. Cache `ComponentMetadata` instances in `ComponentFactory`**

`metadataFor()` constructed a new `ComponentMetadata` on every call, and it is called twice per render (`create()` and `ComponentRenderer::preRender()`). The class is immutable, so instances are now cached per component name (~1,260 fewer allocations on the page above). The cache is cleared in `reset()` like the other per-request memo caches.

**2. Skip event allocation/dispatch when nobody listens**

Every render dispatched 5 freshly-allocated events (`PreCreateForRender`, `PreMount`, `PostMount`, `PreRender`, `PostRender`) even with zero listeners registered, the common case in production when the LiveComponent bridge is not installed (~3,150 event allocations + dispatches per request on the page above).

When the injected dispatcher implements the introspectable `Symfony\Component\EventDispatcher\EventDispatcherInterface`, `hasListeners()` is now checked (a cheap `!empty()` array lookup) before creating and dispatching each event:

- the check is done per dispatch call, so listeners registered at runtime keep working;
- any other PSR-14 dispatcher keeps the previous unconditional behavior;
- `PreRenderEvent` is still always created, because it carries the resolved template and variables to the compiled code; only its dispatch is skipped;
- when `PostMountEvent` is skipped, the extra metadata defaults to `[]`, exactly as an undispatched event would report.

The LiveComponent test suite (whose bridge subscribes to these events) passes unchanged against this branch.

**3. Build the render variables in a single pass in `preRender()`**

The variables array was spread-copied twice per render: once to create the `PreRenderEvent`, then a second full `[...spread]` to append `this`, `computed`, `outerScope`, `__props` and `__context`. The second copy is replaced with in-place assignments, the variables are only re-read from the event when it was actually dispatched, and the `array_diff_key()` call is skipped when there is no outer context (the `{{ component() }}` function path).

### Benchmark

Throw-away Symfony app (`prod` env, no profiler, OPcache on, Xdebug off) rendering a page of **642 components of 15 types** modeled on a real EasyAdmin index-page profile: 225 class-backed icons, 161 nested anonymous items with `{% props %}` defaults, 100 anonymous table cells with attributes, 23 dropdowns with named blocks, 40 renders via the `component()` function, etc. Numbers are the median of 5 processes × 30 measured iterations each (5 warmup), `hrtime()` around a full page render, on PHP 8.5 / Apple Silicon.

| Step (cumulative)            | p50 / page | Δ vs 3.x
| ---------------------------- | ---------- | --------
| 3.x baseline                 | 6.16 ms    | —
| + metadata cache             | 6.02 ms    | −2.3 %
| + event guards               | 5.54 ms    | −10.1 %
| + single-pass variables      | 5.36 ms    | **−13.1 %**

The rendered HTML is byte-identical (same SHA-1) for every step, and both the TwigComponent (299 tests) and LiveComponent (387 tests) suites pass.
