### PR TITLE
[CI] Replace Corepack with pnpm/setup

### DIFF
--- a/.github/workflows/app-encore.yaml
+++ b/.github/workflows/app-encore.yaml
@@ -30,11 +30,9 @@ jobs:
         steps:
             - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-            - run: npm i -g corepack && corepack enable
-
-            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+            - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
               with:
-                  node-version-file: '.nvmrc'
+                  install: false
 
             - uses: shivammathur/setup-php@690cb7c9d81dbfe51eba732cfca0a00ca42db777
 

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -36,17 +36,9 @@ jobs:
         steps:
             - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-            - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+            - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
               with:
-                  node-version-file: '.nvmrc'
-                  cache: 'pnpm'
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      package.json
-
-            - name: Install root JS dependencies
-              run: pnpm install --frozen-lockfile
+                  cache: true
 
             - name: Install custom browsers
               run: node ./bin/get_browsers.mjs

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -132,14 +132,9 @@ jobs:
         steps:
             - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-            - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+            - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
               with:
-                  node-version-file: '.nvmrc'
-                  cache: 'pnpm'
-
-            - name: Install root JS dependencies
-              run: pnpm install --frozen-lockfile
+                  cache: true
 
             - run: pnpm run fmt:check
 
@@ -149,14 +144,9 @@ jobs:
         steps:
             - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-            - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+            - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
               with:
-                  node-version-file: '.nvmrc'
-                  cache: 'pnpm'
-
-            - name: Install root JS dependencies
-              run: pnpm install --frozen-lockfile
+                  cache: true
 
             - run: pnpm run lint
 

--- a/.github/workflows/dist-files-unbuilt.yaml
+++ b/.github/workflows/dist-files-unbuilt.yaml
@@ -24,17 +24,9 @@ jobs:
         steps:
             - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-            - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+            - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
               with:
-                  node-version-file: '.nvmrc'
-                  cache: 'pnpm'
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      **/package.json
-
-            - name: Install root JS dependencies
-              run: pnpm install --frozen-lockfile
+                  cache: true
 
             - name: Build
               run: pnpm run build

--- a/.github/workflows/release-on-npm.yaml
+++ b/.github/workflows/release-on-npm.yaml
@@ -35,7 +35,7 @@ jobs:
                   fi
                   echo "Tag ${GITHUB_REF_NAME} verified as ancestor of ${BRANCH}."
 
-            - run: npm i -g corepack && corepack enable
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
               with:
                   registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -161,17 +161,8 @@ jobs:
         steps:
             - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-            - run: npm i -g corepack && corepack enable
-            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+            - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
               with:
-                  node-version-file: '.nvmrc'
-                  cache: 'pnpm'
-                  cache-dependency-path: |
-                      pnpm-lock.yaml
-                      package.json
-                      src/**/package.json
-
-            - name: Install root JS dependencies
-              run: pnpm install --frozen-lockfile
+                  cache: true
 
             - run: pnpm run test:unit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,7 @@ To set up the development environment, you need the following tools:
 - **[PHP](https://www.php.net/downloads.php) 8.1 or higher** - Required for running Symfony components
 - **[Composer](https://getcomposer.org/download/)** - PHP dependency manager
 - **[Node.js](https://nodejs.org/en/download/package-manager) 22.18 or higher** - Required for asset compilation
-- **[Corepack](https://github.com/nodejs/corepack)** - Package manager manager (comes with Node.js 16+)
-- **[PNPM](https://pnpm.io/) 11.21.0 or higher** - JavaScript package manager (installed via Corepack)
+- **[pnpm](https://pnpm.io/installation) 11.21.0 or higher** - JavaScript package manager
 
 With these tools installed, you can install the project dependencies:
 
@@ -53,8 +52,8 @@ With these tools installed, you can install the project dependencies:
 # Install root PHP dependencies
 $ composer install
 
-# Enable PNPM through Corepack, and install JavaScript dependencies
-$ corepack enable && pnpm install
+# Install JavaScript dependencies
+$ pnpm install
 ```
 
 ### Linking Symfony UX packages to your project

--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
     "private": true,
     "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
+    "devEngines": {
+        "runtime": {
+            "name": "node",
+            "version": "^22.18.0",
+            "onFail": "warn"
+        }
+    },
     "type": "module",
     "workspaces": [
         "src/*/assets",


### PR DESCRIPTION
Node.js is dropping Corepack, so this replaces the old two-step `npm i -g corepack && corepack enable` + `actions/setup-node` setup with pnpm's dedicated `pnpm/setup` action. That single step installs pnpm, provisions Node, runs the install (pnpm auto-enables `--frozen-lockfile` in CI), and handles the store cache.

The pnpm version still comes from the `packageManager` field in `package.json`. The Node version now comes from a new [`devEngines.runtime` field in the root `package.json`](https://pnpm.io/fr/package_json#devenginesruntime), so the workflows carry no hardcoded version numbers. `.nvmrc` stays for local `nvm`/`fnm` users.

A few intentional details worth calling out:

- `devEngines.runtime` uses `onFail: "warn"` so a local `pnpm install` never tries to download or manage Node itself (which would touch the lockfile). `pnpm/setup` ignores that flag and installs the pinned version in CI regardless.
- The npm release workflow is a deliberate exception: it keeps `actions/setup-node`, because that action's `registry-url` input is what enables npm's OIDC trusted publishing (id-token + provenance, no token). There, Corepack is swapped for `pnpm/action-setup` and the rest is left as-is.
- CONTRIBUTING.md now points contributors to pnpm.io/installation instead of going through Corepack.
- All third-party actions are pinned to commit SHAs, per the repo convention.
