### PR TITLE
[Toolkit][Common] Add `clipboard` and `tooltip` recipes

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.4.0
 
 - [Bootstrap] Add the Bootstrap kit
-- [Common] Add the `common` kit, with design-system agnostic `closeable`, `logout-link` and `post-link` recipes
+- [Common] Add the `common` kit, with design-system agnostic `clipboard`, `closeable`, `logout-link`, `post-link` and `tooltip` recipes
 - Add new linter checker `ClassMergeSpacingChecker` that checks for invalid `'<literal>' ~ attributes.render(...)` pattern
 - Add per-recipe `README.md` documentation
 - Document Stimulus controllers in the recipe API reference from their `@value`/`@target`/`@action` docblocks, and lint those docblocks with the new `StimulusControllerDocChecker`

--- a/src/Toolkit/kits/common/clipboard/README.md
+++ b/src/Toolkit/kits/common/clipboard/README.md
@@ -1,0 +1,168 @@
+# Clipboard
+
+A Stimulus behavior that copies text to the clipboard — either a value you give it or the content of an element — with optional copied feedback.
+
+```twig {"preview":true,"collapseClass":true}
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">composer require symfony/ux-toolkit</code>
+    <span class="relative">
+        <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+        <span data-clipboard-target="success" class="absolute left-full top-1/2 ml-3 -translate-y-1/2 whitespace-nowrap text-sm font-medium text-violet-600 dark:text-violet-400">Copied!</span>
+    </span>
+</div>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+Add `data-controller="clipboard"`, mark the element to copy from with a `source` target, then trigger `clipboard#copy` from a button:
+
+```twig
+<div data-controller="clipboard">
+    <code data-clipboard-target="source">Text to copy</code>
+    <button type="button" data-action="clipboard#copy">Copy</button>
+</div>
+```
+
+To copy a fixed string instead of an element, set a `source` value (`data-clipboard-source-value`) — see [Copy using a Value](#content-copy-using-a-value).
+
+> [!NOTE]
+> Every successful copy also dispatches a `clipboard:copied` event, with the copied text available as `event.detail.text`. Listen for it to drive your own feedback.
+
+## Examples
+
+### Copy a Form Element's Value
+
+Form controls — inputs, textareas, selects — are copied from their `value`:
+
+```twig {"preview":true,"collapseClass":true}
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <input type="text" data-clipboard-target="source" value="hello@example.com" readonly class="rounded-md border border-violet-200 bg-violet-50 px-3 py-2 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy email</button>
+</div>
+```
+
+### Copy an Element's Text
+
+For non-form elements, the `source` target's text content is copied:
+
+```twig {"preview":true,"collapseClass":true}
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <p data-clipboard-target="source" class="flex-1 text-sm text-violet-900 dark:text-violet-100">The quick brown fox jumps over the lazy dog.</p>
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy text</button>
+</div>
+```
+
+### Copy Code
+
+A classic: a code block with its own copy button. Point the `source` target at the `<pre>` — its text content is copied verbatim, indentation and newlines included:
+
+```twig {"preview":true,"collapseClass":true}
+<div data-controller="clipboard" class="relative w-full max-w-sm">
+    <pre data-clipboard-target="source" class="overflow-x-auto rounded-md bg-violet-950 p-4 font-mono text-xs leading-relaxed text-violet-100"><code>$response = new JsonResponse([
+    'status' => 'ok',
+]);</code></pre>
+    <button type="button" data-action="clipboard#copy" class="absolute right-2 top-2 rounded bg-violet-700 px-2 py-1 text-xs font-medium text-violet-100 hover:bg-violet-600">
+        <span data-clipboard-target="idle">Copy</span>
+        <span data-clipboard-target="success" hidden>Copied!</span>
+    </button>
+</div>
+```
+
+### Copy using a Value
+
+Set a `source` value to copy a fixed string, independent of what's shown on screen. Here the field displays a masked key while the button copies the real one:
+
+```twig {"preview":true,"collapseClass":true}
+<div data-controller="clipboard" data-clipboard-source-value="a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6" class="flex items-center gap-3">
+    <input type="text" value="xxxxxxxxxxxxxxxxxxxx" readonly class="rounded-md border border-violet-200 bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy API Key</button>
+</div>
+```
+
+### Copied Feedback
+
+Add a `success` target to reveal a confirmation after a successful copy. It's hidden again after `successDuration` milliseconds (defaults to `2000`):
+
+```twig {"preview":true,"collapseClass":true}
+<div data-controller="clipboard" data-clipboard-success-duration-value="1500" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">symfony serve -d</code>
+    <span class="relative">
+        <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+        <span data-clipboard-target="success" class="absolute left-full top-1/2 ml-3 -translate-y-1/2 whitespace-nowrap text-sm font-medium text-violet-600 dark:text-violet-400">Copied to clipboard!</span>
+    </span>
+</div>
+```
+
+### Swap the Button Label
+
+Put both an `idle` and a `success` label inside the button: the `idle` one is hidden while the `success` one shows, swapping "Copy" for "Copied!" on click.
+
+```twig {"preview":true,"collapseClass":true}
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">git clone git@github.com:symfony/ux.git</code>
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">
+        <span data-clipboard-target="idle">Copy</span>
+        <span data-clipboard-target="success" hidden>Copied!</span>
+    </button>
+</div>
+```
+
+### Animate the Feedback
+
+The `success` target is toggled from `display: none` to visible on copy, and showing a hidden element restarts its CSS animations — so an animated `success` target replays its effect on every click. Give it a burst `@keyframes` and match `successDuration` to the animation's length:
+
+```twig {"preview":true,"collapseClass":true}
+<style>
+@keyframes clipboard-burst {
+    from { transform: scale(.75); opacity: .75; }
+    to { transform: scale(2) rotate(20deg); opacity: 0; }
+}
+</style>
+<div data-controller="clipboard" data-clipboard-success-duration-value="450" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">php bin/console cache:clear</code>
+    <button type="button" data-action="clipboard#copy" class="relative rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">
+        Copy
+        <span data-clipboard-target="success" class="pointer-events-none absolute inset-0 rounded-full border-2 border-dotted border-violet-400" style="animation: clipboard-burst 450ms linear forwards"></span>
+    </button>
+</div>
+```
+
+### Feedback via a CSS Class
+
+Prefer to drive feedback purely from CSS? Instead of `success`/`idle` targets, set a `success` class with `data-clipboard-success-class`. The controller adds it to its element for `successDuration`, so you can restyle anything beneath it — including the trigger itself:
+
+> [!TIP]
+> Pass multiple space-separated classes if you like (`data-clipboard-success-class="ring pulse"`) — they're all applied for the duration.
+
+```twig {"preview":true,"collapseClass":true}
+<style>.clipboard-copied .clipboard-btn { background-color: #16a34a; }</style>
+<div data-controller="clipboard" data-clipboard-success-class="clipboard-copied" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">php bin/console about</code>
+    <button type="button" data-action="clipboard#copy" class="clipboard-btn rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+</div>
+```
+
+### Feedback with a Tooltip
+
+Pair with the [`tooltip`](../tooltip) recipe for a floating confirmation. With both controllers on the button, copying dispatches `clipboard:copied` right there, opening a manual, self-hiding tooltip above it — no `success` target or class needed:
+
+```twig {"preview":true,"collapseClass":true}
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[120px] items-center justify-center">
+    <div class="flex items-center gap-3">
+        <code class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">php bin/console debug:router</code>
+        <button type="button" data-controller="clipboard tooltip" data-clipboard-source-value="php bin/console debug:router" data-action="clipboard#copy clipboard:copied->tooltip#show" data-tooltip-content-value="Copied!" data-tooltip-trigger-value="manual" data-tooltip-auto-hide-value="2000" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+    </div>
+</div>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/common/clipboard/assets/controllers/clipboard_controller.js
+++ b/src/Toolkit/kits/common/clipboard/assets/controllers/clipboard_controller.js
@@ -1,0 +1,68 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * @value      source           Text to copy to the clipboard; when set, it takes precedence over the `source` target.
+ * @value      successDuration  How long, in milliseconds, the success feedback stays active after a copy. Defaults to 2000.
+ * @target     source           Element to copy from when no `source` value is set: its form value (input, textarea, select) or, failing that, its text content.
+ * @target     success          Element revealed briefly after a successful copy, then hidden again. Hidden on connect.
+ * @target     idle             Element hidden while the `success` target is showing, then revealed again; pair it with `success` inside the button to swap the label.
+ * @css-class  success          Class(es) added to the controller element for the same window, as a CSS-only alternative to the `success`/`idle` targets.
+ * @action     copy             Copies the source to the clipboard, then dispatches a `clipboard:copied` event and flashes the success feedback.
+ */
+export default class extends Controller {
+    static targets = ['source', 'success', 'idle'];
+    static classes = ['success'];
+    static values = {
+        source: String,
+        successDuration: { type: Number, default: 2000 },
+    };
+
+    #timeout;
+
+    connect() {
+        if (this.hasSuccessTarget) {
+            this.successTarget.hidden = true;
+        }
+    }
+
+    async copy(event) {
+        event.preventDefault();
+
+        const text = this.#text;
+        await navigator.clipboard.writeText(text);
+
+        this.dispatch('copied', { detail: { text } });
+        this.#flashSuccess();
+    }
+
+    get #text() {
+        if (this.hasSourceValue) {
+            return this.sourceValue;
+        }
+
+        // Form controls expose their content as `value`; everything else falls back to text content.
+        return this.sourceTarget.value ?? this.sourceTarget.textContent;
+    }
+
+    #flashSuccess() {
+        if (!this.hasSuccessTarget && !this.hasSuccessClass) {
+            return;
+        }
+
+        clearTimeout(this.#timeout);
+        this.#toggleSuccess(true);
+        this.#timeout = setTimeout(() => this.#toggleSuccess(false), this.successDurationValue);
+    }
+
+    #toggleSuccess(active) {
+        if (this.hasSuccessTarget) {
+            this.successTarget.hidden = !active;
+        }
+
+        if (this.hasIdleTarget) {
+            this.idleTarget.hidden = active;
+        }
+
+        this.successClasses.forEach((className) => this.element.classList.toggle(className, active));
+    }
+}

--- a/src/Toolkit/kits/common/clipboard/manifest.json
+++ b/src/Toolkit/kits/common/clipboard/manifest.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Clipboard",
+    "version-added": "3.4",
+    "copy-files": {
+        "assets/": "assets/"
+    }
+}

--- a/src/Toolkit/kits/common/tooltip/README.md
+++ b/src/Toolkit/kits/common/tooltip/README.md
@@ -1,0 +1,130 @@
+# Tooltip
+
+A Stimulus behavior that shows a tooltip from a `content` value — or straight from an element's native `title`. Powered by [Floating UI](https://floating-ui.com/): the tooltip is rendered outside the trigger (appended to `<body>`), so it's never clipped by an `overflow` ancestor, and it flips and shifts to stay in view. Put it right on the trigger — it opens on hover and keyboard focus by default — and style the injected `.tooltip` once, globally.
+
+```twig {"preview":true,"collapseClass":true}
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[140px] items-center justify-center">
+    <button type="button" data-controller="tooltip" title="Thanks for hovering!" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Hover me
+    </button>
+</div>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+Style every tooltip once, in your global stylesheet — Floating UI sets the position and the arrow's offsets, so you only own the look:
+
+```css
+.tooltip {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: max-content;
+    border-radius: 0.25rem;
+    background: #1f2937;
+    color: #fff;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    pointer-events: none;
+    z-index: 50;
+}
+.tooltip-arrow {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    background: inherit;
+    transform: rotate(45deg);
+}
+```
+
+Then put the controller on the trigger with a `content` value — hover and focus are wired for you:
+
+```twig
+<button type="button" data-controller="tooltip" data-tooltip-content-value="Tooltip content">
+    Hover me
+</button>
+```
+
+Set `placement` to hint a side (`top` by default, `bottom`, `left`, or `right`) — Floating UI flips and shifts from there to keep it on screen. Set `trigger` to `click` to toggle on click, or `manual` to drive `show`/`hide` yourself (for example from another controller's event). The controller injects the `.tooltip` into `<body>` and points the trigger's `aria-describedby` at it.
+
+As a shortcut — the form shown at the top — drop the controller onto an element that already has a `title` and skip the `content` value: the controller adopts the title text and removes the attribute so the browser's native tooltip is suppressed.
+
+## Examples
+
+### Placement
+
+Set `placement` to `top` (default), `bottom`, `left`, or `right`. It's a _preference_ — Floating UI flips to the opposite side and shifts along the axis whenever the trigger is too close to an edge:
+
+```twig {"preview":true,"collapseClass":true}
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[200px] items-center justify-center gap-12 px-16">
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Top" data-tooltip-placement-value="top" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Top</button>
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Bottom" data-tooltip-placement-value="bottom" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Bottom</button>
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Left" data-tooltip-placement-value="left" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Left</button>
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Right" data-tooltip-placement-value="right" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Right</button>
+</div>
+```
+
+### Click to Toggle
+
+Set `trigger` to `click` for a tooltip that stays open until the next click:
+
+```twig {"preview":true,"collapseClass":true}
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[120px] items-center justify-center">
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Click again to close" data-tooltip-placement-value="bottom" data-tooltip-trigger-value="click" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Click me
+    </button>
+</div>
+```
+
+### Auto-hide
+
+Set `autoHide` (milliseconds) so a shown tooltip dismisses itself — handy when it's opened programmatically rather than by a hover you can leave:
+
+```twig {"preview":true,"collapseClass":true}
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[120px] items-center justify-center">
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="I'll disappear shortly…" data-tooltip-placement-value="bottom" data-tooltip-trigger-value="click" data-tooltip-auto-hide-value="2000" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Show for 2s
+    </button>
+</div>
+```
+
+### Manual Control
+
+With `trigger` set to `manual`, nothing is wired automatically — you drive `show`, `hide`, and `toggle` yourself, from your own actions or another controller's event. The tooltip anchors to the controller's element:
+
+```twig {"preview":true,"collapseClass":true}
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[120px] items-center justify-center">
+    <div data-controller="tooltip" data-tooltip-content-value="Toggled by hand" data-tooltip-trigger-value="manual" class="inline-flex gap-2">
+        <button type="button" data-action="tooltip#show" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Show</button>
+        <button type="button" data-action="tooltip#hide" class="rounded-md bg-violet-100 px-3 py-2 text-sm font-medium text-violet-900 hover:bg-violet-200 dark:bg-violet-900 dark:text-violet-100 dark:hover:bg-violet-800">Hide</button>
+    </div>
+</div>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/common/tooltip/assets/controllers/tooltip_controller.js
+++ b/src/Toolkit/kits/common/tooltip/assets/controllers/tooltip_controller.js
@@ -1,0 +1,157 @@
+import { Controller } from '@hotwired/stimulus';
+import { computePosition, autoUpdate, offset, flip, shift, arrow } from '@floating-ui/dom';
+
+let sequence = 0;
+
+const OPPOSITE_SIDE = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' };
+
+/**
+ * @value  content    The text shown inside the tooltip; falls back to the element's `title` when omitted. Any `title` is removed regardless, so the browser's native tooltip never competes with this one.
+ * @value  placement  Preferred side of the trigger: `top` (default), `bottom`, `left` or `right`. Flips and shifts to stay in view.
+ * @value  trigger    How the tooltip opens: `hover` (on hover and keyboard focus, the default), `click` (toggle on click), or `manual` (you drive `show`/`hide` yourself). Defaults to `hover`.
+ * @value  autoHide   Delay in milliseconds after which a shown tooltip hides itself; when 0, it stays until `hide`. Defaults to 0.
+ * @action show       Shows the tooltip, scheduling an automatic hide when `autoHide` is set.
+ * @action hide       Hides the tooltip.
+ * @action toggle     Shows the tooltip when hidden, hides it when shown.
+ */
+export default class extends Controller {
+    static values = {
+        content: String,
+        placement: { type: String, default: 'top' },
+        trigger: { type: String, default: 'hover' },
+        autoHide: Number,
+    };
+
+    #tooltip;
+    #timeout;
+    #triggers; // AbortController for the auto-wired hover/click listeners
+    #cleanup; // stops Floating UI's autoUpdate while the tooltip is hidden
+
+    connect() {
+        // Remove a tooltip a previous instance left in <body> (e.g. after a Turbo restore).
+        const previous = this.element.getAttribute('aria-describedby');
+        if (previous) {
+            document.getElementById(previous)?.remove();
+        }
+
+        this.#tooltip = this.#build();
+        // The tooltip lives in <body>, so associate it with the trigger by id.
+        this.element.setAttribute('aria-describedby', this.#tooltip.id);
+        this.#wire();
+    }
+
+    disconnect() {
+        this.#triggers?.abort();
+        this.#cleanup?.();
+        this.#tooltip.remove();
+    }
+
+    show() {
+        clearTimeout(this.#timeout);
+        this.#tooltip.hidden = false;
+        // Keep the tooltip anchored while visible: reposition on scroll, resize and layout shifts.
+        this.#cleanup = autoUpdate(this.element, this.#tooltip, () => this.#position());
+
+        if (this.autoHideValue) {
+            this.#timeout = setTimeout(() => this.hide(), this.autoHideValue);
+        }
+    }
+
+    hide() {
+        clearTimeout(this.#timeout);
+        this.#cleanup?.();
+        this.#cleanup = null;
+        this.#tooltip.hidden = true;
+    }
+
+    toggle() {
+        if (this.#tooltip.hidden) {
+            this.show();
+            return;
+        }
+
+        this.hide();
+    }
+
+    #build() {
+        const tooltip = document.createElement('span');
+        tooltip.id = `tooltip-${++sequence}`;
+        tooltip.className = 'tooltip';
+        tooltip.setAttribute('role', 'tooltip');
+        tooltip.hidden = true;
+
+        const arrowElement = document.createElement('span');
+        arrowElement.className = 'tooltip-arrow';
+
+        tooltip.append(this.#content(), arrowElement);
+        document.body.appendChild(tooltip);
+
+        return tooltip;
+    }
+
+    #position() {
+        const arrowElement = this.#tooltip.querySelector('.tooltip-arrow');
+
+        computePosition(this.element, this.#tooltip, {
+            placement: this.placementValue,
+            middleware: [offset(8), flip(), shift({ padding: 8 }), arrow({ element: arrowElement })],
+        }).then(({ x, y, placement, middlewareData }) => {
+            Object.assign(this.#tooltip.style, { left: `${x}px`, top: `${y}px` });
+
+            const { x: arrowX, y: arrowY } = middlewareData.arrow;
+            const staticSide = OPPOSITE_SIDE[placement.split('-')[0]];
+            Object.assign(arrowElement.style, {
+                left: null != arrowX ? `${arrowX}px` : '',
+                top: null != arrowY ? `${arrowY}px` : '',
+                right: '',
+                bottom: '',
+                [staticSide]: '-4px',
+            });
+        });
+    }
+
+    #content() {
+        // Always remove a `title` (even when `content` is set) so the browser's native tooltip never
+        // competes with ours; fall back to its text only when no `content` value is given.
+        this.#stashTitle();
+
+        if (this.hasContentValue) {
+            return this.contentValue;
+        }
+
+        return this.element.getAttribute('data-tooltip-original-title') ?? '';
+    }
+
+    // Move a native `title` into a data attribute the first time we see it: the browser's own tooltip
+    // stops showing, and the text survives a Turbo snapshot/restore (a removed `title` would not).
+    #stashTitle() {
+        const title = this.element.getAttribute('title');
+        if (null === title) {
+            return;
+        }
+
+        this.element.removeAttribute('title');
+        this.element.setAttribute('data-tooltip-original-title', title);
+    }
+
+    // Standard hover (plus keyboard focus) is the default, so the common case needs no `data-action`.
+    #wire() {
+        if ('manual' === this.triggerValue) {
+            return;
+        }
+
+        this.#triggers = new AbortController();
+        const options = { signal: this.#triggers.signal };
+
+        if ('click' === this.triggerValue) {
+            this.element.addEventListener('click', () => this.toggle(), options);
+
+            return;
+        }
+
+        this.element.addEventListener('mouseenter', () => this.show(), options);
+        this.element.addEventListener('mouseleave', () => this.hide(), options);
+        this.element.addEventListener('focusin', () => this.show(), options);
+        this.element.addEventListener('focusout', () => this.hide(), options);
+    }
+}

--- a/src/Toolkit/kits/common/tooltip/manifest.json
+++ b/src/Toolkit/kits/common/tooltip/manifest.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Tooltip",
+    "version-added": "3.4",
+    "copy-files": {
+        "assets/": "assets/"
+    },
+    "dependencies": {
+        "npm": ["@floating-ui/dom"],
+        "importmap": ["@floating-ui/dom"]
+    }
+}

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 0__1.html
@@ -1,0 +1,21 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">composer require symfony/ux-toolkit</code>
+    <span class="relative">
+        <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+        <span data-clipboard-target="success" class="absolute left-full top-1/2 ml-3 -translate-y-1/2 whitespace-nowrap text-sm font-medium text-violet-600 dark:text-violet-400">Copied!</span>
+    </span>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">composer require symfony/ux-toolkit</code>
+    <span class="relative">
+        <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+        <span data-clipboard-target="success" class="absolute left-full top-1/2 ml-3 -translate-y-1/2 whitespace-nowrap text-sm font-medium text-violet-600 dark:text-violet-400">Copied!</span>
+    </span>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 1__1.html
@@ -1,0 +1,15 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <input type="text" data-clipboard-target="source" value="hello@example.com" readonly class="rounded-md border border-violet-200 bg-violet-50 px-3 py-2 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy email</button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <input type="text" data-clipboard-target="source" value="hello@example.com" readonly class="rounded-md border border-violet-200 bg-violet-50 px-3 py-2 text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy email</button>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 2__1.html
@@ -1,0 +1,15 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <p data-clipboard-target="source" class="flex-1 text-sm text-violet-900 dark:text-violet-100">The quick brown fox jumps over the lazy dog.</p>
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy text</button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <p data-clipboard-target="source" class="flex-1 text-sm text-violet-900 dark:text-violet-100">The quick brown fox jumps over the lazy dog.</p>
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy text</button>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 3__1.html
@@ -1,0 +1,25 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<div data-controller="clipboard" class="relative w-full max-w-sm">
+    <pre data-clipboard-target="source" class="overflow-x-auto rounded-md bg-violet-950 p-4 font-mono text-xs leading-relaxed text-violet-100"><code>$response = new JsonResponse([
+    'status' => 'ok',
+]);</code></pre>
+    <button type="button" data-action="clipboard#copy" class="absolute right-2 top-2 rounded bg-violet-700 px-2 py-1 text-xs font-medium text-violet-100 hover:bg-violet-600">
+        <span data-clipboard-target="idle">Copy</span>
+        <span data-clipboard-target="success" hidden>Copied!</span>
+    </button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="clipboard" class="relative w-full max-w-sm">
+    <pre data-clipboard-target="source" class="overflow-x-auto rounded-md bg-violet-950 p-4 font-mono text-xs leading-relaxed text-violet-100"><code>$response = new JsonResponse([
+    'status' =&gt; 'ok',
+]);</code></pre>
+    <button type="button" data-action="clipboard#copy" class="absolute right-2 top-2 rounded bg-violet-700 px-2 py-1 text-xs font-medium text-violet-100 hover:bg-violet-600">
+        <span data-clipboard-target="idle">Copy</span>
+        <span data-clipboard-target="success" hidden>Copied!</span>
+    </button>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 4__1.html
@@ -1,0 +1,15 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<div data-controller="clipboard" data-clipboard-source-value="a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6" class="flex items-center gap-3">
+    <input type="text" value="xxxxxxxxxxxxxxxxxxxx" readonly class="rounded-md border border-violet-200 bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy API Key</button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="clipboard" data-clipboard-source-value="a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6" class="flex items-center gap-3">
+    <input type="text" value="xxxxxxxxxxxxxxxxxxxx" readonly class="rounded-md border border-violet-200 bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:border-violet-900 dark:bg-violet-950 dark:text-violet-100">
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy API Key</button>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 5__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 5__1.html
@@ -1,0 +1,21 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<div data-controller="clipboard" data-clipboard-success-duration-value="1500" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">symfony serve -d</code>
+    <span class="relative">
+        <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+        <span data-clipboard-target="success" class="absolute left-full top-1/2 ml-3 -translate-y-1/2 whitespace-nowrap text-sm font-medium text-violet-600 dark:text-violet-400">Copied to clipboard!</span>
+    </span>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="clipboard" data-clipboard-success-duration-value="1500" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">symfony serve -d</code>
+    <span class="relative">
+        <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+        <span data-clipboard-target="success" class="absolute left-full top-1/2 ml-3 -translate-y-1/2 whitespace-nowrap text-sm font-medium text-violet-600 dark:text-violet-400">Copied to clipboard!</span>
+    </span>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 6__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 6__1.html
@@ -1,0 +1,21 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">git clone git@github.com:symfony/ux.git</code>
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">
+        <span data-clipboard-target="idle">Copy</span>
+        <span data-clipboard-target="success" hidden>Copied!</span>
+    </button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-controller="clipboard" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">git clone git@github.com:symfony/ux.git</code>
+    <button type="button" data-action="clipboard#copy" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">
+        <span data-clipboard-target="idle">Copy</span>
+        <span data-clipboard-target="success" hidden>Copied!</span>
+    </button>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 7__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 7__1.html
@@ -1,0 +1,37 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<style>
+@keyframes clipboard-burst {
+    from { transform: scale(.75); opacity: .75; }
+    to { transform: scale(2) rotate(20deg); opacity: 0; }
+}
+</style>
+<div data-controller="clipboard" data-clipboard-success-duration-value="450" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">php bin/console cache:clear</code>
+    <button type="button" data-action="clipboard#copy" class="relative rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">
+        Copy
+        <span data-clipboard-target="success" class="pointer-events-none absolute inset-0 rounded-full border-2 border-dotted border-violet-400" style="animation: clipboard-burst 450ms linear forwards"></span>
+    </button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<html>
+<head>
+<style>
+@keyframes clipboard-burst {
+    from { transform: scale(.75); opacity: .75; }
+    to { transform: scale(2) rotate(20deg); opacity: 0; }
+}
+</style>
+</head>
+<body><div data-controller="clipboard" data-clipboard-success-duration-value="450" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">php bin/console cache:clear</code>
+    <button type="button" data-action="clipboard#copy" class="relative rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">
+        Copy
+        <span data-clipboard-target="success" class="pointer-events-none absolute inset-0 rounded-full border-2 border-dotted border-violet-400" style="animation: clipboard-burst 450ms linear forwards"></span>
+    </button>
+</div></body>
+</html>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 8__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 8__1.html
@@ -1,0 +1,21 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<style>.clipboard-copied .clipboard-btn { background-color: #16a34a; }</style>
+<div data-controller="clipboard" data-clipboard-success-class="clipboard-copied" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">php bin/console about</code>
+    <button type="button" data-action="clipboard#copy" class="clipboard-btn rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<html>
+<head>
+<style>.clipboard-copied .clipboard-btn { background-color: #16a34a; }</style>
+</head>
+<body><div data-controller="clipboard" data-clipboard-success-class="clipboard-copied" class="flex items-center gap-3">
+    <code data-clipboard-target="source" class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">php bin/console about</code>
+    <button type="button" data-action="clipboard#copy" class="clipboard-btn rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+</div></body>
+</html>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 9__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component clipboard, example 9__1.html
@@ -1,0 +1,31 @@
+<!--
+- Kit: Common
+- Component: Clipboard
+- Code:
+```twig
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[120px] items-center justify-center">
+    <div class="flex items-center gap-3">
+        <code class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">php bin/console debug:router</code>
+        <button type="button" data-controller="clipboard tooltip" data-clipboard-source-value="php bin/console debug:router" data-action="clipboard#copy clipboard:copied->tooltip#show" data-tooltip-content-value="Copied!" data-tooltip-trigger-value="manual" data-tooltip-auto-hide-value="2000" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+    </div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<html>
+<head>
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+</head>
+<body><div class="flex min-h-[120px] items-center justify-center">
+    <div class="flex items-center gap-3">
+        <code class="rounded-md bg-violet-50 px-3 py-2 font-mono text-sm text-violet-900 dark:bg-violet-950 dark:text-violet-100">php bin/console debug:router</code>
+        <button type="button" data-controller="clipboard tooltip" data-clipboard-source-value="php bin/console debug:router" data-action="clipboard#copy clipboard:copied-&gt;tooltip#show" data-tooltip-content-value="Copied!" data-tooltip-trigger-value="manual" data-tooltip-auto-hide-value="2000" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 active:scale-95 active:bg-violet-700">Copy</button>
+    </div>
+</div></body>
+</html>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 0__1.html
@@ -1,0 +1,29 @@
+<!--
+- Kit: Common
+- Component: Tooltip
+- Code:
+```twig
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[140px] items-center justify-center">
+    <button type="button" data-controller="tooltip" title="Thanks for hovering!" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Hover me
+    </button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<html>
+<head>
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+</head>
+<body><div class="flex min-h-[140px] items-center justify-center">
+    <button type="button" data-controller="tooltip" title="Thanks for hovering!" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Hover me
+    </button>
+</div></body>
+</html>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 1__1.html
@@ -1,0 +1,31 @@
+<!--
+- Kit: Common
+- Component: Tooltip
+- Code:
+```twig
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[200px] items-center justify-center gap-12 px-16">
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Top" data-tooltip-placement-value="top" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Top</button>
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Bottom" data-tooltip-placement-value="bottom" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Bottom</button>
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Left" data-tooltip-placement-value="left" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Left</button>
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Right" data-tooltip-placement-value="right" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Right</button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<html>
+<head>
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+</head>
+<body><div class="flex min-h-[200px] items-center justify-center gap-12 px-16">
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Top" data-tooltip-placement-value="top" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Top</button>
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Bottom" data-tooltip-placement-value="bottom" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Bottom</button>
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Left" data-tooltip-placement-value="left" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Left</button>
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Right" data-tooltip-placement-value="right" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Right</button>
+</div></body>
+</html>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 2__1.html
@@ -1,0 +1,29 @@
+<!--
+- Kit: Common
+- Component: Tooltip
+- Code:
+```twig
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[120px] items-center justify-center">
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Click again to close" data-tooltip-placement-value="bottom" data-tooltip-trigger-value="click" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Click me
+    </button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<html>
+<head>
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+</head>
+<body><div class="flex min-h-[120px] items-center justify-center">
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="Click again to close" data-tooltip-placement-value="bottom" data-tooltip-trigger-value="click" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Click me
+    </button>
+</div></body>
+</html>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 3__1.html
@@ -1,0 +1,29 @@
+<!--
+- Kit: Common
+- Component: Tooltip
+- Code:
+```twig
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[120px] items-center justify-center">
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="I'll disappear shortly…" data-tooltip-placement-value="bottom" data-tooltip-trigger-value="click" data-tooltip-auto-hide-value="2000" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Show for 2s
+    </button>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<html>
+<head>
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+</head>
+<body><div class="flex min-h-[120px] items-center justify-center">
+    <button type="button" data-controller="tooltip" data-tooltip-content-value="I'll disappear shortly…" data-tooltip-placement-value="bottom" data-tooltip-trigger-value="click" data-tooltip-auto-hide-value="2000" class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500">
+        Show for 2s
+    </button>
+</div></body>
+</html>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit common, component tooltip, example 4__1.html
@@ -1,0 +1,31 @@
+<!--
+- Kit: Common
+- Component: Tooltip
+- Code:
+```twig
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+<div class="flex min-h-[120px] items-center justify-center">
+    <div data-controller="tooltip" data-tooltip-content-value="Toggled by hand" data-tooltip-trigger-value="manual" class="inline-flex gap-2">
+        <button type="button" data-action="tooltip#show" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Show</button>
+        <button type="button" data-action="tooltip#hide" class="rounded-md bg-violet-100 px-3 py-2 text-sm font-medium text-violet-900 hover:bg-violet-200 dark:bg-violet-900 dark:text-violet-100 dark:hover:bg-violet-800">Hide</button>
+    </div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<html>
+<head>
+<style>
+    .tooltip { position: absolute; top: 0; left: 0; width: max-content; border-radius: .25rem; background: #4c1d95; color: #fff; padding: .25rem .5rem; font-size: .75rem; font-weight: 500; pointer-events: none; z-index: 50; }
+    .tooltip-arrow { position: absolute; width: 8px; height: 8px; background: inherit; transform: rotate(45deg); }
+</style>
+</head>
+<body><div class="flex min-h-[120px] items-center justify-center">
+    <div data-controller="tooltip" data-tooltip-content-value="Toggled by hand" data-tooltip-trigger-value="manual" class="inline-flex gap-2">
+        <button type="button" data-action="tooltip#show" class="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500">Show</button>
+        <button type="button" data-action="tooltip#hide" class="rounded-md bg-violet-100 px-3 py-2 text-sm font-medium text-violet-900 hover:bg-violet-200 dark:bg-violet-900 dark:text-violet-100 dark:hover:bg-violet-800">Hide</button>
+    </div>
+</div></body>
+</html>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

Two design-system-agnostic recipes for the `common` kit.

`clipboard` copies to the clipboard from a `source` value or element (a form control's value, an element's text, or a code block). Copied feedback is opt-in: a `success`/`idle` target swap, or a CSS `success` class the controller toggles for `successDuration`. Every copy also dispatches a `clipboard:copied` event, so you can drive your own feedback.

<img width="692" height="458" alt="Screenshot 2026-07-29 at 9 17 21 AM" src="https://github.com/user-attachments/assets/0e1488d6-8bed-409b-8e34-f9e51792f914" />

---

`tooltip` shows a tooltip from a `content` value or an element's native `title` (which it adopts and removes, suppressing the browser's own). It opens on hover and keyboard focus by default (`trigger` also supports `click` and `manual`), and uses [Floating UI](https://floating-ui.com/) to flip/shift into view and escape `overflow` clipping (the tooltip is rendered in `<body>`). Placement and appearance come from a single global `.tooltip` rule. It adds `@floating-ui/dom` as a dependency — the `common` kit's first.

<img width="694" height="579" alt="Screenshot 2026-07-29 at 9 18 29 AM" src="https://github.com/user-attachments/assets/34246d1e-d60e-4fe5-aa03-4ba475f1ef4f" />

