### PR TITLE
[Toolkit] Resolve `ux:install` recipe name case-insensitively and suggest alternatives

### DIFF
--- a/src/Toolkit/src/Command/InstallCommand.php
+++ b/src/Toolkit/src/Command/InstallCommand.php
@@ -92,16 +92,24 @@ class InstallCommand extends Command
 
         // If the kit name is not explicitly provided, we need to suggest one
         if (null === $kitName) {
+            /** @var list<Kit> $kits */
+            $kits = [];
+            foreach (LocalRegistry::getAvailableKitsName() as $availableKitName) {
+                $kits[] = $this->registryFactory->getForKit($availableKitName)->getKit($availableKitName);
+            }
+
             /** @var list<Kit> $availableKits */
             $availableKits = [];
-            $availableKitNames = LocalRegistry::getAvailableKitsName();
-            foreach ($availableKitNames as $availableKitName) {
-                $kit = $this->registryFactory->getForKit($availableKitName)->getKit($availableKitName);
-
-                if (null === $recipeName) {
-                    $availableKits[] = $kit;
-                } elseif (null !== $kit->getRecipe(name: $recipeName)) {
-                    $availableKits[] = $kit;
+            if (null === $recipeName) {
+                $availableKits = $kits;
+            } else {
+                // Recipe names are stored in lower-case, so we match them case-insensitively
+                // (e.g. "Alert" resolves to the "alert" recipe) and keep the canonical name.
+                foreach ($kits as $kit) {
+                    if (null !== $recipe = $this->findRecipeIgnoringCase($kit, $recipeName)) {
+                        $availableKits[] = $kit;
+                        $recipeName = $recipe->name;
+                    }
                 }
             }
             // If more than one kit is available, we ask the user which one to use
@@ -119,9 +127,24 @@ class InstallCommand extends Command
             } else {
                 if (null === $recipeName) {
                     $io->error('It seems that no official kits are available and it should not happens. Please open an issue on https://github.com/symfony/ux to report this.');
+
+                    return Command::FAILURE;
+                }
+
+                // Suggest close recipes found across all official kits.
+                $alternativeRecipes = [];
+                foreach ($kits as $kit) {
+                    foreach ($this->getAlternativeRecipes($kit, $recipeName) as $alternativeRecipe) {
+                        $alternativeRecipes[$alternativeRecipe->name] = $alternativeRecipe;
+                    }
+                }
+                ksort($alternativeRecipes);
+
+                $message = \sprintf('The recipe "%s" does not exist in any official kit.', $recipeName);
+                if ([] !== $alternativeRecipes) {
+                    $io->warning(\sprintf('%s'."\n".'Possible alternatives: "%s". You can install one of them with: %s <recipe>', $message, implode('", "', array_keys($alternativeRecipes)), $this->getName()));
                 } else {
-                    $io->error(\sprintf('The recipe "%s" does not exist in any official kits.', $recipeName));
-                    // $io->error(\sprintf("The recipe \"%s\" does not exist in any official kits.\n\nYou can try to run one of the following commands to interactively install recipes:\n%s\n\nOr you can try one of the community kits https://github.com/search?q=topic:ux-toolkit&type=repositories", $recipeName, implode("\n", array_map(fn (string $availableKitName) => \sprintf('$ bin/console %s --kit %s', $this->getName(), $availableKitName), $availableKitNames))));
+                    $io->error($message);
                 }
 
                 return Command::FAILURE;
@@ -135,7 +158,7 @@ class InstallCommand extends Command
             // Ask for the recipe name if not provided
             $recipeName = $io->choice('Which recipe do you want to install?', array_map(static fn (Recipe $recipe) => $recipe->manifest->name, $kit->getRecipes()));
             $recipe = $kit->getRecipe(name: $recipeName);
-        } elseif (null === $recipe = $kit->getRecipe($recipeName)) {
+        } elseif (null === $recipe = $this->findRecipeIgnoringCase($kit, $recipeName)) {
             // Suggest alternatives if recipe does not exist
             $message = \sprintf('The recipe "%s" does not exist.', $recipeName);
 
@@ -210,6 +233,21 @@ class InstallCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Recipe names are stored in lower-case, so we resolve them case-insensitively
+     * (e.g. "Alert" resolves to the "alert" recipe).
+     */
+    private function findRecipeIgnoringCase(Kit $kit, string $recipeName): ?Recipe
+    {
+        foreach ($kit->getRecipes() as $recipe) {
+            if (0 === strcasecmp($recipe->name, $recipeName)) {
+                return $recipe;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Toolkit/tests/Command/InstallCommandTest.php
+++ b/src/Toolkit/tests/Command/InstallCommandTest.php
@@ -80,6 +80,37 @@ class InstallCommandTest extends KernelTestCase
         ;
     }
 
+    public function testShouldResolveRecipeNameCaseInsensitively()
+    {
+        $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
+        mkdir($destination);
+
+        $this->bootKernel();
+        $this->consoleCommand('ux:install Alert --destination='.$destination)
+            ->addInput('Shadcn UI')
+            ->execute()
+            ->assertSuccessful()
+            ->assertOutputContains('The recipe "alert" exists in multiple Kits. Which one do you want to use?')
+            ->assertOutputContains('Installing recipe "alert" from the Shadcn UI kit...')
+            ->assertOutputContains('[OK] The recipe has been installed.')
+        ;
+    }
+
+    public function testShouldResolveRecipeNameCaseInsensitivelyWithExplicitKit()
+    {
+        $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
+        mkdir($destination);
+
+        $this->bootKernel();
+        $this->consoleCommand('ux:install Alert --kit=shadcn --destination='.$destination)
+            ->execute()
+            ->assertSuccessful()
+            ->assertOutputContains('Installing recipe "alert" from the Shadcn UI kit...')
+            ->assertOutputContains('[OK] The recipe has been installed.')
+            ->assertOutputNotContains('does not exist')
+        ;
+    }
+
     public function testShouldFailWhenComponentDoesNotExist()
     {
         $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
@@ -90,6 +121,21 @@ class InstallCommandTest extends KernelTestCase
             ->execute()
             ->assertFaulty()
             ->assertOutputContains('The recipe "unknown" does not exist');
+    }
+
+    public function testShouldSuggestAlternativesFromAllKitsWhenRecipeDoesNotExist()
+    {
+        $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
+        mkdir($destination);
+
+        $this->bootKernel();
+        $this->consoleCommand('ux:install buton --destination='.$destination)
+            ->execute()
+            ->assertFaulty()
+            ->assertOutputContains('The recipe "buton" does not exist in any official kit')
+            ->assertOutputContains('Possible alternatives:')
+            ->assertOutputContains('button')
+        ;
     }
 
     public function testShouldWarnWhenComponentFileAlreadyExistsInNonInteractiveMode()


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT


Recipe names are stored in lower-case, so `ux:install Alert` used to fail with a raw "does not exist in any official kits" error. Recipe lookup is now case-insensitive: `Alert` resolves to the `alert` recipe and offers to install it from the kits that contain it, both without `--kit` (the "which kit?" prompt) and with an explicit `--kit=shadcn` (direct install, no redundant confirmation). Genuine typos still go through the alternative-recipe suggestions.

When a recipe truly does not exist in any official kit, the error now suggests
close alternatives found across all kits.