### PR TITLE
[TwigComponent] Fix props evaluated twice by the component tag

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -59,11 +59,22 @@ final class ComponentNode extends Node implements NodeOutputInterface
         }
 
         $componentRuntime = $compiler->getVarName();
+        $props = $compiler->getVarName();
 
         $compiler
                ->write(\sprintf('$%s = $this->env->getRuntime(', $componentRuntime))
                ->string(ComponentRuntime::class)
                ->raw(");\n");
+
+        // Evaluate the props once: some expressions cannot be compiled twice
+        // (e.g. the null-safe operator, whose compilation is stateful since Twig 3.24)
+        // and evaluating them twice would also duplicate any side effect.
+        $compiler
+            ->write(\sprintf('$%s = ', $props))
+            ->raw($twig_to_array)
+            ->raw('(');
+        $this->writeProps($compiler)
+            ->raw(");\n");
 
         /*
          * Block 1) PreCreateForRender handling
@@ -74,11 +85,7 @@ final class ComponentNode extends Node implements NodeOutputInterface
         $compiler
             ->write(\sprintf('$preRendered = $%s->preRender(', $componentRuntime))
             ->string($this->getAttribute('component'))
-            ->raw(', ')
-            ->raw($twig_to_array)
-            ->raw('(');
-        $this->writeProps($compiler)
-            ->raw(')')
+            ->raw(\sprintf(', $%s', $props))
             ->raw(");\n");
 
         $compiler
@@ -106,11 +113,7 @@ final class ComponentNode extends Node implements NodeOutputInterface
         $compiler
             ->write(\sprintf('$preRenderEvent = $%s->startEmbedComponent(', $componentRuntime))
             ->string($this->getAttribute('component'))
-            ->raw(', ')
-            ->raw($twig_to_array)
-            ->raw('(');
-        $this->writeProps($compiler)
-            ->raw('), ')
+            ->raw(\sprintf(', $%s, ', $props))
             ->raw($this->getAttribute('only') ? '[]' : '$context')
             ->raw(', ')
             ->string($this->getAttribute('embedded_template'))

--- a/src/TwigComponent/tests/Fixtures/templates/anonymous_component_nullsafe_props.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/anonymous_component_nullsafe_props.html.twig
@@ -1,0 +1,3 @@
+<twig:Button :label="affaire.commune?.organisation?.raisonSociale ~ ' - ' ~ affaire.libelle">
+    Nullsafe
+</twig:Button>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -201,6 +201,26 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('class variable defined? no', $output);
     }
 
+    public function testRenderComponentTagWithNullsafeProps()
+    {
+        if (Environment::VERSION_ID < 32300) {
+            $this->markTestSkipped('The "?." operator requires Twig 3.23+.');
+        }
+
+        $commune = new class {
+            public $organisation = null;
+        };
+        $affaire = new class {
+            public $commune;
+            public $libelle = 'Libelle';
+        };
+        $affaire->commune = $commune;
+
+        $output = self::getContainer()->get(Environment::class)->render('anonymous_component_nullsafe_props.html.twig', ['affaire' => $affaire]);
+
+        $this->assertStringContainsString('- Libelle', $output);
+    }
+
     public function testComponentPropsOverwriteContextValue()
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_variable_already_in_context.html.twig');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #3704
| License       | MIT

`ComponentNode` compiles the props hash twice: once for `preRender()` and once for `startEmbedComponent()`. Since Twig 3.24, compiling a null-safe chain (`a?.b`) is stateful (twigphp/Twig#4748): the node marks itself as short-circuited and caches its temp variable name. On the second subcompile, the null guard is skipped and the generated code reads a temp variable that is never assigned, so `<twig:Foo :prop="a.b?.c?.d" >...</twig:Foo>` (the tag form, compiled to `{% component %}`) fails with "Impossible to access an attribute on a null variable". The self-closing form (compiled to `{{ component() }}`) only compiles the expression once and is not affected.

This also explains why a bisect on ux would not find anything: `ComponentNode` is identical between v2.32.0 and v2.36.2. The trigger is the Twig upgrade that comes along (`?.` was added in Twig 3.23, the stateful short-circuiting in 3.24).

The fix evaluates the props once into a local variable and passes it to both calls. As a side benefit, props expressions with side effects are no longer evaluated twice at runtime.

The new test errors without the fix and passes with it (it is skipped below Twig 3.23, since the component requires `twig/twig ^3.10.3`).
