### PR TITLE
[TwigComponent] Fix quadratic scanning in TwigPreLexer::consume()

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -366,8 +366,10 @@ class TwigPreLexer
      */
     private function consume(string $string): bool
     {
-        if (str_starts_with(substr($this->input, $this->position), $string)) {
-            $this->position += \strlen($string);
+        $length = \strlen($string);
+
+        if ($this->position + $length <= $this->length && 0 === substr_compare($this->input, $string, $this->position, $length)) {
+            $this->position += $length;
 
             return true;
         }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`consume()` built a copy of the whole remaining template on every call via `substr()`, and it's called several times per character in the main scan loop, so pre-lexing was quadratic in template size.

The fix compares in place with `substr_compare()` instead of copying. Delegating to the existing `check()` helper looked like the obvious move, but it measured slower on small templates, where the extra call costs more than the copy it saves, so the bounds check is inlined instead.

Scaling is now linear, and no template size is slower than before:

    185 B     89 us ->    89 us
    925 B    460 us ->   444 us
    7.4 KB  4649 us ->  3557 us
     55 KB  92.1 ms ->  27.4 ms

Pre-lexing every Twig template in this repository (390 files, median size 332 B) goes from ~23.2 ms to ~19.6 ms.

Benchmarked from the repository root with `blackfire run symfony php bench.php`:

```php
<?php
require __DIR__.'/src/TwigComponent/vendor/autoload.php';

use Symfony\UX\TwigComponent\Twig\TwigPreLexer;

$chunk = <<<'TWIG'
<div class="card">
    <h1>Some title here</h1>
    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.</p>
    {% if foo %}
        <span>{{ bar|upper }}</span>
    {% endif %}
    <twig:Alert type="success" :count="items|length">
        Hello world
    </twig:Alert>
</div>

TWIG;

$input = str_repeat($chunk, 500); // ~154 KB
(new TwigPreLexer())->preLexComponents($input);
```

Blackfire:

- before (3.1s wall / 3.0s CPU): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/fe5bb59f-7312-4adb-ba64-edc0b716f0a2/graph
- after (1.6s wall / 1.6s CPU): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/e1a66952-a9e9-4d88-ad5f-decede4f8df6/graph
- diff: https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/compare/fe5bb59f-7312-4adb-ba64-edc0b716f0a2...e1a66952-a9e9-4d88-ad5f-decede4f8df6/graph

Analysis, implementation and benchmarks by Claude Opus 5.
