### PR TITLE
[Toolkit] Document Stimulus controllers in the recipe API reference

### DIFF
--- a/.agents/skills/symfony-ux-toolkit-kit/SKILL.md
+++ b/.agents/skills/symfony-ux-toolkit-kit/SKILL.md
@@ -400,6 +400,13 @@ Checks:
 ```js
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  open     Whether the component is open on initial render.
+ * @target trigger  The element that toggles the component and reflects its expanded state.
+ * @target content  The region shown or hidden when the component toggles.
+ * @action open     Opens the component.
+ * @action close    Closes the component.
+ */
 export default class extends Controller {
     static targets = ['trigger', 'content'];
     static values = { open: Boolean };
@@ -424,6 +431,19 @@ export default class extends Controller {
   Pipe through `|html_attr_type('sst')` when exposing via `<recipe>_<role>_attrs` so consumers can append own actions.
 - **Hover/focus-triggered components** — never use `group-hover` + `group-focus-within` + `tabindex=0`; use Stimulus controller with `openDelay`/`closeDelay` values instead (see anti-patterns).
 - **Nested open-state** — never use `in-data-[state=open]:visible` on nested components; use named Tailwind groups (`group/<recipe>-menu`, `group/<recipe>-sub`) instead (see anti-patterns).
+
+### Controller docblocks (API reference)
+
+A controller's public API is documented with a `/** ... */` docblock placed **immediately before `export default class`**, using `@value`/`@target`/`@action` tags. `RecipeDocRenderer` renders these under `::: api-reference` (the same block that documents Twig component props), which is the only way a **controller-only recipe** — one with no `templates/components/*.html.twig` — surfaces an API reference. `bin/ux-toolkit-kit-lint` validates them via `StimulusControllerDocChecker` (see [Docblock linting](#docblock-linting)).
+
+**Add the docblock only to controllers whose API you want shown.** It is a deliberate, per-controller choice — not a blanket requirement. Document a controller when its `data-controller`/`data-*` surface is meant to be used or overridden directly by the consumer (always true for a controller-only recipe). **Omit it** — leaving the controller undocumented and rendering no API reference — when the controller is an internal implementation detail the consumer never touches directly (they drive it through the recipe's Twig components, which carry their own `@prop`/`@block` docs). Documenting such a controller would surface `data-*` internals as if they were public API.
+
+- **Format:** `@<tag> <name> <Description.>` — name first, then a one-sentence description that starts Capitalized and ends with a period. Align columns for readability (whitespace is normalized). Do **not** document types or defaults in the docblock — the renderer reads value types/defaults from the `static values` declaration.
+- **`@value <name>`** — one per key in `static values`. For object-form values (`open: { type: Boolean, default: false }`), document the **top-level key** (`open`), never the inner `type`/`default`.
+- **`@target <name>`** — one per string in `static targets`.
+- **`@action <name>`** — opt-in: document only the **public methods actually wired via `data-action`** in the recipe's templates (find them with `grep -rhoE '<identifier>#[a-zA-Z]+' templates`). Never document private methods (`_`/`#` prefixed) or lifecycle methods (`connect`/`disconnect`). Every `@action` must match a real method.
+- **All-or-nothing once you opt in:** a controller with **no tags at all** renders no API reference and is left untouched by the linter. But once **any** tag is present, the linter requires every `static values` key and every `static targets` string to have a matching tag (and vice versa) — partial documentation fails CI. So the choice is per-controller: document its whole surface, or leave it entirely undocumented.
+- The controller identifier is derived from the filename (`<recipe>_controller.js` → `<recipe>`; nested `_` → `-`, e.g. `alert_dialog_controller.js` → `alert-dialog`), and each value's `data-*` attribute is derived from it (`autoClose` on `widget` → `data-widget-auto-close-value`).
 
 ---
 

--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Common] Add the `common` kit, with design-system agnostic `logout-link` and `post-link` recipes
 - Add new linter checker `ClassMergeSpacingChecker` that checks for invalid `'<literal>' ~ attributes.render(...)` pattern
 - Add per-recipe `README.md` documentation
+- Document Stimulus controllers in the recipe API reference from their `@value`/`@target`/`@action` docblocks, and lint those docblocks with the new `StimulusControllerDocChecker`
 - Add `RecipeDocRenderer` that renders recipes docs as HTML or Markdown, to ease wiring official kits into ux.symfony.com and, in the future, previewing community kits
 - Add optional `color` and `icon` fields to the kit manifest
 - Include kit-global dependencies when installing a recipe

--- a/src/Toolkit/src/Component/StimulusController.php
+++ b/src/Toolkit/src/Component/StimulusController.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Component;
+
+use function Symfony\Component\String\u;
+
+/**
+ * Maps between a Stimulus controller's filename and its identifier, following the Stimulus
+ * convention: a snake_case `<name>_controller.js` file exposes the kebab-case `<name>` identifier
+ * used in `data-controller`. Single source of truth shared by the linter and the doc renderer.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusController
+{
+    private const FILENAME_SUFFIX = '_controller.js';
+
+    public static function isFilename(string $filename): bool
+    {
+        return str_ends_with($filename, self::FILENAME_SUFFIX);
+    }
+
+    /**
+     * Derives the `data-controller` identifier from a controller filename or path
+     * (e.g. `assets/controllers/alert_dialog_controller.js` => `alert-dialog`).
+     */
+    public static function identifier(string $filename): string
+    {
+        return (string) u(basename($filename, self::FILENAME_SUFFIX))->kebab();
+    }
+
+    /**
+     * The controller filename an identifier maps to (e.g. `alert-dialog` => `alert_dialog_controller.js`).
+     */
+    public static function filename(string $identifier): string
+    {
+        return u($identifier)->snake().self::FILENAME_SUFFIX;
+    }
+
+    /**
+     * The `data-*` attribute a Stimulus value binds to, matching Stimulus' dasherization
+     * (e.g. identifier `widget` + value `autoClose` => `data-widget-auto-close-value`).
+     */
+    public static function valueAttribute(string $identifier, string $value): string
+    {
+        return \sprintf('data-%s-%s-value', $identifier, u($value)->kebab());
+    }
+}

