### PR TITLE
[Icons] Add `auto_lock` to persist on-demand icons

### DIFF
--- a/src/Icons/CHANGELOG.md
+++ b/src/Icons/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.4.0
+
+- Add `iconify.auto_lock` option to persist "on demand" icons to the local icon directory as they are rendered
+
 ## 3.2.0
 
 - Sanitize rendered SVG icons (Iconify bodies and local files) to prevent XSS. See section 2.36.1 below for details

--- a/src/Icons/config/services.php
+++ b/src/Icons/config/services.php
@@ -20,6 +20,7 @@ use Symfony\UX\Icons\IconFactory;
 use Symfony\UX\Icons\Iconify;
 use Symfony\UX\Icons\IconRenderer;
 use Symfony\UX\Icons\IconRendererInterface;
+use Symfony\UX\Icons\Registry\AutoLockIconRegistry;
 use Symfony\UX\Icons\Registry\CacheIconRegistry;
 use Symfony\UX\Icons\Registry\ChainIconRegistry;
 use Symfony\UX\Icons\Registry\IconifyOnDemandRegistry;
@@ -111,6 +112,13 @@ return static function (ContainerConfigurator $container): void {
                 service('.ux_icons.iconify'),
             ])
             ->tag('ux_icons.registry', ['priority' => -10])
+
+        ->set('.ux_icons.auto_lock_icon_registry', AutoLockIconRegistry::class)
+            ->args([
+                service('.ux_icons.iconify_on_demand_registry'),
+                service('.ux_icons.local_svg_icon_registry'),
+                service('logger')->ignoreOnInvalid(),
+            ])
 
         ->set('.ux_icons.command.import', ImportIconCommand::class)
             ->args([

--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -351,6 +351,35 @@ the report to overwrite existing icons by using the ``--force`` option:
 
         $ php bin/console ux:icons:lock -v
 
+Automatically Locking On-Demand Icons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 3.4
+
+    The ``auto_lock`` option was added in UX Icons 3.4.
+
+Running ``ux:icons:lock`` is easy to forget, and its Twig template scan cannot
+find icons whose names are built dynamically. As an alternative, enable
+``auto_lock`` to *lock* every *on-demand* icon to ``assets/icons/`` the first
+time it is actually rendered:
+
+.. code-block:: yaml
+
+    # config/packages/ux_icons.yaml
+    when@dev:
+        ux_icons:
+            iconify:
+                auto_lock: true
+
+With this enabled, browsing your application in development downloads and saves
+each *on-demand* icon to disk, ready to be committed. Production then renders
+the icons from these local files, without any request to the Iconify API.
+
+.. note::
+
+    Enable ``auto_lock`` in development only: the icons it writes must be
+    committed to your repository so they are available in production.
+
 Rendering Icons
 ---------------
 
@@ -694,6 +723,9 @@ Full Configuration
 
            # Whether to use the "on demand" icons powered by Iconify.design
            on_demand: true
+
+           # Whether to persist "on demand" icons to icon_dir (recommended in dev only)
+           auto_lock: false
 
            # The endpoint for the Iconify API
            endpoint: 'https://api.iconify.design'

--- a/src/Icons/src/DependencyInjection/UXIconsExtension.php
+++ b/src/Icons/src/DependencyInjection/UXIconsExtension.php
@@ -119,6 +119,10 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
                             ->info('Whether to download icons "on demand".')
                             ->defaultTrue()
                         ->end()
+                        ->booleanNode('auto_lock')
+                            ->info("Persist \"on demand\" icons to the local icon directory (see \"icon_dir\").\nRecommended in dev only. Requires \"on_demand\" to be enabled.")
+                            ->defaultFalse()
+                        ->end()
                         ->scalarNode('endpoint')
                             ->info('The endpoint for the Iconify icons API.')
                             ->defaultValue(Iconify::API_ENDPOINT)
@@ -207,6 +211,13 @@ final class UXIconsExtension extends ConfigurableExtension implements Configurat
 
         if (!$mergedConfig['iconify']['on_demand'] || !$mergedConfig['iconify']['enabled']) {
             $container->removeDefinition('.ux_icons.iconify_on_demand_registry');
+            $container->removeDefinition('.ux_icons.auto_lock_icon_registry');
+        } elseif ($mergedConfig['iconify']['auto_lock']) {
+            $container->getDefinition('.ux_icons.iconify_on_demand_registry')->clearTag('ux_icons.registry');
+            $container->getDefinition('.ux_icons.auto_lock_icon_registry')
+                ->addTag('ux_icons.registry', ['priority' => -10]);
+        } else {
+            $container->removeDefinition('.ux_icons.auto_lock_icon_registry');
         }
     }
 }

