### PR TITLE
[Toolkit] Restore the filename above installation code blocks (`filename` code options)

### DIFF
--- a/src/Toolkit/src/Doc/RecipeDocRenderer.php
+++ b/src/Toolkit/src/Doc/RecipeDocRenderer.php
@@ -29,6 +29,7 @@ use Symfony\UX\Toolkit\Component\StimulusControllerDoc;
 use Symfony\UX\Toolkit\Component\StimulusControllerDocParser;
 use Symfony\UX\Toolkit\Installer\PoolResolver;
 use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Markdown\CodeOptions;
 use Symfony\UX\Toolkit\Markdown\Extension\Alert\AlertExtension;
 use Symfony\UX\Toolkit\Markdown\Extension\CodePreview\CodePreviewExtension;
 use Symfony\UX\Toolkit\Markdown\Extension\FencedCodePreview\FencedCodePreviewExtension;
@@ -159,6 +160,7 @@ final class RecipeDocRenderer
                     'path_name' => $file->sourceRelativePathName,
                     'content' => is_file($source) ? file_get_contents($source) : '',
                     'language' => pathinfo($source, \PATHINFO_EXTENSION),
+                    'info' => new CodeOptions(filename: $file->sourceRelativePathName)->toInfoJson(),
                 ];
             }
         }

--- a/src/Toolkit/src/Markdown/CodeOptions.php
+++ b/src/Toolkit/src/Markdown/CodeOptions.php
@@ -12,44 +12,63 @@
 namespace Symfony\UX\Toolkit\Markdown;
 
 /**
- * The typed options a `{"preview": true}` fenced code block declares.
+ * The typed options a fenced code block declares in its `{json}` info string.
  *
  * It owns the Toolkit's slice of the info-string contract at both ends — the read (`fromInfoJson`) and
- * the code-tab write (`toCodeTabInfoJson`); the wider info-string vocabulary (e.g. a host `filename`) is
- * not modelled here. Pure PHP — no league/commonmark dependency.
+ * the write (`toInfoJson`): the file `filename` shown above the block and whether the code collapses long
+ * `class` attributes. The `"preview": true` opt-in itself is a routing trigger owned by
+ * {@see Extension\FencedCodePreview\FencedCodePreviewExtension}, not an
+ * option modelled here. Pure PHP — no league/commonmark dependency.
  *
  * @author Hugo Alliaume <hugo@alliau.me>
  */
 final class CodeOptions
 {
     public function __construct(
+        public readonly ?string $filename = null,
         public readonly bool $collapseClass = false,
     ) {
     }
 
     /**
-     * Builds the options from a fenced block's `{json}` info string, or null when the block does not opt
-     * into a preview (`"preview": true` absent, or malformed JSON).
+     * Builds the options from a fenced block's `{json}` info string, or null when it carries no JSON
+     * (or malformed JSON).
      */
     public static function fromInfoJson(string $json): ?self
     {
         $options = json_decode($json, true);
-        if (!\is_array($options) || true !== ($options['preview'] ?? null)) {
-            return null;
-        }
 
+        return \is_array($options) ? self::fromDecoded($options) : null;
+    }
+
+    /**
+     * Builds the options from an already-decoded info string, so a caller that has parsed the JSON for
+     * its own check (e.g. the preview opt-in) does not decode it twice.
+     *
+     * @param array<string, mixed> $options
+     */
+    public static function fromDecoded(array $options): self
+    {
         return new self(
+            filename: \is_string($options['filename'] ?? null) ? $options['filename'] : null,
             collapseClass: (bool) ($options['collapseClass'] ?? false),
         );
     }
 
     /**
-     * The code-tab styling options as a fenced info-string JSON fragment,
-     * or null when there is nothing to carry. Symmetric with
-     * {@see self::fromInfoJson()} so encode and decode of the format live together.
+     * The options as a fenced info-string JSON fragment, or null when there is nothing to carry.
+     * Symmetric with {@see self::fromInfoJson()} so encode and decode of the format live together.
      */
-    public function toCodeTabInfoJson(): ?string
+    public function toInfoJson(): ?string
     {
-        return $this->collapseClass ? json_encode(['collapseClass' => $this->collapseClass]) : null;
+        $data = [];
+        if (null !== $this->filename) {
+            $data['filename'] = $this->filename;
+        }
+        if ($this->collapseClass) {
+            $data['collapseClass'] = true;
+        }
+
+        return $data ? json_encode($data, \JSON_UNESCAPED_SLASHES) : null;
     }
 }

