### PR TITLE
[Autocomplete] Translate the optgroup labels returned by the AJAX endpoint

### DIFF
--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+
+- Translate the `optgroup` labels returned by the AJAX endpoint, so that the `group_by`
+  option can use translation keys, like the ones rendered by the form theme already do.
+  The `getTranslationDomain()` method can be implemented by custom autocompleters to
+  choose the domain; entity autocomplete fields use their `choice_translation_domain` option.
+
 ## 2.36.2
 
 - Fix the autocomplete search query throwing an exception on PostgreSQL because of

--- a/src/Autocomplete/CHANGELOG.md
+++ b/src/Autocomplete/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 3.5
+
+- Translate the `optgroup` labels returned by the AJAX endpoint, so `group_by` can use translation keys
+- Add `EntityAutocompleterInterface::getTranslationDomain()` to choose the translation domain used for the `optgroup` labels
+
 ## 3.2
 
 - Fix the XSS vulnerability fix introduced in 3.1, which was broken on PostgreSQL. See section 2.36.2 below for details.

--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -29,7 +29,8 @@
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-foundation": "^6.3|^7.0|^8.0",
         "symfony/http-kernel": "^6.3|^7.0|^8.0",
-        "symfony/property-access": "^6.3|^7.0|^8.0"
+        "symfony/property-access": "^6.3|^7.0|^8.0",
+        "symfony/translation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "doctrine/collections": "^1.6.8|^2.0",
@@ -44,6 +45,7 @@
         "symfony/phpunit-bridge": "^6.3|^7.0|^8.0",
         "symfony/process": "^6.3|^7.0|^8.0",
         "symfony/security-bundle": "^6.3|^7.0|^8.0",
+        "symfony/translation": "^6.3|^7.0|^8.0",
         "symfony/twig-bundle": "^6.3|^7.0|^8.0",
         "symfony/uid": "^6.3|^7.0|^8.0",
         "twig/twig": "^2.14.7|^3.0.4",

--- a/src/Autocomplete/composer.json
+++ b/src/Autocomplete/composer.json
@@ -29,7 +29,8 @@
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-foundation": "^7.4|^8.0",
         "symfony/http-kernel": "^7.4|^8.0",
-        "symfony/property-access": "^7.4|^8.0"
+        "symfony/property-access": "^7.4|^8.0",
+        "symfony/translation-contracts": "^3.0"
     },
     "require-dev": {
         "doctrine/collections": "^1.6.8|^2.0",
@@ -44,6 +45,7 @@
         "symfony/maker-bundle": "^1.40",
         "symfony/process": "^7.4|^8.0",
         "symfony/security-bundle": "^7.4|^8.0",
+        "symfony/translation": "^7.4|^8.0",
         "symfony/twig-bundle": "^7.4|^8.0",
         "symfony/uid": "^7.4|^8.0",
         "twig/twig": "^2.14.7|^3.0.4",

--- a/src/Autocomplete/src/AutocompleteResultsExecutor.php
+++ b/src/Autocomplete/src/AutocompleteResultsExecutor.php
@@ -19,6 +19,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\UX\Autocomplete\Doctrine\DoctrineRegistryWrapper;
 
 /**
@@ -28,19 +30,22 @@ final class AutocompleteResultsExecutor
 {
     private PropertyAccessorInterface $propertyAccessor;
     private ?Security $security;
+    private ?TranslatorInterface $translator;
 
     public function __construct(
         private DoctrineRegistryWrapper $managerRegistry,
         $propertyAccessor,
-        /* Security $security = null */
+        /* Security $security = null, TranslatorInterface $translator = null */
     ) {
         if ($propertyAccessor instanceof Security) {
             trigger_deprecation('symfony/ux-autocomplete', '2.8.0', 'Passing a "%s" instance as the second argument of "%s()" is deprecated, pass a "%s" instance instead.', Security::class, __METHOD__, PropertyAccessorInterface::class);
             $this->security = $propertyAccessor;
             $this->propertyAccessor = new PropertyAccessor();
+            $this->translator = \func_num_args() >= 3 ? func_get_arg(2) : null;
         } else {
             $this->propertyAccessor = $propertyAccessor;
             $this->security = \func_num_args() >= 3 ? func_get_arg(2) : null;
+            $this->translator = \func_num_args() >= 4 ? func_get_arg(3) : null;
         }
     }
 
