### PR TITLE
 Add a local release.sh to cut npm releases

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,26 +1,29 @@
 # Maintainers' guide
 
-This document is for Symfony UX maintainers. It collects procedures that are not
-needed by regular contributors.
+This document is for Symfony UX maintainers. It covers procedures that regular contributors don't need.
 
-## Releasing UX packages on NPM
+## Releasing UX packages on npm
 
-The Git tag is the source of truth for the released version. The
-`release-on-npm.yaml` workflow refuses to publish if any workspace
-`package.json` does not match the tag — bump and commit **before** tagging.
+The Git tag is the source of truth for the released version. Workspace `package.json` files must already match the tag at publish time — `release-on-npm.yaml` publishes whatever versions are committed and does not verify that they match the tag.
 
-From the release branch (`2.x` or `3.x`), with `upstream` pointing to `symfony/ux`:
+`release.sh` keeps everything in sync. It rebuilds assets to confirm the committed `dist/` files are up to date, bumps every workspace `package.json`, commits `Bump npm packages to v2.37.0`, and creates the signed `v2.37.0` tag — all in one step. Nothing is pushed.
+
+From the release branch, with `upstream` pointing to `symfony/ux`:
 
 ```shell
 $ git checkout 2.x # or 3.x
-$ VERSION=2.36.0 && \
-  pnpm install --frozen-lockfile && \
-  pnpm build && \
-  pnpm version $VERSION --no-git-tag-version --workspaces --no-workspaces-update && \
-  git add . && \
-  git commit -m "Bump npm packages to v$VERSION"
-$ git push upstream HEAD
+$ git pull upstream 2.x
+$ ./release.sh 2.37.0
 ```
 
-The tag is created and pushed afterwards by following the Symfony's release process.
-The `release-on-npm.yaml` workflow then publishes via OIDC trusted publisher.
+Review the commit and tag, then push:
+
+```shell
+$ git push upstream 2.x --follow-tags
+```
+
+Pushing the tag triggers `release-on-npm.yaml`, which publishes each package to npm via the OIDC trusted publisher.
+
+## Splitting packages into read-only repositories
+
+Each `symfony/ux-*` package lives in its own read-only repository split from this monorepo, managed on the [split.sh dashboard](https://go.split.sh/dashboard#project-symfonyux).

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Cut a release: bump every workspace package.json, commit, and tag it.
+#
+# Usage: ./release.sh <x.y.z>
+#
+# It only prepares the commit and tag locally. Pushing the tag is left to you,
+# because that is what triggers the npm publish (see MAINTAINERS.md).
+
+set -euo pipefail
+
+version="${1:-}"
+if [ -z "$version" ]; then
+    echo "Usage: $0 <x.y.z>" >&2
+    exit 1
+fi
+
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    echo "Error: invalid version '$version'. Expected semver without leading 'v' (e.g. 3.3.0 or 3.3.0-rc1)." >&2
+    exit 1
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" != "2.x" ] && [ "$branch" != "3.x" ]; then
+    echo "Error: releases are cut from '2.x' or '3.x', but you are on '$branch'." >&2
+    exit 1
+fi
+
+if [ "${version%%.*}" != "${branch%%.*}" ]; then
+    echo "Error: version '$version' does not match branch '$branch' (major version mismatch)." >&2
+    exit 1
+fi
+
+tag="v${version}"
+if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+    echo "Error: tag '$tag' already exists." >&2
+    exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Error: the working tree is not clean. Commit or stash your changes first." >&2
+    exit 1
+fi
+
+git fetch --quiet upstream "$branch"
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then
+    echo "Error: local '$branch' is not in sync with 'upstream/$branch'. Pull first." >&2
+    exit 1
+fi
+
+# release-on-npm.yaml publishes the committed dist/ files as-is, so rebuild them
+# and refuse to tag if they drift from the committed sources.
+pnpm install --frozen-lockfile
+pnpm build
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Error: built dist files differ from the committed ones. Rebuild and commit them first." >&2
+    git status --porcelain >&2
+    exit 1
+fi
+
+# Recursive mode bumps every workspace package.json but always skips the commit
+# and tag (and leaves the private root package untouched), so we do both by hand.
+pnpm version "$version" --recursive --no-git-checks
+if [ -z "$(git status --porcelain)" ]; then
+    echo "Error: no package.json changes after 'pnpm version'. Version '$version' may already be set." >&2
+    exit 1
+fi
+
+git commit -a -m "Bump npm packages to $tag"
+git tag -s -m "Create tag $tag" "$tag"
+
+echo
+echo "Prepared $tag. Review the commit and tag, then publish with:"
+echo
+echo "    git push upstream $branch --follow-tags"
+echo
+echo "Pushing $tag triggers the Release on NPM workflow, which publishes to npm."


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

As discussed on Slack with the team. 

Following https://github.com/symfony/ux/issues/3522#issuecomment-5231998827, and the fact that creating a git tag is enough to release UX, it means that we can now have a little script for bumping versions in `package.json` + create the associated git tag. 

The "publish on npm" stays as git workflow, for the OIDC thing (the green medal on npm)