### PR TITLE
[TwigComponent] Support `MergeableInterface` in `ComponentAttributes`

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.5.0
+
+- Add support for `MergeableInterface` from `twig/html-extra` in `ComponentAttributes#defaults()`
+
 ## 3.4.0
 
 - Add support for dynamic component names in the `{% component %}` tag using a

--- a/src/TwigComponent/src/ComponentAttributes.php
+++ b/src/TwigComponent/src/ComponentAttributes.php
@@ -14,6 +14,7 @@ namespace Symfony\UX\TwigComponent;
 use Symfony\UX\StimulusBundle\Dto\StimulusAttributes;
 use Symfony\UX\TwigComponent\Exception\RuntimeException;
 use Twig\Extra\Html\HtmlAttr\AttributeValueInterface;
+use Twig\Extra\Html\HtmlAttr\MergeableInterface;
 use Twig\Runtime\EscaperRuntime;
 
 /**
@@ -116,6 +117,10 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
             return null;
         }
 
+        if ($value instanceof AttributeValueInterface && null === $value = $value->getValue()) {
+            return null;
+        }
+
         if ($value instanceof \Stringable) {
             $value = (string) $value;
         }
@@ -145,8 +150,11 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
      * Set default attributes. These are used if they are not already
      * defined.
      *
-     * "class" and "data-controller" are special, these defaults are prepended to
-     * the existing attribute (if available).
+     * "class", "data-controller" and "data-action" are special, these defaults are
+     * prepended to the existing attribute (if available).
+     *
+     * Values implementing Twig HTML extra's MergeableInterface (e.g. from the
+     * "tailwind_classes" filter) are merged through the merge protocol, for any key.
      */
     public function defaults(iterable $attributes): self
     {
@@ -159,13 +167,23 @@ final class ComponentAttributes implements \Stringable, \IteratorAggregate, \Cou
         }
 
         foreach ($this->attributes as $key => $value) {
-            if (\in_array($key, ['class', 'data-controller', 'data-action'], true) && isset($attributes[$key])) {
-                $attributes[$key] = "{$attributes[$key]} {$value}";
+            if (!isset($attributes[$key])) {
+                $attributes[$key] = $value;
 
                 continue;
             }
 
-            $attributes[$key] = $value;
+            $default = $attributes[$key];
+
+            if ($value instanceof MergeableInterface) {
+                $attributes[$key] = $value->mergeInto($default);
+            } elseif ($default instanceof MergeableInterface) {
+                $attributes[$key] = $default->appendFrom($value);
+            } elseif (\in_array($key, ['class', 'data-controller', 'data-action'], true)) {
+                $attributes[$key] = "{$default} {$value}";
+            } else {
+                $attributes[$key] = $value;
+            }
         }
 
         foreach (array_keys($this->rendered) as $attribute) {

--- a/src/TwigComponent/tests/Fixtures/MergeableExtension.php
+++ b/src/TwigComponent/tests/Fixtures/MergeableExtension.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * Test-only stub exposing a "mergeable_tokens" filter that returns a lenient
+ * MergeableInterface value object, so the component render pipeline can be
+ * exercised without depending on a concrete implementation (e.g. tailwind_classes).
+ *
+ * The value object is an anonymous class built at runtime: reflecting this
+ * extension never loads it, so nothing breaks when twig/html-extra is too old to
+ * provide MergeableInterface (the filter is only ever called from a guarded test).
+ */
+final class MergeableExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('mergeable_tokens', [self::class, 'mergeableTokens']),
+        ];
+    }
+
+    public static function mergeableTokens(mixed $tokens): object
+    {
+        return new class(is_iterable($tokens) ? [...$tokens] : [$tokens]) implements \Stringable, \Twig\Extra\Html\HtmlAttr\AttributeValueInterface, \Twig\Extra\Html\HtmlAttr\MergeableInterface {
+            /** @param list<string> $tokens */
+            public function __construct(private array $tokens)
+            {
+            }
+
+            public function __toString(): string
+            {
+                return $this->getValue() ?? '';
+            }
+
+            public function getValue(): ?string
+            {
+                return $this->tokens ? implode(' ', $this->tokens) : null;
+            }
+
+            public function mergeInto(mixed $previous): mixed
+            {
+                $previousTokens = $previous instanceof self ? $previous->tokens : array_filter([(string) $previous], 'strlen');
+
+                return new self([...$previousTokens, ...$this->tokens]);
+            }
+
+            public function appendFrom(mixed $newValue): mixed
+            {
+                $newTokens = $newValue instanceof self ? $newValue->tokens : (is_iterable($newValue) ? [...$newValue] : array_filter([(string) $newValue], 'strlen'));
+
+                return new self([...$this->tokens, ...$newTokens]);
+            }
+        };
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/templates/components/MergeableBadge.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/MergeableBadge.html.twig
@@ -1,0 +1,1 @@
+<span {{ attributes.defaults({ 'data-foo': 'a b'|mergeable_tokens }) }}>badge</span>

--- a/src/TwigComponent/tests/Fixtures/templates/mergeable_tokens.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/mergeable_tokens.html.twig
@@ -1,0 +1,1 @@
+<twig:MergeableBadge data-foo="c" />

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -18,6 +18,7 @@ use Twig\Environment;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
 use Twig\Extra\Html\HtmlAttr\AttributeValueInterface;
+use Twig\Extra\Html\HtmlAttr\MergeableInterface;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -690,6 +691,21 @@ final class ComponentExtensionTest extends KernelTestCase
         // When no HTML Attr Type has been defined, the very last takes precedence
         $this->assertStringContainsString('data-no-html-attr-type="trigger"', $output);
         $this->assertStringContainsString('data-html-attr-type-cst="dialog, trigger"', $output);
+    }
+
+    public function testDefaultsWithMergeableFilter()
+    {
+        if (!interface_exists(MergeableInterface::class)) {
+            $this->markTestSkipped('Test requires Twig HTML extra >= 3.24.');
+        }
+
+        $output = self::getContainer()->get(Environment::class)->render('mergeable_tokens.html.twig');
+
+        // "data-foo" is not one of the special (class/data-controller/data-action) keys:
+        // without the MergeableInterface routing the caller value would simply override the
+        // default ("c"). Getting the merged "a b c" proves the protocol runs for any key,
+        // across the full component render.
+        $this->assertStringContainsString('data-foo="a b c"', $output);
     }
 
     private function renderComponent(string $name, array $data = []): string

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -16,6 +16,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\UX\StimulusBundle\Dto\StimulusAttributes;
 use Symfony\UX\TwigComponent\ComponentAttributes;
 use Twig\Environment;
