### PR TITLE
[Toolkit] Add `ClassMergeSpacingChecker` checker to the linter

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.4.0
+
+- Add new linter checker `ClassMergeSpacingChecker` that checks for invalid `'<literal>' ~ attributes.render(...)` pattern
+
 ## 3.3.0
 
 - Lint component docblocks: check the `{# @prop #}` and `{# @block #}` format and their consistency with the `{% props %}` declaration and the rendered blocks

--- a/src/Toolkit/src/Kit/Lint/Checker/ClassMergeSpacingChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/ClassMergeSpacingChecker.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
+
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Finder\Finder;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+
+/**
+ * Detects the class-merge idiom `('<base classes> ' ~ attributes.render('class'))|tailwind_merge`
+ * where the base classes literal is missing its trailing space.
+ *
+ * Without that space, the last class of the literal and the first class coming from `attributes`
+ * are concatenated into a single, invalid class name (e.g. `...pe-0` + `foo` => `pe-0foo`), so the
+ * consumer's first class is silently dropped.
+ *
+ * Only the `'<literal>' ~ attributes.render(...)` concatenation is checked: the argument form
+ * `style.apply({...}, attributes.render('class'))` inserts the separator itself and is left alone.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class ClassMergeSpacingChecker implements KitCheckerInterface
+{
+    /**
+     * A single- or double-quoted string literal directly concatenated with `attributes.render(...)`.
+     * The captured `content` never contains a quote, matching the existing checker convention.
+     */
+    private const RE_CONCAT = '/([\'"])(?<content>[^\'"]*)\1\s*~\s*attributes\.render\(/';
+
+    public function check(Kit $kit): iterable
+    {
+        foreach ($kit->getRecipes() as $recipe) {
+            $templatesDir = Path::join($recipe->absolutePath, 'templates');
+            if (!is_dir($templatesDir)) {
+                continue;
+            }
+
+            $finder = new Finder()->in($templatesDir)->files()->name('*.html.twig')->sortByName();
+            foreach ($finder as $file) {
+                yield from $this->checkFile($recipe->name, $file->getRelativePathname(), $file->getContents());
+            }
+        }
+    }
+
+    /**
+     * @return iterable<LintIssue>
+     */
+    private function checkFile(string $recipe, string $file, string $contents): iterable
+    {
+        if (!preg_match_all(self::RE_CONCAT, $contents, $matches, \PREG_OFFSET_CAPTURE | \PREG_SET_ORDER)) {
+            return;
+        }
+
+        foreach ($matches as $match) {
+            $content = $match['content'][0];
+
+            // An empty literal (`'' ~ attributes.render('class')`) needs no separator.
+            if ('' === $content || preg_match('/\s$/', $content)) {
+                continue;
+            }
+
+            $line = substr_count($contents, "\n", 0, $match[0][1]) + 1;
+            $tail = \strlen($content) > 40 ? '…'.substr($content, -40) : $content;
+
+            yield new LintIssue(
+                severity: LintSeverity::Error,
+                category: 'component.class.missing-space',
+                message: \sprintf(
+                    'Missing space before `attributes.render(...)` on line %d: the class list literal ending with "%s" must end with a space, otherwise its last class and the first class coming from `attributes` are merged into a single class name. Add a space before the closing quote.',
+                    $line,
+                    $tail,
+                ),
+                recipe: $recipe,
+                file: $file,
+            );
+        }
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/KitLinter.php
+++ b/src/Toolkit/src/Kit/Lint/KitLinter.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\Toolkit\Kit\Lint;
 
 use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\ClassMergeSpacingChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\ComponentDocChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\ComposerSymbolChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\CopyFilesExistenceChecker;
@@ -47,6 +48,7 @@ final class KitLinter
             new JsImportChecker(),
             new ComposerSymbolChecker(),
             new ComponentDocChecker(),
+            new ClassMergeSpacingChecker(),
         ];
     }
 