--- a/src/Toolkit/src/Component/StimulusControllerAction.php
+++ b/src/Toolkit/src/Component/StimulusControllerAction.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Component;
+
+/**
+ * A Stimulus action method documented with an `@action` tag.
+ *
+ * Actions are opt-in: only methods flagged with `@action` are treated as public API, so internal
+ * (but still public) helper methods stay out of the reference.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusControllerAction
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $description,
+    ) {
+    }
+}

--- a/src/Toolkit/src/Component/StimulusControllerDoc.php
+++ b/src/Toolkit/src/Component/StimulusControllerDoc.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Component;
+
+/**
+ * The API reference extracted from a Stimulus controller: its values, targets and actions.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusControllerDoc
+{
+    /**
+     * @param list<StimulusControllerValue>  $values
+     * @param list<StimulusControllerTarget> $targets
+     * @param list<StimulusControllerAction> $actions
+     */
+    public function __construct(
+        public readonly array $values = [],
+        public readonly array $targets = [],
+        public readonly array $actions = [],
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->values && [] === $this->targets && [] === $this->actions;
+    }
+}

--- a/src/Toolkit/src/Component/StimulusControllerDocParser.php
+++ b/src/Toolkit/src/Component/StimulusControllerDocParser.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Component;
+
+/**
+ * Builds the {@see StimulusControllerDoc} (values, targets and actions) from a controller's source.
+ *
+ * The source is scanned by {@see StimulusControllerSource}: the code is the single source of truth
+ * for value names/types and target names, while their descriptions come from `@value`/`@target`
+ * docblock tags. Actions are opt-in — declared entirely by `@action` tags — so internal public
+ * methods are not documented. Each value's `data-*` attribute is derived from the controller identifier.
+ *
+ * Documentation as a whole is opt-in: a controller carrying no `@value`/`@target`/`@action` tag
+ * yields an empty doc and thus no API reference, even when it declares values or targets in code.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusControllerDocParser
+{
+    public function parse(string $source, string $identifier): StimulusControllerDoc
+    {
+        $controller = new StimulusControllerSource($source);
+        $tags = $controller->tags();
+
+        // Documentation is opt-in: without any @value/@target/@action tag, the controller
+        // exposes no API reference, even though its values/targets could be read from the code.
+        if ([] === $tags['value'] && [] === $tags['target'] && [] === $tags['action']) {
+            return new StimulusControllerDoc();
+        }
+
+        $values = [];
+        foreach ($controller->values() as $value) {
+            $values[] = new StimulusControllerValue(
+                $value['name'],
+                StimulusController::valueAttribute($identifier, $value['name']),
+                $value['type'],
+                $value['default'],
+                $tags['value'][$value['name']] ?? '',
+            );
+        }
+
+        $targets = [];
+        foreach ($controller->targets() as $name) {
+            $targets[] = new StimulusControllerTarget($name, $tags['target'][$name] ?? '');
+        }
+
+        $actions = [];
+        foreach ($tags['action'] as $name => $description) {
+            $actions[] = new StimulusControllerAction($name, $description);
+        }
+
+        return new StimulusControllerDoc($values, $targets, $actions);
+    }
+}

--- a/src/Toolkit/src/Component/StimulusControllerSource.php
+++ b/src/Toolkit/src/Component/StimulusControllerSource.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Component;
+
+/**
+ * Reads a Stimulus controller's documented + declared surface from its source: the
+ * `@value`/`@target`/`@action` docblock tags and the `static values`/`static targets`
+ * declarations. Shared by {@see StimulusControllerDocParser} (rendering) and
+ * {@see \Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerDocChecker} (linting) so both
+ * scan a controller identically.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusControllerSource
+{
+    private const RE_DOCBLOCK = '#/\*\*(?P<body>.*?)\*/#s';
+    // The description ends only at the next annotation *line* (\R\h*@), so an `@` mid-sentence isn't a boundary.
+    private const RE_TAG = '/@(?P<tag>value|target|action)\h+(?P<name>[A-Za-z_$][\w$]*)(?P<description>(?:(?!\R\h*@[a-zA-Z]).)*)/s';
+    private const RE_VALUES = '/static\s+values\s*=\s*\{(?P<body>(?:[^{}]|\{[^{}]*\})*)\}/s';
+    private const RE_VALUE_ENTRY = '/(?P<name>[A-Za-z_$][\w$]*)\s*:\s*(?P<type>\{[^{}]*\}|[A-Za-z_$][\w$]*)/';
+    private const RE_TARGETS = '/static\s+targets\s*=\s*\[(?P<body>[^\]]*)\]/s';
+    private const RE_STRING = '/[\'"](?P<value>[^\'"]+)[\'"]/';
+
+    public function __construct(private readonly string $source)
+    {
+    }
+
+    /**
+     * Docblock tag descriptions, keyed by name within each tag type.
+     *
+     * @return array{value: array<string, string>, target: array<string, string>, action: array<string, string>}
+     */
+    public function tags(): array
+    {
+        $tags = ['value' => [], 'target' => [], 'action' => []];
+
+        if (!preg_match_all(self::RE_DOCBLOCK, $this->source, $blocks)) {
+            return $tags;
+        }
+
+        // Parse each docblock independently so a tag's description is bounded by its own block and
+        // cannot swallow trailing prose from an unrelated method docblock elsewhere in the file.
+        foreach ($blocks['body'] as $rawBody) {
+            $body = preg_replace('/^\h*\*\h?/m', '', $rawBody);
+            if (!preg_match_all(self::RE_TAG, $body, $matches, \PREG_SET_ORDER)) {
+                continue;
+            }
+
+            foreach ($matches as $match) {
+                $tags[$match['tag']][$match['name']] = trim(preg_replace('/\s+/', ' ', $match['description']));
+            }
+        }
+
+        return $tags;
+    }
+
+    /**
+     * Values declared in `static values`, with type/default read from the code.
+     *
+     * @return list<array{name: string, type: string, default: ?string}>
+     */
+    public function values(): array
+    {
+        if (!preg_match(self::RE_VALUES, $this->source, $matches)) {
+            return [];
+        }
+
+        if (!preg_match_all(self::RE_VALUE_ENTRY, $matches['body'], $entries, \PREG_SET_ORDER)) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($entries as $entry) {
+            [$type, $default] = $this->normalizeValueType($entry['type']);
+            $values[] = ['name' => $entry['name'], 'type' => $type, 'default' => $default];
+        }
+
+        return $values;
+    }
+
+    /**
+     * Target names declared in `static targets`.
+     *
+     * @return list<string>
+     */
+    public function targets(): array
+    {
+        if (!preg_match(self::RE_TARGETS, $this->source, $matches)) {
+            return [];
+        }
+
+        if (!preg_match_all(self::RE_STRING, $matches['body'], $strings)) {
+            return [];
+        }
+
+        return $strings['value'];
+    }
+
+    /**
+     * A value type is either shorthand (`autoClose: Number`) or an object
+     * (`autoClose: { type: Number, default: 0 }`); both yield a type and an optional default.
+     *
+     * @return array{0: string, 1: ?string}
+     */
+    private function normalizeValueType(string $type): array
+    {
+        if (!str_starts_with($type, '{')) {
+            return [$type, null];
+        }
+
+        $resolvedType = preg_match('/type\s*:\s*(?P<type>[A-Za-z_$][\w$]*)/', $type, $m) ? $m['type'] : 'mixed';
+        $default = preg_match('/default\s*:\s*(?P<default>[^,}]+)/', $type, $m) ? trim($m['default']) : null;
+
+        return [$resolvedType, $default];
+    }
+}