@@ -98,7 +103,9 @@ final class AutocompleteResultsExecutor
             throw new \InvalidArgumentException(\sprintf('Option "group_by" must be callable, "%s" given.', get_debug_type($groupBy)));
         }
 
-        $optgroupLabels = [];
+        $translationDomain = method_exists($autocompleter, 'getTranslationDomain') ? $autocompleter->getTranslationDomain() : null;
+
+        $optgroups = [];
 
         foreach ($paginator as $entity) {
             $result = $this->formatResult($autocompleter, $entity);
@@ -106,17 +113,39 @@ final class AutocompleteResultsExecutor
             $groupLabels = $groupBy($entity, $result['value'], $result['text']);
 
             if (null !== $groupLabels) {
-                $groupLabels = \is_array($groupLabels) ? array_map('strval', $groupLabels) : [(string) $groupLabels];
-                $result['group_by'] = $groupLabels;
-                $optgroupLabels = array_merge($optgroupLabels, $groupLabels);
+                $groupLabels = \is_array($groupLabels) ? $groupLabels : [$groupLabels];
+                $groupValues = [];
+
+                foreach ($groupLabels as $groupLabel) {
+                    $label = $this->translateGroupLabel($groupLabel, $translationDomain);
+                    // the value ties the results to their optgroup: keep the untranslated
+                    // one whenever it is available, so that it does not depend on the locale
+                    $value = $groupLabel instanceof TranslatableInterface ? $label : (string) $groupLabel;
+
+                    $groupValues[] = $value;
+                    $optgroups[$value] ??= ['value' => $value, 'label' => $label];
+                }
+
+                $result['group_by'] = $groupValues;
             }
 
             $results[] = $result;
         }
 
-        $optgroups = array_map(static fn (string $label) => ['value' => $label, 'label' => $label], array_unique($optgroupLabels));
+        return new AutocompleteResults($results, $hasNextPage, array_values($optgroups));
+    }
 
