### PR TITLE
[Toolkit] Document Stimulus controller CSS classes and outlets in the API reference

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [Common] Add the `common` kit, with design-system agnostic `closeable`, `logout-link` and `post-link` recipes
 - Add new linter checker `ClassMergeSpacingChecker` that checks for invalid `'<literal>' ~ attributes.render(...)` pattern
 - Add per-recipe `README.md` documentation
-- Document Stimulus controllers in the recipe API reference from their `@value`/`@target`/`@action` docblocks, and lint those docblocks with the new `StimulusControllerDocChecker`
+- Document Stimulus controllers in the recipe API reference from their `@value`/`@target`/`@css-class`/`@outlet`/`@action` docblocks, and lint those docblocks with the new `StimulusControllerDocChecker`
 - Add `RecipeDocRenderer` that renders recipes docs as HTML or Markdown, to ease wiring official kits into ux.symfony.com and, in the future, previewing community kits
 - Add optional `color` and `icon` fields to the kit manifest
 - Include kit-global dependencies when installing a recipe

--- a/src/Toolkit/src/Component/StimulusController.php
+++ b/src/Toolkit/src/Component/StimulusController.php
@@ -56,4 +56,22 @@ final class StimulusController
     {
         return \sprintf('data-%s-%s-value', $identifier, u($value)->kebab());
     }
+
+    /**
+     * The `data-*` attribute a Stimulus class binds to, matching Stimulus' dasherization
+     * (e.g. identifier `widget` + class `success` => `data-widget-success-class`).
+     */
+    public static function classAttribute(string $identifier, string $class): string
+    {
+        return \sprintf('data-%s-%s-class', $identifier, u($class)->kebab());
+    }
+
+    /**
+     * The `data-*` attribute a Stimulus outlet binds to, matching Stimulus' dasherization
+     * (e.g. identifier `widget` + outlet `user-status` => `data-widget-user-status-outlet`).
+     */
+    public static function outletAttribute(string $identifier, string $outlet): string
+    {
+        return \sprintf('data-%s-%s-outlet', $identifier, u($outlet)->kebab());
+    }
 }

--- a/src/Toolkit/src/Component/StimulusControllerClass.php
+++ b/src/Toolkit/src/Component/StimulusControllerClass.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Component;
+
+/**
+ * A Stimulus CSS class declared by a controller's `static classes` and documented with a `@css-class` tag.
+ *
+ * The name is read from the code; the description comes from the docblock. The `attribute` is the
+ * `data-*-class` attribute the class is bound to, precomputed from the controller identifier and the name.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusControllerClass
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $attribute,
+        public readonly string $description,
+    ) {
+    }
+}

--- a/src/Toolkit/src/Component/StimulusControllerDoc.php
+++ b/src/Toolkit/src/Component/StimulusControllerDoc.php
@@ -12,7 +12,7 @@
 namespace Symfony\UX\Toolkit\Component;
 
 /**
- * The API reference extracted from a Stimulus controller: its values, targets and actions.
+ * The API reference extracted from a Stimulus controller: its values, targets, classes, outlets and actions.
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  *
@@ -23,17 +23,21 @@ final class StimulusControllerDoc
     /**
      * @param list<StimulusControllerValue>  $values
      * @param list<StimulusControllerTarget> $targets
+     * @param list<StimulusControllerClass>  $classes
+     * @param list<StimulusControllerOutlet> $outlets
      * @param list<StimulusControllerAction> $actions
      */
     public function __construct(
         public readonly array $values = [],
         public readonly array $targets = [],
+        public readonly array $classes = [],
+        public readonly array $outlets = [],
         public readonly array $actions = [],
     ) {
     }
 
     public function isEmpty(): bool
     {
-        return [] === $this->values && [] === $this->targets && [] === $this->actions;
+        return [] === $this->values && [] === $this->targets && [] === $this->classes && [] === $this->outlets && [] === $this->actions;
     }
 }