--- a/src/Toolkit/src/Component/StimulusControllerTarget.php
+++ b/src/Toolkit/src/Component/StimulusControllerTarget.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Component;
+
+/**
+ * A Stimulus target declared by a controller's `static targets` and documented with a `@target` tag.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusControllerTarget
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $description,
+    ) {
+    }
+}

--- a/src/Toolkit/src/Component/StimulusControllerValue.php
+++ b/src/Toolkit/src/Component/StimulusControllerValue.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Component;
+
+/**
+ * A Stimulus value declared by a controller's `static values` and documented with an `@value` tag.
+ *
+ * The name and type are read from the code; the description comes from the docblock. The
+ * `attribute` is the `data-*` attribute Stimulus binds the value to, precomputed from the
+ * controller identifier and the value name.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusControllerValue
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $attribute,
+        public readonly string $type,
+        public readonly ?string $default,
+        public readonly string $description,
+    ) {
+    }
+}

--- a/src/Toolkit/src/Doc/RecipeDocRenderer.php
+++ b/src/Toolkit/src/Doc/RecipeDocRenderer.php
@@ -24,6 +24,9 @@ use Symfony\Component\Filesystem\Path;
 use Symfony\UX\Toolkit\Assert;
 use Symfony\UX\Toolkit\Component\ComponentDoc;
 use Symfony\UX\Toolkit\Component\ComponentDocParser;
+use Symfony\UX\Toolkit\Component\StimulusController;
+use Symfony\UX\Toolkit\Component\StimulusControllerDoc;
+use Symfony\UX\Toolkit\Component\StimulusControllerDocParser;
 use Symfony\UX\Toolkit\Installer\PoolResolver;
 use Symfony\UX\Toolkit\Kit\Kit;
 use Symfony\UX\Toolkit\Markdown\Extension\Alert\AlertExtension;
@@ -47,12 +50,15 @@ use Symfony\UX\Toolkit\Recipe\Recipe;
 final class RecipeDocRenderer
 {
     private readonly ComponentDocParser $componentDocParser;
+    private readonly StimulusControllerDocParser $stimulusControllerDocParser;
 
     public function __construct(
         private readonly \Twig\Environment $twig,
         ?ComponentDocParser $componentDocParser = null,
+        ?StimulusControllerDocParser $stimulusControllerDocParser = null,
     ) {
         $this->componentDocParser = $componentDocParser ?? new ComponentDocParser($twig);
+        $this->stimulusControllerDocParser = $stimulusControllerDocParser ?? new StimulusControllerDocParser();
     }
 
     public function renderAsMarkdown(Kit $kit, Recipe $recipe): string
@@ -123,7 +129,7 @@ final class RecipeDocRenderer
     {
         $context = $this->buildContext($kit, $recipe, $format);
 
-        $body = $recipe->doc ?? $this->defaultBody($recipe, [] !== $context['api_reference']);
+        $body = $recipe->doc ?? $this->defaultBody($recipe, [] !== $context['api_reference'] || [] !== $context['stimulus_reference']);
 
         return preg_replace_callback('/^::: (?<directive>installation|api-reference)\s*$/m', fn (array $matches): string => trim($this->twig->render(\sprintf('@UXToolkit/doc/_%s.md.twig', str_replace('-', '_', $matches['directive'])), $context)), $body);
     }
@@ -166,6 +172,7 @@ final class RecipeDocRenderer
             'npm_package_dependencies' => array_values($pool->getNpmPackageDependencies()),
             'importmap_package_dependencies' => array_values($pool->getImportmapPackageDependencies()),
             'api_reference' => $this->extractApiReference($recipe),
+            'stimulus_reference' => $this->extractStimulusControllerReference($recipe),
             'format' => $format,
         ];
     }
@@ -198,5 +205,35 @@ final class RecipeDocRenderer
         }
 
         return $apiReference;
+    }
+
+    /**
+     * @return array<string, StimulusControllerDoc>
+     */
+    private function extractStimulusControllerReference(Recipe $recipe): array
+    {
+        $stimulusReference = [];
+
+        foreach ($recipe->getFiles() as $file) {
+            $source = $file->sourceRelativePathName;
+            if (!StimulusController::isFilename($source) || !str_starts_with($source, 'assets/controllers/')) {
+                continue;
+            }
+
+            $filePath = Path::join($recipe->absolutePath, $source);
+            if (!is_file($filePath) || false === $contents = file_get_contents($filePath)) {
+                continue;
+            }
+
+            $identifier = StimulusController::identifier($source);
+            $controllerDoc = $this->stimulusControllerDocParser->parse($contents, $identifier);
+            if ($controllerDoc->isEmpty()) {
+                continue;
+            }
+
+            $stimulusReference[$identifier] = $controllerDoc;
+        }
+
+        return $stimulusReference;
     }
 }

