### PR TITLE
[StimulusBundle] Sort custom controllers to keep the generated loader deterministic

### DIFF
--- a/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
+++ b/src/StimulusBundle/src/AssetMapper/ControllersMapGenerator.php
@@ -66,7 +66,10 @@ class ControllersMapGenerator
         $finder = new Finder();
         $finder->in($this->controllerPaths)
             ->files()
-            ->name(self::FILENAME_REGEX);
+            ->name(self::FILENAME_REGEX)
+            // the filesystem iteration order is not stable, sort to keep the
+            // generated controllers loader (and so its digest) deterministic
+            ->sortByName();
 
         $controllersMap = [];
         foreach ($finder as $file) {

--- a/src/StimulusBundle/tests/AssetMapper/ControllersMapGeneratorTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/ControllersMapGeneratorTest.php
@@ -119,4 +119,49 @@ class ControllersMapGeneratorTest extends TestCase
         $minifiedController = $map['minified'];
         $this->assertTrue($minifiedController->isLazy);
     }
+
+    public function testCustomControllersAreSortedByName()
+    {
+        $mapper = $this->createMock(AssetMapperInterface::class);
+        $mapper->expects($this->any())
+            ->method('getAssetFromSourcePath')
+            ->willReturnCallback(static function ($path) {
+                // replace windows slashes
+                $path = str_replace('\\', '/', $path);
+                $assetsPosition = strpos($path, '/assets/');
+
+                return new MappedAsset(substr($path, $assetsPosition + 1), $path);
+            });
+
+        $autoImportLocator = $this->createMock(AutoImportLocator::class);
+        $autoImportLocator->expects($this->any())
+            ->method('locateAutoImport')
+            ->willReturnCallback(static function ($path) {
+                return new MappedControllerAutoImport('/path/to'.$path, false);
+            });
+
+        $generator = new ControllersMapGenerator(
+            $mapper,
+            new UxPackageReader(__DIR__.'/../fixtures'),
+            [__DIR__.'/../fixtures/assets/controllers'],
+            __DIR__.'/../fixtures/assets/controllers.json',
+            $autoImportLocator,
+        );
+
+        $customControllers = array_values(array_filter(
+            array_keys($generator->getControllersMap()),
+            static fn (string $name) => !str_starts_with($name, 'fake-vendor--'),
+        ));
+
+        $this->assertSame([
+            'bye',
+            'hello',
+            'hello-with-dashes',
+            'hello-with-underscores',
+            'subdir--deeper',
+            'subdir--deeper-with-dashes',
+            'subdir--deeper-with-underscores',
+            'typescript',
+        ], $customControllers);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #3562
| License       | MIT

`ControllersMapGenerator::loadCustomControllers()` iterates a `Finder` without any sort:

```php
$finder->in($this->controllerPaths)
    ->files()
    ->name(self::FILENAME_REGEX);
```

Directory iteration order is filesystem-dependent (ext4/btrfs store entries in a hash tree), so the custom controllers land in the map in an arbitrary order. `StimulusLoaderJavaScriptCompiler` then emits the `import` statements in that same order, so the generated loader's contents — and therefore its digest — change between builds even though no controller changed. Cache busting is defeated.

Adding `->sortByName()` makes the order deterministic. Thanks @ywjdlq for the report, which already contained the root cause and the fix.

### Tests

`testCustomControllersAreSortedByName` asserts the order of the custom controllers in the map. It genuinely fails without the fix on my machine (ext4): the fixtures come back as `hello, hello-with-dashes, …, bye, typescript`, with `bye_controller.js` next to last.

### Note

The same code is on `2.x`. I targeted `3.x` since that is what `CONTRIBUTING.md` points at, but I'm happy to retarget if you'd rather have it on the older branch.