--- a/src/Toolkit/src/Component/StimulusControllerDocParser.php
+++ b/src/Toolkit/src/Component/StimulusControllerDocParser.php
@@ -12,7 +12,7 @@
 namespace Symfony\UX\Toolkit\Component;
 
 /**
- * Builds the {@see StimulusControllerDoc} (values, targets and actions) from a controller's source.
+ * Builds the {@see StimulusControllerDoc} (values, targets, classes, outlets and actions) from a controller's source.
  *
  * The source is scanned by {@see StimulusControllerSource}: the code is the single source of truth
  * for value names/types and target names, while their descriptions come from `@value`/`@target`
@@ -33,9 +33,9 @@ final class StimulusControllerDocParser
         $controller = new StimulusControllerSource($source);
         $tags = $controller->tags();
 
-        // Documentation is opt-in: without any @value/@target/@action tag, the controller
-        // exposes no API reference, even though its values/targets could be read from the code.
-        if ([] === $tags['value'] && [] === $tags['target'] && [] === $tags['action']) {
+        // Documentation is opt-in: without any @value/@target/@action/@css-class/@outlet tag, the controller
+        // exposes no API reference, even though its values/targets/classes/outlets could be read from the code.
+        if ([] === $tags['value'] && [] === $tags['target'] && [] === $tags['action'] && [] === $tags['class'] && [] === $tags['outlet']) {
             return new StimulusControllerDoc();
         }
 
@@ -55,11 +55,29 @@ final class StimulusControllerDocParser
             $targets[] = new StimulusControllerTarget($name, $tags['target'][$name] ?? '');
         }
 
+        $classes = [];
+        foreach ($controller->classes() as $name) {
+            $classes[] = new StimulusControllerClass(
+                $name,
+                StimulusController::classAttribute($identifier, $name),
+                $tags['class'][$name] ?? '',
+            );
+        }
+
+        $outlets = [];
+        foreach ($controller->outlets() as $name) {
+            $outlets[] = new StimulusControllerOutlet(
+                $name,
+                StimulusController::outletAttribute($identifier, $name),
+                $tags['outlet'][$name] ?? '',
+            );
+        }
+
         $actions = [];
         foreach ($tags['action'] as $name => $description) {
             $actions[] = new StimulusControllerAction($name, $description);
         }
 
-        return new StimulusControllerDoc($values, $targets, $actions);
+        return new StimulusControllerDoc($values, $targets, $classes, $outlets, $actions);
     }
 }

--- a/src/Toolkit/src/Component/StimulusControllerOutlet.php
+++ b/src/Toolkit/src/Component/StimulusControllerOutlet.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Component;
+
+/**
+ * A Stimulus outlet declared by a controller's `static outlets` and documented with an `@outlet` tag.
+ *
+ * The name is read from the code; the description comes from the docblock. The `attribute` is the
+ * `data-*-outlet` attribute the outlet is bound to, precomputed from the controller identifier and the name.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class StimulusControllerOutlet
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $attribute,
+        public readonly string $description,
+    ) {
+    }
+}

--- a/src/Toolkit/src/Component/StimulusControllerSource.php
+++ b/src/Toolkit/src/Component/StimulusControllerSource.php
@@ -13,7 +13,8 @@ namespace Symfony\UX\Toolkit\Component;
 
 /**
  * Reads a Stimulus controller's documented + declared surface from its source: the
- * `@value`/`@target`/`@action` docblock tags and the `static values`/`static targets`
+ * `@value`/`@target`/`@action`/`@css-class`/`@outlet` docblock tags and the
+ * `static values`/`static targets`/`static classes`/`static outlets`
  * declarations. Shared by {@see StimulusControllerDocParser} (rendering) and
  * {@see \Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerDocChecker} (linting) so both
  * scan a controller identically.
@@ -26,10 +27,12 @@ final class StimulusControllerSource
 {
     private const RE_DOCBLOCK = '#/\*\*(?P<body>.*?)\*/#s';
     // The description ends only at the next annotation *line* (\R\h*@), so an `@` mid-sentence isn't a boundary.
