### PR TITLE
[Toolkit] Add install disclaimer to README

### DIFF
--- a/src/Toolkit/README.md
+++ b/src/Toolkit/README.md
@@ -5,6 +5,9 @@ likely to change, or even change drastically.
 
 Symfony UX Toolkit provides a set of ready-to-use UI components for Symfony applications.
 
+> [!IMPORTANT]
+> **Once installed, components live in your app and are yours to modify as you wish** — installing copies the files into your project. Because of that, components come with **no backward-compatibility guarantee**: they can change or be removed in any release, and your installed copy is unaffected. Re-install a component to pick up the latest version, but since it may differ from your copy, be sure to verify it still works in your app.
+
 **This repository is a READ-ONLY sub-tree split**. See
 https://github.com/symfony/ux to create issues or submit pull requests.
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | n/a
| License        | MIT

Adds a note clarifying that installed components live in your app and come with no backward-compatibility guarantee — re-install to pick up the latest version.

Related to https://github.com/symfony/ux.symfony.com/pull/174