### PR TITLE
[TwigComponent] Fix syntax

### DIFF
--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -1941,8 +1941,8 @@ Debugging Components
 
 As your application grows, you'll eventually have a lot of components.
 This command will help you to debug some components issues.
-First, the debug:twig-component command lists all your application components
-that live in ``templates/components/``:
+First, the ``debug:twig-component`` command lists all your application
+components that live in ``templates/components/``:
 
 .. code-block:: terminal
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | 
| License        | MIT

I suppose it's caused by rst syntax about internal references, on [TwigComponent documentation](https://symfony.com/bundles/ux-twig-component/current/index.html#debugging-components), a command name not wrapped as code is rendered as a link.
<img width="810" height="137" alt="Capture d’écran 2026-07-05 à 17 45 48" src="https://github.com/user-attachments/assets/426533d1-145f-471e-a1a8-4b000725c65c" />