-    private const RE_TAG = '/@(?P<tag>value|target|action)\h+(?P<name>[A-Za-z_$][\w$]*)(?P<description>(?:(?!\R\h*@[a-zA-Z]).)*)/s';
+    private const RE_TAG = '/@(?P<tag>value|target|action|css-class|outlet)\h+(?P<name>[A-Za-z_$][\w$-]*)(?P<description>(?:(?!\R\h*@[a-zA-Z]).)*)/s';
     private const RE_VALUES = '/static\s+values\s*=\s*\{(?P<body>(?:[^{}]|\{[^{}]*\})*)\}/s';
     private const RE_VALUE_ENTRY = '/(?P<name>[A-Za-z_$][\w$]*)\s*:\s*(?P<type>\{[^{}]*\}|[A-Za-z_$][\w$]*)/';
     private const RE_TARGETS = '/static\s+targets\s*=\s*\[(?P<body>[^\]]*)\]/s';
+    private const RE_CLASSES = '/static\s+classes\s*=\s*\[(?P<body>[^\]]*)\]/s';
+    private const RE_OUTLETS = '/static\s+outlets\s*=\s*\[(?P<body>[^\]]*)\]/s';
     private const RE_STRING = '/[\'"](?P<value>[^\'"]+)[\'"]/';
 
     public function __construct(private readonly string $source)
@@ -39,11 +42,11 @@ final class StimulusControllerSource
     /**
      * Docblock tag descriptions, keyed by name within each tag type.
      *
-     * @return array{value: array<string, string>, target: array<string, string>, action: array<string, string>}
+     * @return array{value: array<string, string>, target: array<string, string>, action: array<string, string>, class: array<string, string>, outlet: array<string, string>}
      */
     public function tags(): array
     {
-        $tags = ['value' => [], 'target' => [], 'action' => []];
+        $tags = ['value' => [], 'target' => [], 'action' => [], 'class' => [], 'outlet' => []];
 
         if (!preg_match_all(self::RE_DOCBLOCK, $this->source, $blocks)) {
             return $tags;
@@ -58,7 +61,9 @@ final class StimulusControllerSource
             }
 
             foreach ($matches as $match) {
-                $tags[$match['tag']][$match['name']] = trim(preg_replace('/\s+/', ' ', $match['description']));
+                // The docblock tag is `@css-class` (avoiding a clash with JSDoc's `@class`); internally it maps to the `class` group.
+                $tag = 'css-class' === $match['tag'] ? 'class' : $match['tag'];
+                $tags[$tag][$match['name']] = trim(preg_replace('/\s+/', ' ', $match['description']));
             }
         }
 