--- a/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerChecker.php
@@ -13,14 +13,13 @@ namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
 
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
+use Symfony\UX\Toolkit\Component\StimulusController;
 use Symfony\UX\Toolkit\Dependency\RecipeDependency;
 use Symfony\UX\Toolkit\Kit\Kit;
 use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
 use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
 use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
 use Symfony\UX\Toolkit\Recipe\Recipe;
-
-use function Symfony\Component\String\u;
 
 /**
  * Detects `data-controller="..."` usages in Twig templates and verifies that a matching
@@ -74,10 +73,9 @@ final class StimulusControllerChecker implements KitCheckerInterface
                     severity: LintSeverity::Warning,
                     category: 'stimulus.controller.missing',
                     message: \sprintf(
-                        'Template references Stimulus controller "%s" but no matching file "assets/controllers/%s_controller.js" was found in the recipe.',
+                        'Template references Stimulus controller "%s" but no matching file "assets/controllers/%s" was found in the recipe.',
                         $controllerName,
-                        // Stimulus convention: kebab-case identifier <-> snake_case filename.
-                        u($controllerName)->snake(),
+                        StimulusController::filename($controllerName),
                     ),
                     recipe: $recipe->name,
                     file: $file,
@@ -133,9 +131,7 @@ final class StimulusControllerChecker implements KitCheckerInterface
         $controllers = [];
         $finder = new Finder()->in($dir)->files()->name('*_controller.js');
         foreach ($finder as $file) {
-            $basename = substr($file->getFilename(), 0, -\strlen('_controller.js'));
-            // Stimulus convention: snake_case in filename, kebab-case in identifier.
-            $controllers[] = (string) u($basename)->kebab();
+            $controllers[] = StimulusController::identifier($file->getFilename());
         }
 
         return $controllers;

--- a/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerDocChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerDocChecker.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
+
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Finder\Finder;
+use Symfony\UX\Toolkit\Component\StimulusControllerSource;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+
+/**
+ * Normalizes a Stimulus controller's `@value`/`@target`/`@action` docblock tags and keeps them
+ * consistent with the code, mirroring {@see ComponentDocChecker} for Twig components:
+ *  - the description itself (present, capitalized, ending with a period);
+ *  - `@value`/`@target` tags against the `static values`/`static targets` declarations (both ways);
+ *  - each `@action` against a method actually defined on the controller.
+ *
+ * Documentation is opt-in: a controller with no tags at all is left untouched, so existing
+ * undocumented controllers are not reported. Once any tag is present, the whole surface is enforced.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusControllerDocChecker implements KitCheckerInterface
+{
+    private const RE_BARE_TAG = '/@(?P<tag>value|target|action)(?!\h+[A-Za-z_$])/';
+
+    public function check(Kit $kit): iterable
+    {
+        foreach ($kit->getRecipes() as $recipe) {
+            $dir = Path::join($recipe->absolutePath, 'assets/controllers');
+            if (!is_dir($dir)) {
+                continue;
+            }
+
+            $finder = new Finder()->in($dir)->files()->name('*_controller.js')->sortByName();
+            foreach ($finder as $file) {
+                yield from $this->checkFile($recipe->name, 'assets/controllers/'.$file->getRelativePathname(), $file->getContents());
+            }
+        }
+    }
+
+    /**
+     * @return iterable<LintIssue>
+     */
+    private function checkFile(string $recipe, string $file, string $contents): iterable
+    {
+        $controller = new StimulusControllerSource($contents);
+        $tags = $controller->tags();
+
+        // Opt-in: nothing documented, nothing to enforce.
+        if ([] === $tags['value'] && [] === $tags['target'] && [] === $tags['action']) {
+            return;
+        }
+
+        if (preg_match(self::RE_BARE_TAG, $contents)) {
+            yield $this->issue($recipe, $file, 'stimulus.doc.invalid', 'A `@value`/`@target`/`@action` tag must be written as `@<tag> <name> <Description.>`.');
+        }
+
+        yield from $this->checkGroup($recipe, $file, 'value', 'Value', $tags['value'], array_column($controller->values(), 'name'));
+        yield from $this->checkGroup($recipe, $file, 'target', 'Target', $tags['target'], $controller->targets());
+
+        foreach ($tags['action'] as $name => $description) {
+            if (!$this->hasMethod($contents, $name)) {
+                yield $this->issue($recipe, $file, 'stimulus.action.mismatch', \sprintf('Action "%s" is documented with `@action` but no matching method is defined on the controller.', $name));
+            }
+
+            yield from $this->checkDescription($recipe, $file, 'stimulus.action.invalid', \sprintf('Action "%s"', $name), $description);
+        }
+    }
+
+    /**
+     * @param array<string, string> $documented documented name => description
+     * @param list<string>          $declared   names declared in the code
+     *
+     * @return iterable<LintIssue>
+     */
+    private function checkGroup(string $recipe, string $file, string $tag, string $label, array $documented, array $declared): iterable
+    {
+        foreach ($documented as $name => $description) {
+            if (!\in_array($name, $declared, true)) {
+                yield $this->issue($recipe, $file, \sprintf('stimulus.%s.mismatch', $tag), \sprintf('%s "%s" is documented with `@%s` but is not declared in the controller.', $label, $name, $tag));
+            }
+
+            yield from $this->checkDescription($recipe, $file, \sprintf('stimulus.%s.invalid', $tag), \sprintf('%s "%s"', $label, $name), $description);
+        }
+
+        foreach ($declared as $name) {
+            if (!\array_key_exists($name, $documented)) {
+                yield $this->issue($recipe, $file, \sprintf('stimulus.%s.mismatch', $tag), \sprintf('%s "%s" is declared in the controller but has no `@%s %2$s ...` tag.', $label, $name, $tag));
+            }
+        }
+    }
+
+    /**
+     * A method definition (`name(...) {`) or a function-valued class field (`name = () =>`,
+     * `name = function`). Bare call-sites like `name()` are deliberately not matched, so an
+     * `@action` whose method is only *called* (never defined) is still reported.
+     */
+    private function hasMethod(string $contents, string $name): bool
+    {
+        $name = preg_quote($name, '/');
+
+        return 1 === preg_match('/(?<![\w.$#])'.$name.'\s*(?:\([^)]*\)\s*\{|=\s*(?:async\s+)?(?:function\b|\([^)]*\)\s*=>))/', $contents);
+    }
+
+    /**
+     * @return iterable<LintIssue>
+     */
+    private function checkDescription(string $recipe, string $file, string $category, string $subject, string $description): iterable
+    {
+        if ('' === $description) {
+            yield $this->issue($recipe, $file, $category, \sprintf('%s is missing a description.', $subject));
+
+            return;
+        }
+
+        if (!preg_match('/^\p{Lu}/u', $description)) {
+            yield $this->issue($recipe, $file, $category, \sprintf('%s description must start with a capital letter.', $subject));
+        }
+
+        if (!str_ends_with($description, '.')) {
+            yield $this->issue($recipe, $file, $category, \sprintf('%s description must end with a period.', $subject));
+        }
+    }
+
+    private function issue(string $recipe, string $file, string $category, string $message): LintIssue
+    {
+        return new LintIssue(LintSeverity::Warning, $category, $message, $recipe, $file);
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/KitLinter.php
+++ b/src/Toolkit/src/Kit/Lint/KitLinter.php
@@ -21,6 +21,7 @@ use Symfony\UX\Toolkit\Kit\Lint\Checker\JsImportChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\MissingRecipeManifestChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\RecipeReferenceChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerDocChecker;
 
 /**
  * Runs every registered {@see KitCheckerInterface} against a kit and aggregates issues.
@@ -46,6 +47,7 @@ final class KitLinter
             new CopyFilesExistenceChecker(),
             new RecipeReferenceChecker(),
             new StimulusControllerChecker(),
+            new StimulusControllerDocChecker(),
             new JsImportChecker(),
             new ComposerSymbolChecker(),
             new ComponentDocChecker(),

--- a/src/Toolkit/templates/doc/_api_reference.md.twig
+++ b/src/Toolkit/templates/doc/_api_reference.md.twig
@@ -25,3 +25,38 @@
 {% endfor %}
 {% endif %}
 {% endfor %}
+{% for identifier, ref in stimulus_reference %}
+### `data-controller="{{ identifier }}"`
+{% if ref.values is not empty %}
+
+{% if 'markdown' == format %}
+| Value | Type | Default | Description |
+|:------|:-----|:--------|:------------|
+{% for value in ref.values %}
+| `{{ value.attribute }}` | `{{ value.type|replace({'|': '\\|'})|raw }}` | {{ (value.default is not null ? '`' ~ value.default|replace({'|': '\\|'}) ~ '`' : '-')|raw }} | {{ value.description|replace({'|': '\\|'})|raw }} |
+{% endfor %}
+{% else %}
+| Value | Type | Default |
+|:------|:-----|:--------|
+{% for value in ref.values %}
+| `{{ value.attribute }}`{% if value.description %}&nbsp;(?)[{{ value.description|replace({'|': '\\|'})|raw }}]{% endif %} | `{{ value.type|replace({'|': '\\|'})|raw }}` | {{ (value.default is not null ? '`' ~ value.default|replace({'|': '\\|'}) ~ '`' : '-')|raw }} |
+{% endfor %}
+{% endif %}
+{% endif %}
+{% if ref.targets is not empty %}
+
+| Target | Description |
+|:-------|:------------|
+{% for target in ref.targets %}
+| `{{ target.name }}` | {{ target.description|replace({'|': '\\|'})|raw }} |
+{% endfor %}
+{% endif %}
+{% if ref.actions is not empty %}
+
+| Action | Description |
+|:-------|:------------|
+{% for action in ref.actions %}
+| `{{ action.name }}` | {{ action.description|replace({'|': '\\|'})|raw }} |
+{% endfor %}
+{% endif %}
+{% endfor %}

--- a/src/Toolkit/tests/Component/StimulusControllerDocParserTest.php
+++ b/src/Toolkit/tests/Component/StimulusControllerDocParserTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Component;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Component\StimulusControllerDoc;
+use Symfony\UX\Toolkit\Component\StimulusControllerDocParser;
+
+// Source scanning (tags, value types, targets) is covered by StimulusControllerSourceTest; these
+// tests focus on what the parser itself does: assemble the DTOs (deriving each value's `data-*`
+// attribute, wiring descriptions) and honor the opt-in gate.
+class StimulusControllerDocParserTest extends TestCase
+{
+    public function testParsesValueNameTypeAndDerivedAttribute()
+    {
+        $doc = new StimulusControllerDocParser()->parse(<<<'JS'
+            /**
+             * @value autoClose Delay in milliseconds before the element removes itself.
+             */
+            export default class extends Controller {
+                static values = { autoClose: Number }
+            }
+            JS, 'closeable');
+
+        self::assertInstanceOf(StimulusControllerDoc::class, $doc);
+        self::assertCount(1, $doc->values);
+        self::assertSame('autoClose', $doc->values[0]->name);
+        self::assertSame('data-closeable-auto-close-value', $doc->values[0]->attribute);
+        self::assertSame('Number', $doc->values[0]->type);
+        self::assertNull($doc->values[0]->default);
+        self::assertSame('Delay in milliseconds before the element removes itself.', $doc->values[0]->description);
+    }
+
+    public function testActionsAreOptInFromTags()
+    {
+        $doc = new StimulusControllerDocParser()->parse(<<<'JS'
+            /**
+             * @action close Removes the element.
+             * @action cancel Cancels a pending close.
+             */
+            export default class extends Controller {
+                close() {}
+                cancel() {}
+                #remove() {}
+                internalHelper() {}
+            }
+            JS, 'closeable');
+
+        // Actions come only from `@action` tags, so undocumented methods are not exposed.
+        self::assertCount(2, $doc->actions);
+        self::assertSame('close', $doc->actions[0]->name);
+        self::assertSame('Removes the element.', $doc->actions[0]->description);
+        self::assertSame('cancel', $doc->actions[1]->name);
+    }
+
+    public function testUndocumentedControllerYieldsEmptyDocEvenWithDeclaredValuesAndTargets()
+    {
+        $doc = new StimulusControllerDocParser()->parse(<<<'JS'
+            export default class extends Controller {
+                static values = { open: Boolean }
+                static targets = ['panel']
+            }
+            JS, 'closeable');
+
+        // Documentation is opt-in: no docblock tag means no API reference, even though the
+        // controller declares a value and a target in code.
+        self::assertTrue($doc->isEmpty());
+    }
+
+    public function testReturnsEmptyDocWhenNothingDeclared()
+    {
+        $doc = new StimulusControllerDocParser()->parse('export default class extends Controller {}', 'closeable');
+
+        self::assertTrue($doc->isEmpty());
+    }
+}

