### PR TITLE
[Toolkit][Shadcn] Add native-select recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Bootstrap] Add the Bootstrap kit
 - [Common] Add the `common` kit, with design-system agnostic `clipboard`, `closeable`, `logout-link`, `post-link` and `tooltip` recipes
+- [Shadcn] Add the `native-select` recipe
 - Add new linter checker `ClassMergeSpacingChecker` that checks for invalid `'<literal>' ~ attributes.render(...)` pattern
 - Add new linter checker `AttributesDefaultsChecker` that forbids `data-slot` (and, in Tailwind kits, ARIA, Stimulus value `data-*-value` and state `data-*` attributes) inside `attributes.defaults()`
 - [Shadcn][Flowbite] Normalize `attributes.defaults()` usage: render `data-slot`, state `data-*` and ARIA attributes directly, and keep only `data-controller`/`data-action` (plus overridable HTML defaults) in `attributes.defaults()`

--- a/src/Toolkit/kits/shadcn/native-select/README.md
+++ b/src/Toolkit/kits/shadcn/native-select/README.md
@@ -1,0 +1,159 @@
+# Native Select
+
+A styled native HTML select element with consistent design system integration.
+
+```twig {"preview":true}
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select status</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="todo">Todo</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="in-progress">In Progress</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="done">Done</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="cancelled">Cancelled</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+```twig
+<twig:NativeSelect name="fruit">
+    <twig:NativeSelect:Option value="">Select a fruit</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+Native `option` and `optgroup` elements can also be used directly.
+
+```twig
+<twig:NativeSelect name="fruit">
+    <option value="">Select a fruit</option>
+    <option value="apple">Apple</option>
+    <option value="banana">Banana</option>
+</twig:NativeSelect>
+```
+
+## Examples
+
+### Basic
+
+```twig {"preview":true}
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select a fruit</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="grapes" disabled>Grapes</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="pineapple">Pineapple</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+### With Groups
+
+```twig {"preview":true}
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select a food</twig:NativeSelect:Option>
+    <twig:NativeSelect:OptGroup label="Fruits">
+        <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+    <twig:NativeSelect:OptGroup label="Vegetables">
+        <twig:NativeSelect:Option value="carrot">Carrot</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="broccoli">Broccoli</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="spinach">Spinach</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+</twig:NativeSelect>
+```
+
+### Sizes
+
+```twig {"preview":true}
+<div class="flex flex-col items-start gap-4">
+    <twig:NativeSelect size="sm">
+        <twig:NativeSelect:Option value="">Select a fruit</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+    </twig:NativeSelect>
+    <twig:NativeSelect size="default">
+        <twig:NativeSelect:Option value="">Select a fruit</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+    </twig:NativeSelect>
+</div>
+```
+
+### With Field
+
+```twig {"preview":true}
+<twig:Field>
+    <twig:Field:Label for="native-select-country">Country</twig:Field:Label>
+    <twig:NativeSelect id="native-select-country">
+        <twig:NativeSelect:Option value="">Select a country</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="us">United States</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="uk">United Kingdom</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="ca">Canada</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="au">Australia</twig:NativeSelect:Option>
+    </twig:NativeSelect>
+    <twig:Field:Description>Select your country of residence.</twig:Field:Description>
+</twig:Field>
+```
+
+### Disabled
+
+```twig {"preview":true}
+<twig:NativeSelect disabled>
+    <twig:NativeSelect:Option value="">Disabled</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+### Invalid
+
+```twig {"preview":true}
+<twig:NativeSelect aria-invalid="true">
+    <twig:NativeSelect:Option value="">Error state</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+## Native Select vs Select
+
+Use `NativeSelect` for native browser behavior, better performance, or mobile-optimized dropdowns. Use `Select` for custom styling, animations, or richer interactions.
+
+## RTL
+
+Use the `dir` attribute to switch the select direction.
+
+```twig {"preview":true}
+<twig:NativeSelect dir="rtl">
+    <twig:NativeSelect:Option value="">اختر الحالة</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="todo">مهام</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="in-progress">قيد التنفيذ</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="done">منجز</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="cancelled">ملغي</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+```twig {"preview":true}
+<twig:NativeSelect dir="rtl">
+    <twig:NativeSelect:Option value="">בחר סטטוס</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="todo">לעשות</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="in-progress">בתהליך</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="done">הושלם</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="cancelled">בוטל</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/shadcn/native-select/manifest.json
+++ b/src/Toolkit/kits/shadcn/native-select/manifest.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Native Select",
+    "description": "A styled native HTML select element with consistent design system integration.",
+    "version-added": "3.4",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": ["symfony/ux-icons", "tales-from-a-dev/twig-tailwind-extra:^1.0.0"]
+    }
+}

--- a/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect.html.twig
+++ b/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect.html.twig
@@ -1,0 +1,22 @@
+{# @prop size 'default'|'sm' The native select size. #}
+{# @block content The native `option` and `optgroup` elements. #}
+{%- props size = 'default' -%}
+<div
+    data-slot="native-select-wrapper"
+    class="{{ ('group/native-select relative w-fit has-[select:disabled]:opacity-50 ' ~ attributes.render('class'))|tailwind_merge }}"
+>
+    <select
+        data-slot="native-select"
+        data-size="{{ size }}"
+        class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
+        {{ attributes.without('class') }}
+    >
+        {%- block content %}{% endblock -%}
+    </select>
+    <twig:ux:icon
+        name="lucide:chevron-down"
+        aria-hidden="true"
+        data-slot="native-select-icon"
+        class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"
+    />
+</div>

--- a/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect/OptGroup.html.twig
+++ b/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect/OptGroup.html.twig
@@ -1,0 +1,8 @@
+{# @block content The grouped native options. #}
+<optgroup
+    data-slot="native-select-optgroup"
+    class="{{ ('bg-[Canvas] text-[CanvasText] ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.without('class') }}
+>
+    {%- block content %}{% endblock -%}
+</optgroup>

--- a/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect/Option.html.twig
+++ b/src/Toolkit/kits/shadcn/native-select/templates/components/NativeSelect/Option.html.twig
@@ -1,0 +1,8 @@
+{# @block content The option label. #}
+<option
+    data-slot="native-select-option"
+    class="{{ ('bg-[Canvas] text-[CanvasText] ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.without('class') }}
+>
+    {%- block content %}{% endblock -%}
+</option>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 0__1.html
@@ -1,0 +1,23 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select status</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="todo">Todo</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="in-progress">In Progress</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="done">Done</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="cancelled">Cancelled</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">Select status</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="todo">Todo</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="in-progress">In Progress</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="done">Done</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="cancelled">Cancelled</option>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 1__1.html
@@ -1,0 +1,25 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select a fruit</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="grapes" disabled>Grapes</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="pineapple">Pineapple</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">Select a fruit</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="apple">Apple</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="banana">Banana</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="blueberry">Blueberry</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="grapes" disabled>Grapes</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="pineapple">Pineapple</option>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 2__1.html
@@ -1,0 +1,35 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect>
+    <twig:NativeSelect:Option value="">Select a food</twig:NativeSelect:Option>
+    <twig:NativeSelect:OptGroup label="Fruits">
+        <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+    <twig:NativeSelect:OptGroup label="Vegetables">
+        <twig:NativeSelect:Option value="carrot">Carrot</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="broccoli">Broccoli</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="spinach">Spinach</twig:NativeSelect:Option>
+    </twig:NativeSelect:OptGroup>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">Select a food</option>
+    <optgroup data-slot="native-select-optgroup" class="bg-[Canvas] text-[CanvasText]" label="Fruits">
+<option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="apple">Apple</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="banana">Banana</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="blueberry">Blueberry</option>
+    </optgroup>
+    <optgroup data-slot="native-select-optgroup" class="bg-[Canvas] text-[CanvasText]" label="Vegetables">
+<option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="carrot">Carrot</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="broccoli">Broccoli</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="spinach">Spinach</option>
+    </optgroup>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 3__1.html
@@ -1,0 +1,39 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<div class="flex flex-col items-start gap-4">
+    <twig:NativeSelect size="sm">
+        <twig:NativeSelect:Option value="">Select a fruit</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+    </twig:NativeSelect>
+    <twig:NativeSelect size="default">
+        <twig:NativeSelect:Option value="">Select a fruit</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+    </twig:NativeSelect>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col items-start gap-4">
+    <div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="sm" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">Select a fruit</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="apple">Apple</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="banana">Banana</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="blueberry">Blueberry</option>
+    </select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>
+    <div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">Select a fruit</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="apple">Apple</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="banana">Banana</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="blueberry">Blueberry</option>
+    </select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 4__1.html
@@ -1,0 +1,31 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:Field>
+    <twig:Field:Label for="native-select-country">Country</twig:Field:Label>
+    <twig:NativeSelect id="native-select-country">
+        <twig:NativeSelect:Option value="">Select a country</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="us">United States</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="uk">United Kingdom</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="ca">Canada</twig:NativeSelect:Option>
+        <twig:NativeSelect:Option value="au">Australia</twig:NativeSelect:Option>
+    </twig:NativeSelect>
+    <twig:Field:Description>Select your country of residence.</twig:Field:Description>
+</twig:Field>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div role="group" data-slot="field" data-orientation="vertical" class="group/field flex w-full gap-2 data-[invalid=true]:text-destructive flex-col *:w-full [&amp;&gt;.sr-only]:w-auto">
+<label data-slot="label" class="items-center text-sm font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-checked:border-primary/30 has-checked:bg-primary/5 has-[&gt;[data-slot=field]]:rounded-lg has-[&gt;[data-slot=field]]:border *:data-[slot=field]:p-2.5 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10 dark:has-checked:border-primary/20 dark:has-checked:bg-primary/10 has-[&gt;[data-slot=field]]:w-full has-[&gt;[data-slot=field]]:flex-col" for="native-select-country">Country</label>
+    <div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40" id="native-select-country"><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">Select a country</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="us">United States</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="uk">United Kingdom</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="ca">Canada</option>
+        <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="au">Australia</option>
+    </select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>
+    <p data-slot="field-description" class="ltr:text-left rtl:text-start text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&amp;]:-mt-1.5 last:mt-0 nth-last-2:-mt-1 [&amp;&gt;a]:underline [&amp;&gt;a]:underline-offset-4 [&amp;&gt;a:hover]:text-primary">Select your country of residence.</p>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 5__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 5__1.html
@@ -1,0 +1,21 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect disabled>
+    <twig:NativeSelect:Option value="">Disabled</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40" disabled><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">Disabled</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="apple">Apple</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="banana">Banana</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="blueberry">Blueberry</option>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 6__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 6__1.html
@@ -1,0 +1,21 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect aria-invalid="true">
+    <twig:NativeSelect:Option value="">Error state</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="apple">Apple</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="banana">Banana</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="blueberry">Blueberry</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40" aria-invalid="true"><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">Error state</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="apple">Apple</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="banana">Banana</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="blueberry">Blueberry</option>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 7__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 7__1.html
@@ -1,0 +1,23 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect dir="rtl">
+    <twig:NativeSelect:Option value="">اختر الحالة</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="todo">مهام</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="in-progress">قيد التنفيذ</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="done">منجز</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="cancelled">ملغي</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40" dir="rtl"><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">اختر الحالة</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="todo">مهام</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="in-progress">قيد التنفيذ</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="done">منجز</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="cancelled">ملغي</option>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 8__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component native-select, example 8__1.html
@@ -1,0 +1,23 @@
+<!--
+- Kit: Shadcn UI
+- Component: Native Select
+- Code:
+```twig
+<twig:NativeSelect dir="rtl">
+    <twig:NativeSelect:Option value="">בחר סטטוס</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="todo">לעשות</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="in-progress">בתהליך</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="done">הושלם</twig:NativeSelect:Option>
+    <twig:NativeSelect:Option value="cancelled">בוטל</twig:NativeSelect:Option>
+</twig:NativeSelect>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div data-slot="native-select-wrapper" class="group/native-select relative w-fit has-[select:disabled]:opacity-50">
+    <select data-slot="native-select" data-size="default" class="h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground ltr:pr-9 rtl:pl-9 disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40" dir="rtl"><option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="">בחר סטטוס</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="todo">לעשות</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="in-progress">בתהליך</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="done">הושלם</option>
+    <option data-slot="native-select-option" class="bg-[Canvas] text-[CanvasText]" value="cancelled">בוטל</option>
+</select>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="native-select-icon" class="pointer-events-none absolute top-1/2 size-4 -translate-y-1/2 text-muted-foreground opacity-50 select-none ltr:right-3.5 rtl:left-3.5"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | Part of #3233
| License        | MIT

Shadcn now distinguishes the native HTML control from its fully custom Select component. This adds the `native-select` recipe so the native behavior has the same dedicated API in Symfony UX Toolkit.

The recipe includes `NativeSelect`, `NativeSelect:Option`, and `NativeSelect:OptGroup`, the upstream size and validation states, LTR/RTL styling, and all upstream examples. The existing `select` recipe remains unchanged in this PR; #3744 aligns it with the custom upstream component, in keeping with the one-recipe-per-PR convention.

No companion site change is required: the current documentation renders recipe READMEs directly and its Tailwind entry scans the installed Shadcn kit.

Tests:

- `bin/ux-toolkit-kit-lint --fail-on-warning kits/shadcn`
- `pnpm exec oxfmt --check src/Toolkit/CHANGELOG.md src/Toolkit/kits/shadcn/native-select/README.md src/Toolkit/kits/shadcn/native-select/manifest.json`
- `php -d memory_limit=-1 vendor/bin/phpunit` (1083 tests, 2622 assertions)
