### PR TITLE
[Toolkit][Common] Add the `common` kit with `logout-link` and `post-link` recipes

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.4.0
 
 - Add new linter checker `ClassMergeSpacingChecker` that checks for invalid `'<literal>' ~ attributes.render(...)` pattern
+- [Common] Add the `common` kit, with design-system agnostic `logout-link` and `post-link` recipes
 
 ## 3.3.0
 

--- a/src/Toolkit/kits/common/INSTALL.md
+++ b/src/Toolkit/kits/common/INSTALL.md
@@ -1,0 +1,18 @@
+# Getting started
+
+This kit provides ready-to-use and fully-customizable Twig components for common Symfony needs.
+
+Unlike the other kits, the `common` kit is **design-system agnostic**: its components ship no styling of their own, so they blend into any project regardless of the CSS framework (or design system) you use.
+
+> [!NOTE]
+> The demos and examples on the component pages use a few Tailwind CSS classes purely so they look presentable. The components themselves are unstyled — **how they look is entirely up to you**. Style them with your own classes, utilities, or design system; nothing about the kit assumes Tailwind.
+
+## Installation
+
+The components are installed on demand, each one pulling in its own dependencies. For example:
+
+```shell
+php bin/console ux:install logout-link --kit common
+```
+
+Once installed, the components live in your project (typically under `templates/components/`) and are yours to customize.

--- a/src/Toolkit/kits/common/logout-link/examples/Demo.html.twig
+++ b/src/Toolkit/kits/common/logout-link/examples/Demo.html.twig
@@ -1,0 +1,3 @@
+<twig:LogoutLink class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+    Logout
+</twig:LogoutLink>

--- a/src/Toolkit/kits/common/logout-link/examples/Specific Firewall.html.twig
+++ b/src/Toolkit/kits/common/logout-link/examples/Specific Firewall.html.twig
@@ -1,0 +1,3 @@
+<twig:LogoutLink firewall="main" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+    Logout from the main firewall
+</twig:LogoutLink>

--- a/src/Toolkit/kits/common/logout-link/examples/Usage.html.twig
+++ b/src/Toolkit/kits/common/logout-link/examples/Usage.html.twig
@@ -1,0 +1,3 @@
+<twig:LogoutLink>
+    Logout
+</twig:LogoutLink>

--- a/src/Toolkit/kits/common/logout-link/manifest.json
+++ b/src/Toolkit/kits/common/logout-link/manifest.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Logout Link",
+    "description": "A link that logs the current user out through a secure POST form.",
+    "version-added": "3.4",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["symfony/security-bundle"],
+        "recipe": ["post-link"]
+    }
+}

--- a/src/Toolkit/kits/common/logout-link/templates/components/LogoutLink.html.twig
+++ b/src/Toolkit/kits/common/logout-link/templates/components/LogoutLink.html.twig
@@ -1,0 +1,10 @@
+{# @prop firewall string|null The firewall name to log out from; when null, the current firewall is used. #}
+{# @block content The link label. #}
+{% props firewall = null %}
+
+<twig:PostLink {{ ...attributes.defaults({
+    href: logout_path(firewall),
+    csrfTokenId: 'logout',
+}) }}>
+    {{ block(outerBlocks.content)|default('Logout') }}
+</twig:PostLink>

--- a/src/Toolkit/kits/common/manifest.json
+++ b/src/Toolkit/kits/common/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../schema-kit-v1.json",
+    "name": "Common",
+    "description": "Design-system agnostic, ready-to-use Twig components for common Symfony needs, like logout links and links submitted as forms.",
+    "license": "MIT",
+    "homepage": "https://ux.symfony.com/toolkit/kits/common"
+}

--- a/src/Toolkit/kits/common/post-link/examples/Custom Method.html.twig
+++ b/src/Toolkit/kits/common/post-link/examples/Custom Method.html.twig
@@ -1,0 +1,3 @@
+<twig:PostLink href="/link/posts/42" method="DELETE" class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500">
+    Delete post
+</twig:PostLink>

--- a/src/Toolkit/kits/common/post-link/examples/Demo.html.twig
+++ b/src/Toolkit/kits/common/post-link/examples/Demo.html.twig
@@ -1,0 +1,3 @@
+<twig:PostLink href="/link/newsletter/subscribe" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+    Subscribe
+</twig:PostLink>

--- a/src/Toolkit/kits/common/post-link/examples/Usage.html.twig
+++ b/src/Toolkit/kits/common/post-link/examples/Usage.html.twig
@@ -1,0 +1,3 @@
+<twig:PostLink href="/posts/42/publish">
+    Publish
+</twig:PostLink>

--- a/src/Toolkit/kits/common/post-link/examples/With CSRF Protection.html.twig
+++ b/src/Toolkit/kits/common/post-link/examples/With CSRF Protection.html.twig
@@ -1,0 +1,3 @@
+<twig:PostLink href="/link/posts/42/delete" csrfTokenId="delete-post" class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500">
+    Delete post
+</twig:PostLink>

--- a/src/Toolkit/kits/common/post-link/examples/With Confirmation.html.twig
+++ b/src/Toolkit/kits/common/post-link/examples/With Confirmation.html.twig
@@ -1,0 +1,3 @@
+<twig:PostLink href="/link/posts/42/delete" confirm="Are you sure you want to delete this post?" class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500">
+    Delete post
+</twig:PostLink>

--- a/src/Toolkit/kits/common/post-link/manifest.json
+++ b/src/Toolkit/kits/common/post-link/manifest.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Post Link",
+    "description": "A link submitted as a form, with optional HTTP method spoofing, CSRF protection, and a confirmation prompt.",
+    "version-added": "3.4",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["symfony/security-csrf"]
+    }
+}

