### PR TITLE
[Toolkit] Stop re-walking the filesystem on every Recipe::getFiles()

### DIFF
--- a/src/Toolkit/src/Recipe/Recipe.php
+++ b/src/Toolkit/src/Recipe/Recipe.php
@@ -24,6 +24,11 @@ use Symfony\UX\Toolkit\Markdown\CodeOptions;
 final class Recipe
 {
     /**
+     * @var list<File>|null
+     */
+    private ?array $files = null;
+
+    /**
      * @param non-empty-string $name
      * @param non-empty-string $absolutePath
      */
@@ -102,12 +107,22 @@ final class Recipe
      */
     public function getFiles(): iterable
     {
+        // This used to be a generator, so every consumer re-walked the recipe
+        // directories from disk. Several of them iterate the same recipe more
+        // than once while rendering or installing it.
+        if (null !== $this->files) {
+            return $this->files;
+        }
+
+        $files = [];
         foreach ($this->manifest->copyFiles as $source => $destination) {
             $finder = new Finder()->in(Path::join($this->absolutePath, $source))->sortByName()->files();
 
             foreach ($finder as $file) {
-                yield new File(Path::join($source, $file->getRelativePathname()), Path::join($destination, $file->getRelativePathname()));
+                $files[] = new File(Path::join($source, $file->getRelativePathname()), Path::join($destination, $file->getRelativePathname()));
             }
         }
+
+        return $this->files = $files;
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`Recipe::getFiles()` is a generator that runs a `Finder` over the recipe directories every time it's iterated. It has six consumers, and several of them iterate the same recipe more than once: `RecipeDocRenderer` walks it twice while building one doc context, on top of the walk `PoolResolver` just did, and `ComponentFactory::metadataFor()` reaches it once per anonymous component lookup.

Build the list once per `Recipe` and return it. `Recipe` is `@internal`, immutable, and constructed per kit load from read-only sources, so there's nothing to invalidate. The return type is already `iterable<File>`, so returning an array is signature-compatible and the `iterator_to_array()` call sites keep working.

Resolving the shadcn kit's components went from 22,140 `Finder` walks to one per recipe. The Toolkit test suite goes from ~13.3 s to ~9.5 s.

Benchmarked on the rendering test suite, from `src/Toolkit`:

```bash
blackfire run --ignore-exit-status symfony php vendor/bin/phpunit \
    --filter 'Kit shadcn, component [a-d]'
```

Blackfire:

- before (19.2s wall / 245MB): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/ddc20fda-bf4c-4344-9037-0dc0054d496a/graph
- after (16.2s wall / 210MB): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/2f7d0363-b44a-4a2b-80e6-8f1ed92bc7fb/graph
- diff: https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/compare/ddc20fda-bf4c-4344-9037-0dc0054d496a...2f7d0363-b44a-4a2b-80e6-8f1ed92bc7fb/graph

Analysis, implementation and benchmarks by Claude Opus 5.