-        return new AutocompleteResults($results, $hasNextPage, $optgroups);
+    private function translateGroupLabel(mixed $groupLabel, string|false|null $translationDomain): string
+    {
+        if (null === $this->translator || false === $translationDomain) {
+            return (string) $groupLabel;
+        }
+
+        if ($groupLabel instanceof TranslatableInterface) {
+            return $groupLabel->trans($this->translator);
+        }
+
+        return $this->translator->trans((string) $groupLabel, [], $translationDomain);
     }
 
     /**

--- a/src/Autocomplete/src/AutocompleteResultsExecutor.php
+++ b/src/Autocomplete/src/AutocompleteResultsExecutor.php
@@ -18,6 +18,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\UX\Autocomplete\Doctrine\DoctrineRegistryWrapper;
 
 /**
@@ -29,6 +31,7 @@ final class AutocompleteResultsExecutor
         private DoctrineRegistryWrapper $managerRegistry,
         private PropertyAccessorInterface $propertyAccessor,
         private ?Security $security = null,
+        private ?TranslatorInterface $translator = null,
     ) {
     }
 
@@ -86,7 +89,9 @@ final class AutocompleteResultsExecutor
             throw new \InvalidArgumentException(\sprintf('Option "group_by" must be callable, "%s" given.', get_debug_type($groupBy)));
         }
 
-        $optgroupLabels = [];
+        $translationDomain = method_exists($autocompleter, 'getTranslationDomain') ? $autocompleter->getTranslationDomain() : null;
+
+        $optgroups = [];
 
         foreach ($paginator as $entity) {
             $result = $this->formatResult($autocompleter, $entity);
@@ -94,17 +99,39 @@ final class AutocompleteResultsExecutor
             $groupLabels = $groupBy($entity, $result['value'], $result['text']);
 
             if (null !== $groupLabels) {
-                $groupLabels = \is_array($groupLabels) ? array_map('strval', $groupLabels) : [(string) $groupLabels];
-                $result['group_by'] = $groupLabels;
-                $optgroupLabels = array_merge($optgroupLabels, $groupLabels);
+                $groupLabels = \is_array($groupLabels) ? $groupLabels : [$groupLabels];
+                $groupValues = [];
+
+                foreach ($groupLabels as $groupLabel) {
+                    $label = $this->translateGroupLabel($groupLabel, $translationDomain);
+                    // the value ties the results to their optgroup: keep the untranslated
+                    // one whenever it is available, so that it does not depend on the locale
+                    $value = $groupLabel instanceof TranslatableInterface ? $label : (string) $groupLabel;
+
+                    $groupValues[] = $value;
+                    $optgroups[$value] ??= ['value' => $value, 'label' => $label];
+                }
+
+                $result['group_by'] = $groupValues;
             }
 
             $results[] = $result;
         }
 
-        $optgroups = array_map(static fn (string $label) => ['value' => $label, 'label' => $label], array_unique($optgroupLabels));
+        return new AutocompleteResults($results, $hasNextPage, array_values($optgroups));
+    }
 
-        return new AutocompleteResults($results, $hasNextPage, $optgroups);
+    private function translateGroupLabel(mixed $groupLabel, string|false|null $translationDomain): string
+    {
+        if (null === $this->translator || false === $translationDomain) {
+            return (string) $groupLabel;
+        }
+
+        if ($groupLabel instanceof TranslatableInterface) {
+            return $groupLabel->trans($this->translator);
+        }
+
+        return $this->translator->trans((string) $groupLabel, [], $translationDomain);
     }
 
     /**

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
@@ -94,6 +94,7 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
                 new Reference('ux.autocomplete.doctrine_registry_wrapper'),
                 new Reference('property_accessor'),
                 new Reference('security.helper', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                new Reference('translator', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
         ;
 

--- a/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
+++ b/src/Autocomplete/src/DependencyInjection/AutocompleteExtension.php
@@ -93,6 +93,7 @@ final class AutocompleteExtension extends Extension implements PrependExtensionI
                 new Reference('ux.autocomplete.doctrine_registry_wrapper'),
                 new Reference('property_accessor'),
                 new Reference('security.helper', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                new Reference('translator', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
         ;
 

--- a/src/Autocomplete/src/EntityAutocompleterInterface.php
+++ b/src/Autocomplete/src/EntityAutocompleterInterface.php
@@ -22,8 +22,9 @@ use Symfony\Bundle\SecurityBundle\Security;
  *
  * TODO Remove next lines for Symfony UX 3
  *
- * @method array getAttributes(object $entity) Returns extra attributes to add to the autocomplete result.
- * @method mixed getGroupBy()                  Return group_by option.
+ * @method array             getAttributes(object $entity) Returns extra attributes to add to the autocomplete result.
+ * @method mixed             getGroupBy()                  Return group_by option.
+ * @method string|false|null getTranslationDomain()        Return the translation domain used for the "group_by" labels.
  */
 interface EntityAutocompleterInterface
 {
@@ -75,4 +76,13 @@ interface EntityAutocompleterInterface
      * TODO Uncomment for Symfony UX 3
      */
     /* public function getGroupBy(): mixed; */
+
+    /*
+     * Return the translation domain used for the "group_by" labels.
+     *
+     * Returning null uses the default domain, false disables the translation.
+     *
+     * TODO Uncomment for Symfony UX 3
+     */
+    /* public function getTranslationDomain(): string|false|null; */
 }

--- a/src/Autocomplete/src/EntityAutocompleterInterface.php
+++ b/src/Autocomplete/src/EntityAutocompleterInterface.php
@@ -19,6 +19,10 @@ use Symfony\Bundle\SecurityBundle\Security;
  * Interface for classes that will have an "autocomplete" endpoint exposed.
  *
  * @template T of object
