### PR TITLE
 Fix broken assets/tsconfig.json reference breaking webpack 5.109+ builds

### DIFF
--- a/src/Autocomplete/.gitattributes
+++ b/src/Autocomplete/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/Chartjs/.gitattributes
+++ b/src/Chartjs/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/Cropperjs/.gitattributes
+++ b/src/Cropperjs/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/Dropzone/.gitattributes
+++ b/src/Dropzone/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/LazyImage/.gitattributes
+++ b/src/LazyImage/.gitattributes
@@ -2,6 +2,7 @@
 /.symfony.bundle.yaml export-ignore
 /assets/src export-ignore
 /assets/test export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/LiveComponent/.gitattributes
+++ b/src/LiveComponent/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/Map/.gitattributes
+++ b/src/Map/.gitattributes
@@ -4,6 +4,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /tests export-ignore

--- a/src/Notify/.gitattributes
+++ b/src/Notify/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/React/.gitattributes
+++ b/src/React/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/StimulusBundle/.gitattributes
+++ b/src/StimulusBundle/.gitattributes
@@ -2,6 +2,7 @@
 /.symfony.bundle.yaml export-ignore
 /assets/src export-ignore
 /assets/test export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/Svelte/.gitattributes
+++ b/src/Svelte/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore

--- a/src/Swup/.gitattributes
+++ b/src/Swup/.gitattributes
@@ -2,5 +2,6 @@
 /.symfony.bundle.yaml export-ignore
 /assets/src export-ignore
 /assets/test export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore

--- a/src/TogglePassword/.gitattributes
+++ b/src/TogglePassword/.gitattributes
@@ -3,6 +3,7 @@
 /phpunit.xml.dist export-ignore
 /assets/src export-ignore
 /assets/test export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /tests export-ignore

--- a/src/Translator/.gitattributes
+++ b/src/Translator/.gitattributes
@@ -4,6 +4,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /tests export-ignore

--- a/src/Turbo/.gitattributes
+++ b/src/Turbo/.gitattributes
@@ -5,6 +5,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /CONTRIBUTING.md export-ignore
 /docker-compose.yml

--- a/src/Typed/.gitattributes
+++ b/src/Typed/.gitattributes
@@ -2,5 +2,6 @@
 /.symfony.bundle.yaml export-ignore
 /assets/src export-ignore
 /assets/test export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore

--- a/src/Vue/.gitattributes
+++ b/src/Vue/.gitattributes
@@ -3,6 +3,7 @@
 /assets/src export-ignore
 /assets/test export-ignore
 /assets/playwright.config.ts export-ignore
+/assets/tsconfig.json export-ignore
 /assets/vitest.config.mjs export-ignore
 /doc export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #3728 
| License        | MIT

### Description

Backport of the `assets/tsconfig.json` export-ignore fix to the `2.x` branch. 

This prevents Webpack 5.109.0+ from throwing `ModuleNotFoundError (ENOENT)` due to the dangling `tsconfig.package.json` reference when UX packages are installed via Composer in older Symfony/UX setups.