--- a/src/Toolkit/tests/Component/StimulusControllerSourceTest.php
+++ b/src/Toolkit/tests/Component/StimulusControllerSourceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Component;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Component\StimulusControllerSource;
+
+class StimulusControllerSourceTest extends TestCase
+{
+    public function testTags()
+    {
+        $source = new StimulusControllerSource(<<<'JS'
+            /**
+             * @value  open   Whether it is open.
+             * @target panel  The panel.
+             * @action toggle Toggles it.
+             */
+            export default class extends Controller {}
+            JS);
+
+        self::assertSame(['open' => 'Whether it is open.'], $source->tags()['value']);
+        self::assertSame(['panel' => 'The panel.'], $source->tags()['target']);
+        self::assertSame(['toggle' => 'Toggles it.'], $source->tags()['action']);
+    }
+
+    public function testValuesReadTypeAndDefaultFromCode()
+    {
+        $source = new StimulusControllerSource(<<<'JS'
+            export default class extends Controller {
+                static values = { autoClose: Number, open: { type: Boolean, default: false } }
+            }
+            JS);
+
+        self::assertSame([
+            ['name' => 'autoClose', 'type' => 'Number', 'default' => null],
+            ['name' => 'open', 'type' => 'Boolean', 'default' => 'false'],
+        ], $source->values());
+    }
+
+    public function testTargets()
+    {
+        $source = new StimulusControllerSource(<<<'JS'
+            export default class extends Controller {
+                static targets = ['trigger', 'content']
+            }
+            JS);
+
+        self::assertSame(['trigger', 'content'], $source->targets());
+    }
+
+    public function testEmptySourceYieldsNothing()
+    {
+        $source = new StimulusControllerSource('export default class extends Controller {}');
+
+        self::assertSame(['value' => [], 'target' => [], 'action' => []], $source->tags());
+        self::assertSame([], $source->values());
+        self::assertSame([], $source->targets());
+    }
+
+    public function testTagWithoutDescriptionIsRecognizedWithEmptyDescription()
+    {
+        $source = new StimulusControllerSource(<<<'JS'
+            /**
+             * @action save
+             */
+            export default class extends Controller {}
+            JS);
+
+        self::assertSame(['save' => ''], $source->tags()['action']);
+    }
+
+    public function testDescriptionStopsAtTheNextAnnotationLine()
+    {
+        $source = new StimulusControllerSource(<<<'JS'
+            /**
+             * @action close Closes the element.
+             *
+             * @param {Event} event The click event.
+             * @return {void}
+             */
+            export default class extends Controller {}
+            JS);
+
+        // The description must not swallow `@param`/`@return`.
+        self::assertSame(['close' => 'Closes the element.'], $source->tags()['action']);
+    }
+
+    public function testDescriptionKeepsInlineAtMentions()
+    {
+        $source = new StimulusControllerSource(<<<'JS'
+            /**
+             * @value theme Theme forwarded to @hotwired/stimulus consumers.
+             */
+            export default class extends Controller {}
+            JS);
+
+        // An `@` mid-sentence must not truncate the description; only a new annotation line does.
+        self::assertSame(['theme' => 'Theme forwarded to @hotwired/stimulus consumers.'], $source->tags()['value']);
+    }
+
+    public function testEachDocblockIsParsedIndependently()
+    {
+        $source = new StimulusControllerSource(<<<'JS'
+            /**
+             * @action cancel Cancels a pending close.
+             */
+            export default class extends Controller {
+                /**
+                 * @param delay in ms
+                 */
+                close({ params }) {}
+            }
+            JS);
+
+        // A tag's description is bounded by its own docblock and cannot swallow another's prose.
+        self::assertSame(['cancel' => 'Cancels a pending close.'], $source->tags()['action']);
+    }
+}