+ *
+ * TODO Remove next lines for Symfony UX 4
+ *
+ * @method string|false|null getTranslationDomain() Return the translation domain used for the "group_by" labels.
  */
 interface EntityAutocompleterInterface
 {
@@ -72,4 +76,13 @@ interface EntityAutocompleterInterface
      * @return string|null
      */
     public function getGroupBy(): mixed;
+
+    /*
+     * Return the translation domain used for the "group_by" labels.
+     *
+     * Returning null uses the default domain, false disables the translation.
+     *
+     * TODO Uncomment for Symfony UX 4
+     */
+    /* public function getTranslationDomain(): string|false|null; */
 }

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -138,6 +138,14 @@ final class WrappedEntityTypeAutocompleter implements OptionsAwareEntityAutocomp
         return $this->getFormOption('group_by');
     }
 
+    public function getTranslationDomain(): string|false|null
+    {
+        // the "choice_translation_domain" option is normalized to the form
+        // "translation_domain" when it is true, and to false when translation
+        // is disabled
+        return $this->getFormOption('choice_translation_domain');
+    }
+
     private function getFormOption(string $name): mixed
     {
         $form = $this->getForm();

--- a/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
+++ b/src/Autocomplete/src/Form/WrappedEntityTypeAutocompleter.php
@@ -157,6 +157,14 @@ final class WrappedEntityTypeAutocompleter implements OptionsAwareEntityAutocomp
         throw new \InvalidArgumentException('The "additional_attributes" option must be either an array or a callable.');
     }
 
