### PR TITLE
[Toolkit][Common] Add `closeable` recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.4.0
 
 - [Bootstrap] Add the Bootstrap kit
-- [Common] Add the `common` kit, with design-system agnostic `logout-link` and `post-link` recipes
+- [Common] Add the `common` kit, with design-system agnostic `closeable`, `logout-link` and `post-link` recipes
 - Add new linter checker `ClassMergeSpacingChecker` that checks for invalid `'<literal>' ~ attributes.render(...)` pattern
 - Add per-recipe `README.md` documentation
 - Add `RecipeDocRenderer` that renders recipes docs as HTML or Markdown, to ease wiring official kits into ux.symfony.com and, in the future, previewing community kits

--- a/src/Toolkit/kits/common/closeable/README.md
+++ b/src/Toolkit/kits/common/closeable/README.md
@@ -1,0 +1,86 @@
+# Closeable
+
+A Stimulus behavior that removes its element from the page when dismissed, with optional delayed and automatic closing and an animated countdown bar.
+
+```twig {"preview":true,"height":"140px","collapseClass":true}
+<div data-controller="closeable" class="flex items-start gap-3 rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Heads up!</p>
+        <p class="text-violet-700 dark:text-violet-300">This message can be dismissed.</p>
+    </div>
+    <button type="button" data-action="click->closeable#close" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">&times;</span>
+    </button>
+</div>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+Add `data-controller="closeable"` to the element you want to remove, then trigger `closeable#close` from a child element:
+
+```twig
+<div data-controller="closeable">
+    <button type="button" data-action="click->closeable#close">Dismiss</button>
+</div>
+```
+
+## Examples
+
+### Delayed Close
+
+Set a `data-closeable-delay-param` (in milliseconds) on the close action to defer the removal. Add a `timerbar` target to visualize the countdown.
+
+```twig {"preview":true,"height":"140px","collapseClass":true}
+<div data-controller="closeable" class="relative flex items-start gap-3 overflow-hidden rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Saved!</p>
+        <p class="text-violet-700 dark:text-violet-300">Dismiss to close after a short delay.</p>
+    </div>
+    <button type="button" data-action="click->closeable#close" data-closeable-delay-param="3000" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">&times;</span>
+    </button>
+    <div data-closeable-target="timerbar" class="absolute bottom-0 left-0 h-1 w-full bg-violet-500 transition-[width] ease-linear dark:bg-violet-400"></div>
+</div>
+```
+
+### Auto Close
+
+Set `data-closeable-auto-close-value` (in milliseconds) to remove the element automatically once it connects. The `timerbar` target animates down over the same duration.
+
+```twig {"preview":true,"height":"140px","collapseClass":true}
+<div data-controller="closeable" data-closeable-auto-close-value="5000" class="relative flex items-start gap-3 overflow-hidden rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Copied to clipboard</p>
+        <p class="text-violet-700 dark:text-violet-300">This message closes on its own.</p>
+    </div>
+    <button type="button" data-action="click->closeable#close" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">&times;</span>
+    </button>
+    <div data-closeable-target="timerbar" class="absolute bottom-0 left-0 h-1 w-full bg-violet-500 transition-[width] ease-linear dark:bg-violet-400"></div>
+</div>
+```
+
+### Cancel Auto Close
+
+Call `closeable#cancel` to stop a pending close. Here, hovering the message cancels the automatic close so the user has time to read it.
+
+```twig {"preview":true,"height":"140px","collapseClass":true}
+<div data-controller="closeable" data-closeable-auto-close-value="5000" data-action="mouseenter->closeable#cancel" class="relative flex items-start gap-3 overflow-hidden rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Hover to keep me</p>
+        <p class="text-violet-700 dark:text-violet-300">Move your pointer over this message to cancel the automatic close.</p>
+    </div>
+    <button type="button" data-action="click->closeable#close" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">&times;</span>
+    </button>
+    <div data-closeable-target="timerbar" class="absolute bottom-0 left-0 h-1 w-full bg-violet-500 transition-[width] ease-linear dark:bg-violet-400"></div>
+</div>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/common/closeable/assets/controllers/closeable_controller.js
+++ b/src/Toolkit/kits/common/closeable/assets/controllers/closeable_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * @value  autoClose  Delay in milliseconds after which the element removes itself once connected.
+ * @target timerbar   Element whose width animates down to 0 over the close delay to visualize the countdown. It is hidden until a delayed or automatic close starts.
+ * @action close      Removes the element. Accepts a `data-closeable-delay-param` (milliseconds) to defer the removal.
+ * @action cancel     Cancels a pending delayed or automatic close.
+ */
+export default class extends Controller {
+    static targets = ['timerbar'];
+    static values = {
+        autoClose: Number, // auto close delay in ms
+    };
+
+    #timeout;
+
+    connect() {
+        if (this.hasTimerbarTarget) {
+            this.timerbarTarget.hidden = true;
+        }
+
+        if (this.hasAutoCloseValue) {
+            this.#remove(this.autoCloseValue);
+        }
+    }
+
+    close({ params }) {
+        this.#remove(Math.max(0, params.delay || 0));
+    }
+
+    cancel() {
+        clearTimeout(this.#timeout);
+
+        if (this.hasTimerbarTarget) {
+            this.timerbarTarget.hidden = true;
+        }
+    }
+
+    #remove(delay = 0) {
+        // Cancel any pending close so repeated triggers can't race an earlier timeout.
+        clearTimeout(this.#timeout);
+
+        if (this.hasTimerbarTarget && delay) {
+            const timerbar = this.timerbarTarget;
+            timerbar.hidden = false;
+            // Snap to full width without animating, then transition down to 0 over the delay.
+            timerbar.style.transitionDuration = '0ms';
+            timerbar.style.width = '100%';
+            setTimeout(() => {
+                timerbar.style.transitionDuration = `${delay}ms`;
+                timerbar.style.width = '0';
+            }, 10);
+        }
+
+        this.#timeout = setTimeout(() => this.element.remove(), delay);
+    }
+}

--- a/src/Toolkit/kits/common/closeable/manifest.json
+++ b/src/Toolkit/kits/common/closeable/manifest.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Closeable",
+    "version-added": "3.4",
+    "copy-files": {
+        "assets/": "assets/"
+    }
+}

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component closeable, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component closeable, example 0__1.html
@@ -1,0 +1,25 @@
+<!--
+- Kit: Common
+- Component: Closeable
+- Code:
+```twig
+<div data-controller="closeable" class="flex items-start gap-3 rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Heads up!</p>
+        <p class="text-violet-700 dark:text-violet-300">This message can be dismissed.</p>
+    </div>
+    <button type="button" data-action="click->closeable#close" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">&times;</span>
+    </button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="closeable" class="flex items-start gap-3 rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Heads up!</p>
+        <p class="text-violet-700 dark:text-violet-300">This message can be dismissed.</p>
+    </div>
+    <button type="button" data-action="click-&gt;closeable#close" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">×</span>
+    </button>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component closeable, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component closeable, example 1__1.html
@@ -1,0 +1,27 @@
+<!--
+- Kit: Common
+- Component: Closeable
+- Code:
+```twig
+<div data-controller="closeable" class="relative flex items-start gap-3 overflow-hidden rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Saved!</p>
+        <p class="text-violet-700 dark:text-violet-300">Dismiss to close after a short delay.</p>
+    </div>
+    <button type="button" data-action="click->closeable#close" data-closeable-delay-param="3000" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">&times;</span>
+    </button>
+    <div data-closeable-target="timerbar" class="absolute bottom-0 left-0 h-1 w-full bg-violet-500 transition-[width] ease-linear dark:bg-violet-400"></div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="closeable" class="relative flex items-start gap-3 overflow-hidden rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Saved!</p>
+        <p class="text-violet-700 dark:text-violet-300">Dismiss to close after a short delay.</p>
+    </div>
+    <button type="button" data-action="click-&gt;closeable#close" data-closeable-delay-param="3000" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">×</span>
+    </button>
+    <div data-closeable-target="timerbar" class="absolute bottom-0 left-0 h-1 w-full bg-violet-500 transition-[width] ease-linear dark:bg-violet-400"></div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component closeable, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component closeable, example 2__1.html
@@ -1,0 +1,27 @@
+<!--
+- Kit: Common
+- Component: Closeable
+- Code:
+```twig
+<div data-controller="closeable" data-closeable-auto-close-value="5000" class="relative flex items-start gap-3 overflow-hidden rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Copied to clipboard</p>
+        <p class="text-violet-700 dark:text-violet-300">This message closes on its own.</p>
+    </div>
+    <button type="button" data-action="click->closeable#close" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">&times;</span>
+    </button>
+    <div data-closeable-target="timerbar" class="absolute bottom-0 left-0 h-1 w-full bg-violet-500 transition-[width] ease-linear dark:bg-violet-400"></div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="closeable" data-closeable-auto-close-value="5000" class="relative flex items-start gap-3 overflow-hidden rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Copied to clipboard</p>
+        <p class="text-violet-700 dark:text-violet-300">This message closes on its own.</p>
+    </div>
+    <button type="button" data-action="click-&gt;closeable#close" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">×</span>
+    </button>
+    <div data-closeable-target="timerbar" class="absolute bottom-0 left-0 h-1 w-full bg-violet-500 transition-[width] ease-linear dark:bg-violet-400"></div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component closeable, example 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component closeable, example 3__1.html
@@ -1,0 +1,27 @@
+<!--
+- Kit: Common
+- Component: Closeable
+- Code:
+```twig
+<div data-controller="closeable" data-closeable-auto-close-value="5000" data-action="mouseenter->closeable#cancel" class="relative flex items-start gap-3 overflow-hidden rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Hover to keep me</p>
+        <p class="text-violet-700 dark:text-violet-300">Move your pointer over this message to cancel the automatic close.</p>
+    </div>
+    <button type="button" data-action="click->closeable#close" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">&times;</span>
+    </button>
+    <div data-closeable-target="timerbar" class="absolute bottom-0 left-0 h-1 w-full bg-violet-500 transition-[width] ease-linear dark:bg-violet-400"></div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="closeable" data-closeable-auto-close-value="5000" data-action="mouseenter-&gt;closeable#cancel" class="relative flex items-start gap-3 overflow-hidden rounded-md border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <div class="flex-1">
+        <p class="font-medium">Hover to keep me</p>
+        <p class="text-violet-700 dark:text-violet-300">Move your pointer over this message to cancel the automatic close.</p>
+    </div>
+    <button type="button" data-action="click-&gt;closeable#close" aria-label="Dismiss" class="text-violet-500 hover:text-violet-700 dark:text-violet-400 dark:hover:text-violet-200">
+        <span aria-hidden="true" class="text-lg leading-none">×</span>
+    </button>
+    <div data-closeable-target="timerbar" class="absolute bottom-0 left-0 h-1 w-full bg-violet-500 transition-[width] ease-linear dark:bg-violet-400"></div>
+</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Adds `common/closeable`, a controller-only recipe that removes its element on demand — with optional delayed close, auto-close, and a cancel action, plus an animated countdown bar. It's the first controller-only recipe in the kits.

Depends on #3724 for its API reference to render. A companion PR on `symfony/ux.symfony.com` will register the controller so the live previews boot.
