### PR TITLE
[Image] Add Image component

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -7,6 +7,7 @@
         "ux-chartjs": "src/Chartjs",
         "ux-cropperjs": "src/Cropperjs",
         "ux-icons": "src/Icons",
+        "ux-image": "src/Image",
         "ux-live-component": "src/LiveComponent",
         "ux-map": {
             "prefixes": [{ "from": "src/Map", "to": "", "excludes": ["src/Bridge"] }]

--- a/src/Image/.gitattributes
+++ b/src/Image/.gitattributes
@@ -1,0 +1,5 @@
+/.git* export-ignore
+/.symfony.bundle.yaml export-ignore
+/doc export-ignore
+/phpunit.dist.xml export-ignore
+/tests export-ignore

--- a/src/Image/.gitignore
+++ b/src/Image/.gitignore
@@ -1,0 +1,7 @@
+/assets/node_modules/
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.cache
+
+/var

--- a/src/Image/.symfony.bundle.yaml
+++ b/src/Image/.symfony.bundle.yaml
@@ -1,0 +1,3 @@
+branches: ['2.x', '3.x']
+maintained_branches: ['3.x']
+doc_dir: 'doc'

--- a/src/Image/CHANGELOG.md
+++ b/src/Image/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 3.5.0
+
+- Add the component.

--- a/src/Image/LICENSE
+++ b/src/Image/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Image/README.md
+++ b/src/Image/README.md
@@ -1,0 +1,14 @@
+# Symfony UX Image
+
+Twig components for rendering optimized HTML image elements (`<img>`, `<picture>`, `<source>`),
+conforming to the HTML specification.
+
+**This repository is a READ-ONLY sub-tree split**. See
+https://github.com/symfony/ux to create issues or submit pull requests.
+
+## Resources
+
+- [Documentation](https://symfony.com/bundles/ux-image/current/index.html)
+- [Report issues](https://github.com/symfony/ux/issues) and
+  [send Pull Requests](https://github.com/symfony/ux/pulls)
+  in the [main Symfony UX repository](https://github.com/symfony/ux)

--- a/src/Image/composer.json
+++ b/src/Image/composer.json
@@ -1,0 +1,59 @@
+{
+    "name": "symfony/ux-image",
+    "type": "symfony-bundle",
+    "description": "Twig components for rendering optimized HTML image elements.",
+    "keywords": [
+        "symfony-ux",
+        "twig",
+        "image",
+        "picture",
+        "responsive"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Sébastien Jean",
+            "email": "sebastien.jean@magnolia.fr"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Symfony\\UX\\Image\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\UX\\Image\\Tests\\": "tests/"
+        }
+    },
+    "require": {
+        "php": ">=8.4",
+        "symfony/framework-bundle": "^7.4|^8.0"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "dev-master",
+        "phpunit/phpunit": "^11.1|^12.0",
+        "symfony/asset-mapper": "^7.4|^8.0",
+        "symfony/twig-bundle": "^7.4|^8.0",
+        "symfony/ux-twig-component": "^2.14|^3.0"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "conflict": {
+        "symfony/flex": "<1.13",
+        "symfony/ux-twig-component": "<2.21"
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Image/config/services.php
+++ b/src/Image/config/services.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\UX\Image\ImageRenderer;
+use Symfony\UX\Image\Twig\ImageExtension;
+use Symfony\UX\Image\Twig\ImgRuntime;
+use Symfony\UX\Image\Twig\SourceRuntime;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->set('.ux_image.image_renderer', ImageRenderer::class)
+
+        ->set('.ux_image.twig_extension', ImageExtension::class)
+            ->tag('twig.extension')
+
+        ->set('.ux_image.twig_runtime', ImgRuntime::class)
+            ->args([
+                service('.ux_image.image_renderer'),
+            ])
+            ->tag('twig.runtime')
+            ->tag('ux.twig_component.twig_renderer', ['key' => 'ux:img'])
+
+        ->set('.ux_image.twig_source_runtime', SourceRuntime::class)
+            ->args([
+                service('.ux_image.image_renderer'),
+            ])
+            ->tag('ux.twig_component.twig_renderer', ['key' => 'ux:source'])
+    ;
+};

--- a/src/Image/config/twig_component.php
+++ b/src/Image/config/twig_component.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\UX\Image\Twig\UXImgComponent;
+use Symfony\UX\Image\Twig\UXPictureComponent;
+use Symfony\UX\Image\Twig\UXSourceComponent;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->set('.ux_image.twig_component.img', UXImgComponent::class)
+            ->tag('twig.component', ['key' => 'ux:img'])
+
+        ->set('.ux_image.twig_component.picture', UXPictureComponent::class)
+            ->tag('twig.component', [
+                'key' => 'ux:picture',
+                'template' => '@UXImage/components/ux/picture.html.twig',
+            ])
+
+        ->set('.ux_image.twig_component.source', UXSourceComponent::class)
+            ->tag('twig.component', ['key' => 'ux:source'])
+    ;
+};

--- a/src/Image/doc/index.rst
+++ b/src/Image/doc/index.rst
@@ -1,0 +1,343 @@
+Symfony UX Image
+================
+
+**EXPERIMENTAL** This component is currently experimental and is likely
+to change, or even change drastically.
+
+Symfony UX Image provides Twig components for rendering ``<img>``,
+``<picture>`` and ``<source>`` HTML elements. It validates attributes
+against the HTML specification at render time and supports responsive images,
+format selection, art direction and lazy loading.
+
+Installation
+------------
+
+.. code-block:: terminal
+
+    $ composer require symfony/ux-image
+
+If you are using ``symfony/ux-twig-component``, the Twig components
+``<twig:ux:img>``, ``<twig:ux:picture>`` and ``<twig:ux:source>`` are
+registered automatically.
+
+Usage
+-----
+
+Basic image
+~~~~~~~~~~~
+
+Use the ``<twig:ux:img>`` component to render an ``<img>`` element:
+
+.. code-block:: html+twig
+
+    <twig:ux:img
+        src="/photos/hero.jpg"
+        alt="A beautiful landscape"
+        width="1200"
+        height="800"
+        loading="lazy"
+        decoding="async"
+    />
+
+The ``alt`` attribute is always required. Use an empty string for
+decorative images (``alt=""``), but never omit it.
+
+Any extra attribute (``class``, ``id``, ``data-*``, etc.) is passed
+through to the rendered ``<img>`` element:
+
+.. code-block:: html+twig
+
+    <twig:ux:img
+        src="/photos/hero.jpg"
+        alt="Hero"
+        class="rounded shadow"
+        data-lightbox="gallery"
+    />
+
+Responsive images with srcset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pass ``srcset`` and ``sizes`` as PHP arrays for a clean, readable syntax.
+The component normalizes them to the correct HTML format:
+
+.. code-block:: html+twig
+
+    <twig:ux:img
+        src="/photos/hero-800.jpg"
+        alt="Responsive hero image"
+        :srcset="[
+            '/photos/hero-480.jpg 480w',
+            '/photos/hero-800.jpg 800w',
+            '/photos/hero-1200.jpg 1200w',
+        ]"
+        :sizes="[
+            '(max-width: 600px) 480px',
+            '(max-width: 1000px) 800px',
+            '1200px',
+        ]"
+        loading="lazy"
+    />
+
+You can also pass ``srcset`` and ``sizes`` as plain strings:
+
+.. code-block:: html+twig
+
+    <twig:ux:img
+        src="/photos/hero-800.jpg"
+        alt="Responsive hero image"
+        srcset="/photos/hero-480.jpg 480w, /photos/hero-800.jpg 800w, /photos/hero-1200.jpg 1200w"
+        sizes="(max-width: 600px) 480px, (max-width: 1000px) 800px, 1200px"
+    />
+
+Pixel density descriptors (``1x``, ``2x``) are supported for fixed-size
+images like logos or avatars:
+
+.. code-block:: html+twig
+
+    <twig:ux:img
+        src="/logo.png"
+        alt="Logo"
+        :srcset="['/logo.png 1x', '/logo@2x.png 2x']"
+    />
+
+.. caution::
+
+    You cannot mix width descriptors (``w``) and density descriptors (``x``)
+    in the same ``srcset``.
+
+Format selection with picture
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``<twig:ux:picture>`` with ``<twig:ux:source>`` to serve modern image
+formats with automatic fallback. The browser picks the first format it
+supports:
+
+.. code-block:: html+twig
+
+    <twig:ux:picture>
+        <twig:ux:source
+            srcset="/photos/landscape.avif"
+            type="image/avif"
+        />
+        <twig:ux:source
+            srcset="/photos/landscape.webp"
+            type="image/webp"
+        />
+        <twig:ux:img
+            src="/photos/landscape.jpg"
+            alt="Mountain landscape"
+            width="800"
+            height="600"
+        />
+    </twig:ux:picture>
+
+Browsers that support AVIF download the smallest file, those that only
+support WebP get the WebP version, and all others fall back to JPEG.
+
+Art direction
+~~~~~~~~~~~~~
+
+Use the ``media`` attribute on ``<twig:ux:source>`` to serve different
+images depending on viewport size — for example, a wide landscape on
+desktop and a cropped portrait on mobile:
+
+.. code-block:: html+twig
+
+    <twig:ux:picture class="hero">
+        <twig:ux:source
+            srcset="/photos/hero-desktop.webp"
+            media="(min-width: 800px)"
+            type="image/webp"
+        />
+        <twig:ux:source
+            srcset="/photos/hero-mobile.webp"
+            type="image/webp"
+        />
+        <twig:ux:img
+            src="/photos/hero-mobile.jpg"
+            alt="Hero image"
+            width="400"
+            height="300"
+        />
+    </twig:ux:picture>
+
+Art direction and format selection can be combined by adding both
+``media`` and ``type`` on the same ``<twig:ux:source>``.
+
+Responsive sources with srcset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``<twig:ux:source>`` also accepts ``srcset`` and ``sizes`` for responsive
+resolution switching inside a ``<picture>``:
+
+.. code-block:: html+twig
+
+    <twig:ux:picture>
+        <twig:ux:source
+            :srcset="[
+                '/photos/hero-480.avif 480w',
+                '/photos/hero-800.avif 800w',
+                '/photos/hero-1200.avif 1200w',
+            ]"
+            sizes="(max-width: 600px) 480px, 800px"
+            type="image/avif"
+        />
+        <twig:ux:img
+            src="/photos/hero-800.jpg"
+            alt="Hero"
+            width="800"
+            height="600"
+        />
+    </twig:ux:picture>
+
+Lazy loading and sizes="auto"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``loading="lazy"`` to defer loading of off-screen images. Do **not**
+lazy-load the largest above-the-fold image (LCP) — use ``fetchpriority="high"``
+instead:
+
+.. code-block:: html+twig
+
+    {# Below-the-fold image: lazy load #}
+    <twig:ux:img src="/photos/footer.jpg" alt="Footer" loading="lazy" />
+
+    {# LCP image: prioritize #}
+    <twig:ux:img src="/photos/hero.jpg" alt="Hero" fetchpriority="high" />
+
+The ``sizes="auto"`` keyword lets the browser compute the display size
+automatically. It requires ``loading="lazy"``:
+
+.. code-block:: html+twig
+
+    <twig:ux:img
+        src="/photos/hero.jpg"
+        alt="Hero"
+        :srcset="['/photos/hero-480.jpg 480w', '/photos/hero-800.jpg 800w']"
+        sizes="auto"
+        loading="lazy"
+    />
+
+You can provide a fallback value for browsers that don't support
+``auto``: ``sizes="auto, 100vw"``.
+
+Twig functions
+~~~~~~~~~~~~~~
+
+If you prefer a programmatic approach, two Twig functions are available:
+
+.. code-block:: html+twig
+
+    {# Render an <img> #}
+    {{ ux_img(
+        src: '/photos/hero.jpg',
+        alt: 'Hero image',
+        width: 1200,
+        height: 800,
+        loading: 'lazy',
+    ) }}
+
+    {# Render a <picture> with format fallbacks #}
+    {{ ux_picture(
+        sources: [
+            { srcset: '/photos/hero.avif', type: 'image/avif' },
+            { srcset: '/photos/hero.webp', type: 'image/webp' },
+        ],
+        src: '/photos/hero.jpg',
+        alt: 'Hero image',
+        width: 1200,
+        height: 800,
+    ) }}
+
+Supported attributes
+--------------------
+
+``<twig:ux:img>``
+~~~~~~~~~~~~~~~~~
+
+========================= ================== ===========================================
+Attribute                 Type               Description
+========================= ================== ===========================================
+``src``                   ``string``         Image URL (required if no ``srcset``)
+``alt``                   ``string``         Alternative text (**always required**)
+``srcset``                ``string|array``   Image candidates with descriptors
+``sizes``                 ``string|array``   Display size hints for the browser
+``width``                 ``int``            Intrinsic width in pixels
+``height``                ``int``            Intrinsic height in pixels
+``loading``               ``string``         ``lazy`` or ``eager``
+``decoding``              ``string``         ``sync``, ``async`` or ``auto``
+``fetchpriority``         ``string``         ``high``, ``low`` or ``auto``
+``crossorigin``           ``string``         ``anonymous`` or ``use-credentials``
+``referrerpolicy``        ``string``         Referrer policy value
+``ismap``                 ``bool``           Server-side image map
+``usemap``                ``string``         Client-side image map reference
+========================= ================== ===========================================
+
+Any additional attribute (``class``, ``id``, ``data-*``, ``style``, …) is
+passed through to the rendered ``<img>`` element.
+
+``<twig:ux:source>``
+~~~~~~~~~~~~~~~~~~~~
+
+========================= ================== ===========================================
+Attribute                 Type               Description
+========================= ================== ===========================================
+``srcset``                ``string|array``   Image candidates (**required**)
+``sizes``                 ``string|array``   Display size hints
+``media``                 ``string``         Media query for art direction
+``type``                  ``string``         MIME type (e.g. ``image/avif``)
+``width``                 ``int``            Intrinsic width in pixels
+``height``                ``int``            Intrinsic height in pixels
+========================= ================== ===========================================
+
+.. note::
+
+    The ``src`` attribute is **not** allowed on ``<source>`` — use ``srcset``.
+
+``<twig:ux:picture>``
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``<picture>`` element accepts any global HTML attribute (``class``,
+``id``, etc.) and wraps ``<twig:ux:source>`` and ``<twig:ux:img>`` children.
+
+Validation
+----------
+
+The components validate attributes against the HTML specification
+at render time. Invalid usage throws an ``\InvalidArgumentException`` with a
+clear error message:
+
+``alt`` is required
+    Use ``alt=""`` for decorative images. Omitting ``alt`` entirely throws
+    an error.
+
+``src`` or ``srcset`` required
+    At least one of them must be provided on ``<twig:ux:img>``.
+
+No mixing ``w`` and ``x`` descriptors
+    A ``srcset`` must use either width descriptors (``480w``) or pixel density
+    descriptors (``2x``), never both.
+
+No duplicate descriptors
+    Each descriptor value must appear only once in a ``srcset``.
+
+``sizes`` requires width descriptors
+    When ``sizes`` is present, all ``srcset`` candidates must use ``w``
+    descriptors.
+
+``sizes="auto"`` requires ``loading="lazy"``
+    The ``auto`` keyword (or ``auto, <fallback>``) is only valid with lazy
+    loading.
+
+Enum attributes validated
+    ``loading``, ``decoding``, ``fetchpriority``, ``crossorigin`` and
+    ``referrerpolicy`` only accept their spec-defined values.
+
+No ``src`` on ``<source>``
+    The ``<source>`` element only accepts ``srcset``, not ``src``.
+
+Backward compatibility promise
+------------------------------
+
+This bundle follows the same backward-compatibility promise as
+`Symfony itself <https://symfony.com/doc/current/contributing/code/bc.html>`_.

--- a/src/Image/phpunit.dist.xml
+++ b/src/Image/phpunit.dist.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+        failOnDeprecation="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UX Image Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source
+            ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/src/Image/src/ImageBundle.php
+++ b/src/Image/src/ImageBundle.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use Symfony\UX\TwigComponent\TwigComponentBundle;
+
+/**
+ * @author Sébastien Jean <sebastien.jean76@gmail.com>
+ */
+final class ImageBundle extends AbstractBundle
+{
+    protected string $extensionAlias = 'ux_image';
+
+    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $container->import('../config/services.php');
+
+        if (ContainerBuilder::willBeAvailable('symfony/ux-twig-component', TwigComponentBundle::class, ['symfony/ux-image'])) {
+            $container->import('../config/twig_component.php');
+        }
+    }
+
+    public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $builder->prependExtensionConfig('twig', [
+            'paths' => [
+                __DIR__.'/../templates' => 'UXImage',
+            ],
+        ]);
+    }
+}

--- a/src/Image/src/ImageRenderer.php
+++ b/src/Image/src/ImageRenderer.php
@@ -1,0 +1,333 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image;
+
+/**
+ * @author Sébastien Jean <sebastien.jean76@gmail.com>
+ *
+ * @internal
+ */
+final class ImageRenderer
+{
+    public function renderImg(
+        ?string $src = null,
+        ?string $alt = null,
+        string|array|null $srcset = null,
+        string|array|null $sizes = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?string $loading = null,
+        ?string $decoding = null,
+        ?string $fetchpriority = null,
+        ?string $crossorigin = null,
+        ?string $referrerpolicy = null,
+        ?bool $ismap = null,
+        ?string $usemap = null,
+        array $attributes = [],
+    ): string {
+        if (null === $alt) {
+            throw new \InvalidArgumentException('The "alt" attribute must be explicitly provided for the <img> element. Use an empty string for decorative images.');
+        }
+
+        if (null === $src && null === $srcset) {
+            throw new \InvalidArgumentException('The "src" attribute is required when "srcset" is not provided.');
+        }
+
+        $this->validateEnumAttribute('loading', $loading, ['lazy', 'eager']);
+        $this->validateEnumAttribute('decoding', $decoding, ['sync', 'async', 'auto']);
+        $this->validateEnumAttribute('fetchpriority', $fetchpriority, ['high', 'low', 'auto']);
+        $this->validateEnumAttribute('crossorigin', $crossorigin, ['anonymous', 'use-credentials']);
+        $this->validateEnumAttribute('referrerpolicy', $referrerpolicy, [
+            'no-referrer',
+            'no-referrer-when-downgrade',
+            'origin',
+            'origin-when-cross-origin',
+            'same-origin',
+            'strict-origin',
+            'strict-origin-when-cross-origin',
+            'unsafe-url',
+        ]);
+
+        if (null !== $srcset) {
+            $srcset = $this->normalizeSrcset($srcset);
+            $this->validateSrcset($srcset);
+        }
+
+        if (null !== $sizes) {
+            $sizes = $this->normalizeSizes($sizes);
+
+            if ($this->sizesStartsWithAuto($sizes) && 'lazy' !== $loading) {
+                throw new \InvalidArgumentException('The "sizes" attribute set to "auto" requires the "loading" attribute to be set to "lazy".');
+            }
+
+            if (null !== $srcset && !$this->srcsetUsesWidthDescriptors($srcset)) {
+                throw new \InvalidArgumentException('The "sizes" attribute requires all image candidates in "srcset" to use width descriptors ("w").');
+            }
+        }
+
+        $attrs = [];
+
+        if (null !== $src) {
+            $attrs['src'] = $src;
+        }
+
+        $attrs['alt'] = $alt;
+
+        if (null !== $srcset) {
+            $attrs['srcset'] = $srcset;
+        }
+
+        if (null !== $sizes) {
+            $attrs['sizes'] = $sizes;
+        }
+
+        if (null !== $width) {
+            $attrs['width'] = (string) $width;
+        }
+
+        if (null !== $height) {
+            $attrs['height'] = (string) $height;
+        }
+
+        if (null !== $loading) {
+            $attrs['loading'] = $loading;
+        }
+
+        if (null !== $decoding) {
+            $attrs['decoding'] = $decoding;
+        }
+
+        if (null !== $fetchpriority) {
+            $attrs['fetchpriority'] = $fetchpriority;
+        }
+
+        if (null !== $crossorigin) {
+            $attrs['crossorigin'] = $crossorigin;
+        }
+
+        if (null !== $referrerpolicy) {
+            $attrs['referrerpolicy'] = $referrerpolicy;
+        }
+
+        if (true === $ismap) {
+            $attrs['ismap'] = true;
+        }
+
+        if (null !== $usemap) {
+            $attrs['usemap'] = $usemap;
+        }
+
+        $attrs = array_merge($attrs, $attributes);
+
+        return '<img'.$this->renderAttributes($attrs).' />';
+    }
+
+    public function renderSource(
+        string|array $srcset,
+        string|array|null $sizes = null,
+        ?string $media = null,
+        ?string $type = null,
+        ?int $width = null,
+        ?int $height = null,
+        array $attributes = [],
+    ): string {
+        if (isset($attributes['src'])) {
+            throw new \InvalidArgumentException('The "src" attribute is not allowed on a <source> element.');
+        }
+
+        $attrs = [];
+        $attrs['srcset'] = $this->normalizeSrcset($srcset);
+        $this->validateSrcset($attrs['srcset']);
+
+        if (null !== $sizes) {
+            $attrs['sizes'] = $this->normalizeSizes($sizes);
+        }
+
+        if (null !== $media) {
+            $attrs['media'] = $media;
+        }
+
+        if (null !== $type) {
+            $attrs['type'] = $type;
+        }
+
+        if (null !== $width) {
+            $attrs['width'] = (string) $width;
+        }
+
+        if (null !== $height) {
+            $attrs['height'] = (string) $height;
+        }
+
+        $attrs = array_merge($attrs, $attributes);
+
+        return '<source'.$this->renderAttributes($attrs).' />';
+    }
+
+    public function renderPicture(
+        array $sources,
+        ?string $src = null,
+        ?string $alt = null,
+        string|array|null $srcset = null,
+        string|array|null $sizes = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?string $loading = null,
+        ?string $decoding = null,
+        array $attributes = [],
+        array $imgAttributes = [],
+    ): string {
+        $html = '<picture'.$this->renderAttributes($attributes).'>';
+
+        foreach ($sources as $source) {
+            $html .= $this->renderSource(
+                $source['srcset'],
+                $source['sizes'] ?? null,
+                $source['media'] ?? null,
+                $source['type'] ?? null,
+                $source['width'] ?? null,
+                $source['height'] ?? null,
+                $source['attributes'] ?? [],
+            );
+        }
+
+        $html .= $this->renderImg(
+            $src,
+            $alt,
+            $srcset,
+            $sizes,
+            $width,
+            $height,
+            $loading,
+            $decoding,
+            fetchpriority: null,
+            crossorigin: null,
+            referrerpolicy: null,
+            ismap: null,
+            usemap: null,
+            attributes: $imgAttributes,
+        );
+
+        $html .= '</picture>';
+
+        return $html;
+    }
+
+    private function normalizeSrcset(string|array $srcset): string
+    {
+        if (\is_string($srcset)) {
+            return $srcset;
+        }
+
+        return implode(', ', $srcset);
+    }
+
+    private function normalizeSizes(string|array $sizes): string
+    {
+        if (\is_string($sizes)) {
+            return $sizes;
+        }
+
+        return implode(', ', $sizes);
+    }
+
+    private function renderAttributes(array $attributes): string
+    {
+        $html = '';
+
+        foreach ($attributes as $name => $value) {
+            if (true === $value) {
+                $html .= ' '.$name;
+                continue;
+            }
+
+            if (false === $value || null === $value) {
+                continue;
+            }
+
+            $html .= ' '.$name.'="'.$this->escape((string) $value).'"';
+        }
+
+        return $html;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+    }
+
+    private function validateSrcset(string $srcset): void
+    {
+        $candidates = array_map('trim', explode(',', $srcset));
+        $hasWidthDescriptor = false;
+        $hasDensityDescriptor = false;
+        $seenDescriptors = [];
+
+        foreach ($candidates as $candidate) {
+            if ('' === $candidate) {
+                continue;
+            }
+
+            $parts = preg_split('/\s+/', $candidate);
+            $descriptor = $parts[1] ?? '1x';
+
+            if (str_ends_with($descriptor, 'w')) {
+                $hasWidthDescriptor = true;
+            } else {
+                $hasDensityDescriptor = true;
+            }
+
+            if (\in_array($descriptor, $seenDescriptors, true)) {
+                throw new \InvalidArgumentException(\sprintf('The "srcset" attribute must not contain duplicate descriptors. The descriptor "%s" is specified more than once.', $descriptor));
+            }
+
+            $seenDescriptors[] = $descriptor;
+        }
+
+        if ($hasWidthDescriptor && $hasDensityDescriptor) {
+            throw new \InvalidArgumentException('The "srcset" attribute must not mix width descriptors ("w") and pixel density descriptors ("x").');
+        }
+    }
+
+    private function sizesStartsWithAuto(string $sizes): bool
+    {
+        return 'auto' === $sizes || str_starts_with(strtolower($sizes), 'auto,');
+    }
+
+    private function srcsetUsesWidthDescriptors(string $srcset): bool
+    {
+        foreach (array_map('trim', explode(',', $srcset)) as $candidate) {
+            if ('' === $candidate) {
+                continue;
+            }
+
+            $parts = preg_split('/\s+/', $candidate);
+
+            if (!isset($parts[1]) || !str_ends_with($parts[1], 'w')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function validateEnumAttribute(string $name, ?string $value, array $allowed): void
+    {
+        if (null === $value) {
+            return;
+        }
+
+        if (!\in_array($value, $allowed, true)) {
+            throw new \InvalidArgumentException(\sprintf('The "%s" attribute value "%s" is not valid. Allowed values are: "%s".', $name, $value, implode('", "', $allowed)));
+        }
+    }
+}

--- a/src/Image/src/Twig/ImageExtension.php
+++ b/src/Image/src/Twig/ImageExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @author Sébastien Jean <sebastien.jean76@gmail.com>
+ *
+ * @internal
+ */
+final class ImageExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('ux_img', [ImgRuntime::class, 'renderImg'], ['is_safe' => ['html']]),
+            new TwigFunction('ux_picture', [ImgRuntime::class, 'renderPicture'], ['is_safe' => ['html']]),
+        ];
+    }
+}

--- a/src/Image/src/Twig/ImgRuntime.php
+++ b/src/Image/src/Twig/ImgRuntime.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+use Symfony\UX\Image\ImageRenderer;
+use Twig\Extension\RuntimeExtensionInterface;
+
+/**
+ * @author Sébastien Jean <sebastien.jean76@gmail.com>
+ *
+ * @internal
+ */
+final class ImgRuntime implements RuntimeExtensionInterface
+{
+    private const IMG_PROPS = ['src', 'alt', 'srcset', 'sizes', 'width', 'height', 'loading', 'decoding', 'fetchpriority', 'crossorigin', 'referrerpolicy', 'ismap', 'usemap'];
+
+    public function __construct(
+        private readonly ImageRenderer $renderer,
+    ) {
+    }
+
+    public function renderImg(
+        ?string $src = null,
+        ?string $alt = null,
+        string|array|null $srcset = null,
+        string|array|null $sizes = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?string $loading = null,
+        ?string $decoding = null,
+        ?string $fetchpriority = null,
+        ?string $crossorigin = null,
+        ?string $referrerpolicy = null,
+        ?bool $ismap = null,
+        ?string $usemap = null,
+        array $attributes = [],
+    ): string {
+        return $this->renderer->renderImg($src, $alt, $srcset, $sizes, $width, $height, $loading, $decoding, $fetchpriority, $crossorigin, $referrerpolicy, $ismap, $usemap, $attributes);
+    }
+
+    public function renderPicture(
+        array $sources,
+        ?string $src = null,
+        ?string $alt = null,
+        string|array|null $srcset = null,
+        string|array|null $sizes = null,
+        ?int $width = null,
+        ?int $height = null,
+        ?string $loading = null,
+        ?string $decoding = null,
+        array $attributes = [],
+        array $imgAttributes = [],
+    ): string {
+        return $this->renderer->renderPicture($sources, $src, $alt, $srcset, $sizes, $width, $height, $loading, $decoding, $attributes, $imgAttributes);
+    }
+
+    public function render(array $args = []): string
+    {
+        $props = array_intersect_key($args, array_flip(self::IMG_PROPS));
+        $attrs = array_diff_key($args, array_flip(self::IMG_PROPS));
+
+        return $this->renderImg(
+            src: $props['src'] ?? null,
+            alt: $props['alt'] ?? null,
+            srcset: $props['srcset'] ?? null,
+            sizes: $props['sizes'] ?? null,
+            width: $props['width'] ?? null,
+            height: $props['height'] ?? null,
+            loading: $props['loading'] ?? null,
+            decoding: $props['decoding'] ?? null,
+            fetchpriority: $props['fetchpriority'] ?? null,
+            crossorigin: $props['crossorigin'] ?? null,
+            referrerpolicy: $props['referrerpolicy'] ?? null,
+            ismap: $props['ismap'] ?? null,
+            usemap: $props['usemap'] ?? null,
+            attributes: $attrs,
+        );
+    }
+}

--- a/src/Image/src/Twig/SourceRuntime.php
+++ b/src/Image/src/Twig/SourceRuntime.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+use Symfony\UX\Image\ImageRenderer;
+
+/**
+ * @author Sébastien Jean <sebastien.jean76@gmail.com>
+ *
+ * @internal
+ */
+final class SourceRuntime
+{
+    private const SOURCE_PROPS = ['srcset', 'sizes', 'media', 'type', 'width', 'height'];
+
+    public function __construct(
+        private readonly ImageRenderer $renderer,
+    ) {
+    }
+
+    public function render(array $args = []): string
+    {
+        $props = array_intersect_key($args, array_flip(self::SOURCE_PROPS));
+        $attrs = array_diff_key($args, array_flip(self::SOURCE_PROPS));
+
+        return $this->renderer->renderSource(
+            srcset: $props['srcset'] ?? '',
+            sizes: $props['sizes'] ?? null,
+            media: $props['media'] ?? null,
+            type: $props['type'] ?? null,
+            width: $props['width'] ?? null,
+            height: $props['height'] ?? null,
+            attributes: $attrs,
+        );
+    }
+}

--- a/src/Image/src/Twig/UXImgComponent.php
+++ b/src/Image/src/Twig/UXImgComponent.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+/**
+ * @author Sébastien Jean <sebastien.jean76@gmail.com>
+ *
+ * @internal
+ */
+final class UXImgComponent
+{
+    public ?string $src = null;
+    public ?string $alt = null;
+    public string|array|null $srcset = null;
+    public string|array|null $sizes = null;
+    public ?int $width = null;
+    public ?int $height = null;
+    public ?string $loading = null;
+    public ?string $decoding = null;
+    public ?string $fetchpriority = null;
+    public ?string $crossorigin = null;
+    public ?string $referrerpolicy = null;
+    public ?bool $ismap = null;
+    public ?string $usemap = null;
+}

--- a/src/Image/src/Twig/UXPictureComponent.php
+++ b/src/Image/src/Twig/UXPictureComponent.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+/**
+ * @author Sébastien Jean <sebastien.jean76@gmail.com>
+ *
+ * @internal
+ */
+final class UXPictureComponent
+{
+}

--- a/src/Image/src/Twig/UXSourceComponent.php
+++ b/src/Image/src/Twig/UXSourceComponent.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+/**
+ * @author Sébastien Jean <sebastien.jean76@gmail.com>
+ *
+ * @internal
+ */
+final class UXSourceComponent
+{
+    public string|array|null $srcset = null;
+    public string|array|null $sizes = null;
+    public ?string $media = null;
+    public ?string $type = null;
+    public ?int $width = null;
+    public ?int $height = null;
+}

--- a/src/Image/templates/components/ux/picture.html.twig
+++ b/src/Image/templates/components/ux/picture.html.twig
@@ -1,0 +1,3 @@
+<picture{{ attributes }}>
+    {%- block content %}{% endblock -%}
+</picture>

--- a/src/Image/tests/ImageBundleTest.php
+++ b/src/Image/tests/ImageBundleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\ImageBundle;
+
+final class ImageBundleTest extends TestCase
+{
+    public function testBundleCanBeInstantiated()
+    {
+        $bundle = new ImageBundle();
+
+        $this->assertInstanceOf(ImageBundle::class, $bundle);
+    }
+}

--- a/src/Image/tests/ImageRendererTest.php
+++ b/src/Image/tests/ImageRendererTest.php
@@ -1,0 +1,478 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\ImageRenderer;
+
+final class ImageRendererTest extends TestCase
+{
+    private ImageRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $this->renderer = new ImageRenderer();
+    }
+
+    // === renderImg tests ===
+
+    public function testRenderBasicImg()
+    {
+        $html = $this->renderer->renderImg(src: '/photo.jpg', alt: 'A photo');
+
+        $this->assertStringContainsString('<img', $html);
+        $this->assertStringContainsString('src="/photo.jpg"', $html);
+        $this->assertStringContainsString('alt="A photo"', $html);
+    }
+
+    public function testRenderImgWithAllAttributes()
+    {
+        $html = $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'A photo',
+            width: 800,
+            height: 600,
+            loading: 'lazy',
+            decoding: 'async',
+            fetchpriority: 'high',
+            crossorigin: 'anonymous',
+            referrerpolicy: 'no-referrer',
+        );
+
+        $this->assertStringContainsString('width="800"', $html);
+        $this->assertStringContainsString('height="600"', $html);
+        $this->assertStringContainsString('loading="lazy"', $html);
+        $this->assertStringContainsString('decoding="async"', $html);
+        $this->assertStringContainsString('fetchpriority="high"', $html);
+        $this->assertStringContainsString('crossorigin="anonymous"', $html);
+        $this->assertStringContainsString('referrerpolicy="no-referrer"', $html);
+    }
+
+    public function testRenderImgWithSrcsetString()
+    {
+        $html = $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'A photo',
+            srcset: '/photo-480.jpg 480w, /photo-800.jpg 800w',
+            sizes: '(max-width: 600px) 480px, 800px',
+        );
+
+        $this->assertStringContainsString('srcset="/photo-480.jpg 480w, /photo-800.jpg 800w"', $html);
+        $this->assertStringContainsString('sizes="(max-width: 600px) 480px, 800px"', $html);
+    }
+
+    public function testRenderImgWithSrcsetArray()
+    {
+        $html = $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'A photo',
+            srcset: ['/photo-480.jpg 480w', '/photo-800.jpg 800w'],
+            sizes: ['(max-width: 600px) 480px', '800px'],
+        );
+
+        $this->assertStringContainsString('srcset="/photo-480.jpg 480w, /photo-800.jpg 800w"', $html);
+        $this->assertStringContainsString('sizes="(max-width: 600px) 480px, 800px"', $html);
+    }
+
+    public function testRenderImgWithIsmap()
+    {
+        $html = $this->renderer->renderImg(src: '/map.jpg', alt: 'Map', ismap: true);
+
+        $this->assertStringContainsString(' ismap', $html);
+        $this->assertStringNotContainsString('ismap="', $html);
+    }
+
+    public function testRenderImgWithIsmapFalse()
+    {
+        $html = $this->renderer->renderImg(src: '/map.jpg', alt: 'Map', ismap: false);
+
+        $this->assertStringNotContainsString('ismap', $html);
+    }
+
+    public function testRenderImgWithUsemap()
+    {
+        $html = $this->renderer->renderImg(src: '/map.jpg', alt: 'Map', usemap: '#mymap');
+
+        $this->assertStringContainsString('usemap="#mymap"', $html);
+    }
+
+    public function testRenderImgWithExtraAttributes()
+    {
+        $html = $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'A photo',
+            attributes: ['class' => 'rounded shadow', 'id' => 'hero', 'data-lightbox' => 'gallery'],
+        );
+
+        $this->assertStringContainsString('class="rounded shadow"', $html);
+        $this->assertStringContainsString('id="hero"', $html);
+        $this->assertStringContainsString('data-lightbox="gallery"', $html);
+    }
+
+    public function testRenderImgWithEmptyAlt()
+    {
+        $html = $this->renderer->renderImg(src: '/decorative.jpg', alt: '');
+
+        $this->assertStringContainsString('alt=""', $html);
+    }
+
+    public function testRenderImgEscapesAttributes()
+    {
+        $html = $this->renderer->renderImg(src: '/photo.jpg?a=1&b=2', alt: 'A "quoted" <photo>');
+
+        $this->assertStringContainsString('src="/photo.jpg?a=1&amp;b=2"', $html);
+        $this->assertStringContainsString('alt="A &quot;quoted&quot; &lt;photo&gt;"', $html);
+    }
+
+    public function testRenderImgIsSelfClosing()
+    {
+        $html = $this->renderer->renderImg(src: '/photo.jpg', alt: 'Photo');
+
+        $this->assertStringEndsWith('>', $html);
+        $this->assertStringNotContainsString('</img>', $html);
+    }
+
+    // === Validation tests ===
+
+    public function testRenderImgThrowsWhenAltIsNull()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('alt');
+
+        $this->renderer->renderImg(src: '/photo.jpg');
+    }
+
+    public function testRenderImgThrowsWhenNoSrcAndNoSrcset()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->renderer->renderImg(alt: 'A photo');
+    }
+
+    public function testRenderImgAllowsSrcsetWithoutSrc()
+    {
+        $html = $this->renderer->renderImg(
+            alt: 'A photo',
+            srcset: '/photo-480.jpg 480w, /photo-800.jpg 800w',
+            sizes: '100vw',
+        );
+
+        $this->assertStringContainsString('srcset=', $html);
+        $this->assertStringNotContainsString('src=', $html);
+    }
+
+    public function testRenderImgThrowsOnInvalidLoading()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('loading');
+
+        $this->renderer->renderImg(src: '/photo.jpg', alt: 'Photo', loading: 'invalid');
+    }
+
+    public function testRenderImgThrowsOnInvalidDecoding()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('decoding');
+
+        $this->renderer->renderImg(src: '/photo.jpg', alt: 'Photo', decoding: 'invalid');
+    }
+
+    public function testRenderImgThrowsOnInvalidFetchpriority()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('fetchpriority');
+
+        $this->renderer->renderImg(src: '/photo.jpg', alt: 'Photo', fetchpriority: 'medium');
+    }
+
+    public function testRenderImgThrowsOnInvalidCrossorigin()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('crossorigin');
+
+        $this->renderer->renderImg(src: '/photo.jpg', alt: 'Photo', crossorigin: 'invalid');
+    }
+
+    public function testRenderImgThrowsOnInvalidReferrerpolicy()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('referrerpolicy');
+
+        $this->renderer->renderImg(src: '/photo.jpg', alt: 'Photo', referrerpolicy: 'invalid');
+    }
+
+    public function testRenderImgThrowsOnSizesAutoWithoutLazyLoading()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('auto');
+
+        $this->renderer->renderImg(src: '/photo.jpg', alt: 'Photo', srcset: '/photo.jpg 800w', sizes: 'auto');
+    }
+
+    public function testRenderImgAllowsSizesAutoWithLazyLoading()
+    {
+        $html = $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo.jpg 800w',
+            sizes: 'auto',
+            loading: 'lazy',
+        );
+
+        $this->assertStringContainsString('sizes="auto"', $html);
+    }
+
+    public function testRenderImgThrowsOnSizesAutoWithFallbackWithoutLazyLoading()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('auto');
+
+        $this->renderer->renderImg(src: '/photo.jpg', alt: 'Photo', srcset: '/photo.jpg 800w', sizes: 'auto, 100vw');
+    }
+
+    public function testRenderImgAllowsSizesAutoWithFallbackAndLazyLoading()
+    {
+        $html = $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo.jpg 800w',
+            sizes: 'auto, 100vw',
+            loading: 'lazy',
+        );
+
+        $this->assertStringContainsString('sizes="auto, 100vw"', $html);
+    }
+
+    public function testRenderImgThrowsOnMixedSrcsetDescriptors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not mix');
+
+        $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo-480.jpg 480w, /photo-2x.jpg 2x',
+        );
+    }
+
+    public function testRenderImgThrowsOnDuplicateWidthDescriptors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('duplicate');
+
+        $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo-a.jpg 480w, /photo-b.jpg 480w',
+        );
+    }
+
+    public function testRenderImgThrowsOnDuplicateDensityDescriptors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('duplicate');
+
+        $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo-a.jpg 2x, /photo-b.jpg 2x',
+        );
+    }
+
+    public function testRenderImgAllowsValidWidthDescriptors()
+    {
+        $html = $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo-480.jpg 480w, /photo-800.jpg 800w, /photo-1200.jpg 1200w',
+            sizes: '100vw',
+        );
+
+        $this->assertStringContainsString('srcset=', $html);
+    }
+
+    public function testRenderImgAllowsValidDensityDescriptors()
+    {
+        $html = $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo.jpg 1x, /photo-2x.jpg 2x',
+        );
+
+        $this->assertStringContainsString('srcset=', $html);
+    }
+
+    public function testRenderSourceThrowsOnMixedSrcsetDescriptors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not mix');
+
+        $this->renderer->renderSource(
+            srcset: '/photo-480.webp 480w, /photo-2x.webp 2x',
+        );
+    }
+
+    public function testRenderSourceThrowsOnDuplicateDescriptors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('duplicate');
+
+        $this->renderer->renderSource(
+            srcset: '/photo-a.webp 800w, /photo-b.webp 800w',
+        );
+    }
+
+    public function testRenderImgThrowsOnSizesWithDensityDescriptors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('width descriptors');
+
+        $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo.jpg 1x, /photo-2x.jpg 2x',
+            sizes: '100vw',
+        );
+    }
+
+    public function testRenderImgThrowsOnSizesWithNoDescriptors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('width descriptors');
+
+        $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo.jpg',
+            sizes: '100vw',
+        );
+    }
+
+    public function testRenderImgAllowsSizesWithWidthDescriptors()
+    {
+        $html = $this->renderer->renderImg(
+            src: '/photo.jpg',
+            alt: 'Photo',
+            srcset: '/photo-480.jpg 480w, /photo-800.jpg 800w',
+            sizes: '(max-width: 600px) 480px, 800px',
+        );
+
+        $this->assertStringContainsString('sizes=', $html);
+    }
+
+    // === renderSource tests ===
+
+    public function testRenderSource()
+    {
+        $html = $this->renderer->renderSource(
+            srcset: '/photo.avif',
+            type: 'image/avif',
+        );
+
+        $this->assertStringContainsString('<source', $html);
+        $this->assertStringContainsString('srcset="/photo.avif"', $html);
+        $this->assertStringContainsString('type="image/avif"', $html);
+        $this->assertStringNotContainsString('</source>', $html);
+    }
+
+    public function testRenderSourceWithMedia()
+    {
+        $html = $this->renderer->renderSource(
+            srcset: '/photo-wide.webp',
+            type: 'image/webp',
+            media: '(min-width: 800px)',
+        );
+
+        $this->assertStringContainsString('media="(min-width: 800px)"', $html);
+    }
+
+    public function testRenderSourceWithDimensions()
+    {
+        $html = $this->renderer->renderSource(
+            srcset: '/photo.webp',
+            width: 800,
+            height: 600,
+        );
+
+        $this->assertStringContainsString('width="800"', $html);
+        $this->assertStringContainsString('height="600"', $html);
+    }
+
+    public function testRenderSourceWithSrcsetArray()
+    {
+        $html = $this->renderer->renderSource(
+            srcset: ['/photo-480.webp 480w', '/photo-800.webp 800w'],
+            sizes: '100vw',
+        );
+
+        $this->assertStringContainsString('srcset="/photo-480.webp 480w, /photo-800.webp 800w"', $html);
+    }
+
+    public function testRenderSourceThrowsWhenSrcInAttributes()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('src');
+
+        $this->renderer->renderSource(
+            srcset: '/photo.webp',
+            attributes: ['src' => '/photo.jpg'],
+        );
+    }
+
+    // === renderPicture tests ===
+
+    public function testRenderPicture()
+    {
+        $html = $this->renderer->renderPicture(
+            sources: [
+                ['srcset' => '/photo.avif', 'type' => 'image/avif'],
+                ['srcset' => '/photo.webp', 'type' => 'image/webp'],
+            ],
+            src: '/photo.jpg',
+            alt: 'A photo',
+            width: 800,
+            height: 600,
+        );
+
+        $this->assertStringStartsWith('<picture>', $html);
+        $this->assertStringEndsWith('</picture>', $html);
+        $this->assertStringContainsString('<source srcset="/photo.avif" type="image/avif" />', $html);
+        $this->assertStringContainsString('<source srcset="/photo.webp" type="image/webp" />', $html);
+        $this->assertStringContainsString('<img', $html);
+        $this->assertStringContainsString('src="/photo.jpg"', $html);
+        $this->assertStringContainsString('alt="A photo"', $html);
+    }
+
+    public function testRenderPictureWithAttributes()
+    {
+        $html = $this->renderer->renderPicture(
+            sources: [['srcset' => '/photo.webp', 'type' => 'image/webp']],
+            src: '/photo.jpg',
+            alt: 'A photo',
+            attributes: ['class' => 'hero-picture'],
+        );
+
+        $this->assertStringContainsString('<picture class="hero-picture">', $html);
+    }
+
+    public function testRenderPictureWithImgAttributes()
+    {
+        $html = $this->renderer->renderPicture(
+            sources: [['srcset' => '/photo.webp', 'type' => 'image/webp']],
+            src: '/photo.jpg',
+            alt: 'A photo',
+            imgAttributes: ['class' => 'img-fluid'],
+        );
+
+        $this->assertStringContainsString('class="img-fluid"', $html);
+    }
+}