+    public function getTranslationDomain(): string|false|null
+    {
+        // the "choice_translation_domain" option is normalized to the form
+        // "translation_domain" when it is true, and to false when translation
+        // is disabled
+        return $this->getFormOption('choice_translation_domain');
+    }
+
     private function getFormOption(string $name): mixed
     {
         $form = $this->getForm();

--- a/src/Autocomplete/tests/Fixtures/Autocompleter/CustomGroupByTranslatedProductAutocompleter.php
+++ b/src/Autocomplete/tests/Fixtures/Autocompleter/CustomGroupByTranslatedProductAutocompleter.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter;
+
+class CustomGroupByTranslatedProductAutocompleter extends CustomGroupByProductAutocompleter
+{
+    public function getTranslationDomain(): string|false|null
+    {
+        return 'autocomplete';
+    }
+}

--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -35,6 +35,7 @@ use Symfony\UX\Autocomplete\AutocompleteBundle;
 use Symfony\UX\Autocomplete\DependencyInjection\AutocompleteFormTypePass;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomAttributesProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByProductAutocompleter;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByTranslatedProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Form\CategoryWithCallbackAsCustomValue;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Form\CategoryWithPropertyNameAsCustomValue;
@@ -102,6 +103,10 @@ final class Kernel extends BaseKernel
             'secrets' => false,
             'session' => ['storage_factory_id' => 'session.storage.factory.mock_file'],
             'form' => ['enabled' => $this->enableForms],
+            'translator' => [
+                'default_path' => '%kernel.project_dir%/tests/Fixtures/translations',
+                'fallbacks' => ['en'],
+            ],
         ]);
 
         $c->extension('twig', [
@@ -189,6 +194,13 @@ final class Kernel extends BaseKernel
             ->arg(1, new Reference('ux.autocomplete.entity_search_util'))
             ->tag(AutocompleteFormTypePass::ENTITY_AUTOCOMPLETER_TAG, [
                 'alias' => 'custom_group_by_product',
+            ]);
+
+        $services->set(CustomGroupByTranslatedProductAutocompleter::class)
+            ->public()
+            ->arg(1, new Reference('ux.autocomplete.entity_search_util'))
+            ->tag(AutocompleteFormTypePass::ENTITY_AUTOCOMPLETER_TAG, [
+                'alias' => 'custom_group_by_translated_product',
             ]);
 
         $services->set(CustomAttributesProductAutocompleter::class)

--- a/src/Autocomplete/tests/Fixtures/Kernel.php
+++ b/src/Autocomplete/tests/Fixtures/Kernel.php
@@ -35,6 +35,7 @@ use Symfony\UX\Autocomplete\AutocompleteBundle;
 use Symfony\UX\Autocomplete\DependencyInjection\AutocompleteFormTypePass;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomAttributesProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByProductAutocompleter;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByTranslatedProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Form\CategoryWithCallbackAsCustomValue;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Form\CategoryWithPropertyNameAsCustomValue;
@@ -102,6 +103,10 @@ final class Kernel extends BaseKernel
             'secrets' => false,
             'session' => ['storage_factory_id' => 'session.storage.factory.mock_file'],
             'form' => ['enabled' => $this->enableForms],
+            'translator' => [
+                'default_path' => '%kernel.project_dir%/tests/Fixtures/translations',
+                'fallbacks' => ['en'],
+            ],
         ]);
 
         $c->extension('twig', [
@@ -192,6 +197,13 @@ final class Kernel extends BaseKernel
             ->arg(1, new Reference('ux.autocomplete.entity_search_util'))
             ->tag(AutocompleteFormTypePass::ENTITY_AUTOCOMPLETER_TAG, [
                 'alias' => 'custom_group_by_product',
+            ]);
+
+        $services->set(CustomGroupByTranslatedProductAutocompleter::class)
+            ->public()
+            ->arg(1, new Reference('ux.autocomplete.entity_search_util'))
+            ->tag(AutocompleteFormTypePass::ENTITY_AUTOCOMPLETER_TAG, [
+                'alias' => 'custom_group_by_translated_product',
             ]);
 
         $services->set(CustomAttributesProductAutocompleter::class)

--- a/src/Autocomplete/tests/Fixtures/translations/autocomplete.en.php
+++ b/src/Autocomplete/tests/Fixtures/translations/autocomplete.en.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    'foods' => 'Food & drinks',
+    'toys' => 'Toys',
+];

--- a/src/Autocomplete/tests/Integration/WiringTest.php
+++ b/src/Autocomplete/tests/Integration/WiringTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\UX\Autocomplete\AutocompleteResultsExecutor;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByProductAutocompleter;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByTranslatedProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Factory\CategoryFactory;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Factory\ProductFactory;
@@ -93,6 +94,37 @@ class WiringTest extends KernelTestCase
         $autocompleter = $kernel->getContainer()->get(CustomGroupByProductAutocompleter::class);
         $data = $executor->fetchResults($autocompleter, '', 1);
         $this->assertCount(3, $data->results);
-        $this->assertCount(2, $data->optgroups);
+        $this->assertSame([
+            ['value' => 'foods', 'label' => 'foods'],
+            ['value' => 'toys', 'label' => 'toys'],
+        ], $data->optgroups);
+    }
+
+    public function testWiringWithoutFormAndTranslatedGroupByOption()
+    {
+        $kernel = new Kernel('test', true);
+        $kernel->disableForms();
+        $kernel->boot();
+
+        $category1 = CategoryFactory::createOne(['name' => 'foods']);
+        $category2 = CategoryFactory::createOne(['name' => 'toys']);
+        ProductFactory::createOne(['name' => 'pizza', 'category' => $category1]);
+        ProductFactory::createOne(['name' => 'toy food', 'category' => $category2]);
+        ProductFactory::createOne(['name' => 'puzzle', 'category' => $category2]);
+
+        /** @var AutocompleteResultsExecutor $executor */
+        $executor = $kernel->getContainer()->get('public.results_executor');
+        $autocompleter = $kernel->getContainer()->get(CustomGroupByTranslatedProductAutocompleter::class);
+        $data = $executor->fetchResults($autocompleter, '', 1);
+
+        $this->assertCount(3, $data->results);
+        // the label is translated, while the value stays untranslated so that it
+        // keeps tying the results to their optgroup whatever the locale is
+        $this->assertSame([
+            ['value' => 'foods', 'label' => 'Food & drinks'],
+            ['value' => 'toys', 'label' => 'Toys'],
+        ], $data->optgroups);
+        $this->assertSame(['foods'], $data->results[0]['group_by']);
+        $this->assertSame(['toys'], $data->results[1]['group_by']);
     }
 }

--- a/src/Autocomplete/tests/Integration/WiringTest.php
+++ b/src/Autocomplete/tests/Integration/WiringTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\UX\Autocomplete\AutocompleteResultsExecutor;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByProductAutocompleter;
+use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomGroupByTranslatedProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Autocompleter\CustomProductAutocompleter;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Factory\CategoryFactory;
 use Symfony\UX\Autocomplete\Tests\Fixtures\Factory\ProductFactory;