--- a/src/Toolkit/src/Markdown/Extension/FencedCodePreview/FencedCodePreviewExtension.php
+++ b/src/Toolkit/src/Markdown/Extension/FencedCodePreview/FencedCodePreviewExtension.php
@@ -65,11 +65,13 @@ final class FencedCodePreviewExtension implements ExtensionInterface
             return null;
         }
 
-        $options = CodeOptions::fromInfoJson($matches['json']);
-        if (null === $options) {
+        // The preview opt-in is a routing trigger, not a CodeOptions field: only `"preview": true` blocks
+        // become tabs; every other JSON info string (e.g. a `filename`) stays a plain fenced block.
+        $decoded = json_decode($matches['json'], true);
+        if (!\is_array($decoded) || true !== ($decoded['preview'] ?? null)) {
             return null;
         }
 
-        return [$matches['language'], $options];
+        return [$matches['language'], CodeOptions::fromDecoded($decoded)];
     }
 }

--- a/src/Toolkit/src/Markdown/PreviewTabsBuilder.php
+++ b/src/Toolkit/src/Markdown/PreviewTabsBuilder.php
@@ -34,7 +34,7 @@ final class PreviewTabsBuilder
 
         $codeTab = new Tab('Code');
         $fencedCode = new FencedCode(3, '`', 0);
-        $codeTabInfoJson = $options->toCodeTabInfoJson();
+        $codeTabInfoJson = $options->toInfoJson();
         $fencedCode->setInfo(null === $codeTabInfoJson ? $language : $language.' '.$codeTabInfoJson);
         $fencedCode->setLiteral($code);
         $codeTab->appendChild($fencedCode);

--- a/src/Toolkit/templates/doc/_installation.md.twig
+++ b/src/Toolkit/templates/doc/_installation.md.twig
@@ -30,7 +30,7 @@ php bin/console importmap:require {{ importmap_package_dependencies|join(' ') }}
 {% endif %}
 Copy the following file(s) into your app:
 {% for file in files %}