--- a/src/Toolkit/tests/Component/StimulusControllerTest.php
+++ b/src/Toolkit/tests/Component/StimulusControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Component;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Component\StimulusController;
+
+class StimulusControllerTest extends TestCase
+{
+    public function testIsFilename()
+    {
+        self::assertTrue(StimulusController::isFilename('assets/controllers/alert_controller.js'));
+        self::assertTrue(StimulusController::isFilename('closeable_controller.js'));
+        self::assertFalse(StimulusController::isFilename('assets/controllers/helper.js'));
+        self::assertFalse(StimulusController::isFilename('alert.html.twig'));
+    }
+
+    public function testIdentifierFromFilenameOrPath()
+    {
+        self::assertSame('closeable', StimulusController::identifier('closeable_controller.js'));
+        self::assertSame('alert-dialog', StimulusController::identifier('alert_dialog_controller.js'));
+        self::assertSame('hover-card', StimulusController::identifier('assets/controllers/hover_card_controller.js'));
+    }
+
+    public function testFilenameFromIdentifier()
+    {
+        self::assertSame('closeable_controller.js', StimulusController::filename('closeable'));
+        self::assertSame('alert_dialog_controller.js', StimulusController::filename('alert-dialog'));
+    }
+
+    public function testValueAttributeDasherizesCamelCaseAndSnakeCase()
+    {
+        self::assertSame('data-widget-auto-close-value', StimulusController::valueAttribute('widget', 'autoClose'));
+        self::assertSame('data-widget-open-value', StimulusController::valueAttribute('widget', 'open'));
+        // Underscores are normalized to kebab-case too.
+        self::assertSame('data-widget-auto-close-value', StimulusController::valueAttribute('widget', 'auto_close'));
+    }
+}