@@ -93,6 +94,37 @@ class WiringTest extends KernelTestCase
         $autocompleter = $kernel->getContainer()->get(CustomGroupByProductAutocompleter::class);
         $data = $executor->fetchResults($autocompleter, '', 1);
         $this->assertCount(3, $data->results);
-        $this->assertCount(2, $data->optgroups);
+        $this->assertSame([
+            ['value' => 'foods', 'label' => 'foods'],
+            ['value' => 'toys', 'label' => 'toys'],
+        ], $data->optgroups);
+    }
+
+    public function testWiringWithoutFormAndTranslatedGroupByOption(): void
+    {
+        $kernel = new Kernel('test', true);
+        $kernel->disableForms();
+        $kernel->boot();
+
+        $category1 = CategoryFactory::createOne(['name' => 'foods']);
+        $category2 = CategoryFactory::createOne(['name' => 'toys']);
+        ProductFactory::createOne(['name' => 'pizza', 'category' => $category1]);
+        ProductFactory::createOne(['name' => 'toy food', 'category' => $category2]);
+        ProductFactory::createOne(['name' => 'puzzle', 'category' => $category2]);
+
+        /** @var AutocompleteResultsExecutor $executor */
+        $executor = $kernel->getContainer()->get('public.results_executor');
+        $autocompleter = $kernel->getContainer()->get(CustomGroupByTranslatedProductAutocompleter::class);
+        $data = $executor->fetchResults($autocompleter, '', 1);
+
+        $this->assertCount(3, $data->results);
+        // the label is translated, while the value stays untranslated so that it
+        // keeps tying the results to their optgroup whatever the locale is
+        $this->assertSame([
+            ['value' => 'foods', 'label' => 'Food & drinks'],
+            ['value' => 'toys', 'label' => 'Toys'],
+        ], $data->optgroups);
+        $this->assertSame(['foods'], $data->results[0]['group_by']);
+        $this->assertSame(['toys'], $data->results[1]['group_by']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Issues        | -
| License       | MIT

The `group_by` option of an autocomplete field produces the `<optgroup>` labels. When the `<select>` is rendered by the form theme, those labels go through `|trans`:

```twig
<optgroup label="{{ choice_translation_domain is same as(false) ? group_label : group_label|trans({}, choice_translation_domain) }}">
```

But the labels sent as JSON by the autocomplete endpoint are emitted verbatim by `AutocompleteResultsExecutor`:

```php
$optgroups = array_map(static fn (string $label) => ['value' => $label, 'label' => $label], array_unique($optgroupLabels));
```

For an AJAX autocompleter this is the path that matters: the server-rendered `<select>` only holds the preselected option(s), so every group the user sees while typing comes from that JSON. Using a translation key in `group_by` therefore shows the raw key. It also makes the labels disagree with the server-rendered ones, which the Stimulus controller looks up by label:

```ts
const optgroupElement = parentElement.querySelector(`optgroup[label="${optgroupData.label}"]`);
```

### What this PR does

* `AutocompleteResultsExecutor` takes an optional `TranslatorInterface` and translates the optgroup labels. Values returned by `group_by` that implement `TranslatableInterface` are no longer cast to string either (casting a `TranslatableMessage` is a fatal error).
* The domain comes from a new optional `getTranslationDomain(): string|false|null` method on the autocompleter — `null` uses the default domain, `false` disables the translation. It is declared as a `@method` on `EntityAutocompleterInterface` and commented out in the interface body, like `getGroupBy()`, and detected with `method_exists()`, so existing autocompleters keep working untouched.
* `WrappedEntityTypeAutocompleter` implements it by reading the field's `choice_translation_domain` option, which is exactly what the form theme uses. So the AJAX results and the rendered `<select>` now agree.
* The optgroup `value` keeps the untranslated label, so it still ties a result to its group whatever the locale is. Only the `label` is translated.

### BC

The translator is an optional constructor argument wired with `NULL_ON_INVALID_REFERENCE`, and without it the previous behavior is kept. Autocompleters that do not implement `getTranslationDomain()` translate in the default domain, which matches what the form theme already does for the same labels.