-```{{ file.language }}
+```{{ file.language }}{{ (file.info ? ' ' ~ file.info : '')|raw }}
 {{ file.content|trim|raw }}
 ```
 {% endfor %}

--- a/src/Toolkit/tests/Doc/RecipeDocRendererTest.php
+++ b/src/Toolkit/tests/Doc/RecipeDocRendererTest.php
@@ -11,11 +11,18 @@
 
 namespace Symfony\UX\Toolkit\Tests\Doc;
 
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\Toolkit\Doc\RecipeDocRenderer;
 use Symfony\UX\Toolkit\Kit\Kit;
 use Symfony\UX\Toolkit\Kit\KitFactory;
 use Symfony\UX\Toolkit\Markdown\CodeOptions;
+use Symfony\UX\Toolkit\Markdown\Extension\Tabs\TabsExtension;
 use Symfony\UX\Toolkit\Markdown\PreviewUrlGenerator;
 use Symfony\UX\Toolkit\Recipe\Recipe;
 
@@ -137,6 +144,39 @@ final class RecipeDocRendererTest extends KernelTestCase
         $this->assertStringContainsString('data-widget-status-outlet', $html);
         $this->assertStringContainsString('toggle', $html);
         $this->assertStringContainsString('Toggles the widget open state.', $html);
+    }
+
+    public function testHtmlInstallationStepsCarryTheFileNameInTheInfoString()
+    {
+        [$kit, $recipe] = $this->loadPostLinkRecipe();
+
+        // A doc with only the install directive: no previews/alerts, so a small environment is enough.
+        $recipe = new Recipe($recipe->name, $recipe->absolutePath, $recipe->manifest, doc: "## Installation\n\n::: installation");
+
+        $urlGenerator = new class implements PreviewUrlGenerator {
+            public function generate(string $code, CodeOptions $options): ?string
+            {
+                return null;
+            }
+        };
+
+        // Mirror the host: a fenced-code renderer that surfaces the info string so we can assert the
+        // filename travels with the block (as ux.symfony.com's renderer reads it back).
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new TabsExtension(self::getContainer()->get('twig')));
+        $environment->addRenderer(FencedCode::class, new class implements NodeRendererInterface {
+            public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
+            {
+                \assert($node instanceof FencedCode);
+
+                return \sprintf('<pre data-info="%s"></pre>', htmlspecialchars($node->getInfo(), \ENT_QUOTES));
+            }
+        }, 10);
+
+        $html = $this->renderer()->renderAsHtml($kit, $recipe, $urlGenerator, $environment)->html;
+
+        $this->assertStringContainsString('&quot;filename&quot;:&quot;templates/components/PostLink.html.twig&quot;', $html);
     }
 
     private function renderer(): RecipeDocRenderer

--- a/src/Toolkit/tests/Markdown/CodeOptionsTest.php
+++ b/src/Toolkit/tests/Markdown/CodeOptionsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Toolkit\Tests\Markdown;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Toolkit\Markdown\CodeOptions;
+
+class CodeOptionsTest extends TestCase
+{
+    public function testFromInfoJsonReadsFilenameAndCollapseClass()
+    {
+        $options = CodeOptions::fromInfoJson('{"filename": "templates/components/Alert.html.twig", "collapseClass": true}');
+
+        $this->assertSame('templates/components/Alert.html.twig', $options?->filename);
+        $this->assertTrue($options->collapseClass);
+    }
+
+    public function testFromInfoJsonDefaultsToEmptyOptions()
+    {
+        $options = CodeOptions::fromInfoJson('{}');
+
+        $this->assertNull($options?->filename);
+        $this->assertFalse($options->collapseClass);
+    }
+
+    public function testFromInfoJsonIgnoresANonStringFilename()
+    {
+        $this->assertNull(CodeOptions::fromInfoJson('{"filename": 42}')?->filename);
+    }
+
+    public function testFromInfoJsonReturnsNullOnMalformedJson()
+    {
+        $this->assertNull(CodeOptions::fromInfoJson('not json'));
+        $this->assertNull(CodeOptions::fromInfoJson('"a string"'));
+    }
+
+    public function testToInfoJsonCarriesTheFilenameWithUnescapedSlashes()
+    {
+        $json = new CodeOptions(filename: 'templates/components/Alert.html.twig')->toInfoJson();
+
+        $this->assertSame('{"filename":"templates/components/Alert.html.twig"}', $json);
+    }
+
+    public function testToInfoJsonCarriesCollapseClass()
+    {
+        $this->assertSame('{"collapseClass":true}', new CodeOptions(collapseClass: true)->toInfoJson());
+    }
+
+    public function testToInfoJsonIsNullWhenThereIsNothingToCarry()
+    {
+        $this->assertNull(new CodeOptions()->toInfoJson());
+    }
+
+    public function testInfoJsonRoundTrips()
+    {
+        $options = new CodeOptions(filename: 'assets/controllers/alert_controller.js', collapseClass: true);
+
+        $decoded = CodeOptions::fromInfoJson($options->toInfoJson());
+
+        $this->assertSame($options->filename, $decoded?->filename);
+        $this->assertSame($options->collapseClass, $decoded->collapseClass);
+    }
+}

--- a/src/Toolkit/tests/Markdown/FencedCodePreviewExtensionTest.php
+++ b/src/Toolkit/tests/Markdown/FencedCodePreviewExtensionTest.php
@@ -53,6 +53,20 @@ class FencedCodePreviewExtensionTest extends TestCase
         $this->assertStringContainsString('language-twig', $html);
     }
 
+    public function testJsonFenceWithoutPreviewOptInIsLeftUntouched()
+    {
+        // A `filename` (or any non-preview JSON) must not turn the block into preview tabs — the info
+        // string is left in place for the host's fenced-code renderer.
+        $html = $this->convert(<<<'MARKDOWN'
+            ```twig {"filename": "templates/components/Button.html.twig"}
+            <twig:Button>Hi</twig:Button>
+            ```
+            MARKDOWN);
+
+        $this->assertStringNotContainsString('toolkit-tabs', $html);
+        $this->assertStringContainsString('language-twig', $html);
+    }
+
     public function testJsonOptionsAreThreadedToTheLivePreview()
     {
         $urlGenerator = new class implements PreviewUrlGenerator {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix symfony/ux.symfony.com#176 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch 3.x.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