--- a/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/manifest.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Cases",
+    "description": "One template per class-merge spacing scenario.",
+    "copy-files": {
+        "templates/": "templates/"
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/ApplyArg.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/ApplyArg.html.twig
@@ -1,0 +1,2 @@
+{%- set style = html_cva(base: 'inline-flex items-center') -%}
+<button class="{{ style.apply({}, attributes.render('class'))|tailwind_merge }}"></button>

--- a/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/DoubleQuote.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/DoubleQuote.html.twig
@@ -1,0 +1,2 @@
+{%- set classes = "flex gap-2" ~ attributes.render('class') -%}
+<div class="{{ classes|tailwind_merge }}"></div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/EmptyLiteral.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/EmptyLiteral.html.twig
@@ -1,0 +1,1 @@
+<div class="{{ ('' ~ attributes.render('class'))|tailwind_merge }}"></div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/MissingSpace.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/MissingSpace.html.twig
@@ -1,0 +1,1 @@
+<div class="{{ ('flex items-center gap-2' ~ attributes.render('class'))|tailwind_merge }}"></div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/Mixed.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/Mixed.html.twig
@@ -1,0 +1,3 @@
+<div class="{{ ('rounded-md border ' ~ attributes.render('class'))|tailwind_merge }}">
+    <span class="{{ ('text-sm font-medium' ~ attributes.render('class'))|tailwind_merge }}"></span>
+</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/Valid.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-class-merge/cases/templates/components/Valid.html.twig
@@ -1,0 +1,1 @@
+<div class="{{ ('flex items-center gap-2 ' ~ attributes.render('class'))|tailwind_merge }}"></div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-class-merge/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-class-merge/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "Lint Class Merge",
+    "description": "Kit covering ClassMergeSpacingChecker scenarios.",
+    "license": "MIT",
+    "homepage": "https://example.com/lint-class-merge"
+}

--- a/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
+++ b/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\UX\Toolkit\Kit\Kit;
 use Symfony\UX\Toolkit\Kit\KitFactory;
 use Symfony\UX\Toolkit\Kit\KitSynchronizer;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\ClassMergeSpacingChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\ComposerSymbolChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\CopyFilesExistenceChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\JsImportChecker;
@@ -253,5 +254,39 @@ class KitLinterTest extends TestCase
         $this->assertSame($category, $issues[0]->category);
         $this->assertSame(LintSeverity::Warning, $issues[0]->severity);
         $this->assertStringContainsString($needle, $issues[0]->message);
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function provideClassMergeCases(): iterable
+    {
+        // template file => number of expected issues
+        yield 'literal ending with a space' => ['Valid.html.twig', 0];
+        yield 'literal missing the trailing space' => ['MissingSpace.html.twig', 1];
+        yield 'empty literal needs no separator' => ['EmptyLiteral.html.twig', 0];
+        yield 'argument form (.apply) is not concatenation' => ['ApplyArg.html.twig', 0];
+        yield 'double-quoted literal missing the trailing space' => ['DoubleQuote.html.twig', 1];
+        yield 'one valid and one invalid concatenation' => ['Mixed.html.twig', 1];
+    }
+
+    #[DataProvider('provideClassMergeCases')]
+    public function testClassMergeSpacingChecker(string $file, int $expectedCount)
+    {
+        $kit = $this->loadFixtureKit('lint-class-merge');
+
+        $report = new KitLinter([new ClassMergeSpacingChecker()])->lint($kit);
+
+        $matching = array_values(array_filter(
+            $report->getIssues(),
+            static fn (LintIssue $i) => 'component.class.missing-space' === $i->category
+                && null !== $i->file && str_contains($i->file, $file),
+        ));
+
+        $this->assertCount($expectedCount, $matching, \sprintf('File "%s" must produce %d issue(s).', $file, $expectedCount));
+        foreach ($matching as $issue) {
+            $this->assertSame(LintSeverity::Error, $issue->severity);
+            $this->assertSame('cases', $issue->recipe);
+        }
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

We have some occurences `'foo' ~ attributes.render('class')` which generates invalid classes when the user is passing `class` attr  (e.g.: `<twig:Toto class="bar">` will render `class="foobar"`

Related to https://github.com/symfony/ux/pull/3708#pullrequestreview-4720468133