### PR TITLE
[TwigComponent] Reduce per-character work in the pre-lexer scan loops

### DIFF
--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -203,7 +203,7 @@ class TwigPreLexer
             // handle adding a default block if we find non-whitespace outside of a block
             if (!empty($this->currentComponents)
                 && !$this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock']
-                && preg_match('/\S/', $char)
+                && !ctype_space($char)
                 && !$this->check('{% block')
             ) {
                 $this->currentComponents[\count($this->currentComponents) - 1]['hasDefaultBlock'] = true;
@@ -495,42 +495,59 @@ class TwigPreLexer
         $depth = 1;
         $inComment = false;
         while ($this->position < $this->length) {
-            if ($inComment && '#}' === substr($this->input, $this->position, 2)) {
-                $inComment = false;
-            }
-            if (!$inComment && '{#' === substr($this->input, $this->position, 2)) {
-                $inComment = true;
-            }
+            $char = $this->input[$this->position];
 
-            if (!$inComment && '</twig:block>' === substr($this->input, $this->position, 13)) {
-                if (1 === $depth) {
+            // Each delimiter family starts with a distinct character, so ordinary
+            // template text runs no substr() at all and the rest run only theirs.
+            switch ($char) {
+                case '#':
+                    if ($inComment && '#}' === substr($this->input, $this->position, 2)) {
+                        $inComment = false;
+                    }
                     break;
-                }
 
-                --$depth;
-            }
+                case '{':
+                    if ('{#' === substr($this->input, $this->position, 2)) {
+                        $inComment = true;
+                        break;
+                    }
+                    if ($inComment) {
+                        break;
+                    }
 
-            if (!$inComment && '{% endblock %}' === substr($this->input, $this->position, 14)) {
-                if (1 === $depth) {
-                    // in this case, we want to advance ALL the way beyond the endblock
-                    // strlen('{% endblock %}') = 14
-                    $this->position += 14;
+                    if ('{% endblock %}' === substr($this->input, $this->position, 14)) {
+                        if (1 === $depth) {
+                            // in this case, we want to advance ALL the way beyond the endblock
+                            // strlen('{% endblock %}') = 14
+                            $this->position += 14;
+                            break 2;
+                        }
+
+                        --$depth;
+                    } elseif ('{% block' === substr($this->input, $this->position, 8)) {
+                        ++$depth;
+                    }
                     break;
-                }
 
-                --$depth;
-            }
+                case '<':
+                    if ($inComment) {
+                        break;
+                    }
 
-            if (!$inComment && '<twig:block' === substr($this->input, $this->position, 11)) {
-                ++$depth;
-            }
+                    if ('</twig:block>' === substr($this->input, $this->position, 13)) {
+                        if (1 === $depth) {
+                            break 2;
+                        }
 
-            if (!$inComment && '{% block' === substr($this->input, $this->position, 8)) {
-                ++$depth;
-            }
+                        --$depth;
+                    } elseif ('<twig:block' === substr($this->input, $this->position, 11)) {
+                        ++$depth;
+                    }
+                    break;
 
-            if ("\n" === $this->input[$this->position]) {
-                ++$this->line;
+                case "\n":
+                    ++$this->line;
+                    break;
             }
 
             ++$this->position;


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`consumeUntilEndBlock()` ran six `substr()` comparisons on every character of a block body, and the main loop ran a `preg_match()` per character to test for whitespace.

Guard the delimiter comparisons behind the only three characters that can start one (`{`, `<`, `#`), and swap the regex for `ctype_space()`.

This only kicks in for templates where a component contains a traditional `{% block %}`; `consumeUntilEndBlock()` is never reached otherwise. Only 9 of this repository's 390 Twig templates match, so it doesn't move a whole-repo aggregate, but on the ones that do, the gain holds at realistic sizes too:

    206 B    46.6 us -> 24.7 us
    322 B    79.3 us -> 29.5 us
    728 B     194 us -> 45.8 us
   1.9 KB     520 us -> 92.3 us

On the synthetic 167 KB template used in the benchmark below, pre-lexing goes from ~64 ms to ~16 ms. That gain only shows up at compile time though: Twig compiles a template once and caches the result, so this is a cache-warmup and dev-loop win, not something you'll see on every request, as smnandre pointed out during review.

Benchmarked from the repository root with `blackfire run symfony php bench.php`:

```php
<?php
require __DIR__.'/src/TwigComponent/vendor/autoload.php';

use Symfony\UX\TwigComponent\Twig\TwigPreLexer;

$body = str_repeat("    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>\n", 40);
$chunk = "<twig:Card>\n    {% block header %}\n{$body}\n    {% endblock %}\n</twig:Card>\n\n";

$input = str_repeat($chunk, 60); // ~167 KB
(new TwigPreLexer())->preLexComponents($input);
```

Blackfire:

- before (1061ms wall / 1056ms CPU): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/f4c9789b-4a34-43d6-bca9-87e67832a3f0/graph
- after (73ms wall / 72ms CPU): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/3d2c3cc2-f4c1-471c-aa3d-1246f8514429/graph
- diff: https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/compare/f4c9789b-4a34-43d6-bca9-87e67832a3f0...3d2c3cc2-f4c1-471c-aa3d-1246f8514429/graph

Analysis, implementation and benchmarks by Claude Opus 5.