--- a/src/Toolkit/tests/Doc/RecipeDocRendererTest.php
+++ b/src/Toolkit/tests/Doc/RecipeDocRendererTest.php
@@ -93,9 +93,66 @@ final class RecipeDocRendererTest extends KernelTestCase
         $this->assertStringNotContainsString('```twig', $markdown);
     }
 
+    public function testRenderAsMarkdownIncludesStimulusControllerApiReference()
+    {
+        [$kit, $recipe] = $this->loadWidgetRecipe();
+
+        $markdown = $this->renderer()->renderAsMarkdown($kit, $recipe);
+
+        $this->assertStringContainsString('## API Reference', $markdown);
+        // The controller identifier is derived from the `*_controller.js` filename.
+        $this->assertStringContainsString('`data-controller="widget"`', $markdown);
+        // Value: name/type from the code, `data-*` attribute derived (camelCase to kebab-case), description from the `@value` tag.
+        $this->assertStringContainsString('`data-widget-auto-close-value`', $markdown);
+        $this->assertStringContainsString('Delay in milliseconds before the widget closes.', $markdown);
+        // Target from `static targets`, described by the `@target` tag.
+        $this->assertStringContainsString('| `panel` |', $markdown);
+        // Actions are opt-in from `@action` tags, each bounded to its own description.
+        $this->assertStringContainsString('| `toggle` | Toggles the widget open state. |', $markdown);
+    }
+
+    public function testRenderAsHtmlIncludesStimulusControllerApiReference()
+    {
+        [$kit, $recipe] = $this->loadWidgetRecipe();
+
+        $urlGenerator = new class implements PreviewUrlGenerator {
+            public function generate(string $code, CodeOptions $options): ?string
+            {
+                return 'https://preview.test/render';
+            }
+        };
+
+        $html = $this->renderer()->renderAsHtml($kit, $recipe, $urlGenerator)->html;
+
+        // The Stimulus API reference must also render on the HTML path (tables, not just Markdown).
+        $this->assertStringContainsString('<table', $html);
+        $this->assertStringContainsString('data-controller', $html);
+        $this->assertStringContainsString('data-widget-auto-close-value', $html);
+        $this->assertStringContainsString('panel', $html);
+        $this->assertStringContainsString('toggle', $html);
+        $this->assertStringContainsString('Toggles the widget open state.', $html);
+    }
+
     private function renderer(): RecipeDocRenderer
     {
         return new RecipeDocRenderer(self::getContainer()->get('twig'));
+    }
+
+    /**
+     * @return array{0: Kit, 1: Recipe}
+     */
+    private function loadWidgetRecipe(): array
+    {
+        $kitFactory = new KitFactory(
+            self::getContainer()->get('filesystem'),
+            self::getContainer()->get('ux_toolkit.kit.kit_synchronizer'),
+        );
+
+        $kit = $kitFactory->createKitFromAbsolutePath(\dirname(__DIR__).'/Fixtures/kits/render-stimulus-doc');
+        $recipe = $kit->getRecipe('widget');
+        $this->assertNotNull($recipe);
+
+        return [$kit, $recipe];
     }
 
     /**

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/bad_description_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/bad_description_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * @value autoClose delay in ms
+ */
+export default class extends Controller {
+    static values = { autoClose: Number }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/mismatch_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/mismatch_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * @value  ghost     Documented but not declared in the code.
+ * @target timerbar  Countdown bar element.
+ */
+export default class extends Controller {
+    static values = { autoClose: Number }
+    static targets = ['timerbar']
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/orphan_action_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/orphan_action_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * @action save Saves the thing.
+ */
+export default class extends Controller {
+    connect() {
+        // A bare call-site, not a definition: the documented `save` action is never defined.
+        save();
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/undocumented_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/undocumented_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from '@hotwired/stimulus'
+
+// No doc tags at all: documentation is opt-in, so this controller must not be reported.
+export default class extends Controller {
+    static values = { delay: Number }
+    static targets = ['panel']
+
+    toggle() {}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/valid_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/valid_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * @value  autoClose    Delay in milliseconds before auto-removal.
+ * @value  orientation  The split direction, declared in object form.
+ * @target timerbar     Countdown bar element.
+ * @action close        Removes the element.
+ */
+export default class extends Controller {
+    static values = { autoClose: Number, orientation: { type: String, default: 'horizontal' } }
+    static targets = ['timerbar']
+
+    close() {}
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/manifest.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Cases",
+    "description": "Controllers exercising each StimulusControllerDocChecker rule.",
+    "copy-files": {
+        "assets/": "assets/"
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "Lint Stimulus Doc",
+    "description": "Kit covering StimulusControllerDocChecker scenarios.",
+    "license": "MIT",
+    "homepage": "https://example.com/lint-stimulus-doc"
+}

--- a/src/Toolkit/tests/Fixtures/kits/render-stimulus-doc/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/render-stimulus-doc/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "Render Stimulus Doc",
+    "description": "Kit exercising the Stimulus controller API reference rendering.",
+    "license": "MIT",
+    "homepage": "https://example.com/render-stimulus-doc"
+}

--- a/src/Toolkit/tests/Fixtures/kits/render-stimulus-doc/widget/assets/controllers/widget_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/render-stimulus-doc/widget/assets/controllers/widget_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * @value  autoClose  Delay in milliseconds before the widget closes.
+ * @value  open       Whether the widget is open on initial render.
+ * @target panel      The panel shown or hidden by the widget.
+ * @action toggle     Toggles the widget open state.
+ */
+export default class extends Controller {
+    static values = {
+        autoClose: Number,
+        open: { type: Boolean, default: false },
+    };
+    static targets = ['panel'];
+
+    toggle() {}
+}

--- a/src/Toolkit/tests/Fixtures/kits/render-stimulus-doc/widget/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/render-stimulus-doc/widget/manifest.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Widget",
+    "description": "A controller-only recipe used to render the Stimulus API reference.",
+    "copy-files": {
+        "assets/": "assets/"
+    }
+}

--- a/src/Toolkit/tests/Kit/Lint/StimulusControllerDocCheckerTest.php
+++ b/src/Toolkit/tests/Kit/Lint/StimulusControllerDocCheckerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Kit\Lint;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\UX\Toolkit\Kit\KitFactory;
+use Symfony\UX\Toolkit\Kit\KitSynchronizer;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerDocChecker;
+use Symfony\UX\Toolkit\Kit\Lint\KitLinter;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintReport;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+use Symfony\UX\Toolkit\Recipe\RecipeSynchronizer;
+use Symfony\UX\Toolkit\Tests\TestHelperTrait;
+
+class StimulusControllerDocCheckerTest extends TestCase
+{
+    use TestHelperTrait;
+
+    private function lintCases(): LintReport
+    {
+        $factory = new KitFactory(new Filesystem(), new KitSynchronizer(new Filesystem(), new RecipeSynchronizer()));
+        $kit = $factory->createKitFromAbsolutePath(self::getFixtureKitPath('lint-stimulus-doc'));
+
+        return new KitLinter([new StimulusControllerDocChecker()])->lint($kit);
+    }
+
+    /**
+     * @return list<LintIssue>
+     */
+    private function issuesForFile(LintReport $report, string $fileNeedle): array
+    {
+        return array_values(array_filter(
+            $report->getIssues(),
+            static fn (LintIssue $i) => null !== $i->file && str_contains($i->file, $fileNeedle),
+        ));
+    }
+
+    public function testValidControllerProducesNoIssues()
+    {
+        self::assertSame([], $this->issuesForFile($this->lintCases(), 'valid_controller.js'));
+    }
+
+    public function testUndocumentedControllerIsNotReported()
+    {
+        // Documentation is opt-in: a controller with no tags at all must be left alone.
+        self::assertSame([], $this->issuesForFile($this->lintCases(), 'undocumented_controller.js'));
+    }
+
+    public function testAllIssuesAreWarnings()
+    {
+        foreach ($this->lintCases()->getIssues() as $issue) {
+            self::assertSame(LintSeverity::Warning, $issue->severity);
+        }
+    }
+
+    public function testMismatchesAreReportedBothWays()
+    {
+        $issues = $this->issuesForFile($this->lintCases(), 'mismatch_controller.js');
+        $messages = array_map(static fn (LintIssue $i) => $i->message, $issues);
+
+        self::assertCount(2, $issues);
+        foreach ($issues as $issue) {
+            self::assertSame('stimulus.value.mismatch', $issue->category);
+        }
+        self::assertStringContainsString('"ghost" is documented with `@value` but is not declared', implode("\n", $messages));
+        self::assertStringContainsString('"autoClose" is declared in the controller but has no `@value', implode("\n", $messages));
+    }
+
+    public function testBadDescriptionIsReported()
+    {
+        $issues = $this->issuesForFile($this->lintCases(), 'bad_description_controller.js');
+
+        self::assertCount(2, $issues);
+        foreach ($issues as $issue) {
+            self::assertSame('stimulus.value.invalid', $issue->category);
+        }
+    }
+
+    public function testActionWithoutMatchingMethodIsReported()
+    {
+        $issues = $this->issuesForFile($this->lintCases(), 'orphan_action_controller.js');
+
+        self::assertCount(1, $issues);
+        self::assertSame('stimulus.action.mismatch', $issues[0]->category);
+        self::assertStringContainsString('"save"', $issues[0]->message);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Recipes that ship a Stimulus controller had no way to surface its public API in their documentation. This teaches `RecipeDocRenderer` to parse a controller's `@value`/`@target`/`@action` docblock tags and render them under `::: api-reference`, alongside the existing Twig component tables. The code stays the source of truth for value names/types and target names; the docblocks add descriptions, and actions are opt-in via `@action` so internal methods stay private.

Documentation is opt-in: the API reference renders only for controllers that actually carry docblock tags. A controller with no `@value`/`@target`/`@action` tag produces no API reference at all, even though its values and targets could be read from the code — nothing is documented until you choose to.

A new `StimulusControllerDocChecker` keeps those docblocks honest — descriptions capitalized and period-terminated, `@value`/`@target` tags consistent with the `static values`/`static targets` declarations in both directions, and every `@action` matching a real method.