--- a/src/Image/tests/bootstrap.php
+++ b/src/Image/tests/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\ErrorHandler\ErrorHandler;
+
+require __DIR__.'/../vendor/autoload.php';
+
+// @see https://github.com/symfony/symfony/issues/53812
+ErrorHandler::register(null, false);


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | Fix https://github.com/symfony/ux/pull/3188 / https://github.com/symfony/ux/pull/3549 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

This PR adds a new `symfony/ux-image` package providing Twig components for rendering `<img>`, `<picture>` and `<source>` HTML elements.

**Components**

- `<twig:ux:img>` :  renders an `<img>` element (runtime renderer, void element)
- `<twig:ux:picture>` : renders a `<picture>` wrapper (template-based, accepts children)
- `<twig:ux:source>` : renders a `<source>` element (runtime renderer, void element)

**Twig functions**

- `ux_img()` : programmatic alternative to the component
- `ux_picture()` : programmatic alternative with sources array

**Supported attributes**

All standard HTML attributes: `src`, `alt`, `srcset`, `sizes`, `width`, `height`, `loading`, `decoding`, `fetchpriority`, `crossorigin`, `referrerpolicy`, `ismap`, `usemap`. Extra attributes (`class`, `id`, `data-*`,  …) are passed through.

`srcset` and `sizes` accept both strings and PHP arrays for readability.