--- a/src/Icons/src/Registry/AutoLockIconRegistry.php
+++ b/src/Icons/src/Registry/AutoLockIconRegistry.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons\Registry;
+
+use Psr\Log\LoggerInterface;
+use Symfony\UX\Icons\Icon;
+use Symfony\UX\Icons\IconRegistryInterface;
+
+/**
+ * Persists "on demand" icons to the local icon directory as they are first rendered.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class AutoLockIconRegistry implements IconRegistryInterface
+{
+    public function __construct(
+        private readonly IconRegistryInterface $inner,
+        private readonly LocalSvgIconRegistry $localRegistry,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function get(string $name): Icon
+    {
+        $icon = $this->inner->get($name);
+
+        try {
+            $this->localRegistry->add(str_replace(':', '/', $name), $icon->toHtml());
+        } catch (\Throwable $e) {
+            $this->logger?->warning('Could not auto-lock icon "{name}".', ['name' => $name, 'exception' => $e]);
+        }
+
+        return $icon;
+    }
+}

--- a/src/Icons/tests/UXIconsBundleTest.php
+++ b/src/Icons/tests/UXIconsBundleTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\UX\Icons\DependencyInjection\UXIconsExtension;
 
 class UXIconsBundleTest extends TestCase
@@ -96,6 +97,51 @@ class UXIconsBundleTest extends TestCase
                 'default_icon_attributes' => $value,
             ],
         ]);
+    }
+
+    private function buildContainer(array $config = []): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.project_dir', __DIR__);
+
+        new UXIconsExtension()->load([$config], $container);
+
+        return $container;
+    }
+
+    public function testAutoLockDefaultsToFalse()
+    {
+        $config = new Processor()->processConfiguration(new UXIconsExtension(), [[]]);
+
+        $this->assertFalse($config['iconify']['auto_lock']);
+    }
+
+    public function testAutoLockRegistryIsWiredWhenEnabled()
+    {
+        $container = $this->buildContainer(['iconify' => ['auto_lock' => true]]);
+
+        $this->assertTrue($container->hasDefinition('.ux_icons.auto_lock_icon_registry'));
+        $this->assertTrue($container->getDefinition('.ux_icons.auto_lock_icon_registry')->hasTag('ux_icons.registry'));
+        $this->assertSame([['priority' => -10]], $container->getDefinition('.ux_icons.auto_lock_icon_registry')->getTag('ux_icons.registry'));
+        // the raw on-demand registry drops out of the chain; the decorator takes its slot
+        $this->assertFalse($container->getDefinition('.ux_icons.iconify_on_demand_registry')->hasTag('ux_icons.registry'));
+    }
+
+    public function testAutoLockRegistryIsRemovedWhenDisabled()
+    {
+        $container = $this->buildContainer(['iconify' => ['auto_lock' => false]]);
+
+        $this->assertFalse($container->hasDefinition('.ux_icons.auto_lock_icon_registry'));
+        $this->assertTrue($container->getDefinition('.ux_icons.iconify_on_demand_registry')->hasTag('ux_icons.registry'));
+    }
+
+    public function testAutoLockRegistryIsRemovedWhenOnDemandDisabled()
+    {
+        $container = $this->buildContainer(['iconify' => ['on_demand' => false]]);
+
+        $this->assertFalse($container->hasDefinition('.ux_icons.auto_lock_icon_registry'));
+        $this->assertFalse($container->hasDefinition('.ux_icons.iconify_on_demand_registry'));
     }
 
     public static function provideTestValidIconAttributesConfiguration(): iterable

--- a/src/Icons/tests/Unit/Registry/AutoLockIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/AutoLockIconRegistryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons\Tests\Unit\Registry;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\UX\Icons\Exception\IconNotFoundException;
+use Symfony\UX\Icons\Icon;
+use Symfony\UX\Icons\IconFactory;
+use Symfony\UX\Icons\Registry\AutoLockIconRegistry;
+use Symfony\UX\Icons\Registry\LocalSvgIconRegistry;
+use Symfony\UX\Icons\Tests\Util\InMemoryIconRegistry;
+
+final class AutoLockIconRegistryTest extends TestCase
+{
+    private string $iconDir;
+
+    protected function setUp(): void
+    {
+        $this->iconDir = sys_get_temp_dir().'/ux_icons_autolock_'.uniqid();
+    }
+
+    protected function tearDown(): void
+    {
+        new Filesystem()->remove($this->iconDir);
+    }
+
+    public function testReturnsIconFromInnerAndPersistsItToDisk()
+    {
+        $icon = new Icon('<path d="M0 0"/>', ['viewBox' => '0 0 24 24']);
+        $inner = new InMemoryIconRegistry(['lucide:heart' => $icon]);
+        $local = new LocalSvgIconRegistry(new IconFactory(), $this->iconDir);
+
+        $result = new AutoLockIconRegistry($inner, $local)->get('lucide:heart');
+
+        $this->assertSame($icon, $result);
+        $this->assertFileExists($this->iconDir.'/lucide/heart.svg');
+        $this->assertStringEqualsFile($this->iconDir.'/lucide/heart.svg', $icon->toHtml());
+    }
+
+    public function testPropagatesIconNotFoundAndWritesNothing()
+    {
+        $local = new LocalSvgIconRegistry(new IconFactory(), $this->iconDir);
+        $registry = new AutoLockIconRegistry(new InMemoryIconRegistry(), $local);
+
+        try {
+            $registry->get('lucide:heart');
+            $this->fail('Expected IconNotFoundException.');
+        } catch (IconNotFoundException) {
+            $this->assertFileDoesNotExist($this->iconDir.'/lucide/heart.svg');
+        }
+    }
+
+    public function testWriteFailureIsNonFatalAndLogged()
+    {
+        $icon = new Icon('<path d="M0 0"/>');
+        $inner = new InMemoryIconRegistry(['lucide:heart' => $icon]);
+
+        // Point the local registry at a *file* so writing "<file>/lucide/heart.svg" fails.
+        $file = tempnam(sys_get_temp_dir(), 'ux_icons_autolock_file_');
+        $local = new LocalSvgIconRegistry(new IconFactory(), $file);
+
+        $logger = new class extends AbstractLogger {
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => $message, 'context' => $context];
+            }
+        };
+
+        $result = new AutoLockIconRegistry($inner, $local, $logger)->get('lucide:heart');
+
+        unlink($file);
+
+        $this->assertSame($icon, $result);
+        $this->assertCount(1, $logger->records);
+        $this->assertSame(LogLevel::WARNING, $logger->records[0]['level']);
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3170 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

I can't remember how many projects, or how many times it happened, where an issue happened during a deployment because Iconify was unreachable, because some icons were not locked.

I suggest a new configuration `iconify.auto_lock`, `false` by default.

When `iconify.auto_lock` is enabled, each on-demand icon is written to the local icon directory the first time it is rendered, so it can be committed and served from disk in production without hitting the Iconify API.
