### PR TITLE
[LiveComponent] Cache the attribute-method lookups per component class

### DIFF
--- a/src/LiveComponent/src/Attribute/AsLiveComponent.php
+++ b/src/LiveComponent/src/Attribute/AsLiveComponent.php
@@ -25,6 +25,11 @@ use Symfony\UX\TwigComponent\Attribute\FromMethod;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class AsLiveComponent extends AsTwigComponent
 {
+    /**
+     * @var array<class-string, array<class-string, \ReflectionMethod[]>>
+     */
+    private static array $methodsPerAttribute = [];
+
     public string $route;
     public string $method;
     public int $urlReferenceType;
@@ -93,7 +98,7 @@ final class AsLiveComponent extends AsTwigComponent
      */
     public static function isActionAllowed(object|string $component, string $action): bool
     {
-        foreach (self::attributeMethodsFor(LiveAction::class, $component) as $method) {
+        foreach (self::cachedMethodsFor($component, LiveAction::class) as $method) {
             if ($action === $method->getName()) {
                 return true;
             }
@@ -111,7 +116,7 @@ final class AsLiveComponent extends AsTwigComponent
      */
     public static function preReRenderMethods(object|string $component): iterable
     {
-        return self::attributeMethodsByPriorityFor($component, PreReRender::class);
+        return self::cachedMethodsByPriorityFor($component, PreReRender::class);
     }
 
     /**
@@ -123,7 +128,7 @@ final class AsLiveComponent extends AsTwigComponent
      */
     public static function postHydrateMethods(object|string $component): iterable
     {
-        return self::attributeMethodsByPriorityFor($component, PostHydrate::class);
+        return self::cachedMethodsByPriorityFor($component, PostHydrate::class);
     }
 
     /**
@@ -135,7 +140,7 @@ final class AsLiveComponent extends AsTwigComponent
      */
     public static function preDehydrateMethods(object|string $component): iterable
     {
-        return self::attributeMethodsByPriorityFor($component, PreDehydrate::class);
+        return self::cachedMethodsByPriorityFor($component, PreDehydrate::class);
     }
 
     /**
@@ -148,12 +153,38 @@ final class AsLiveComponent extends AsTwigComponent
     public static function liveListeners(object|string $component): array
     {
         $listeners = [];
-        foreach (self::attributeMethodsFor(LiveListener::class, $component) as $method) {
+        foreach (self::cachedMethodsFor($component, LiveListener::class) as $method) {
             foreach ($method->getAttributes(LiveListener::class) as $attribute) {
                 $listeners[] = ['action' => $method->getName(), 'event' => $attribute->newInstance()->getEventName()];
             }
         }
 
         return $listeners;
+    }
+
+    /**
+     * @param object|class-string $component
+     * @param class-string        $attribute
+     *
+     * @return \ReflectionMethod[]
+     */
+    private static function cachedMethodsFor(object|string $component, string $attribute): array
+    {
+        $class = \is_object($component) ? $component::class : $component;
+
+        return self::$methodsPerAttribute[$class][$attribute] ??= iterator_to_array(self::attributeMethodsFor($attribute, $component));
+    }
+
+    /**
+     * @param object|class-string $component
+     * @param class-string        $attribute
+     *
+     * @return \ReflectionMethod[]
+     */
+    private static function cachedMethodsByPriorityFor(object|string $component, string $attribute): array
+    {
+        $class = \is_object($component) ? $component::class : $component;
+
+        return self::$methodsPerAttribute[$class][$attribute] ??= self::attributeMethodsByPriorityFor($component, $attribute);
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`liveListeners()`, `preDehydrateMethods()`, `postHydrateMethods()`, `preReRenderMethods()` and `isActionAllowed()` each rebuild a `ReflectionClass` and walk every public method of the component, on every render and every request, even though what they return only depends on the component class.

Memoize the resolved methods per class and attribute. An earlier revision of this branch put the cache in `AsTwigComponent`, where those helpers live, but they have no other consumer than `AsLiveComponent`, so the cache belongs here and `TwigComponent` is left untouched.

Timings use the call counts from the review: a page holding five LiveComponents calls `liveListeners()` and `preDehydrateMethods()` once per component on the initial render, and a single component update calls each of the five once.

    initial render, 5 components   18.1 us -> 2.9 us
    one component update            8.2 us -> 1.0 us

Sixteen microseconds off a page render isn't going to show up in a profile; the ratio is what it is because reflection simply isn't needed more than once per class.

Benchmarked from the repository root with `symfony php bench.php`:

```php
<?php
require __DIR__.'/src/LiveComponent/vendor/autoload.php';

use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
use Symfony\UX\LiveComponent\Attribute\LiveAction;
use Symfony\UX\LiveComponent\Attribute\LiveListener;
use Symfony\UX\LiveComponent\Attribute\PostHydrate;
use Symfony\UX\LiveComponent\Attribute\PreDehydrate;
use Symfony\UX\LiveComponent\Attribute\PreReRender;

#[AsLiveComponent('Bench')]
class BenchComponent
{
    #[PreDehydrate] public function onPreDehydrate() {}
    #[PostHydrate] public function onPostHydrate() {}
    #[PreReRender] public function onPreReRender() {}
    #[LiveAction] public function save() {}
    #[LiveListener('foo:bar')] public function onFooBar() {}

    public function noise1() {} public function noise2() {} public function noise3() {}
    public function noise4() {} public function noise5() {} public function noise6() {}
}

$component = new BenchComponent();

$render = static function () use ($component) {
    for ($i = 0; $i < 5; ++$i) {
        AsLiveComponent::liveListeners($component);
        AsLiveComponent::preDehydrateMethods($component);
    }
};
$update = static function () use ($component) {
    AsLiveComponent::liveListeners($component);
    AsLiveComponent::preDehydrateMethods($component);
    AsLiveComponent::postHydrateMethods($component);
    AsLiveComponent::preReRenderMethods($component);
    AsLiveComponent::isActionAllowed($component, 'save');
};

foreach (['initial render' => $render, 'one update' => $update] as $label => $fn) {
    $fn();
    $start = hrtime(true);
    for ($i = 0; $i < 2000; ++$i) { $fn(); }
    printf("%-16s %6.1f us\n", $label, (hrtime(true) - $start) / 1e3 / 2000);
}
```

Blackfire:

- before: https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/8f8d948b-732a-44ca-a0a3-ebb9cbc48637/graph
- after: https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/f0d0d013-2120-471b-8569-f0866a905d9e/graph
- diff: https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/compare/8f8d948b-732a-44ca-a0a3-ebb9cbc48637...f0d0d013-2120-471b-8569-f0866a905d9e/graph

Analysis, implementation and benchmarks by Claude Opus 5.
