### PR TITLE
[TwigComponent] Fix {% verbatim %} pre-lexing

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -19,6 +19,9 @@ use Twig\Lexer;
  */
 class TwigPreLexer
 {
+    private const VERBATIM_REGEX = '/\G\{%[-~]?\s*verbatim\s*[-~]?%\}/';
+    private const ENDVERBATIM_REGEX = '/\{%[-~]?\s*endverbatim\s*[-~]?%\}/';
+
     private string $input;
     private int $length;
     private int $position = 0;
@@ -47,11 +50,14 @@ class TwigPreLexer
 
         while ($this->position < $this->length) {
             // ignore content inside verbatim block #947
-            if ($this->consume('{% verbatim %}')) {
-                $output .= '{% verbatim %}';
-                $output .= $this->consumeUntil('{% endverbatim %}');
-                $this->consume('{% endverbatim %}');
-                $output .= '{% endverbatim %}';
+            if ('{' === $this->input[$this->position] && preg_match(self::VERBATIM_REGEX, $this->input, $matches, 0, $this->position)) {
+                if (!empty($this->currentComponents)
+                    && !$this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock']) {
+                    $output .= '{% block content %}';
+                    $this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock'] = true;
+                }
+
+                $output .= $this->consumeVerbatim($matches[0]);
 
                 if ($this->position === $this->length) {
                     break;
@@ -197,6 +203,26 @@ class TwigPreLexer
         }
 
         return $output;
+    }
+
+    /**
+     * Consumes a whole verbatim block, opening tag included, and returns it unchanged.
+     */
+    private function consumeVerbatim(string $openingTag): string
+    {
+        $this->line += substr_count($openingTag, "\n");
+        $this->position += \strlen($openingTag);
+
+        if (!preg_match(self::ENDVERBATIM_REGEX, $this->input, $matches, \PREG_OFFSET_CAPTURE, $this->position)) {
+            $consumed = substr($this->input, $this->position);
+        } else {
+            $consumed = substr($this->input, $this->position, $matches[0][1] - $this->position + \strlen($matches[0][0]));
+        }
+
+        $this->line += substr_count($consumed, "\n");
+        $this->position += \strlen($consumed);
+
+        return $openingTag.$consumed;
     }
 
     private function consumeComponentName(?string $customExceptionMessage = null): string

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -348,6 +348,46 @@ final class TwigPreLexerTest extends TestCase
             '{% verbatim %}<twig:Alert/>{% endverbatim %}',
         ];
 
+        yield 'ignore_content_of_verbatim_block_with_whitespace_trim' => [
+            '{%- verbatim -%}<twig:Alert/>{%- endverbatim -%}',
+            '{%- verbatim -%}<twig:Alert/>{%- endverbatim -%}',
+        ];
+
+        yield 'ignore_content_of_verbatim_block_with_line_trim' => [
+            '{%~ verbatim ~%}<twig:Alert/>{%~ endverbatim ~%}',
+            '{%~ verbatim ~%}<twig:Alert/>{%~ endverbatim ~%}',
+        ];
+
+        yield 'ignore_content_of_verbatim_block_without_spaces' => [
+            '{%verbatim%}<twig:Alert/>{%endverbatim%}',
+            '{%verbatim%}<twig:Alert/>{%endverbatim%}',
+        ];
+
+        yield 'ignore_content_of_verbatim_block_with_extra_spaces' => [
+            '{%   verbatim   %}<twig:Alert/>{%   endverbatim   %}',
+            '{%   verbatim   %}<twig:Alert/>{%   endverbatim   %}',
+        ];
+
+        yield 'ignore_content_of_verbatim_block_with_newlines_in_tags' => [
+            "{%\nverbatim\n%}<twig:Alert/>{%\nendverbatim\n%}",
+            "{%\nverbatim\n%}<twig:Alert/>{%\nendverbatim\n%}",
+        ];
+
+        yield 'ignore_content_of_verbatim_block_with_mixed_delimiters' => [
+            '{%- verbatim %}<twig:Alert/>{% endverbatim -%}',
+            '{%- verbatim %}<twig:Alert/>{% endverbatim -%}',
+        ];
+
+        yield 'verbatim_block_as_the_whole_component_content' => [
+            '<twig:foo>{% verbatim %}<twig:Alert/>{% endverbatim %}</twig:foo>',
+            '{% component \'foo\' %}{% block content %}{% verbatim %}<twig:Alert/>{% endverbatim %}{% endblock %}{% endcomponent %}',
+        ];
+
+        yield 'verbatim_block_after_text_in_a_component' => [
+            '<twig:foo>a{% verbatim %}<twig:Alert/>{% endverbatim %}</twig:foo>',
+            '{% component \'foo\' %}{% block content %}a{% verbatim %}<twig:Alert/>{% endverbatim %}{% endblock %}{% endcomponent %}',
+        ];
+
         yield 'component_attr_spreading_self_closing' => [
             '<twig:foobar bar="baz"{{...attr}}/>',
             '{{ component(\'foobar\', { bar: \'baz\', ...attr }) }}',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`{% verbatim %}` is supposed to stop the pre-lexer from rewriting what it wraps. It does,
in one exact spelling, and only when it is not the first thing inside a component.

## Reproducer 1: any other spelling of the tag

```twig
{%- verbatim -%}<twig:Alert/>{%- endverbatim -%}
```

The content is rewritten to `{{ component('Alert') }}` instead of being left alone. Same
with `{%~ verbatim ~%}`, `{%verbatim%}`, `{%   verbatim   %}`, a newline inside the tag,
and mixed delimiters such as `{%- verbatim %} … {% endverbatim -%}`.

Twig accepts all of these. The pre-lexer recognises only the literal string
`{% verbatim %}`, one space on each side.

## Reproducer 2: verbatim as the whole content of a component

```twig
<twig:BasicComponent>{% verbatim %}hello{% endverbatim %}</twig:BasicComponent>
```

```
Twig\Error\SyntaxError: A template that extends another one cannot include content
outside Twig blocks. Did you forget to put the content inside a {% block %} tag?
```

Adding any character before the tag makes it work again, which is the tell:

```twig
{# renders "ahello" #}
<twig:BasicComponent>a{% verbatim %}hello{% endverbatim %}</twig:BasicComponent>
```

## Cause

Both come from the same branch at the top of the scanning loop.

```php
if ($this->consume('{% verbatim %}')) {
```

`consume()` compares a fixed string, hence reproducer 1.

That branch also runs before the rule that opens the implicit default block when
non-whitespace content shows up inside a component. So verbatim content is emitted
outside any `{% block %}`, and Twig rejects it. A single character before the tag trips
the default-block rule first, which is why it then works.

## Fix

Match the tag with a regex covering the whitespace control tokens Twig declares
(`whitespace_trim` is `-`, `whitespace_line_trim` is `~`):

```php
private const VERBATIM_REGEX = '/\G\{%[-~]?\s*verbatim\s*[-~]?%\}/';
private const ENDVERBATIM_REGEX = '/\{%[-~]?\s*endverbatim\s*[-~]?%\}/';
```

`consumeVerbatim()` finds the closing tag with the same pattern and copies the block
through unchanged, counting the newlines of the tags themselves, which the previous code
did not do.

The branch now opens the default block first, like every other kind of content.

Delimiter consistency is not enforced: `{%- verbatim %} … {% endverbatim -%}` is accepted,
as Twig accepts it.

## Tests

Eight cases added to the existing `TwigPreLexerTest` provider. Seven fail on `3.x`:
the five tag spellings above, mixed delimiters, and verbatim as the whole content of a
component. The eighth is a control that already passes and must keep passing, verbatim
placed after some text.

Checked in a real render too, not only through the pre-lexer: reproducer 2 now outputs
`hello`, and `{%- verbatim -%}<twig:Nope/>{%- endverbatim -%}` keeps `<twig:Nope/>` in the
output.
