### PR TITLE
[TwigComponent] Add dynamic component support for HTML-syntax

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.5.0
 
 - Add support for `MergeableInterface` from `twig/html-extra` in `ComponentAttributes#defaults()`
+- Add support for dynamic component names in the HTML syntax using `<twig:component is="myComponent" ...`
 
 ## 3.4.0
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -854,8 +854,7 @@ There is also a non-HTML syntax that can be used:
 
 .. versionadded:: 3.4
 
-    Support for dynamic component names in the ``{% component %}`` tag was
-    added in TwigComponent 3.4.
+    Support for dynamic component names was added in TwigComponent 3.4.
 
 The ``{% component %}`` tag also accepts dynamic expressions, but they must be
 wrapped in parentheses. Without parentheses, the value is treated as the
@@ -866,6 +865,31 @@ literal component name:
     {% set prefix = 'DynamicNameComponent' %}
     {% for i in 1..2 %}
         {% component (prefix ~ i) %}{% endcomponent %}
+    {% endfor %}
+
+.. versionadded:: 3.5
+
+    Support for dynamic component names in the HTML syntax was added in TwigComponent 3.5.
+
+With the HTML syntax, use the ``<twig:component>`` tag with
+the ``is`` attribute:
+
+.. code-block:: html+twig
+
+    <twig:component is="Alert" type="success" />
+
+    {# Dynamic component name #}
+    <twig:component is="{{ componentName }}" type="success" />
+
+    {# Dynamic with content #}
+    <twig:component is="{{ componentName }}" type="success">
+        Content here
+    </twig:component>
+
+    {# Dynamic in a loop #}
+    {% set prefix = 'DynamicNameComponent' %}
+    {% for i in 1..2 %}
+        <twig:component is="{{ prefix ~ i }}" />
     {% endfor %}
 
 .. _embedded-components-context:

--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -130,6 +130,17 @@ class TwigPreLexer
                     $this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock'] = true;
                 }
 
+                // Handle <twig:component is="..." /> and <twig:component is="{{ ... }}" />
+                $isDynamicComponent = false;
+                $componentExpression = $componentName;
+                if ('component' === strtolower($componentName)) {
+                    $resolved = $this->consumeDynamicComponentName();
+                    if (null !== $resolved) {
+                        $componentExpression = $resolved['expression'];
+                        $isDynamicComponent = $resolved['isDynamic'];
+                    }
+                }
+
                 $attributes = $this->consumeAttributes($componentName);
                 $isSelfClosing = $this->consume('/>');
                 if (!$isSelfClosing) {
@@ -137,13 +148,19 @@ class TwigPreLexer
                     $this->currentComponents[] = ['name' => $componentName, 'hasDefaultBlock' => false];
                 }
 
-                if ($isSelfClosing) {
+                if ($isDynamicComponent) {
+                    if ($isSelfClosing) {
+                        $output .= "{{ component({$componentExpression}".($attributes ? ", { {$attributes} }" : '').') }}';
+                    } else {
+                        $output .= "{% component ({$componentExpression})".($attributes ? " with { {$attributes} }" : '').' %}';
+                    }
+                } elseif ($isSelfClosing) {
                     // use the simpler component() format, so that the system doesn't think
                     // this is an "embedded" component with blocks
                     // see https://github.com/symfony/ux/issues/810
-                    $output .= "{{ component('{$componentName}'".($attributes ? ", { {$attributes} }" : '').') }}';
+                    $output .= "{{ component('{$componentExpression}'".($attributes ? ", { {$attributes} }" : '').') }}';
                 } else {
-                    $output .= "{% component '{$componentName}'".($attributes ? " with { {$attributes} }" : '').' %}';
+                    $output .= "{% component '{$componentExpression}'".($attributes ? " with { {$attributes} }" : '').' %}';
                 }
 
                 continue;
@@ -209,6 +226,48 @@ class TwigPreLexer
         }
 
         throw new SyntaxError($customExceptionMessage ?? 'Expected component name when resolving the "<twig:" syntax.', $this->line);
+    }
+
+    /**
+     * @return array{expression: string, isDynamic: bool}|null
+     */
+    private function consumeDynamicComponentName(): ?array
+    {
+        $savedPosition = $this->position;
+        $savedLine = $this->line;
+
+        $this->consumeWhitespace();
+
+        $isDynamic = false;
+
+        if ($this->consume(':is=')) {
+            $isDynamic = true;
+        } elseif ($this->consume('is=')) {
+            $isDynamic = false;
+        } else {
+            $this->position = $savedPosition;
+            $this->line = $savedLine;
+
+            return null;
+        }
+
+        $quote = $this->consumeChar(["'", '"']);
+        $componentExpression = $this->consumeUntil($quote);
+        $this->expectAndConsumeChar($quote);
+
+        if ('' === $componentExpression) {
+            throw new SyntaxError(\sprintf('The "%s" attribute of "<twig:component>" must not be empty', $isDynamic ? ':is' : 'is'), $this->line);
+        }
+
+        if (!$isDynamic && str_starts_with($componentExpression, '{{') && str_ends_with($componentExpression, '}}')) {
+            $componentExpression = trim(substr($componentExpression, 2, -2));
+            if ('' === $componentExpression) {
+                throw new SyntaxError('The "is" attribute of "<twig:component>" must not be empty.', $this->line);
+            }
+            $isDynamic = true;
+        }
+
+        return ['expression' => $componentExpression, 'isDynamic' => $isDynamic];
     }
 
     private function consumeAttributes(string $componentName): string

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -244,6 +244,101 @@ final class ComponentExtensionTest extends KernelTestCase
         $template->render(['obj' => new \stdClass()]);
     }
 
