### PR TITLE
[TwigComponent] Fix twig:blockquote is not a block

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -455,6 +455,11 @@ class TwigPreLexer
             && 0 === substr_compare($this->input, $chars, $this->position, \strlen($chars));
     }
 
+    private function isNameChar(string $char): bool
+    {
+        return '' !== $char && (ctype_alnum($char) || str_contains('_:@-.', $char));
+    }
+
     private function consumeBlock(string $componentName): string
     {
         $attributes = $this->consumeAttributes($componentName);
@@ -542,7 +547,9 @@ class TwigPreLexer
                         }
 
                         --$depth;
-                    } elseif ('<twig:block' === substr($this->input, $this->position, 11)) {
+                    } elseif ('<twig:block' === substr($this->input, $this->position, 11)
+                        && !$this->isNameChar($this->input[$this->position + 11] ?? '')
+                    ) {
                         ++$depth;
                     }
                     break;

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -110,6 +110,52 @@ final class TwigPreLexerTest extends TestCase
             '{% component \'foo\' %}{% block foo_block %}{% component \'bar\' %}{% block content %}{{ component(\'baz\') }}{% endblock %}{% endcomponent %}{% endblock %}{% endcomponent %}',
         ];
 
+        yield 'block_prefixed_component_name' => [
+            '<twig:foo><twig:block name="foo_block"><twig:blockquote>Quote</twig:blockquote></twig:block></twig:foo>',
+            '{% component \'foo\' %}{% block foo_block %}{% component \'blockquote\' %}{% block content %}Quote{% endblock %}{% endcomponent %}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'block_prefixed_component_name_self_closing' => [
+            '<twig:foo><twig:block name="foo_block"><twig:blockquote /></twig:block></twig:foo>',
+            '{% component \'foo\' %}{% block foo_block %}{{ component(\'blockquote\') }}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'block_prefixed_component_name_with_dash' => [
+            '<twig:foo><twig:block name="foo_block"><twig:block-title /></twig:block></twig:foo>',
+            '{% component \'foo\' %}{% block foo_block %}{{ component(\'block-title\') }}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'block_prefixed_component_name_with_colon' => [
+            '<twig:foo><twig:block name="foo_block"><twig:block:title /></twig:block></twig:foo>',
+            '{% component \'foo\' %}{% block foo_block %}{{ component(\'block:title\') }}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'block_prefixed_component_name_with_suffix' => [
+            '<twig:foo><twig:block name="foo_block"><twig:blocked /></twig:block></twig:foo>',
+            '{% component \'foo\' %}{% block foo_block %}{{ component(\'blocked\') }}{% endblock %}{% endcomponent %}',
+        ];
+
+        // a traditional block does not pre-lex the components nested in it, hence the verbatim tag
+        yield 'block_prefixed_component_name_in_traditional_block' => [
+            '<twig:foo>{% block foo_block %}<twig:blockquote />{% endblock %}</twig:foo>',
+            '{% component \'foo\' %}{% block foo_block %}<twig:blockquote />{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'block_prefixed_component_name_capitalized' => [
+            '<twig:foo><twig:block name="foo_block"><twig:Blockquote /></twig:block></twig:foo>',
+            '{% component \'foo\' %}{% block foo_block %}{{ component(\'Blockquote\') }}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'block_prefixed_component_name_outside_block' => [
+            '<twig:foo><twig:blockquote /></twig:foo>',
+            '{% component \'foo\' %}{% block content %}{{ component(\'blockquote\') }}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'block_prefixed_component_name_around_a_real_nested_block' => [
+            '<twig:foo><twig:block name="a"><twig:blockquote /><twig:bar><twig:block name="b">x</twig:block></twig:bar></twig:block></twig:foo>',
+            '{% component \'foo\' %}{% block a %}{{ component(\'blockquote\') }}{% component \'bar\' %}{% block b %}x{% endblock %}{% endcomponent %}{% endblock %}{% endcomponent %}',
+        ];
+
         yield 'component_with_embedded_component' => [
             '<twig:foo>foo_content<twig:bar><twig:baz /></twig:bar></twig:foo>',
             '{% component \'foo\' %}{% block content %}foo_content{% component \'bar\' %}{% block content %}{{ component(\'baz\') }}{% endblock %}{% endcomponent %}{% endblock %}{% endcomponent %}',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A component whose name starts with `block` breaks the block it sits in.

## Reproducer

```twig
<twig:Card>
    <twig:block name="footer">
        <twig:blockquote cite="Matt">He ho!</twig:blockquote>
    </twig:block>
</twig:Card>
```

```
Twig\Error\SyntaxError: Expected closing tag "</twig:Card>" not found at line 5.
```

The error points at `Card`, which is correctly closed, and at the last line of the
template. Nothing mentions `blockquote`, so there is little to go on.

Same failure with `<twig:blockquote />`, `<twig:block-title />`, `<twig:blocked />`, and
inside a traditional `{% block %} … {% endblock %}`.

Not affected: `<twig:Blockquote />` (the comparison is case-sensitive), and any of these
outside a block.

## Cause

`TwigPreLexer::consumeUntilEndBlock()` tracks block nesting with a fixed-length prefix
comparison:

```php
if (!$inComment && '<twig:block' === substr($this->input, $this->position, 11)) {
    ++$depth;
}
```

`'<twig:block'` is also the first 11 characters of `<twig:blockquote`, so the depth is
incremented for a component that is not a block. It is never decremented back: the
closing comparison is `'</twig:block>'`, which ends with `>` and therefore does not
match `</twig:blockquote>`. The enclosing `<twig:block>` never terminates, scanning runs
to the end of the template, and the outer component is reported as unclosed.

## Fix

Anchor the match and require that `block` is not followed by another component-name
character, using the same character class as `consumeComponentName()`:

```php
if (!$inComment && preg_match('/\G<twig:block(?![A-Za-z0-9_:@\-.])/', $this->input, $matches, 0, $this->position)) {
    ++$depth;
}
```

The closing comparison needs no change.