**Validation**

The components validate attributes against the HTML specification at render time:

- `alt` is always required (empty string allowed for decorative images)
- `src` or `srcset` must be provided
- `srcset` must not mix width (`w`) and density (`x`) descriptors
- `srcset` must not contain duplicate descriptors
- `sizes` requires all `srcset `candidates to use `w` descriptors
- `sizes="auto"` (or `"auto, <fallback>"`) requires `loading="lazy"`
- Enum attributes (`loading`, `decoding`, `fetchpriority`, `crossorigin`, `referrerpolicy`) are validated
- `<source>` does not accept `src`

**Example**

```twig
{# Basic image #}
<twig:ux:img src="/photo.jpg" alt="A photo" width="800" height="600" loading="lazy" />
```

```twig
{# Responsive with srcset #}
<twig:ux:img
    src="/photo-800.jpg"
    alt="Hero"
    :srcset="['/photo-480.jpg 480w', '/photo-800.jpg 800w', '/photo-1200.jpg 1200w']"
    :sizes="['(max-width: 600px) 480px', '800px']"
/>
```

```twig
{# Format selection: AVIF → WebP → JPEG #}
<twig:ux:picture>
    <twig:ux:source srcset="/photo.avif" type="image/avif" />
    <twig:ux:source srcset="/photo.webp" type="image/webp" />
    <twig:ux:img src="/photo.jpg" alt="A photo" width="800" height="600" />
</twig:ux:picture>
```