+    public function testCanRenderSelfClosingDynamicComponentWithStaticIs()
+    {
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('<twig:component is="DynamicNameComponent1" />');
+        $output = $template->render();
+
+        $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
+    }
+
+    public function testCanRenderSelfClosingDynamicComponentWithDynamicIs()
+    {
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('<twig:component :is="componentName" />');
+        $output = $template->render(['componentName' => 'DynamicNameComponent1']);
+
+        $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
+    }
+
+    public function testCanRenderPairedDynamicComponentWithStaticIs()
+    {
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('<twig:component is="DynamicNameComponent1">content</twig:component>');
+        $output = $template->render();
+
+        $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
+    }
+
+    public function testCanRenderPairedDynamicComponentWithDynamicIs()
+    {
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('<twig:component :is="componentName">content</twig:component>');
+        $output = $template->render(['componentName' => 'DynamicNameComponent1']);
+
+        $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
+    }
+
+    public function testCanRenderDynamicComponentWithDynamicIsInLoop()
+    {
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('{% set prefix = "DynamicNameComponent" %}{% for i in 1..2 %}<twig:component :is="prefix ~ i" />{% endfor %}');
+        $output = $template->render();
+
+        $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
+        $this->assertStringContainsString('DynamicNameComponent2 rendered', $output);
+    }
+
+    public function testCanRenderDynamicComponentWithDynamicIsFromArray()
+    {
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('{% for i in 0..1 %}<twig:component :is="names[i]" />{% endfor %}');
+        $output = $template->render(['names' => ['DynamicNameComponent1', 'DynamicNameComponent2']]);
+
+        $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
+        $this->assertStringContainsString('DynamicNameComponent2 rendered', $output);
+    }
+
+    public function testCanRenderDynamicComponentWithPropsViaStaticIs()
+    {
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('<twig:component is="component_a" propA="A" propB="B" />');
+        $output = $template->render();
+
+        $this->assertStringContainsString('propA: A', $output);
+        $this->assertStringContainsString('propB: B', $output);
+    }
+
+    public function testCanRenderDynamicComponentWithPropsViaDynamicIs()
+    {
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('<twig:component :is="name" propA="A" propB="B" />');
+        $output = $template->render(['name' => 'component_a']);
+
+        $this->assertStringContainsString('propA: A', $output);
+        $this->assertStringContainsString('propB: B', $output);
+    }
+
+    public function testThrowsWhenDynamicComponentHtmlSyntaxNameDoesNotExist()
+    {
+        $this->expectException(RuntimeError::class);
+        $this->expectExceptionMessage('Unknown component "NonExistent"');
+
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('<twig:component :is="name" />');
+        $template->render(['name' => 'NonExistent']);
+    }
+
+    public function testCanRenderDynamicComponentInsideRegularComponent()
+    {
+        $environment = self::getContainer()->get(Environment::class);
+        $template = $environment->createTemplate('<twig:BasicComponent><twig:component :is="name" /></twig:BasicComponent>');
+        $output = $template->render(['name' => 'DynamicNameComponent1']);
+
+        $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
+    }
+
     public function testComponentWithNamespace()
     {
         $output = $this->renderComponent('foo:bar:baz');

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -41,6 +41,21 @@ final class TwigPreLexerTest extends TestCase
             '<twig:foo name="bar">{% block a %}</twig:foo>',
             'Expected closing tag "</twig:foo>" not found at line 1.',
         ];