+use Twig\Extra\Html\HtmlAttr\AttributeValueInterface;
+use Twig\Extra\Html\HtmlAttr\InlineStyle;
+use Twig\Extra\Html\HtmlAttr\MergeableInterface;
 use Twig\Loader\ArrayLoader;
 use Twig\Runtime\EscaperRuntime;
 
@@ -64,6 +67,111 @@ final class ComponentAttributesTest extends TestCase
         );
 
         $this->assertSame(['class' => 'foo'], new ComponentAttributes([], new EscaperRuntime())->defaults(['class' => 'foo'])->all());
+    }
+
+    public function testDefaultsMergesMergeableDefaultViaAppendFrom()
+    {
+        if (!interface_exists(MergeableInterface::class)) {
+            $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
+        }
+
+        // The component default is mergeable, the caller passed a plain "class".
+        $attributes = new ComponentAttributes(['class' => 'override'], new EscaperRuntime());
+
+        $merged = $attributes->defaults(['class' => $this->mergeableClasses('base-1', 'base-2')]);
+
+        // default (base) is on the left, caller (override) is appended on the right
+        $this->assertSame(' class="base-1 base-2 override"', (string) $merged);
+        $this->assertSame('base-1 base-2 override', $merged->render('class'));
+    }
+
+    public function testDefaultsMergesMergeableCallerViaMergeInto()
+    {
+        if (!interface_exists(MergeableInterface::class)) {
+            $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
+        }
+
+        // The caller passed a mergeable "class", the component default is a plain string.
+        $attributes = new ComponentAttributes(['class' => $this->mergeableClasses('override')], new EscaperRuntime());
+
+        $merged = $attributes->defaults(['class' => 'base']);
+
+        $this->assertSame(' class="base override"', (string) $merged);
+    }
+
+    public function testRenderReturnsNullWhenMergeableValueResolvesToNull()
+    {
+        if (!interface_exists(MergeableInterface::class)) {
+            $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
+        }
+
+        $attributes = new ComponentAttributes(['class' => $this->mergeableClasses()], new EscaperRuntime());
+
+        $this->assertNull($attributes->render('class'));
+    }
+
+    public function testDefaultsMergesMergeableDefaultOnNonSpecialKey()
+    {
+        if (!interface_exists(MergeableInterface::class)) {
+            $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
+        }
+
+        // "data-foo" is not a special key, yet a mergeable default is merged
+        // instead of being overwritten by the caller's plain value.
+        $attributes = new ComponentAttributes(['data-foo' => 'caller'], new EscaperRuntime());
+
+        $merged = $attributes->defaults(['data-foo' => $this->mergeableClasses('base')]);
+
+        $this->assertSame('base caller', $merged->render('data-foo'));
+    }
+
+    public function testDefaultsMergesRealMergeableOnNonSpecialKey()
+    {
+        if (!class_exists(InlineStyle::class)) {
+            $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
+        }
+
+        // Generalization with a real Twig HTML extra mergeable (InlineStyle) on "style":
+        // the caller value wins conflicts, appended after the default.
+        $attributes = new ComponentAttributes(['style' => new InlineStyle(['display: block'])], new EscaperRuntime());
+
+        $merged = $attributes->defaults(['style' => new InlineStyle(['color: red'])]);
+
+        $this->assertSame('color: red; display: block;', $merged->render('style'));
+    }
+
+    /**
+     * A minimal space-separated token list implementing the Twig HTML extra merge protocol,
+     * so these tests exercise ComponentAttributes routing without depending on a concrete
+     * implementation (e.g. tailwind_classes).
+     */
+    private function mergeableClasses(string ...$classes): object
+    {
+        return new class($classes) implements AttributeValueInterface, MergeableInterface {
+            /** @param list<string> $classes */
+            public function __construct(private array $classes)
+            {
+            }
+
+            public function getValue(): ?string
+            {
+                return $this->classes ? implode(' ', $this->classes) : null;
+            }
+
+            public function mergeInto(mixed $previous): mixed
+            {
+                $previousClasses = $previous instanceof self ? $previous->classes : array_filter([(string) $previous], 'strlen');
+
+                return new self([...$previousClasses, ...$this->classes]);
+            }
+
+            public function appendFrom(mixed $newValue): mixed
+            {
+                $newClasses = $newValue instanceof self ? $newValue->classes : array_filter([(string) $newValue], 'strlen');
+
+                return new self([...$this->classes, ...$newClasses]);
+            }
+        };
     }
 
     public function testCanGetOnly()


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3754 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT


The main interest is customizing how CSS classes are merged, especially for Tailwind. More broadly, any value passed to `attributes.defaults()` that implements twig/html-extra's `MergeableInterface` is now merged through its own merge protocol, for every attribute key, not just the special `class` / `data-controller` / `data-action` ones. Plain (non-mergeable) values keep the existing behavior (space-concatenation for those three keys, override otherwise), so this is fully backward compatible.

This is a big win for our UX Toolkit kits based on Tailwind, meaning that we can now write:
```twig
<span
    {# ... #}
    {{ attributes.defaults({
        class: 'a bunch of tailwind classes' | tailwind_classes
    }) }}
>
    {# ... #}
</span>
```

instead of:

```twig
<span
    {# ... #}
    class="{{ ('a bunch of tailwind classes' ~ attributes.render('class')) | tailwind_merge }}"
    {{ attributes }}
>
    {# ... #}
</span>
```

## Notes

The `tailwind_classes` filter used in the example comes from [tales-from-a-dev/twig-tailwind-extra](https://github.com/tales-from-a-dev/twig-tailwind-extra), added in [PR #27](https://github.com/tales-from-a-dev/twig-tailwind-extra/pull/27). Until that lands in a tagged release, this PR wires it via a `repositories` VCS entry and a `dev-feature/tailwind-classes-filter` constraint in `composer.json` (require-dev only); needs to be swapped for the real version before merge.

`twig/html-extra` is a soft dependency: the `MergeableInterface` routing is guarded with `interface_exists` checks and graceful `instanceof` guards, so nothing breaks when the package isn't installed.
