### PR TITLE
[Toolkit] Enforce single-line props declarations with a linter

### DIFF
--- a/.agents/skills/symfony-ux-toolkit-kit/SKILL.md
+++ b/.agents/skills/symfony-ux-toolkit-kit/SKILL.md
@@ -247,6 +247,19 @@ One `{# @prop ... #}` per declared prop + one `{# @block ... #}` per block the c
 {%- props id, open = false -%}
 ```
 
+**The `{%- props ... -%}` tag stays on a single line**, however many props it declares — the per-prop documentation already lives in the `{# @prop ... #}` docblock above it, so the tag itself is just the variable/default list. Every kit follows this (`bin/ux-toolkit-kit-lint` enforces it via `PropsSingleLineChecker`):
+
+```twig
+{# Bad — spread across several lines #}
+{%- props
+    color = 'primary',
+    label = ''
+-%}
+
+{# Good — one line #}
+{%- props color = 'primary', label = '' -%}
+```
+
 Format is enforced by `bin/ux-toolkit-kit-lint` (CI fails on any warning — see [Docblock linting](#docblock-linting)):
 
 - **`@prop <name> <type> <Description.>`** — name first (camelCase Twig variable, `[a-z][a-zA-Z0-9]*`), then type, then description.
@@ -415,6 +428,7 @@ php bin/ux-toolkit-kit-lint --fail-on-warning kits/<kit>
 Checks:
 - **`@prop`** — camelCase name, valid **spaceless** PHPStan type, description Capitalized + ending with a period. Every `@prop` maps to a prop in `{%- props -%}` and vice versa.
 - **`@block`** — valid Twig block name, description Capitalized + ending with a period. Every `@block` maps to a rendered block (`{% block x %}` / `block(outerBlocks.x)` / `block('x')`) and vice versa.
+- **`props` single line** (`PropsSingleLineChecker`) — the `{%- props ... -%}` tag must not span multiple lines; collapse it onto one line.
 - Default values are **not** documented in the docblock — they are read from `{%- props -%}`.
 
 ---
@@ -555,7 +569,7 @@ Reviewers explicitly check snapshots regenerated (`#3488`).
 - [ ] Companion PR on `symfony/ux.symfony.com` linked **only if** recipe ships JS or new Tailwind classes
 - [ ] `php-cs-fixer`, `twig-cs-fixer`, `pnpm run fmt`, `pnpm run lint` clean
 - [ ] `bin/ux-toolkit-kit-lint --fail-on-warning kits/<kit>` clean
-- [ ] Docblocks: `@prop`/`@block` present; descriptions Capitalized + ending with a period; prop types are spaceless PHPStan types; **no `Defaults to`** (defaults live in `{%- props -%}`); every `@block` matches a rendered block
+- [ ] Docblocks: `@prop`/`@block` present; descriptions Capitalized + ending with a period; prop types are spaceless PHPStan types; **no `Defaults to`** (defaults live in `{%- props -%}`); every `@block` matches a rendered block; `{%- props ... -%}` on a single line
 - [ ] `attributes.defaults()` holds only `data-controller`/`data-action` (+ overridable HTML defaults); `data-slot`, state `data-*`, `aria-*` and Stimulus `data-*-value` are literal attributes; state attrs always emitted with an explicit value
 - [ ] Trigger/Close sub-components use `<recipe>_<role>_attrs` (no wrapping `<button>`)
 - [ ] `data-action` Stimulus actions piped through `|html_attr_type('sst')` when concatenable
@@ -578,6 +592,7 @@ Reviewers explicitly check snapshots regenerated (`#3488`).
 | `data-action="click->x#y"` not piped | `'click->x#y'\|html_attr_type('sst')` |
 | Missing `data-slot` on root/sub-roots (Shadcn) | Add `data-slot="<recipe>"` / `data-slot="<recipe>-<sub>"` |
 | Missing `{# @prop #}` / `{# @block #}` docblocks | Add docblocks before `{%- props -%}` |
+| Multi-line `{%- props ... -%}` declaration | Collapse onto a single line (enforced by `PropsSingleLineChecker`) |
 | `Defaults to \`...\`` in a `@prop` docblock | Remove it — the default lives only in `{%- props -%}` |
 | Prop type with spaces (`'a' \| 'b'`) | Remove spaces (`'a'\|'b'`) |
 | Docblock description not Capitalized / no trailing period | Capitalize + end with a period |

--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -6,6 +6,8 @@
 - [Common] Add the `common` kit, with design-system agnostic `closeable`, `logout-link` and `post-link` recipes
 - Add new linter checker `ClassMergeSpacingChecker` that checks for invalid `'<literal>' ~ attributes.render(...)` pattern
 - Add new linter checker `AttributesDefaultsChecker` that forbids `data-slot` (and, in Tailwind kits, ARIA, Stimulus value `data-*-value` and state `data-*` attributes) inside `attributes.defaults()`
+- Add new linter checker `PropsSingleLineChecker` that enforces single-line `{%- props ... -%}` declarations
+- [Bootstrap] Collapse multi-line `{%- props ... -%}` declarations onto a single line
 - [Shadcn][Flowbite] Normalize `attributes.defaults()` usage: render `data-slot`, state `data-*` and ARIA attributes directly, and keep only `data-controller`/`data-action` (plus overridable HTML defaults) in `attributes.defaults()`
 - Add per-recipe `README.md` documentation
 - Document Stimulus controllers in the recipe API reference from their `@value`/`@target`/`@action` docblocks, and lint those docblocks with the new `StimulusControllerDocChecker`

--- a/src/Toolkit/kits/bootstrap/alert/templates/components/Alert.html.twig
+++ b/src/Toolkit/kits/bootstrap/alert/templates/components/Alert.html.twig
@@ -5,12 +5,7 @@
 {# @block heading The alert heading, rendered before the main content. #}
 {# @block content The alert message and optional additional content. #}
 {# @block close The dismiss control rendered when the alert is dismissible. #}
-{%- props
-    color = 'primary',
-    dismissible = false,
-    heading = null,
-    content = ''
--%}
+{%- props color = 'primary', dismissible = false, heading = null, content = '' -%}
 
 {%- set classes = html_classes({
     alert: true,

--- a/src/Toolkit/kits/bootstrap/badge/templates/components/Badge.html.twig
+++ b/src/Toolkit/kits/bootstrap/badge/templates/components/Badge.html.twig
@@ -2,11 +2,7 @@
 {# @prop pill boolean Whether to use Bootstrap's rounded pill style. #}
 {# @prop label string The fallback badge text when no content block is provided. #}
 {# @block content The badge text and optional inline content. #}
-{%- props
-    color = 'primary',
-    pill = false,
-    label = ''
--%}
+{%- props color = 'primary', pill = false, label = '' -%}
 
 {%- set classes = html_classes({
     badge: true,

--- a/src/Toolkit/kits/bootstrap/breadcrumb/templates/components/Breadcrumb.html.twig
+++ b/src/Toolkit/kits/bootstrap/breadcrumb/templates/components/Breadcrumb.html.twig
@@ -1,10 +1,7 @@
 {# @prop divider string|null The custom text used as the divider between breadcrumb items. #}
 {# @prop label string|null The accessible name for the breadcrumb navigation. #}
 {# @block content The ordered list of breadcrumb items. #}
-{%- props
-    divider = null,
-    label = 'breadcrumb'
--%}
+{%- props divider = null, label = 'breadcrumb' -%}
 
 {%- set default_attrs = {} -%}
 {%- if label is not null -%}

--- a/src/Toolkit/kits/bootstrap/button-group/templates/components/ButtonGroup.html.twig
+++ b/src/Toolkit/kits/bootstrap/button-group/templates/components/ButtonGroup.html.twig
@@ -2,11 +2,7 @@
 {# @prop size 'sm'|'lg'|null The Bootstrap size applied to every button in the group. #}
 {# @prop label string|null The accessible name for the group. #}
 {# @block content The buttons, links, or form controls contained in the group. #}
-{%- props
-    vertical = false,
-    size = null,
-    label = 'Button group'
--%}
+{%- props vertical = false, size = null, label = 'Button group' -%}
 
 {%- set classes = html_classes({
     (vertical ? 'btn-group-vertical' : 'btn-group'): true,

--- a/src/Toolkit/kits/bootstrap/button/templates/components/Button.html.twig
+++ b/src/Toolkit/kits/bootstrap/button/templates/components/Button.html.twig
@@ -8,17 +8,7 @@
 {# @prop value string|null The value rendered by input elements. #}
 {# @prop content string The fallback label when no content block is provided. #}
 {# @block content The button label and optional inline content. #}
-{%- props
-    tag = 'button',
-    type = null,
-    href = null,
-    color = 'primary',
-    outline = false,
-    size = null,
-    disabled = false,
-    value = null,
-    content = ''
--%}
+{%- props tag = 'button', type = null, href = null, color = 'primary', outline = false, size = null, disabled = false, value = null, content = '' -%}
 
 {%- set final_tag = tag|lower in ['a', 'input'] ? tag|lower : 'button' -%}
 {%- set final_type = type in ['button', 'submit', 'reset'] ? type : 'button' -%}

--- a/src/Toolkit/kits/bootstrap/carousel/templates/components/Carousel.html.twig
+++ b/src/Toolkit/kits/bootstrap/carousel/templates/components/Carousel.html.twig
@@ -12,18 +12,7 @@
 {# @block content The carousel items, typically `Carousel:Item` components. #}
 {# @block previous The visually hidden label for the previous control. #}
 {# @block next The visually hidden label for the next control. #}
-{%- props
-    id,
-    controls = true,
-    indicators = false,
-    ride = null,
-    interval = null,
-    pause = null,
-    wrap = true,
-    touch = true,
-    fade = false,
-    theme = null
--%}
+{%- props id, controls = true, indicators = false, ride = null, interval = null, pause = null, wrap = true, touch = true, fade = false, theme = null -%}
 {%- set classes = html_classes({
     carousel: true,
     slide: true,

--- a/src/Toolkit/kits/bootstrap/dropdown/templates/components/Dropdown/Toggle.html.twig
+++ b/src/Toolkit/kits/bootstrap/dropdown/templates/components/Dropdown/Toggle.html.twig
@@ -5,14 +5,7 @@
 {# @prop split boolean Whether to render only the split-menu caret. #}
 {# @prop disabled boolean Whether the toggle is disabled. #}
 {# @block content The visible toggle label. #}
-{%- props
-    tag = 'button',
-    color = 'secondary',
-    outline = false,
-    size = null,
-    split = false,
-    disabled = false
--%}
+{%- props tag = 'button', color = 'secondary', outline = false, size = null, split = false, disabled = false -%}
 {%- set final_tag = tag == 'a' ? 'a' : 'button' -%}
 {%- set classes = html_classes({
     btn: true,

--- a/src/Toolkit/kits/bootstrap/list-group/templates/components/ListGroup.html.twig
+++ b/src/Toolkit/kits/bootstrap/list-group/templates/components/ListGroup.html.twig
@@ -3,12 +3,7 @@
 {# @prop numbered boolean Whether to display CSS-generated item numbers. #}
 {# @prop horizontal boolean|'sm'|'md'|'lg'|'xl'|'xxl' Whether and when to use a horizontal layout. #}
 {# @block content The list group items. #}
-{%- props
-    tag = null,
-    flush = false,
-    numbered = false,
-    horizontal = false
--%}
+{%- props tag = null, flush = false, numbered = false, horizontal = false -%}
 
 {%- set final_tag = tag|lower in ['ul', 'ol', 'div'] ? tag|lower : (numbered ? 'ol' : 'ul') -%}
 {%- set classes = html_classes({

--- a/src/Toolkit/kits/bootstrap/list-group/templates/components/ListGroup/Item.html.twig
+++ b/src/Toolkit/kits/bootstrap/list-group/templates/components/ListGroup/Item.html.twig
@@ -7,16 +7,7 @@
 {# @prop color 'primary'|'secondary'|'success'|'danger'|'warning'|'info'|'light'|'dark'|null The Bootstrap contextual color. #}
 {# @prop label string The fallback label when no content block is provided. #}
 {# @block content The item content. #}
-{%- props
-    tag = null,
-    href = null,
-    type = 'button',
-    active = false,
-    current = null,
-    disabled = false,
-    color = null,
-    label = ''
--%}
+{%- props tag = null, href = null, type = 'button', active = false, current = null, disabled = false, color = null, label = '' -%}
 
 {%- set final_tag = tag|lower in ['li', 'a', 'button'] ? tag|lower : (href is not null ? 'a' : 'li') -%}
 {%- set actionable = final_tag in ['a', 'button'] -%}

--- a/src/Toolkit/kits/bootstrap/modal/templates/components/Modal.html.twig
+++ b/src/Toolkit/kits/bootstrap/modal/templates/components/Modal.html.twig
@@ -7,16 +7,7 @@
 {# @prop keyboard boolean Whether pressing Escape dismisses the modal. #}
 {# @prop fade boolean Whether to use Bootstrap's fade transition. #}
 {# @block content The modal structure, typically `Modal:Header`, `Modal:Body`, and `Modal:Footer`. #}
-{%- props
-    id,
-    size = null,
-    centered = false,
-    scrollable = false,
-    fullscreen = false,
-    backdrop = true,
-    keyboard = true,
-    fade = true
--%}
+{%- props id, size = null, centered = false, scrollable = false, fullscreen = false, backdrop = true, keyboard = true, fade = true -%}
 {%- set title_id = id ~ '-label' -%}
 {%- do provide('modal.titleId', title_id) -%}
 {%- set fullscreen_class = fullscreen is same as(true)

--- a/src/Toolkit/kits/bootstrap/navbar/templates/components/Navbar.html.twig
+++ b/src/Toolkit/kits/bootstrap/navbar/templates/components/Navbar.html.twig
@@ -3,12 +3,7 @@
 {# @prop theme 'light'|'dark'|null The component-specific Bootstrap color mode. #}
 {# @prop label string|null The accessible name for the navigation landmark. #}
 {# @block content The navbar brand, navigation, forms, togglers, and collapsible content. #}
-{%- props
-    expand = null,
-    background = 'body-tertiary',
-    theme = null,
-    label = null
--%}
+{%- props expand = null, background = 'body-tertiary', theme = null, label = null -%}
 
 {%- set classes = html_classes({
     navbar: true,

--- a/src/Toolkit/kits/bootstrap/navs-tabs/templates/components/Nav.html.twig
+++ b/src/Toolkit/kits/bootstrap/navs-tabs/templates/components/Nav.html.twig
@@ -6,15 +6,7 @@
 {# @prop align 'start'|'center'|'end'|null The horizontal alignment of the navigation items. #}
 {# @prop role string|null The ARIA role applied to the navigation container. #}
 {# @block content The navigation links or `Nav:Item` components. #}
-{%- props
-    tag = 'ul',
-    type = null,
-    fill = false,
-    justified = false,
-    vertical = false,
-    align = null,
-    role = null
--%}
+{%- props tag = 'ul', type = null, fill = false, justified = false, vertical = false, align = null, role = null -%}
 
 {%- set final_tag = tag in ['nav', 'div'] ? tag : 'ul' -%}
 {%- set nav_classes = html_classes({

--- a/src/Toolkit/kits/bootstrap/navs-tabs/templates/components/Nav/Link.html.twig
+++ b/src/Toolkit/kits/bootstrap/navs-tabs/templates/components/Nav/Link.html.twig
@@ -7,16 +7,7 @@
 {# @prop disabled boolean Whether the navigation link or tab is disabled. #}
 {# @prop content string The fallback label when no content block is provided. #}
 {# @block content The navigation link or tab label. #}
-{%- props
-    tag = 'a',
-    href = '#',
-    id = null,
-    target = null,
-    toggle = null,
-    active = false,
-    disabled = false,
-    content = ''
--%}
+{%- props tag = 'a', href = '#', id = null, target = null, toggle = null, active = false, disabled = false, content = '' -%}
 
 {%- set final_tag = tag == 'button' ? 'button' : 'a' -%}
 {%- set link_classes = html_classes('nav-link', {

--- a/src/Toolkit/kits/bootstrap/navs-tabs/templates/components/TabPane.html.twig
+++ b/src/Toolkit/kits/bootstrap/navs-tabs/templates/components/TabPane.html.twig
@@ -3,12 +3,7 @@
 {# @prop active boolean Whether the panel is initially visible. #}
 {# @prop fade boolean Whether the panel uses Bootstrap's fade transition. #}
 {# @block content The tab panel content. #}
-{%- props
-    id,
-    labelledBy = null,
-    active = false,
-    fade = false
--%}
+{%- props id, labelledBy = null, active = false, fade = false -%}
 
 {%- set pane_classes = html_classes('tab-pane', {
     fade: fade,

--- a/src/Toolkit/kits/bootstrap/offcanvas/templates/components/Offcanvas.html.twig
+++ b/src/Toolkit/kits/bootstrap/offcanvas/templates/components/Offcanvas.html.twig
@@ -7,16 +7,7 @@
 {# @prop shown boolean Whether to display the panel statically. #}
 {# @prop theme 'light'|'dark'|null The component-specific Bootstrap color mode. #}
 {# @block content The offcanvas structure, typically `Offcanvas:Header` and `Offcanvas:Body`. #}
-{%- props
-    id,
-    placement = 'start',
-    responsive = null,
-    backdrop = true,
-    scroll = false,
-    keyboard = true,
-    shown = false,
-    theme = null
--%}
+{%- props id, placement = 'start', responsive = null, backdrop = true, scroll = false, keyboard = true, shown = false, theme = null -%}
 {%- set title_id = id ~ '-label' -%}
 {%- do provide('offcanvas.titleId', title_id) -%}
 {%- set base_class = responsive in ['sm', 'md', 'lg', 'xl', 'xxl'] ? 'offcanvas-' ~ responsive : 'offcanvas' -%}

--- a/src/Toolkit/kits/bootstrap/pagination/templates/components/Pagination.html.twig
+++ b/src/Toolkit/kits/bootstrap/pagination/templates/components/Pagination.html.twig
@@ -2,11 +2,7 @@
 {# @prop align 'start'|'center'|'end'|null The horizontal alignment of the pagination links. #}
 {# @prop ariaLabel string The accessible name of the navigation landmark. #}
 {# @block content The pagination items, typically `Pagination:Item` components. #}
-{%- props
-    size = null,
-    align = null,
-    ariaLabel = 'Pagination'
--%}
+{%- props size = null, align = null, ariaLabel = 'Pagination' -%}
 
 {%- set pagination_classes = html_classes('pagination', {
     ('pagination-' ~ size): size in ['sm', 'lg'],

--- a/src/Toolkit/kits/bootstrap/pagination/templates/components/Pagination/Item.html.twig
+++ b/src/Toolkit/kits/bootstrap/pagination/templates/components/Pagination/Item.html.twig
@@ -4,13 +4,7 @@
 {# @prop label string The fallback item label when no content block is provided. #}
 {# @prop ariaLabel string|null The accessible label for the page link. #}
 {# @block content The page link content. #}
-{%- props
-    active = false,
-    disabled = false,
-    href = null,
-    label = '',
-    ariaLabel = null
--%}
+{%- props active = false, disabled = false, href = null, label = '', ariaLabel = null -%}
 
 {%- set item_classes = html_classes('page-item', {
     active: active,

--- a/src/Toolkit/kits/bootstrap/placeholder/templates/components/Placeholder.html.twig
+++ b/src/Toolkit/kits/bootstrap/placeholder/templates/components/Placeholder.html.twig
@@ -1,9 +1,6 @@
 {# @prop tag 'span'|'a'|'div'|'p'|'h1'|'h2'|'h3'|'h4'|'h5'|'h6' The HTML element used for the placeholder. #}
 {# @prop size 'lg'|'sm'|'xs'|null The Bootstrap placeholder size. #}
-{%- props
-    tag = 'span',
-    size = null
--%}
+{%- props tag = 'span', size = null -%}
 
 {%- set final_tag = tag in ['span', 'a', 'div', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'] ? tag : 'span' -%}
 {%- set classes = html_classes({

--- a/src/Toolkit/kits/bootstrap/placeholder/templates/components/Placeholder/Animation.html.twig
+++ b/src/Toolkit/kits/bootstrap/placeholder/templates/components/Placeholder/Animation.html.twig
@@ -1,10 +1,7 @@
 {# @prop tag 'span'|'a'|'div'|'p'|'h1'|'h2'|'h3'|'h4'|'h5'|'h6' The HTML element used for the animation wrapper. #}
 {# @prop animation 'glow'|'wave' The Bootstrap placeholder animation. #}
 {# @block content The placeholders animated by this wrapper. #}
-{%- props
-    tag = 'div',
-    animation = 'glow'
--%}
+{%- props tag = 'div', animation = 'glow' -%}
 
 {%- set final_tag = tag in ['span', 'a', 'div', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'] ? tag : 'div' -%}
 {%- set classes = html_classes({

--- a/src/Toolkit/kits/bootstrap/popover/templates/components/Popover.html.twig
+++ b/src/Toolkit/kits/bootstrap/popover/templates/components/Popover.html.twig
@@ -6,15 +6,7 @@
 {# @prop container string|null The optional selector of the element that receives the generated popover. #}
 {# @prop customClass string|null The optional class added to the generated popover. #}
 {# @block content The trigger element, which must render `popover_trigger_attrs` with `html_attr()`. #}
-{%- props
-    title = null,
-    content = '',
-    placement = 'right',
-    trigger = 'click',
-    html = false,
-    container = null,
-    customClass = null
--%}
+{%- props title = null, content = '', placement = 'right', trigger = 'click', html = false, container = null, customClass = null -%}
 {%- set popover_trigger_attrs = {
     'data-bs-toggle': 'popover',
 }|html_attr_merge -%}

--- a/src/Toolkit/kits/bootstrap/progress/templates/components/Progress.html.twig
+++ b/src/Toolkit/kits/bootstrap/progress/templates/components/Progress.html.twig
@@ -11,20 +11,7 @@
 {# @prop barClass string The additional classes applied to the visual bar. #}
 {# @prop stacked boolean Whether this progress indicator is a segment within a stacked progress bar. #}
 {# @block content The text or custom content displayed inside the visual bar. #}
-{%- props
-    value = 0,
-    min = 0,
-    max = 100,
-    ariaLabel = 'Progress',
-    label = '',
-    color = null,
-    striped = false,
-    animated = false,
-    height = null,
-    barWidth = null,
-    barClass = '',
-    stacked = false
--%}
+{%- props value = 0, min = 0, max = 100, ariaLabel = 'Progress', label = '', color = null, striped = false, animated = false, height = null, barWidth = null, barClass = '', stacked = false -%}
 
 {%- set bar_classes = html_classes({
     'progress-bar': true,

--- a/src/Toolkit/kits/bootstrap/scrollspy/templates/components/Scrollspy.html.twig
+++ b/src/Toolkit/kits/bootstrap/scrollspy/templates/components/Scrollspy.html.twig
@@ -4,13 +4,7 @@
 {# @prop rootMargin string|null The optional Intersection Observer root margin. #}
 {# @prop threshold string|null The optional comma-separated Intersection Observer thresholds. #}
 {# @block content The sections observed by Scrollspy. #}
-{%- props
-    target,
-    height = '200px',
-    smoothScroll = false,
-    rootMargin = null,
-    threshold = null
--%}
+{%- props target, height = '200px', smoothScroll = false, rootMargin = null, threshold = null -%}
 {%- set default_attrs = {
     class: 'position-relative overflow-auto',
     style: 'height: ' ~ height ~ ';',

--- a/src/Toolkit/kits/bootstrap/spinner/templates/components/Spinner.html.twig
+++ b/src/Toolkit/kits/bootstrap/spinner/templates/components/Spinner.html.twig
@@ -5,14 +5,7 @@
 {# @prop label string The visually hidden loading message. #}
 {# @prop decorative boolean Whether to hide the spinner from assistive technologies. #}
 {# @block content The accessible loading message or custom inner content. #}
-{%- props
-    type = 'border',
-    color = null,
-    small = false,
-    role = 'status',
-    label = 'Loading...',
-    decorative = false
--%}
+{%- props type = 'border', color = null, small = false, role = 'status', label = 'Loading...', decorative = false -%}
 
 {%- set spinner_type = type == 'grow' ? 'grow' : 'border' -%}
 {%- set spinner_classes = html_classes({

--- a/src/Toolkit/kits/bootstrap/toast/templates/components/Toast.html.twig
+++ b/src/Toolkit/kits/bootstrap/toast/templates/components/Toast.html.twig
@@ -5,14 +5,7 @@
 {# @prop role 'status'|'alert' The accessibility role that describes the notification urgency. #}
 {# @prop live 'polite'|'assertive' The live region politeness level. #}
 {# @block content The toast structure, typically `Toast:Header` and `Toast:Body`. #}
-{%- props
-    show = true,
-    autohide = true,
-    delay = null,
-    animation = true,
-    role = 'status',
-    live = 'polite'
--%}
+{%- props show = true, autohide = true, delay = null, animation = true, role = 'status', live = 'polite' -%}
 {%- set final_role = role in ['status', 'alert'] ? role : 'status' -%}
 {%- set final_live = live in ['polite', 'assertive'] ? live : 'polite' -%}
 {%- set toast_classes = html_classes({

--- a/src/Toolkit/kits/bootstrap/toast/templates/components/Toast/Header.html.twig
+++ b/src/Toolkit/kits/bootstrap/toast/templates/components/Toast/Header.html.twig
@@ -5,14 +5,7 @@
 {# @prop closeButton boolean Whether to render a Bootstrap dismiss button. #}
 {# @prop closeLabel string The accessible label of the dismiss button. #}
 {# @block content The header title or custom header content. #}
-{%- props
-    title = '',
-    timestamp = null,
-    imageSrc = null,
-    imageAlt = '',
-    closeButton = true,
-    closeLabel = 'Close'
--%}
+{%- props title = '', timestamp = null, imageSrc = null, imageAlt = '', closeButton = true, closeLabel = 'Close' -%}
 <div {{ attributes.defaults({class: 'toast-header'}) }}>
     {%- if imageSrc is not null -%}
         <img src="{{ imageSrc }}" class="rounded me-2" alt="{{ imageAlt }}">

--- a/src/Toolkit/kits/bootstrap/tooltip/templates/components/Tooltip.html.twig
+++ b/src/Toolkit/kits/bootstrap/tooltip/templates/components/Tooltip.html.twig
@@ -3,12 +3,7 @@
 {# @prop html boolean Whether the tooltip title contains sanitized HTML. #}
 {# @prop customClass string|null The custom class applied to the generated tooltip. #}
 {# @block content The focusable trigger rendering `tooltip_trigger_attrs` with `html_attr()`. #}
-{%- props
-    title,
-    placement = 'top',
-    html = false,
-    customClass = null
--%}
+{%- props title, placement = 'top', html = false, customClass = null -%}
 
 {%- set final_placement = placement in ['auto', 'top', 'right', 'bottom', 'left'] ? placement : 'top' -%}
 {%- set tooltip_trigger_attrs = {

--- a/src/Toolkit/src/Kit/Lint/Checker/PropsSingleLineChecker.php
+++ b/src/Toolkit/src/Kit/Lint/Checker/PropsSingleLineChecker.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Kit\Lint\Checker;
+
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Finder\Finder;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Kit\Lint\KitCheckerInterface;
+use Symfony\UX\Toolkit\Kit\Lint\LintIssue;
+use Symfony\UX\Toolkit\Kit\Lint\LintSeverity;
+
+/**
+ * Enforces that every component's `{%- props ... -%}` declaration stays on a single line.
+ *
+ * The per-prop documentation lives in the `{# @prop ... #}` docblock above; the `props` tag itself
+ * is only the variable/default declaration and reads best as one line, keeping every kit consistent
+ * (Shadcn, Flowbite and Common already do this). A declaration that spills over several lines is
+ * flagged so it can be collapsed onto one line.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class PropsSingleLineChecker implements KitCheckerInterface
+{
+    /**
+     * Matches a `props` tag — with or without whitespace-trim markers — capturing everything up to
+     * its closing `%}`/`-%}`. The `s` flag lets the body span multiple lines so we can detect one.
+     */
+    private const RE_PROPS = '/\{%-?\s*props\b(?<body>.*?)-?%\}/s';
+
+    public function check(Kit $kit): iterable
+    {
+        foreach ($kit->getRecipes() as $recipe) {
+            $templatesDir = Path::join($recipe->absolutePath, 'templates');
+            if (!is_dir($templatesDir)) {
+                continue;
+            }
+
+            $finder = new Finder()->in($templatesDir)->files()->name('*.html.twig')->sortByName();
+            foreach ($finder as $file) {
+                yield from $this->checkFile($recipe->name, $file->getRelativePathname(), $file->getContents());
+            }
+        }
+    }
+
+    /**
+     * @return iterable<LintIssue>
+     */
+    private function checkFile(string $recipe, string $file, string $contents): iterable
+    {
+        if (!preg_match_all(self::RE_PROPS, $contents, $matches, \PREG_OFFSET_CAPTURE | \PREG_SET_ORDER)) {
+            return;
+        }
+
+        foreach ($matches as $match) {
+            if (!str_contains($match[0][0], "\n")) {
+                continue;
+            }
+
+            $line = substr_count($contents, "\n", 0, $match[0][1]) + 1;
+
+            yield new LintIssue(
+                severity: LintSeverity::Error,
+                category: 'component.props.multiline',
+                message: \sprintf(
+                    'The `props` declaration starting on line %d spans multiple lines: collapse it onto a single line (`{%%- props ... -%%}`). Per-prop documentation belongs in the `{# @prop ... #}` docblock above, not in the `props` tag.',
+                    $line,
+                ),
+                recipe: $recipe,
+                file: $file,
+            );
+        }
+    }
+}

--- a/src/Toolkit/src/Kit/Lint/KitLinter.php
+++ b/src/Toolkit/src/Kit/Lint/KitLinter.php
@@ -20,6 +20,7 @@ use Symfony\UX\Toolkit\Kit\Lint\Checker\CopyFilesExistenceChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\DocHeadingLevelChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\JsImportChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\MissingRecipeManifestChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\PropsSingleLineChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\RecipeReferenceChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerDocChecker;
@@ -54,6 +55,7 @@ final class KitLinter
             new ComponentDocChecker(),
             new ClassMergeSpacingChecker(),
             new AttributesDefaultsChecker(),
+            new PropsSingleLineChecker(),
             new DocHeadingLevelChecker(),
         ];
     }

--- a/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/manifest.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Cases",
+    "description": "One template per props single-line scenario.",
+    "copy-files": {
+        "templates/": "templates/"
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/templates/components/MultiLine.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/templates/components/MultiLine.html.twig
@@ -1,0 +1,7 @@
+{# @prop color string The color. #}
+{# @prop label string The label. #}
+{%- props
+    color = 'primary',
+    label = ''
+-%}
+<span>{{ label }}</span>

--- a/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/templates/components/NoProps.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/templates/components/NoProps.html.twig
@@ -1,0 +1,1 @@
+<div>{{ attributes }}</div>

--- a/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/templates/components/SingleLine.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/templates/components/SingleLine.html.twig
@@ -1,0 +1,3 @@
+{# @prop label string The button label. #}
+{%- props label = '' -%}
+<button>{{ label }}</button>

--- a/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/templates/components/SingleLineNoTrim.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/cases/templates/components/SingleLineNoTrim.html.twig
@@ -1,0 +1,3 @@
+{# @prop label string The button label. #}
+{% props label = '' %}
+<button>{{ label }}</button>

--- a/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/lint-props-single-line/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "Lint Props Single Line",
+    "description": "Kit covering PropsSingleLineChecker scenarios.",
+    "license": "MIT",
+    "homepage": "https://example.com/lint-props-single-line"
+}

--- a/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
+++ b/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
@@ -23,6 +23,7 @@ use Symfony\UX\Toolkit\Kit\Lint\Checker\ComposerSymbolChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\CopyFilesExistenceChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\JsImportChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\MissingRecipeManifestChecker;
+use Symfony\UX\Toolkit\Kit\Lint\Checker\PropsSingleLineChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\RecipeReferenceChecker;
 use Symfony\UX\Toolkit\Kit\Lint\Checker\StimulusControllerChecker;
 use Symfony\UX\Toolkit\Kit\Lint\KitLinter;
@@ -316,6 +317,38 @@ class KitLinterTest extends TestCase
         $matching = array_values(array_filter(
             $report->getIssues(),
             static fn (LintIssue $i) => str_starts_with($i->category, 'component.attributes.')
+                && null !== $i->file && str_contains($i->file, $file),
+        ));
+
+        $this->assertCount($expectedCount, $matching, \sprintf('File "%s" must produce %d issue(s).', $file, $expectedCount));
+        foreach ($matching as $issue) {
+            $this->assertSame(LintSeverity::Error, $issue->severity);
+            $this->assertSame('cases', $issue->recipe);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function providePropsSingleLineCases(): iterable
+    {
+        // template file => number of expected issues
+        yield 'single-line props with trim markers' => ['SingleLine.html.twig', 0];
+        yield 'single-line props without trim markers' => ['SingleLineNoTrim.html.twig', 0];
+        yield 'component without props' => ['NoProps.html.twig', 0];
+        yield 'multi-line props declaration' => ['MultiLine.html.twig', 1];
+    }
+
+    #[DataProvider('providePropsSingleLineCases')]
+    public function testPropsSingleLineChecker(string $file, int $expectedCount)
+    {
+        $kit = $this->loadFixtureKit('lint-props-single-line');
+
+        $report = new KitLinter([new PropsSingleLineChecker()])->lint($kit);
+
+        $matching = array_values(array_filter(
+            $report->getIssues(),
+            static fn (LintIssue $i) => 'component.props.multiline' === $i->category
                 && null !== $i->file && str_contains($i->file, $file),
         ));
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

Collapse the multi-line `{%- props ... -%}` declarations in the Bootstrap kit onto a single line, so every kit is consistent, and add a `PropsSingleLineChecker` to `bin/ux-toolkit-kit-lint` to enforce it.