--- a/src/Toolkit/kits/common/post-link/templates/components/PostLink.html.twig
+++ b/src/Toolkit/kits/common/post-link/templates/components/PostLink.html.twig
@@ -1,0 +1,28 @@
+{# @prop href string The URL the form submits to. #}
+{# @prop csrfTokenId string|null The CSRF token ID used to generate the hidden token field; when null, no token is added. #}
+{# @prop method string The HTTP method used to submit the form; when not `POST`, a hidden `_method` field is added for method spoofing. #}
+{# @prop confirm string|null A confirmation message shown before submitting; when null, no confirmation is required. #}
+{# @block content The button label. #}
+{% props href, csrfTokenId = null, method = 'POST', confirm = null %}
+
+<form{{ attributes.nested('form').defaults({
+    action: href,
+    method: 'post',
+    class: 'inline',
+    onsubmit: confirm ? 'return confirm(' ~ confirm|json_encode ~ ')' : false,
+}) }}>
+    {% if method|upper != 'POST' %}
+        <input type="hidden" name="_method" value="{{ method|upper }}">
+    {% endif %}
+    {% if csrfTokenId %}
+        <input{{ attributes.nested('csrf').defaults({
+            type: 'hidden',
+            name: '_csrf_token',
+            'data-controller': 'csrf-protection',
+            value: csrf_token(csrfTokenId),
+        }) }}>
+    {% endif %}
+    <button{{ attributes.defaults({type: 'submit'}) }}>
+        {% block content %}{% endblock %}
+    </button>
+</form>

--- a/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerChecker.php
@@ -15,12 +15,12 @@ use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\UX\Toolkit\Dependency\RecipeDependency;
 use Symfony\UX\Toolkit\Kit\Kit;
-
-use function Symfony\Component\String\u;
 use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
 use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
 use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
 use Symfony\UX\Toolkit\Recipe\Recipe;
+
+use function Symfony\Component\String\u;
 
 /**
  * Detects `data-controller="..."` usages in Twig templates and verifies that a matching
@@ -32,6 +32,12 @@ use Symfony\UX\Toolkit\Recipe\Recipe;
  */
 final class StimulusControllerChecker implements KitCheckerInterface
 {
+    /**
+     * Controllers provided by the framework/ecosystem rather than shipped by a recipe
+     * (e.g. Symfony's `csrf-protection` controller from symfony/stimulus-bundle).
+     */
+    private const KNOWN_EXTERNAL_CONTROLLERS = ['csrf-protection'];
+
     public function check(Kit $kit): iterable
     {
         foreach ($kit->getRecipes() as $recipe) {
@@ -57,6 +63,9 @@ final class StimulusControllerChecker implements KitCheckerInterface
             }
 
             foreach ($controllerNames as $controllerName => $file) {
+                if (\in_array($controllerName, self::KNOWN_EXTERNAL_CONTROLLERS, true)) {
+                    continue;
+                }
                 if (\in_array($controllerName, $shippedControllers, true)) {
                     continue;
                 }

--- a/src/Toolkit/tests/Fixtures/Kernel.php
+++ b/src/Toolkit/tests/Fixtures/Kernel.php
@@ -68,6 +68,9 @@ final class Kernel extends BaseKernel
         ]);
 
         $container->services()
+            ->set(SecurityTwigStubExtension::class)
+                ->tag('twig.extension')
+
             ->alias('ux_toolkit.kit.kit_factory', '.ux_toolkit.kit.kit_factory')
                 ->public()
 

--- a/src/Toolkit/tests/Fixtures/SecurityTwigStubExtension.php
+++ b/src/Toolkit/tests/Fixtures/SecurityTwigStubExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Fixtures;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Stubs the Security/CSRF Twig functions used by the `common` kit recipes, so the
+ * components can be rendered by the functional snapshot tests without registering
+ * the whole SecurityBundle (and a firewall) in the test kernel.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class SecurityTwigStubExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('logout_path', static fn (?string $key = null): string => '/logout'.(null !== $key ? '?firewall='.$key : '')),
+            new TwigFunction('logout_url', static fn (?string $key = null): string => 'http://localhost/logout'.(null !== $key ? '?firewall='.$key : '')),
+            new TwigFunction('csrf_token', static fn (string $tokenId): string => 'csrf-token-for-'.$tokenId),
+        ];
+    }
+}

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component logout-link, code file Demo.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component logout-link, code file Demo.html.twig__1.html
@@ -1,0 +1,17 @@
+<!--
+- Kit: Common
+- Component: Logout Link
+- Code:
+```twig
+<twig:LogoutLink class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+    Logout
+</twig:LogoutLink>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<form action="/logout" method="post" class="inline">
+                <input type="hidden" name="_csrf_token" data-controller="csrf-protection" value="csrf-token-for-logout">
+        <button type="submit" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Logout
+
+    </button>
+</form>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component logout-link, code file Specific Firewall.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component logout-link, code file Specific Firewall.html.twig__1.html
@@ -1,0 +1,17 @@
+<!--
+- Kit: Common
+- Component: Logout Link
+- Code:
+```twig
+<twig:LogoutLink firewall="main" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+    Logout from the main firewall
+</twig:LogoutLink>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<form action="/logout?firewall=main" method="post" class="inline">
+                <input type="hidden" name="_csrf_token" data-controller="csrf-protection" value="csrf-token-for-logout">
+        <button type="submit" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Logout from the main firewall
+
+    </button>
+</form>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component post-link, code file Custom Method.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component post-link, code file Custom Method.html.twig__1.html
@@ -1,0 +1,16 @@
+<!--
+- Kit: Common
+- Component: Post Link
+- Code:
+```twig
+<twig:PostLink href="/link/posts/42" method="DELETE" class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500">
+    Delete post
+</twig:PostLink>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<form action="/link/posts/42" method="post" class="inline">
+            <input type="hidden" name="_method" value="DELETE">
+            <button type="submit" class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500">
+        Delete post
+    </button>
+</form>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component post-link, code file Demo.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component post-link, code file Demo.html.twig__1.html
@@ -1,0 +1,15 @@
+<!--
+- Kit: Common
+- Component: Post Link
+- Code:
+```twig
+<twig:PostLink href="/link/newsletter/subscribe" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+    Subscribe
+</twig:PostLink>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<form action="/link/newsletter/subscribe" method="post" class="inline">
+            <button type="submit" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Subscribe
+    </button>
+</form>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component post-link, code file With CSRF Protection.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component post-link, code file With CSRF Protection.html.twig__1.html
@@ -1,0 +1,16 @@
+<!--
+- Kit: Common
+- Component: Post Link
+- Code:
+```twig
+<twig:PostLink href="/link/posts/42/delete" csrfTokenId="delete-post" class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500">
+    Delete post
+</twig:PostLink>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<form action="/link/posts/42/delete" method="post" class="inline">
+                <input type="hidden" name="_csrf_token" data-controller="csrf-protection" value="csrf-token-for-delete-post">
+        <button type="submit" class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500">
+        Delete post
+    </button>
+</form>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component post-link, code file With Confirmation.html.twig__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component post-link, code file With Confirmation.html.twig__1.html
@@ -1,0 +1,15 @@
+<!--
+- Kit: Common
+- Component: Post Link
+- Code:
+```twig
+<twig:PostLink href="/link/posts/42/delete" confirm="Are you sure you want to delete this post?" class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500">
+    Delete post
+</twig:PostLink>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<form action="/link/posts/42/delete" method="post" class="inline" onsubmit='return confirm("Are you sure you want to delete this post?")'>
+            <button type="submit" class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500">
+        Delete post
+    </button>
+</form>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | https://github.com/symfony/ux.symfony.com/pull/159
| Documentation? | todo
| Issues         | n/a
| License        | MIT

Introduce a new design-system agnostic kit for common Symfony needs. It ships two recipes:

### `post-link`

A link submitted as a `POST` form instead of a plain anchor — for state-changing actions that shouldn't be `GET` requests.

```twig
<twig:PostLink href="/newsletter/subscribe">Subscribe</twig:PostLink>
```

With HTTP method spoofing:

```twig
<twig:PostLink href="/posts/42" method="DELETE">Delete post</twig:PostLink>
```

With a confirmation prompt:

```twig
<twig:PostLink href="/posts/42/delete" confirm="Are you sure?">Delete post</twig:PostLink>
```

With CSRF protection (hidden token wired to Symfony's `csrf-protection` controller):

```twig
<twig:PostLink href="/posts/42/delete" csrfTokenId="delete-post">Delete post</twig:PostLink>
```

### `logout-link`

A link that logs the current user out through a secure `POST` form — built on top of `post-link`, so it's CSRF-protected out of the box.

```twig
<twig:LogoutLink>Logout</twig:LogoutLink>
```

Targeting a specific firewall:

```twig
<twig:LogoutLink firewall="main">Logout</twig:LogoutLink>
```

I have more *common* recipes in the pipeline, I just wanted to get this started.

Here's the [companion ux.symfony.com PR](https://github.com/symfony/ux.symfony.com/pull/159).
