### PR TITLE
[Toolkit] Document the Stimulus API of existing kit controllers

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `RecipeDocRenderer` that renders recipes docs as HTML or Markdown, to ease wiring official kits into ux.symfony.com and, in the future, previewing community kits
 - Add optional `color` and `icon` fields to the kit manifest
 - Include kit-global dependencies when installing a recipe
+- [Flowbite][Shadcn] Document the Stimulus controllers' API (values, targets, actions) so it renders in the recipe documentation
 
 ## 3.3.0
 

--- a/src/Toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js
+++ b/src/Toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js
@@ -1,6 +1,10 @@
 import { Controller } from '@hotwired/stimulus';
 import { Dismiss } from 'flowbite';
 
+/**
+ * @target alert  The alert element that is dismissed when closed.
+ * @action close  Dismisses the alert.
+ */
 export default class extends Controller {
     alert = null;
     static targets = ['alert'];

--- a/src/Toolkit/kits/flowbite-4/dropdown/assets/controllers/dropdown_controller.js
+++ b/src/Toolkit/kits/flowbite-4/dropdown/assets/controllers/dropdown_controller.js
@@ -1,6 +1,15 @@
 import { Controller } from '@hotwired/stimulus';
 import { Dropdown } from 'flowbite';
 
+/**
+ * @value  placement       Placement of the dropdown relative to its trigger.
+ * @value  triggerType     How the dropdown is triggered (e.g. click or hover).
+ * @value  open            Whether the dropdown is open on initial render.
+ * @value  delay           Delay in milliseconds before the dropdown toggles on hover.
+ * @value  offsetDistance  Distance in pixels between the trigger and the dropdown content.
+ * @target trigger         The element that toggles the dropdown and reflects its expanded state.
+ * @target content         The dropdown menu container that is shown and hidden.
+ */
 export default class extends Controller {
     dropdown = null;
     static targets = ['trigger', 'content'];

--- a/src/Toolkit/kits/flowbite-4/modal/assets/controllers/modal_controller.js
+++ b/src/Toolkit/kits/flowbite-4/modal/assets/controllers/modal_controller.js
@@ -1,5 +1,13 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  open                Whether the modal is open on initial render.
+ * @target trigger             The element that opens the modal and reflects its expanded state.
+ * @target modal               The native `<dialog>` element that is shown and closed.
+ * @action open                Opens the modal.
+ * @action close               Closes the modal.
+ * @action closeOnClickOutside  Closes the modal when the backdrop outside the content is clicked.
+ */
 export default class extends Controller {
     static targets = ['trigger', 'modal'];
 

--- a/src/Toolkit/kits/flowbite-4/tabs/assets/controllers/tabs_controller.js
+++ b/src/Toolkit/kits/flowbite-4/tabs/assets/controllers/tabs_controller.js
@@ -1,5 +1,11 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  activeTab  The `data-tab-id` of the currently active tab.
+ * @target trigger    The clickable elements that switch tabs and reflect their selected state.
+ * @target tab        The tab panels that are shown or hidden based on the active tab.
+ * @action open       Activates the tab identified by the clicked trigger.
+ */
 export default class extends Controller {
     static targets = ['trigger', 'tab'];
     static values = { activeTab: String };

--- a/src/Toolkit/kits/shadcn/accordion/assets/controllers/accordion_controller.js
+++ b/src/Toolkit/kits/shadcn/accordion/assets/controllers/accordion_controller.js
@@ -1,5 +1,14 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  multiple       Whether multiple items can be open at the same time.
+ * @value  orientation    The layout orientation (`vertical` or `horizontal`) that controls keyboard navigation.
+ * @target item           Each accordion item wrapping a trigger and its content.
+ * @target trigger        The button that toggles its item and reflects the expanded state.
+ * @target content        The collapsible region shown or hidden when its item toggles.
+ * @action toggle         Toggles the accordion item of the clicked trigger.
+ * @action handleKeydown  Moves focus between triggers using arrow, Home, and End keys.
+ */
 export default class extends Controller {
     static targets = ['item', 'trigger', 'content'];
 

--- a/src/Toolkit/kits/shadcn/alert-dialog/assets/controllers/alert_dialog_controller.js
+++ b/src/Toolkit/kits/shadcn/alert-dialog/assets/controllers/alert_dialog_controller.js
@@ -1,5 +1,12 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  open     Whether the dialog is open on initial render.
+ * @target trigger  The element that opens the dialog and reflects its expanded state.
+ * @target dialog   The native `<dialog>` element that is shown and closed.
+ * @action open     Opens the dialog.
+ * @action close    Closes the dialog.
+ */
 export default class extends Controller {
     static targets = ['trigger', 'dialog'];
 

--- a/src/Toolkit/kits/shadcn/collapsible/assets/controllers/collapsible_controller.js
+++ b/src/Toolkit/kits/shadcn/collapsible/assets/controllers/collapsible_controller.js
@@ -1,5 +1,11 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  open     Whether the collapsible is expanded on initial render.
+ * @target trigger  The element that toggles the collapsible and reflects its expanded state.
+ * @target content  The collapsible region that is shown or hidden.
+ * @action toggle   Toggles the collapsible between its open and closed states.
+ */
 export default class extends Controller {
     static targets = ['trigger', 'content'];
 

--- a/src/Toolkit/kits/shadcn/combobox/assets/controllers/combobox_controller.js
+++ b/src/Toolkit/kits/shadcn/combobox/assets/controllers/combobox_controller.js
@@ -1,5 +1,25 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  value            The currently selected option's value.
+ * @value  placeholder      The label shown when no option is selected.
+ * @target trigger          The button that opens the popover and reflects its expanded state.
+ * @target label            The element displaying the selected option's label or the placeholder.
+ * @target popover          The floating panel containing the search field and options.
+ * @target search           The text input used to filter the options.
+ * @target option           An individual selectable option.
+ * @target empty            The message shown when no option matches the search query.
+ * @target hiddenInput      The hidden form input that carries the selected value.
+ * @target group            A group of options, hidden when none of its options match.
+ * @target clearButton      The button that clears the current selection.
+ * @action toggle           Opens or closes the popover.
+ * @action clear            Clears the current selection.
+ * @action onSearch         Filters the options against the search query.
+ * @action onSelect         Selects the clicked option.
+ * @action onOptionHover    Marks the hovered option as active.
+ * @action onTriggerKeydown Handles keyboard navigation while the trigger is focused.
+ * @action onSearchKeydown  Handles keyboard navigation and selection while searching.
+ */
 export default class extends Controller {
     static targets = [
         'trigger',

--- a/src/Toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js
+++ b/src/Toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js
@@ -1,5 +1,13 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  open     Whether the dialog is open on initial render.
+ * @target trigger  The element that opens the dialog and reflects its expanded state.
+ * @target dialog   The native `<dialog>` element that is shown and closed.
+ * @action open     Opens the dialog.
+ * @action close    Closes the dialog.
+ * @action closeOnClickOutside  Closes the dialog when the backdrop outside the content is clicked.
+ */
 export default class extends Controller {
     static targets = ['trigger', 'dialog'];
 

--- a/src/Toolkit/kits/shadcn/hover-card/assets/controllers/hover_card_controller.js
+++ b/src/Toolkit/kits/shadcn/hover-card/assets/controllers/hover_card_controller.js
@@ -1,5 +1,11 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  openDelay   The delay in milliseconds before the card opens.
+ * @value  closeDelay  The delay in milliseconds before the card closes.
+ * @action show        Opens the card after the configured open delay.
+ * @action hide        Closes the card after the configured close delay.
+ */
 export default class extends Controller {
     static values = {
         openDelay: { type: Number, default: 0 },

--- a/src/Toolkit/kits/shadcn/resizable/assets/controllers/resizable_controller.js
+++ b/src/Toolkit/kits/shadcn/resizable/assets/controllers/resizable_controller.js
@@ -1,5 +1,10 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  orientation  Layout direction of the panels, either `horizontal` or `vertical`.
+ * @target panel         A resizable panel whose flex size is adjusted when a handle is dragged.
+ * @target handle        A draggable divider that resizes its adjacent panels via pointer or arrow keys.
+ */
 export default class extends Controller {
     static targets = ['panel', 'handle'];
     static values = { orientation: { type: String, default: 'horizontal' } };

--- a/src/Toolkit/kits/shadcn/sonner/assets/controllers/sonner_controller.js
+++ b/src/Toolkit/kits/shadcn/sonner/assets/controllers/sonner_controller.js
@@ -27,6 +27,19 @@ const TYPE_ICONS = {
 const CLOSE_ICON =
     '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
 
+/**
+ * @value  position       Corner where toasts are stacked, e.g. `top-right` or `bottom-left`.
+ * @value  expand         Whether hovering expands the stack to reveal all toasts.
+ * @value  richColors     Whether type-specific background and border colors are applied.
+ * @value  closeButton    Whether a close button is rendered on each toast.
+ * @value  duration       Default lifetime of a toast in milliseconds before auto-dismiss.
+ * @value  gap            Spacing in pixels between stacked toasts.
+ * @value  visibleToasts  Maximum number of toasts visible at once.
+ * @value  dir            Text direction, `ltr` or `rtl`, controlling swipe-to-dismiss direction.
+ * @value  theme          Color theme applied to the container, `system`, `light`, or `dark`.
+ * @target list           The `<ol>` element that holds and stacks the toast items.
+ * @action fire           Creates a toast from the click event's `data-sonner-*-param` attributes.
+ */
 export default class extends Controller {
     static values = {
         position: { type: String, default: 'top-right' },

--- a/src/Toolkit/kits/shadcn/tabs/assets/controllers/tabs_controller.js
+++ b/src/Toolkit/kits/shadcn/tabs/assets/controllers/tabs_controller.js
@@ -1,5 +1,11 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  activeTab  The `data-tab-id` of the currently selected tab.
+ * @target trigger    A tab button that selects its panel and reflects the active state.
+ * @target tab         A tab panel that is shown or hidden based on the active tab.
+ * @action open        Activates the tab identified by the clicked trigger's `data-tab-id`.
+ */
 export default class extends Controller {
     static targets = ['trigger', 'tab'];
     static values = { activeTab: String };

--- a/src/Toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js
+++ b/src/Toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js
@@ -1,5 +1,10 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  type           Selection mode of the group, either `multiple` or `single`.
+ * @value  labelSelector  CSS selector of an element whose text is updated with the selected value in single mode.
+ * @action toggle         Enforces single-selection by deselecting the other toggles and updating the label.
+ */
 export default class extends Controller {
     static values = {
         type: { type: String, default: 'multiple' },

--- a/src/Toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js
+++ b/src/Toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js
@@ -1,5 +1,9 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  pressed  Whether the toggle is currently pressed.
+ * @action toggle   Toggles the pressed state.
+ */
 export default class extends Controller {
     static values = { pressed: Boolean };
 

--- a/src/Toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js
+++ b/src/Toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js
@@ -1,5 +1,15 @@
 import { Controller } from '@hotwired/stimulus';
 
+/**
+ * @value  delayDuration    Delay in milliseconds before the tooltip is shown.
+ * @value  wrapperSelector  CSS selector of the tooltip wrapper element portaled to the body.
+ * @value  contentSelector  CSS selector of the tooltip content element.
+ * @value  arrowSelector    CSS selector of the tooltip arrow element.
+ * @target trigger          The element that triggers the tooltip and anchors its position.
+ * @target wrapper          The tooltip wrapper element, watched to reinitialize on live component rerender.
+ * @action show             Shows the tooltip after the configured delay.
+ * @action hide             Hides the tooltip.
+ */
 export default class extends Controller {
     static values = {
         delayDuration: Number,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Applies the new controller docblocks to every controller that ships one across the `flowbite-4` and `shadcn` kits, so each recipe's documentation gains a Stimulus API reference. Values and targets are documented in full (the linter enforces both directions); actions are limited to the public methods actually wired via `data-action` in each recipe's templates.

Depends on #3724.