+
+        yield 'dynamic_component_empty_is' => [
+            '<twig:component is="" />',
+            'The "is" attribute of "<twig:component>" must not be empty',
+        ];
+
+        yield 'dynamic_component_empty_dynamic_is' => [
+            '<twig:component :is="" />',
+            'The ":is" attribute of "<twig:component>" must not be empty',
+        ];
+
+        yield 'dynamic_component_static_is_with_empty_twig_expression' => [
+            '<twig:component is="{{ }}" />',
+            'The "is" attribute of "<twig:component>" must not be empty',
+        ];
     }
 
     public static function getLexTests(): iterable
@@ -414,6 +429,131 @@ final class TwigPreLexerTest extends TestCase
                 TWIG,
             '{{ component(\'foo\', { bar: \'# bar\' }) }}',
         ];
+        yield 'dynamic_component_self_closing_static_is' => [
+            '<twig:component is="Alert" />',
+            '{{ component(\'Alert\') }}',
+        ];
+
+        yield 'dynamic_component_self_closing_static_is_with_attributes' => [
+            '<twig:component is="Alert" type="success" />',
+            '{{ component(\'Alert\', { type: \'success\' }) }}',
+        ];
+
+        yield 'dynamic_component_self_closing_dynamic_is' => [
+            '<twig:component :is="componentName" />',
+            '{{ component(componentName) }}',
+        ];
+
+        yield 'dynamic_component_self_closing_dynamic_is_with_attributes' => [
+            '<twig:component :is="componentName" type="success" />',
+            '{{ component(componentName, { type: \'success\' }) }}',
+        ];
+
+        yield 'dynamic_component_self_closing_is_with_twig_expression' => [
+            '<twig:component is="{{ componentName }}" />',
+            '{{ component(componentName) }}',
+        ];
+
+        yield 'dynamic_component_self_closing_is_with_twig_expression_and_attributes' => [
+            '<twig:component is="{{ componentName }}" type="success" />',
+            '{{ component(componentName, { type: \'success\' }) }}',
+        ];
+
+        yield 'dynamic_component_paired_static_is' => [
+            '<twig:component is="Alert">content</twig:component>',
+            '{% component \'Alert\' %}{% block content %}content{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'dynamic_component_paired_dynamic_is' => [
+            '<twig:component :is="componentName">content</twig:component>',
+            '{% component (componentName) %}{% block content %}content{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'dynamic_component_paired_dynamic_is_with_attributes' => [
+            '<twig:component :is="componentName" type="success">content</twig:component>',
+            '{% component (componentName) with { type: \'success\' } %}{% block content %}content{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'dynamic_component_paired_is_with_twig_expression' => [
+            '<twig:component is="{{ componentName }}">content</twig:component>',
+            '{% component (componentName) %}{% block content %}content{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'dynamic_component_paired_dynamic_is_with_block' => [
+            '<twig:component :is="componentName"><twig:block name="footer">footer content</twig:block></twig:component>',
+            '{% component (componentName) %}{% block footer %}footer content{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'dynamic_component_dynamic_is_expression' => [
+            '<twig:component :is="prefix ~ i" />',
+            '{{ component(prefix ~ i) }}',
+        ];
+
+        yield 'dynamic_component_without_is_treated_as_regular_component' => [
+            '<twig:component foo="bar" />',
+            '{{ component(\'component\', { foo: \'bar\' }) }}',
+        ];
+
+        yield 'dynamic_component_without_is_no_attributes' => [
+            '<twig:component />',
+            '{{ component(\'component\') }}',
+        ];
+
+        yield 'dynamic_component_nested_inside_other_component' => [
+            '<twig:foo><twig:component :is="componentName" /></twig:foo>',
+            '{% component \'foo\' %}{% block content %}{{ component(componentName) }}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'dynamic_component_with_dynamic_attribute' => [
+            '<twig:component :is="componentName" :myProp="someVar" />',
+            '{{ component(componentName, { myProp: someVar }) }}',
+        ];
+
+        yield 'dynamic_component_with_boolean_attribute' => [
+            '<twig:component :is="componentName" disabled />',
+            '{{ component(componentName, { disabled: true }) }}',
+        ];
+
+        yield 'dynamic_component_with_spread_attributes' => [
+            '<twig:component :is="componentName" {{...attrs}} />',
+            '{{ component(componentName, { ...attrs }) }}',
+        ];
+
+        yield 'dynamic_component_paired_static_is_with_attributes' => [
+            '<twig:component is="Alert" type="success">content</twig:component>',
+            '{% component \'Alert\' with { type: \'success\' } %}{% block content %}content{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'dynamic_component_dynamic_is_array_access' => [
+            '<twig:component :is="components[0]" />',
+            '{{ component(components[0]) }}',
+        ];
+
+        yield 'dynamic_component_dynamic_is_property_access' => [
+            '<twig:component :is="config.component" />',
+            '{{ component(config.component) }}',
+        ];
+
+        yield 'dynamic_component_dynamic_is_ternary' => [
+            '<twig:component :is="condition ? \'Alert\' : \'Warning\'" />',
+            '{{ component(condition ? \'Alert\' : \'Warning\') }}',
+        ];
+
+        yield 'dynamic_component_paired_with_nested_component' => [
+            '<twig:component :is="outer"><twig:component :is="inner" /></twig:component>',
+            '{% component (outer) %}{% block content %}{{ component(inner) }}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'dynamic_component_paired_empty' => [
+            '<twig:component :is="componentName"></twig:component>',
+            '{% component (componentName) %}{% endcomponent %}',
+        ];
+
+        yield 'dynamic_component_with_dashed_attribute' => [
+            '<twig:component :is="componentName" data-action="foo#bar" />',
+            '{{ component(componentName, { \'data-action\': \'foo#bar\' }) }}',
+        ];
+
         yield 'component_with_comment_line_in_argument_array_value_is_kept' => [
             <<<TWIG
                 <twig:foo


### PR DESCRIPTION
| Q              | A
|--------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | no
| License        | MIT

Add support for dynamic component names in the HTML-like syntax using `<twig:component>`.

```twig
{# Static component name #}
<twig:component is="Alert" type="success" />

{# Dynamic component name #}
<twig:component :is="componentName" type="success" />

{# Dynamic with content (paired tag) #}
<twig:component :is="componentName" type="success">
    Content here
</twig:component>

{# Dynamic in a loop #}
{% set prefix = 'DynamicNameComponent' %}
{% for i in 1..2 %}
    <twig:component :is="prefix ~ i" />
{% endfor %}
```