### PR TITLE
[React][Vue] Add support for `import.meta.glob()` (Symfony Reprise)

### DIFF
--- a/src/React/CHANGELOG.md
+++ b/src/React/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.4
+
+- Add support for `import.meta.glob()` (Symfony Reprise) in `registerReactControllerComponents()`
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/React/assets/dist/register_controller.d.ts
+++ b/src/React/assets/dist/register_controller.d.ts
@@ -1,10 +1,14 @@
 import { ComponentClass, FunctionComponent } from "react";
 type Component = string | FunctionComponent<object> | ComponentClass<object, any>;
+type GlobModule = {
+  default: Component;
+};
+type GlobResult = Record<string, GlobModule | (() => Promise<GlobModule>)>;
 declare global {
   function resolveReactComponent(name: string): Component;
   interface Window {
     resolveReactComponent(name: string): Component;
   }
 }
-declare function registerReactControllerComponents(context: __WebpackModuleApi.RequireContext): void;
+declare function registerReactControllerComponents(context: __WebpackModuleApi.RequireContext | GlobResult): void;
 export { registerReactControllerComponents };

--- a/src/React/assets/dist/register_controller.js
+++ b/src/React/assets/dist/register_controller.js
@@ -1,11 +1,15 @@
 function registerReactControllerComponents(context) {
 	const reactControllers = {};
-	const importAllReactComponents = (r) => {
-		r.keys().forEach((key) => {
-			reactControllers[key] = r(key).default;
+	if (typeof context === "function") context.keys().forEach((key) => {
+		reactControllers[key] = context(key).default;
+	});
+	else {
+		const keyMapping = normalizeGlobKeys(Object.keys(context));
+		Object.entries(context).forEach(([key, module]) => {
+			if (typeof module === "function") throw new Error(`React controller "${key}" could not be registered from a lazy "import.meta.glob()". Enable the "eager" option, e.g. import.meta.glob('./react/controllers/**/*.{jsx,tsx}', { eager: true }).`);
+			reactControllers[keyMapping[key]] = module.default;
 		});
-	};
-	importAllReactComponents(context);
+	}
 	window.resolveReactComponent = (name) => {
 		const component = reactControllers[`./${name}.jsx`] || reactControllers[`./${name}.tsx`];
 		if (typeof component === "undefined") {
@@ -16,5 +20,22 @@ function registerReactControllerComponents(context) {
 		}
 		return component;
 	};
+}
+function normalizeGlobKeys(keys) {
+	if (keys.length === 0) return {};
+	const segments = keys.map((key) => key.split("/"));
+	let commonLength = Math.min(...segments.map((parts) => parts.length - 1));
+	for (let i = 0; i < commonLength; i++) {
+		const segment = segments[0][i];
+		if (!segments.every((parts) => parts[i] === segment)) {
+			commonLength = i;
+			break;
+		}
+	}
+	const mapping = {};
+	keys.forEach((key, index) => {
+		mapping[key] = `./${segments[index].slice(commonLength).join("/")}`;
+	});
+	return mapping;
 }
 export { registerReactControllerComponents };

--- a/src/React/assets/src/register_controller.ts
+++ b/src/React/assets/src/register_controller.ts
@@ -13,6 +13,11 @@ import type { ComponentClass, FunctionComponent } from 'react';
 
 type Component = string | FunctionComponent<object> | ComponentClass<object, any>;
 
+// A single entry from Vite's / Rsbuild's `import.meta.glob()`: an eagerly-imported
+// module, or a function returning one for a lazy glob.
+type GlobModule = { default: Component };
+type GlobResult = Record<string, GlobModule | (() => Promise<GlobModule>)>;
+
 declare global {
     function resolveReactComponent(name: string): Component;
 
@@ -21,16 +26,27 @@ declare global {
     }
 }
 
-export function registerReactControllerComponents(context: __WebpackModuleApi.RequireContext) {
+export function registerReactControllerComponents(context: __WebpackModuleApi.RequireContext | GlobResult) {
     const reactControllers: { [key: string]: Component } = {};
 
-    const importAllReactComponents = (r: __WebpackModuleApi.RequireContext) => {
-        r.keys().forEach((key) => {
-            reactControllers[key] = r(key).default;
+    if (typeof context === 'function') {
+        // Webpack's `require.context()`
+        context.keys().forEach((key) => {
+            reactControllers[key] = context(key).default;
         });
-    };
+    } else {
+        // Vite's / Rsbuild's `import.meta.glob(..., { eager: true })`
+        const keyMapping = normalizeGlobKeys(Object.keys(context));
+        Object.entries(context).forEach(([key, module]) => {
+            if (typeof module === 'function') {
+                throw new Error(
+                    `React controller "${key}" could not be registered from a lazy "import.meta.glob()". Enable the "eager" option, e.g. import.meta.glob('./react/controllers/**/*.{jsx,tsx}', { eager: true }).`
+                );
+            }
 
-    importAllReactComponents(context);
+            reactControllers[keyMapping[key]] = module.default;
+        });
+    }
 
     // Expose a global React loader to allow rendering from the Stimulus controller
     window.resolveReactComponent = (name: string): Component => {
@@ -50,4 +66,34 @@ export function registerReactControllerComponents(context: __WebpackModuleApi.Re
 
         return component;
     };
+}
+
+/**
+ * Maps the keys returned by `import.meta.glob()` to the `./<name>.<ext>` form
+ * produced by Webpack's `require.context()`, by stripping the directory prefix
+ * shared by every key (e.g. `./react/controllers/`).
+ */
+function normalizeGlobKeys(keys: string[]): Record<string, string> {
+    if (keys.length === 0) {
+        return {};
+    }
+
+    const segments = keys.map((key) => key.split('/'));
+
+    // Number of leading directory segments shared by every key (the filename is never included).
+    let commonLength = Math.min(...segments.map((parts) => parts.length - 1));
+    for (let i = 0; i < commonLength; i++) {
+        const segment = segments[0][i];
+        if (!segments.every((parts) => parts[i] === segment)) {
+            commonLength = i;
+            break;
+        }
+    }
+
+    const mapping: Record<string, string> = {};
+    keys.forEach((key, index) => {
+        mapping[key] = `./${segments[index].slice(commonLength).join('/')}`;
+    });
+
+    return mapping;
 }

--- a/src/React/assets/test/unit/register_controller.test.tsx
+++ b/src/React/assets/test/unit/register_controller.test.tsx
@@ -7,6 +7,8 @@
  * file that was distributed with this source code.
  */
 
+/// <reference types="vite/client" />
+
 import { describe, expect, it } from 'vitest';
 import { registerReactControllerComponents } from '../../src/register_controller';
 // @ts-expect-error
@@ -55,6 +57,32 @@ describe('registerReactControllerComponents', () => {
 
         expect(() => resolveComponent('NoDefaultExportComponent')).toThrow(
             'React controller "NoDefaultExportComponent" could not be resolved. Ensure the module exports the controller as a default export.'
+        );
+    });
+});
+
+describe('registerReactControllerComponents with import.meta.glob()', () => {
+    it('registers eager components', () => {
+        registerReactControllerComponents(import.meta.glob('../fixtures/*.{jsx,tsx}', { eager: true }));
+        const resolveComponent = (window as any).resolveReactComponent;
+
+        expect(resolveComponent).not.toBeUndefined();
+        expect(resolveComponent('MyTsxComponent')).toBe(MyTsxComponent);
+        expect(resolveComponent('MyJsxComponent')).not.toBeUndefined();
+    });
+
+    it('errors with a bad name', () => {
+        registerReactControllerComponents(import.meta.glob('../fixtures/*.{jsx,tsx}', { eager: true }));
+        const resolveComponent = (window as any).resolveReactComponent;
+
+        expect(() => resolveComponent('MyABCComponent')).toThrow(
+            'React controller "MyABCComponent" does not exist. Possible values: MyJsxComponent, MyTsxComponent'
+        );
+    });
+
+    it('throws a helpful error when given a lazy glob', () => {
+        expect(() => registerReactControllerComponents(import.meta.glob('../fixtures/*.{jsx,tsx}'))).toThrow(
+            /Enable the "eager" option/
         );
     });
 });

--- a/src/React/doc/index.rst
+++ b/src/React/doc/index.rst
@@ -17,8 +17,13 @@ Installation
 
 .. note::
 
-    This package works best with WebpackEncore. To use it with AssetMapper, see
-    :ref:`Using with AssetMapper <using-with-asset-mapper>`.
+    This package works best with `Symfony Reprise`_ (`Vite`_ or `Rsbuild`_). To use it with
+    Webpack Encore, see :ref:`Using with Webpack Encore <react-using-with-webpack-encore>`;
+    to use it with AssetMapper, see :ref:`Using with AssetMapper <using-with-asset-mapper>`.
+
+.. note::
+
+    Symfony Reprise support requires ``symfony/ux-react`` 3.4 and ``symfony/reprise`` 0.4.
 
 Install the bundle using Composer and Symfony Flex:
 
@@ -26,20 +31,11 @@ Install the bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-react
 
-The Flex recipe will automatically set things up for you, like adding
-``.enableReactPreset()`` to your ``webpack.config.js`` file and adding code
-to load your React components inside ``assets/app.js``.
+The Flex recipe will automatically set things up for you, adding the code to load
+your React components inside ``assets/app.js``.
 
-Next, install a package to help React:
-
-.. code-block:: terminal
-
-    $ npm install -D @babel/preset-react --force
-    $ npm run watch
-
-.. note::
-
-    For more complex installation scenarios, you can install the JavaScript assets through the `@symfony/ux-react npm package`_
+You also need the React plugin for your bundler so it can compile JSX:
+`@vitejs/plugin-react`_ for Vite, or `@rsbuild/plugin-react`_ for Rsbuild.
 
 That's it! Any files inside ``assets/react/controllers/`` can now be rendered as
 React components.
@@ -58,11 +54,14 @@ code to your ``assets/app.js`` file:
     // assets/app.js
     import { registerReactControllerComponents } from '@symfony/ux-react';
 
-    registerReactControllerComponents(require.context('./react/controllers', true, /\.(j|t)sx?$/));
+    registerReactControllerComponents(
+        import.meta.glob('./react/controllers/**/*.{jsx,tsx}', { eager: true })
+    );
 
 This will load all React components located in the ``assets/react/controllers``
-directory. These are known as **React controller components**: top-level
-components that are meant to be rendered from Twig.
+directory. These are known as **React controller components**: top-level components
+that are meant to be rendered from Twig. The ``eager: true`` option is required
+because UX React does not support lazy-loaded components.
 
 Render in Twig
 ~~~~~~~~~~~~~~
@@ -120,6 +119,34 @@ in the DOM  or is removed and immediately re-added to the DOM (e.g. when using
          Loading...
     </div>
 
+.. _react-using-with-webpack-encore:
+
+Using with Webpack Encore
+-------------------------
+
+With Webpack Encore, register your components with Webpack's ``require.context()``
+instead of ``import.meta.glob()``:
+
+.. code-block:: javascript
+
+    // assets/app.js
+    import { registerReactControllerComponents } from '@symfony/ux-react';
+
+    registerReactControllerComponents(require.context('./react/controllers', true, /\.(j|t)sx?$/));
+
+The Flex recipe sets Encore up for you, adding ``.enableReactPreset()`` to your
+``webpack.config.js`` file. You also need Babel's React preset:
+
+.. code-block:: terminal
+
+    $ npm install -D @babel/preset-react --force
+    $ npm run watch
+
+.. note::
+
+    For more complex installation scenarios, you can install the JavaScript assets
+    through the `@symfony/ux-react npm package`_.
+
 .. _using-with-asset-mapper:
 
 Using with AssetMapper
@@ -161,3 +188,8 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`Symfony UX React demo`: https://ux.symfony.com/react
 .. _`Turbo`: https://turbo.hotwire.dev/
 .. _`@symfony/ux-react npm package`: https://www.npmjs.com/package/@symfony/ux-react
+.. _`Symfony Reprise`: https://github.com/symfony/reprise
+.. _`Vite`: https://vite.dev/
+.. _`Rsbuild`: https://rsbuild.dev/
+.. _`@vitejs/plugin-react`: https://www.npmjs.com/package/@vitejs/plugin-react
+.. _`@rsbuild/plugin-react`: https://rsbuild.dev/plugins/list/plugin-react

--- a/src/Vue/CHANGELOG.md
+++ b/src/Vue/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.4
+
+- Add support for `import.meta.glob()` (Symfony Reprise) in `registerVueControllerComponents()`
+
 ## 3.0.0
 
 - Minimum required Symfony version is now 7.4

--- a/src/Vue/assets/dist/register_controller.d.ts
+++ b/src/Vue/assets/dist/register_controller.d.ts
@@ -1,9 +1,13 @@
 import { Component } from "vue";
+type GlobModule = {
+  default: Component;
+};
+type GlobResult = Record<string, GlobModule | (() => Promise<GlobModule>)>;
 declare global {
   function resolveVueComponent(name: string): Component;
   interface Window {
     resolveVueComponent(name: string): Component;
   }
 }
-declare function registerVueControllerComponents(context: __WebpackModuleApi.RequireContext): void;
+declare function registerVueControllerComponents(context: __WebpackModuleApi.RequireContext | GlobResult): void;
 export { registerVueControllerComponents };

--- a/src/Vue/assets/dist/register_controller.js
+++ b/src/Vue/assets/dist/register_controller.js
@@ -1,17 +1,24 @@
 import { defineAsyncComponent } from "vue";
 function registerVueControllerComponents(context) {
-	const vueControllers = context.keys().reduce((acc, key) => {
-		acc[key] = void 0;
-		return acc;
-	}, {});
+	const loaders = {};
+	if (typeof context === "function") context.keys().forEach((key) => {
+		loaders[key] = () => context(key);
+	});
+	else {
+		const keyMapping = normalizeGlobKeys(Object.keys(context));
+		Object.entries(context).forEach(([key, value]) => {
+			loaders[keyMapping[key]] = typeof value === "function" ? value : () => value;
+		});
+	}
+	const vueControllers = {};
 	function loadComponent(name) {
 		const componentPath = `./${name}.vue`;
-		if (!(componentPath in vueControllers)) {
-			const possibleValues = Object.keys(vueControllers).map((key) => key.replace("./", "").replace(".vue", ""));
+		if (!(componentPath in loaders)) {
+			const possibleValues = Object.keys(loaders).map((key) => key.replace("./", "").replace(".vue", ""));
 			throw new Error(`Vue controller "${name}" does not exist. Possible values: ${possibleValues.join(", ")}`);
 		}
 		if (typeof vueControllers[componentPath] === "undefined") {
-			const module = context(componentPath);
+			const module = loaders[componentPath]();
 			if (module.default) vueControllers[componentPath] = module.default;
 			else if (module instanceof Promise) vueControllers[componentPath] = defineAsyncComponent(() => new Promise((resolve, reject) => {
 				module.then((resolvedModule) => {
@@ -26,5 +33,22 @@ function registerVueControllerComponents(context) {
 	window.resolveVueComponent = (name) => {
 		return loadComponent(name);
 	};
+}
+function normalizeGlobKeys(keys) {
+	if (keys.length === 0) return {};
+	const segments = keys.map((key) => key.split("/"));
+	let commonLength = Math.min(...segments.map((parts) => parts.length - 1));
+	for (let i = 0; i < commonLength; i++) {
+		const segment = segments[0][i];
+		if (!segments.every((parts) => parts[i] === segment)) {
+			commonLength = i;
+			break;
+		}
+	}
+	const mapping = {};
+	keys.forEach((key, index) => {
+		mapping[key] = `./${segments[index].slice(commonLength).join("/")}`;
+	});
+	return mapping;
 }
 export { registerVueControllerComponents };

--- a/src/Vue/assets/src/register_controller.ts
+++ b/src/Vue/assets/src/register_controller.ts
@@ -12,6 +12,11 @@
 import type { Component } from 'vue';
 import { defineAsyncComponent } from 'vue';
 
+// A single entry from Vite's / Rsbuild's `import.meta.glob()`: an eagerly-imported
+// module, or a function returning one for a lazy glob.
+type GlobModule = { default: Component };
+type GlobResult = Record<string, GlobModule | (() => Promise<GlobModule>)>;
+
 declare global {
     function resolveVueComponent(name: string): Component;
 
@@ -20,25 +25,37 @@ declare global {
     }
 }
 
-export function registerVueControllerComponents(context: __WebpackModuleApi.RequireContext) {
-    const vueControllers = context.keys().reduce(
-        (acc, key) => {
-            acc[key] = undefined;
-            return acc;
-        },
-        {} as Record<string, object | undefined>
-    );
+export function registerVueControllerComponents(context: __WebpackModuleApi.RequireContext | GlobResult) {
+    // Normalize both `require.context()` and `import.meta.glob()` to a common map of
+    // "./<name>.vue" => loader returning the module (synchronously or as a Promise).
+    const loaders: Record<string, () => any> = {};
+
+    if (typeof context === 'function') {
+        // Webpack's `require.context()`
+        context.keys().forEach((key) => {
+            loaders[key] = () => context(key);
+        });
+    } else {
+        // Vite's / Rsbuild's `import.meta.glob()`, either eager (module) or lazy (() => Promise<module>)
+        const keyMapping = normalizeGlobKeys(Object.keys(context));
+        Object.entries(context).forEach(([key, value]) => {
+            loaders[keyMapping[key]] = typeof value === 'function' ? value : () => value;
+        });
+    }
+
+    // Resolved-component cache, populated lazily on first resolution. Keys mirror `loaders`.
+    const vueControllers: Record<string, object | undefined> = {};
 
     function loadComponent(name: string): object | never {
         const componentPath = `./${name}.vue`;
-        if (!(componentPath in vueControllers)) {
-            const possibleValues = Object.keys(vueControllers).map((key) => key.replace('./', '').replace('.vue', ''));
+        if (!(componentPath in loaders)) {
+            const possibleValues = Object.keys(loaders).map((key) => key.replace('./', '').replace('.vue', ''));
 
             throw new Error(`Vue controller "${name}" does not exist. Possible values: ${possibleValues.join(', ')}`);
         }
 
         if (typeof vueControllers[componentPath] === 'undefined') {
-            const module = context(componentPath);
+            const module = loaders[componentPath]();
             if (module.default) {
                 vueControllers[componentPath] = module.default;
             } else if (module instanceof Promise) {
@@ -70,4 +87,34 @@ export function registerVueControllerComponents(context: __WebpackModuleApi.Requ
     window.resolveVueComponent = (name: string): object => {
         return loadComponent(name);
     };
+}
+
+/**
+ * Maps the keys returned by `import.meta.glob()` to the `./<name>.vue` form
+ * produced by Webpack's `require.context()`, by stripping the directory prefix
+ * shared by every key (e.g. `./vue/controllers/`).
+ */
+function normalizeGlobKeys(keys: string[]): Record<string, string> {
+    if (keys.length === 0) {
+        return {};
+    }
+
+    const segments = keys.map((key) => key.split('/'));
+
+    // Number of leading directory segments shared by every key (the filename is never included).
+    let commonLength = Math.min(...segments.map((parts) => parts.length - 1));
+    for (let i = 0; i < commonLength; i++) {
+        const segment = segments[0][i];
+        if (!segments.every((parts) => parts[i] === segment)) {
+            commonLength = i;
+            break;
+        }
+    }
+
+    const mapping: Record<string, string> = {};
+    keys.forEach((key, index) => {
+        mapping[key] = `./${segments[index].slice(commonLength).join('/')}`;
+    });
+
+    return mapping;
 }

--- a/src/Vue/assets/test/unit/register_controller.test.ts
+++ b/src/Vue/assets/test/unit/register_controller.test.ts
@@ -7,6 +7,8 @@
  * file that was distributed with this source code.
  */
 
+/// <reference types="vite/client" />
+
 import { describe, expect, it } from 'vitest';
 import { registerVueControllerComponents } from '../../src/register_controller';
 import Hello from '../fixtures/Hello.vue';
@@ -50,6 +52,36 @@ describe('registerVueControllerComponents', () => {
 
     it('errors with a bad name', () => {
         registerVueControllerComponents(createFakeFixturesContext(false));
+        const resolveComponent = window.resolveVueComponent;
+
+        expect(() => resolveComponent('Helloooo')).toThrow(
+            'Vue controller "Helloooo" does not exist. Possible values: Hello'
+        );
+    });
+});
+
+describe('registerVueControllerComponents with import.meta.glob()', () => {
+    it('should resolve eager components synchronously', () => {
+        registerVueControllerComponents(import.meta.glob('../fixtures/*.vue', { eager: true }));
+        const resolveComponent = window.resolveVueComponent;
+
+        expect(resolveComponent).not.toBeUndefined();
+        expect(resolveComponent('Hello')).toBe(Hello);
+    });
+
+    it('should resolve lazy components asynchronously', () => {
+        registerVueControllerComponents(import.meta.glob('../fixtures-lazy/*.vue'));
+        const resolveComponent = window.resolveVueComponent;
+
+        expect(resolveComponent).not.toBeUndefined();
+        // A lazy glob is wrapped in an async component, so it is not the raw component.
+        const component = resolveComponent('Goodbye');
+        expect(component).toBeDefined();
+        expect(component).not.toBe(Goodbye);
+    });
+
+    it('errors with a bad name', () => {
+        registerVueControllerComponents(import.meta.glob('../fixtures/*.vue', { eager: true }));
         const resolveComponent = window.resolveVueComponent;
 
         expect(() => resolveComponent('Helloooo')).toThrow(

--- a/src/Vue/doc/index.rst
+++ b/src/Vue/doc/index.rst
@@ -15,8 +15,13 @@ Installation
 
 .. note::
 
-    This package works best with WebpackEncore. To use it with AssetMapper, see
-    :ref:`Using with AssetMapper <using-with-asset-mapper>`.
+    This package works best with `Symfony Reprise`_ (`Vite`_ or `Rsbuild`_). To use it with
+    Webpack Encore, see :ref:`Using with Webpack Encore <vue-using-with-webpack-encore>`;
+    to use it with AssetMapper, see :ref:`Using with AssetMapper <using-with-asset-mapper>`.
+
+.. note::
+
+    Symfony Reprise support requires ``symfony/ux-vue`` 3.4.
 
 Install the bundle using Composer and Symfony Flex:
 
@@ -24,20 +29,11 @@ Install the bundle using Composer and Symfony Flex:
 
     $ composer require symfony/ux-vue
 
-The Flex recipe will automatically set things up for you, like adding
-``.enableVueLoader()`` to your ``webpack.config.js`` file and adding code
-to load your Vue components inside ``assets/app.js``.
+The Flex recipe will automatically set things up for you, adding the code to load
+your Vue components inside ``assets/app.js``.
 
-Next, install a package to help Vue:
-
-.. code-block:: terminal
-
-    $ npm install -D vue-loader --force
-    $ npm run watch
-
-.. note::
-
-    For more complex installation scenarios, you can install the JavaScript assets through the `@symfony/ux-vue npm package`_
+You also need the Vue plugin for your bundler so it can compile ``.vue`` files:
+`@vitejs/plugin-vue`_ for Vite, or `@rsbuild/plugin-vue`_ for Rsbuild.
 
 That's it! Any files inside ``assets/vue/controllers/`` can now be rendered as
 Vue components.
@@ -53,11 +49,14 @@ code to your ``assets/app.js`` file:
     // assets/app.js
     import { registerVueControllerComponents } from '@symfony/ux-vue';
 
-    registerVueControllerComponents(require.context('./vue/controllers', true, /\.vue$/));
+    registerVueControllerComponents(
+        // remove `{ eager: true }` to lazy-load the components instead
+        import.meta.glob('./vue/controllers/**/*.vue', { eager: true })
+    );
 
 This will load all Vue components located in the ``assets/vue/controllers``
-directory. These are known as **Vue controller components**: top-level
-components that are meant to be rendered from Twig.
+directory. These are known as **Vue controller components**: top-level components
+that are meant to be rendered from Twig.
 
 You can render any Vue controller component in Twig using the ``vue_component()``.
 
@@ -163,6 +162,34 @@ used for all the Vue routes:
 
     app.use(router);
 
+.. _vue-using-with-webpack-encore:
+
+Using with Webpack Encore
+-------------------------
+
+With Webpack Encore, register your components with Webpack's ``require.context()``
+instead of ``import.meta.glob()``:
+
+.. code-block:: javascript
+
+    // assets/app.js
+    import { registerVueControllerComponents } from '@symfony/ux-vue';
+
+    registerVueControllerComponents(require.context('./vue/controllers', true, /\.vue$/));
+
+The Flex recipe sets Encore up for you, adding ``.enableVueLoader()`` to your
+``webpack.config.js`` file. You also need the Vue loader:
+
+.. code-block:: terminal
+
+    $ npm install -D vue-loader --force
+    $ npm run watch
+
+.. note::
+
+    For more complex installation scenarios, you can install the JavaScript assets
+    through the `@symfony/ux-vue npm package`_.
+
 .. _using-with-asset-mapper:
 
 Using with AssetMapper
@@ -187,3 +214,8 @@ https://symfony.com/doc/current/contributing/code/bc.html
 .. _`the Symfony UX initiative`: https://ux.symfony.com/
 .. _ `the related section of the documentation`: https://symfony.com/doc/current/frontend/encore/vuejs.html
 .. _`@symfony/ux-vue npm package`: https://www.npmjs.com/package/@symfony/ux-vue
+.. _`Symfony Reprise`: https://github.com/symfony/reprise
+.. _`Vite`: https://vite.dev/
+.. _`Rsbuild`: https://rsbuild.dev/
+.. _`@vitejs/plugin-vue`: https://www.npmjs.com/package/@vitejs/plugin-vue
+.. _`@rsbuild/plugin-vue`: https://rsbuild.dev/plugins/list/plugin-vue


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | Fix #3712 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Related:
- https://github.com/symfony/recipes/pull/1546
- https://github.com/symfony/reprise/pull/43

Support for React and HMR with Vite requires Reprise 0.4 