@@ -97,6 +102,42 @@ final class StimulusControllerSource
     public function targets(): array
     {
         if (!preg_match(self::RE_TARGETS, $this->source, $matches)) {
+            return [];
+        }
+
+        if (!preg_match_all(self::RE_STRING, $matches['body'], $strings)) {
+            return [];
+        }
+
+        return $strings['value'];
+    }
+
+    /**
+     * Class names declared in `static classes`.
+     *
+     * @return list<string>
+     */
+    public function classes(): array
+    {
+        if (!preg_match(self::RE_CLASSES, $this->source, $matches)) {
+            return [];
+        }
+
+        if (!preg_match_all(self::RE_STRING, $matches['body'], $strings)) {
+            return [];
+        }
+
+        return $strings['value'];
+    }
+
+    /**
+     * Outlet names declared in `static outlets`.
+     *
+     * @return list<string>
+     */
+    public function outlets(): array
+    {
+        if (!preg_match(self::RE_OUTLETS, $this->source, $matches)) {
             return [];
         }
 

--- a/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerDocChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/StimulusControllerDocChecker.php
@@ -23,7 +23,7 @@ use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
  * Normalizes a Stimulus controller's `@value`/`@target`/`@action` docblock tags and keeps them
  * consistent with the code, mirroring {@see ComponentDocChecker} for Twig components:
  *  - the description itself (present, capitalized, ending with a period);
- *  - `@value`/`@target` tags against the `static values`/`static targets` declarations (both ways);
+ *  - `@value`/`@target`/`@css-class`/`@outlet` tags against the `static values`/`static targets`/`static classes`/`static outlets` declarations (both ways);
  *  - each `@action` against a method actually defined on the controller.
  *
  * Documentation is opt-in: a controller with no tags at all is left untouched, so existing
@@ -35,7 +35,7 @@ use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
  */
 final class StimulusControllerDocChecker implements KitCheckerInterface
 {
-    private const RE_BARE_TAG = '/@(?P<tag>value|target|action)(?!\h+[A-Za-z_$])/';
+    private const RE_BARE_TAG = '/@(?P<tag>value|target|action|css-class|outlet)(?!\h+[A-Za-z_$])/';
 
     public function check(Kit $kit): iterable
     {
@@ -61,16 +61,18 @@ final class StimulusControllerDocChecker implements KitCheckerInterface
         $tags = $controller->tags();
 
         // Opt-in: nothing documented, nothing to enforce.
-        if ([] === $tags['value'] && [] === $tags['target'] && [] === $tags['action']) {
+        if ([] === $tags['value'] && [] === $tags['target'] && [] === $tags['action'] && [] === $tags['class'] && [] === $tags['outlet']) {
             return;
         }
 
         if (preg_match(self::RE_BARE_TAG, $contents)) {
-            yield $this->issue($recipe, $file, 'stimulus.doc.invalid', 'A `@value`/`@target`/`@action` tag must be written as `@<tag> <name> <Description.>`.');
+            yield $this->issue($recipe, $file, 'stimulus.doc.invalid', 'A `@value`/`@target`/`@action`/`@css-class`/`@outlet` tag must be written as `@<tag> <name> <Description.>`.');
         }
 
         yield from $this->checkGroup($recipe, $file, 'value', 'Value', $tags['value'], array_column($controller->values(), 'name'));
         yield from $this->checkGroup($recipe, $file, 'target', 'Target', $tags['target'], $controller->targets());
+        yield from $this->checkGroup($recipe, $file, 'class', 'Class', $tags['class'], $controller->classes());
+        yield from $this->checkGroup($recipe, $file, 'outlet', 'Outlet', $tags['outlet'], $controller->outlets());
 
         foreach ($tags['action'] as $name => $description) {
             if (!$this->hasMethod($contents, $name)) {
@@ -89,9 +91,12 @@ final class StimulusControllerDocChecker implements KitCheckerInterface
      */
     private function checkGroup(string $recipe, string $file, string $tag, string $label, array $documented, array $declared): iterable
     {
+        // The internal `class` group is written as `@css-class` in docblocks (avoiding JSDoc's `@class`); the slug stays `class`.
+        $docTag = 'class' === $tag ? 'css-class' : $tag;
+
         foreach ($documented as $name => $description) {
             if (!\in_array($name, $declared, true)) {
-                yield $this->issue($recipe, $file, \sprintf('stimulus.%s.mismatch', $tag), \sprintf('%s "%s" is documented with `@%s` but is not declared in the controller.', $label, $name, $tag));
+                yield $this->issue($recipe, $file, \sprintf('stimulus.%s.mismatch', $tag), \sprintf('%s "%s" is documented with `@%s` but is not declared in the controller.', $label, $name, $docTag));
             }
 
             yield from $this->checkDescription($recipe, $file, \sprintf('stimulus.%s.invalid', $tag), \sprintf('%s "%s"', $label, $name), $description);
@@ -99,7 +104,7 @@ final class StimulusControllerDocChecker implements KitCheckerInterface
 
         foreach ($declared as $name) {
             if (!\array_key_exists($name, $documented)) {
-                yield $this->issue($recipe, $file, \sprintf('stimulus.%s.mismatch', $tag), \sprintf('%s "%s" is declared in the controller but has no `@%s %2$s ...` tag.', $label, $name, $tag));
+                yield $this->issue($recipe, $file, \sprintf('stimulus.%s.mismatch', $tag), \sprintf('%s "%s" is declared in the controller but has no `@%s %2$s ...` tag.', $label, $name, $docTag));
             }
         }
     }

--- a/src/Toolkit/templates/doc/_api_reference.md.twig
+++ b/src/Toolkit/templates/doc/_api_reference.md.twig
@@ -51,6 +51,22 @@
 | `{{ target.name }}` | {{ target.description|replace({'|': '\\|'})|raw }} |
 {% endfor %}
 {% endif %}
+{% if ref.classes is not empty %}
+
+| Class | Description |
+|:------|:------------|
+{% for class in ref.classes %}
+| `{{ class.attribute }}` | {{ class.description|replace({'|': '\\|'})|raw }} |
+{% endfor %}
+{% endif %}
+{% if ref.outlets is not empty %}
+
+| Outlet | Description |
+|:-------|:------------|
+{% for outlet in ref.outlets %}
+| `{{ outlet.attribute }}` | {{ outlet.description|replace({'|': '\\|'})|raw }} |
+{% endfor %}
+{% endif %}
 {% if ref.actions is not empty %}
 
 | Action | Description |

--- a/src/Toolkit/tests/Component/StimulusControllerDocParserTest.php
+++ b/src/Toolkit/tests/Component/StimulusControllerDocParserTest.php
@@ -40,6 +40,40 @@ class StimulusControllerDocParserTest extends TestCase
         self::assertSame('Delay in milliseconds before the element removes itself.', $doc->values[0]->description);
     }
 
+    public function testParsesClassNameAndDerivedAttribute()
+    {
+        $doc = new StimulusControllerDocParser()->parse(<<<'JS'
+            /**
+             * @css-class success Applied to the element for a short window after a copy.
+             */
+            export default class extends Controller {
+                static classes = ['success']
+            }
+            JS, 'clipboard');
+
+        self::assertCount(1, $doc->classes);
+        self::assertSame('success', $doc->classes[0]->name);
+        self::assertSame('data-clipboard-success-class', $doc->classes[0]->attribute);
+        self::assertSame('Applied to the element for a short window after a copy.', $doc->classes[0]->description);
+    }
+
+    public function testParsesOutletNameAndDerivedAttribute()
+    {
+        $doc = new StimulusControllerDocParser()->parse(<<<'JS'
+            /**
+             * @outlet user-status Status controller reflecting the copy result.
+             */
+            export default class extends Controller {
+                static outlets = ['user-status']
+            }
+            JS, 'clipboard');
+
+        self::assertCount(1, $doc->outlets);
+        self::assertSame('user-status', $doc->outlets[0]->name);
+        self::assertSame('data-clipboard-user-status-outlet', $doc->outlets[0]->attribute);
+        self::assertSame('Status controller reflecting the copy result.', $doc->outlets[0]->description);
+    }
+
     public function testActionsAreOptInFromTags()
     {
         $doc = new StimulusControllerDocParser()->parse(<<<'JS'

--- a/src/Toolkit/tests/Component/StimulusControllerSourceTest.php
+++ b/src/Toolkit/tests/Component/StimulusControllerSourceTest.php
@@ -20,15 +20,19 @@ class StimulusControllerSourceTest extends TestCase
     {
         $source = new StimulusControllerSource(<<<'JS'
             /**
-             * @value  open   Whether it is open.
-             * @target panel  The panel.
-             * @action toggle Toggles it.
+             * @value     open    Whether it is open.
+             * @target    panel   The panel.
+             * @css-class loading Applied while loading.
+             * @outlet    flash   Flashes it.
+             * @action    toggle  Toggles it.
              */
             export default class extends Controller {}
             JS);
 
         self::assertSame(['open' => 'Whether it is open.'], $source->tags()['value']);
         self::assertSame(['panel' => 'The panel.'], $source->tags()['target']);
+        self::assertSame(['loading' => 'Applied while loading.'], $source->tags()['class']);
+        self::assertSame(['flash' => 'Flashes it.'], $source->tags()['outlet']);
         self::assertSame(['toggle' => 'Toggles it.'], $source->tags()['action']);
     }
 
@@ -57,13 +61,37 @@ class StimulusControllerSourceTest extends TestCase
         self::assertSame(['trigger', 'content'], $source->targets());
     }
 
+    public function testClasses()
+    {
+        $source = new StimulusControllerSource(<<<'JS'
+            export default class extends Controller {
+                static classes = ['loading', 'success']
+            }
+            JS);
+
+        self::assertSame(['loading', 'success'], $source->classes());
+    }
+
+    public function testOutlets()
+    {
+        $source = new StimulusControllerSource(<<<'JS'
+            export default class extends Controller {
+                static outlets = ['user-status', 'flash']
+            }
+            JS);
+
+        self::assertSame(['user-status', 'flash'], $source->outlets());
+    }
+
     public function testEmptySourceYieldsNothing()
     {
         $source = new StimulusControllerSource('export default class extends Controller {}');
 
-        self::assertSame(['value' => [], 'target' => [], 'action' => []], $source->tags());
+        self::assertSame(['value' => [], 'target' => [], 'action' => [], 'class' => [], 'outlet' => []], $source->tags());
         self::assertSame([], $source->values());
         self::assertSame([], $source->targets());
+        self::assertSame([], $source->classes());
+        self::assertSame([], $source->outlets());
     }
 
     public function testTagWithoutDescriptionIsRecognizedWithEmptyDescription()

--- a/src/Toolkit/tests/Doc/RecipeDocRendererTest.php
+++ b/src/Toolkit/tests/Doc/RecipeDocRendererTest.php
@@ -107,6 +107,10 @@ final class RecipeDocRendererTest extends KernelTestCase
         $this->assertStringContainsString('Delay in milliseconds before the widget closes.', $markdown);
         // Target from `static targets`, described by the `@target` tag.
         $this->assertStringContainsString('| `panel` |', $markdown);
+        // Class from `static classes`, rendered by its derived `data-*-class` attribute and `@css-class` description.
+        $this->assertStringContainsString('| `data-widget-open-class` | Applied to the widget while it is open. |', $markdown);
+        // Outlet from `static outlets`, rendered by its derived `data-*-outlet` attribute and `@outlet` description.
+        $this->assertStringContainsString('| `data-widget-status-outlet` | Linked status controller updated when the widget toggles. |', $markdown);
         // Actions are opt-in from `@action` tags, each bounded to its own description.
         $this->assertStringContainsString('| `toggle` | Toggles the widget open state. |', $markdown);
     }
@@ -129,6 +133,8 @@ final class RecipeDocRendererTest extends KernelTestCase
         $this->assertStringContainsString('data-controller', $html);
         $this->assertStringContainsString('data-widget-auto-close-value', $html);
         $this->assertStringContainsString('panel', $html);
+        $this->assertStringContainsString('data-widget-open-class', $html);
+        $this->assertStringContainsString('data-widget-status-outlet', $html);
         $this->assertStringContainsString('toggle', $html);
         $this->assertStringContainsString('Toggles the widget open state.', $html);
     }

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/class_conflict_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/class_conflict_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * @css-class ghost Documented but not declared in the code.
+ */
+export default class extends Controller {
+    static classes = ['loading']
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/outlet_conflict_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/outlet_conflict_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * @outlet ghost Documented but not declared in the code.
+ */
+export default class extends Controller {
+    static outlets = ['flash']
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/valid_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/lint-stimulus-doc/cases/assets/controllers/valid_controller.js
@@ -1,14 +1,18 @@
 import { Controller } from '@hotwired/stimulus'
 
 /**
- * @value  autoClose    Delay in milliseconds before auto-removal.
- * @value  orientation  The split direction, declared in object form.
- * @target timerbar     Countdown bar element.
- * @action close        Removes the element.
+ * @value     autoClose    Delay in milliseconds before auto-removal.
+ * @value     orientation  The split direction, declared in object form.
+ * @target    timerbar     Countdown bar element.
+ * @css-class loading      Applied to the element while a request is in flight.
+ * @outlet    flash        Flash controller notified when the element is removed.
+ * @action    close        Removes the element.
  */
 export default class extends Controller {
     static values = { autoClose: Number, orientation: { type: String, default: 'horizontal' } }
     static targets = ['timerbar']
+    static classes = ['loading']
+    static outlets = ['flash']
 
     close() {}
 }

--- a/src/Toolkit/tests/Fixtures/kits/render-stimulus-doc/widget/assets/controllers/widget_controller.js
+++ b/src/Toolkit/tests/Fixtures/kits/render-stimulus-doc/widget/assets/controllers/widget_controller.js
@@ -1,10 +1,12 @@
 import { Controller } from '@hotwired/stimulus';
 
 /**
- * @value  autoClose  Delay in milliseconds before the widget closes.
- * @value  open       Whether the widget is open on initial render.
- * @target panel      The panel shown or hidden by the widget.
- * @action toggle     Toggles the widget open state.
+ * @value     autoClose  Delay in milliseconds before the widget closes.
+ * @value     open       Whether the widget is open on initial render.
+ * @target    panel      The panel shown or hidden by the widget.
+ * @css-class open       Applied to the widget while it is open.
+ * @outlet    status     Linked status controller updated when the widget toggles.
+ * @action    toggle     Toggles the widget open state.
  */
 export default class extends Controller {
     static values = {
@@ -12,6 +14,8 @@ export default class extends Controller {
         open: { type: Boolean, default: false },
     };
     static targets = ['panel'];
+    static classes = ['open'];
+    static outlets = ['status'];
 
     toggle() {}
 }

--- a/src/Toolkit/tests/Kit/Lint/StimulusControllerDocCheckerTest.php
+++ b/src/Toolkit/tests/Kit/Lint/StimulusControllerDocCheckerTest.php
@@ -77,6 +77,32 @@ class StimulusControllerDocCheckerTest extends TestCase
         self::assertStringContainsString('"autoClose" is declared in the controller but has no `@value', implode("\n", $messages));
     }
 
+    public function testClassMismatchesAreReportedBothWays()
+    {
+        $issues = $this->issuesForFile($this->lintCases(), 'class_conflict_controller.js');
+        $messages = array_map(static fn (LintIssue $i) => $i->message, $issues);
+
+        self::assertCount(2, $issues);
+        foreach ($issues as $issue) {
+            self::assertSame('stimulus.class.mismatch', $issue->category);
+        }
+        self::assertStringContainsString('"ghost" is documented with `@css-class` but is not declared', implode("\n", $messages));
+        self::assertStringContainsString('"loading" is declared in the controller but has no `@css-class', implode("\n", $messages));
+    }
+
+    public function testOutletMismatchesAreReportedBothWays()
+    {
+        $issues = $this->issuesForFile($this->lintCases(), 'outlet_conflict_controller.js');
+        $messages = array_map(static fn (LintIssue $i) => $i->message, $issues);
+
+        self::assertCount(2, $issues);
+        foreach ($issues as $issue) {
+            self::assertSame('stimulus.outlet.mismatch', $issue->category);
+        }
+        self::assertStringContainsString('"ghost" is documented with `@outlet` but is not declared', implode("\n", $messages));
+        self::assertStringContainsString('"flash" is declared in the controller but has no `@outlet', implode("\n", $messages));
+    }
+
     public function testBadDescriptionIsReported()
     {
         $issues = $this->issuesForFile($this->lintCases(), 'bad_description_controller.js');


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Issues         | -
| License        | MIT

Documents a Stimulus controller's `static classes` and `static outlets` in the recipe API reference from `@css-class` and `@outlet` docblock tags — rendered as Class and Outlet tables and linted both ways like `@value`/`@target`/`@action`. This rounds out the full controller surface: values, targets, classes, outlets and actions.

The class tag is spelled `@css-class` rather than `@class` to avoid clashing with JSDoc's `@class`.
