### PR TITLE
 Fix broken assets/tsconfig.json reference breaking webpack 5.109+ builds

### DIFF
--- a/src/Autocomplete/.gitattributes
+++ b/src/Autocomplete/.gitattributes
@@ -3,7 +3,9 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.dist.xml export-ignore
 /tests export-ignore
+

--- a/src/Chartjs/.gitattributes
+++ b/src/Chartjs/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.dist.xml export-ignore

--- a/src/Cropperjs/.gitattributes
+++ b/src/Cropperjs/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.dist.xml export-ignore

--- a/src/Dropzone/.gitattributes
+++ b/src/Dropzone/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.dist.xml export-ignore

--- a/src/LiveComponent/.gitattributes
+++ b/src/LiveComponent/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.dist.xml export-ignore

--- a/src/Map/.gitattributes
+++ b/src/Map/.gitattributes
@@ -4,6 +4,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /tests export-ignore

--- a/src/Notify/.gitattributes
+++ b/src/Notify/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.dist.xml export-ignore

--- a/src/React/.gitattributes
+++ b/src/React/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.dist.xml export-ignore

--- a/src/StimulusBundle/.gitattributes
+++ b/src/StimulusBundle/.gitattributes
@@ -2,6 +2,7 @@
 /.symfony.bundle.yaml export-ignore
 /assets/src export-ignore
 /assets/test export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.dist.xml export-ignore

--- a/src/Translator/.gitattributes
+++ b/src/Translator/.gitattributes
@@ -4,6 +4,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /tests export-ignore

--- a/src/Turbo/.gitattributes
+++ b/src/Turbo/.gitattributes
@@ -5,6 +5,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /CONTRIBUTING.md export-ignore
 /docker-compose.yml

--- a/src/Vue/.gitattributes
+++ b/src/Vue/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.dist.xml export-ignore


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3728
| License        | MIT

### Description

This PR fixes a build regression introduced with Webpack 5.109.0, where automatic `tsconfig.json` resolution is enabled by default. 

Every `symfony/ux-*` package currently ships an `assets/tsconfig.json` that extends `../../../tsconfig.package.json`. This relative path breaks when packages are installed via Composer into the `vendor/` directory, as the target file does not exist outside the monorepo boundary. 

As suggested in the issue, this fix adds `/assets/tsconfig.json` to the `.gitattributes` `export-ignore` rules for the split packages so that this development-only configuration file is no longer distributed to consumers.

### Notes
I am also submitting a separate backport PR targeting the `2.x` branch since this issue affects both versions of the monorepo.