### PR TITLE
[LiveComponent] Fix URL-bound array props ignored when documented with a phpdoc shape or generic

### DIFF
--- a/src/LiveComponent/src/Util/RequestPropsExtractor.php
+++ b/src/LiveComponent/src/Util/RequestPropsExtractor.php
@@ -98,6 +98,18 @@ final class RequestPropsExtractor
 
         $type = $livePropMetadata->getType();
 
-        return null === $type || TypeHelper::accepts($type, $value);
+        if (null === $type) {
+            return true;
+        }
+
+        // URL values for array props are stringly-typed and possibly partial:
+        // checking them against a phpdoc-derived shape or generic (e.g.
+        // array{...} or array<string, int>) would always fail, so only ensure
+        // the native type matches.
+        if (\is_array($value) && $type->isIdentifiedBy(TypeIdentifier::ARRAY)) {
+            return true;
+        }
+
+        return TypeHelper::accepts($type, $value);
     }
 }

--- a/src/LiveComponent/tests/Fixtures/Component/ComponentWithUrlBoundProps.php
+++ b/src/LiveComponent/tests/Fixtures/Component/ComponentWithUrlBoundProps.php
@@ -36,6 +36,18 @@ class ComponentWithUrlBoundProps
     #[LiveProp(url: new UrlMapping(as: 'arr_alias'))]
     public array $arrayPropAlias = [];
 
+    /**
+     * @var array{r: array<string, true>, c: array<string, true>}
+     */
+    #[LiveProp(url: true)]
+    public array $shapedArrayProp = ['r' => [], 'c' => []];
+
+    /**
+     * @var int[]
+     */
+    #[LiveProp(url: true)]
+    public array $intListProp = [];
+
     #[LiveProp(writable: true, fieldName: 'getArrayFieldName()', url: true)]
     public array $arrayPropFieldName = [];
 

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -146,6 +146,8 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
             'pathPropForAnotherController' => ['name' => 'pathPropForAnotherController'],
             'arrayPropAlias' => ['name' => 'arr_alias'],
             'arr_field_name' => ['name' => 'arr_field_name'],
+            'shapedArrayProp' => ['name' => 'shapedArrayProp'],
+            'intListProp' => ['name' => 'intListProp'],
         ];
 
         $this->assertEquals($expected, $queryMapping);

--- a/src/LiveComponent/tests/Functional/Util/RequestPropsExtractorTest.php
+++ b/src/LiveComponent/tests/Functional/Util/RequestPropsExtractorTest.php
@@ -62,8 +62,11 @@ class RequestPropsExtractorTest extends KernelTestCase
                 return $address;
             })(),
             ]],
+            'partial shaped array value' => ['shapedArrayProp[r][C-D]=1', ['shapedArrayProp' => ['r' => ['C-D' => '1']]]],
+            'generic array value' => ['intListProp[]=1&intListProp[]=2', ['intListProp' => ['1', '2']]],
             'invalid scalar value' => ['stringProp[]=foo&stringProp[]=bar', []],
             'invalid array value' => ['arrayProp=foo', []],
+            'invalid shaped array value' => ['shapedArrayProp=foo', []],
             'invalid object value' => ['objectProp=foo', []],
             'aliased prop' => ['q=foo', ['boundPropWithAlias' => 'foo']],
             'attribute prop' => ['', ['stringProp' => 'foo'], ['stringProp' => 'foo']],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2900
| License       | MIT

Since the TypeInfo migration (#2607), `RequestPropsExtractor::isValueTypeConsistent()` checks the value coming from the URL against the phpdoc-derived type with `TypeHelper::accepts()`. For an array prop documented with a shape or a generic, e.g.

```php
/** @var array{r: array<string, true>, c: array<string, true>} */
#[LiveProp(url: true)]
public array $expanded = ['r' => [], 'c' => []];
```

this check can never pass: shape keys are marked required while URL values are partial by nature, and query string values are always strings (`'1'` vs `true`). The prop is then silently ignored, while it hydrated fine before the migration (the legacy check only verified the native type, `is_array($value)` for an array prop).

This PR restores that leniency for arrays only: an array value is accepted as soon as the prop type is array-identified, everything else keeps the strict `accepts()` check. Invalid top-level values (`?arrayProp=foo`) are still rejected, as covered by the existing `invalid array value` test case.

Test cases added for the exact scenario reported in #2900 (partial shaped array), for a generic (`int[]`) and for the invalid counterpart (`?shapedArrayProp=foo`).