### PR TITLE
[Translator] Cache the RegExp compiled by strtr()

### DIFF
--- a/src/Translator/assets/dist/translator_controller.js
+++ b/src/Translator/assets/dist/translator_controller.js
@@ -1,10 +1,16 @@
 import { IntlMessageFormat } from "intl-messageformat";
+const compiledPatterns = /* @__PURE__ */ new Map();
+const SPECIAL_CHARS_REGEX = /([-[\]{}()*+?.\\^$|#,])/g;
 function strtr(string, replacePairs) {
-	const regex = Object.entries(replacePairs).map(([from]) => {
-		return from.replace(/([-[\]{}()*+?.\\^$|#,])/g, "\\$1");
-	});
-	if (regex.length === 0) return string;
-	return string.replace(new RegExp(regex.join("|"), "g"), (matched) => replacePairs[matched].toString());
+	const keys = Object.keys(replacePairs);
+	if (keys.length === 0) return string;
+	const pattern = keys.map((from) => from.replace(SPECIAL_CHARS_REGEX, "\\$1")).join("|");
+	let regex = compiledPatterns.get(pattern);
+	if (regex === void 0) {
+		regex = new RegExp(pattern, "g");
+		compiledPatterns.set(pattern, regex);
+	}
+	return string.replace(regex, (matched) => replacePairs[matched].toString());
 }
 function format(id, parameters, locale) {
 	if (null === id || "" === id) return "";

--- a/src/Translator/assets/src/utils.ts
+++ b/src/Translator/assets/src/utils.ts
@@ -1,4 +1,12 @@
 /**
+ * Translation parameters come from a fixed set of names defined in the source
+ * code, so the same patterns are recompiled over and over without this cache.
+ */
+const compiledPatterns = new Map<string, RegExp>();
+
+const SPECIAL_CHARS_REGEX = /([-[\]{}()*+?.\\^$|#,])/g;
+
+/**
  * PHP strtr's equivalent, inspired and adapted from https://stackoverflow.com/a/37949642.
  *
  * @private
@@ -7,13 +15,19 @@
  * @param replacePairs The pairs of characters to replace
  */
 export function strtr(string: string, replacePairs: Record<string, string | number | Date>): string {
-    const regex: Array<string> = Object.entries(replacePairs).map(([from]) => {
-        return from.replace(/([-[\]{}()*+?.\\^$|#,])/g, '\\$1');
-    });
+    const keys = Object.keys(replacePairs);
 
-    if (regex.length === 0) {
+    if (keys.length === 0) {
         return string;
     }
 
-    return string.replace(new RegExp(regex.join('|'), 'g'), (matched) => replacePairs[matched].toString());
+    const pattern = keys.map((from) => from.replace(SPECIAL_CHARS_REGEX, '\\$1')).join('|');
+
+    let regex = compiledPatterns.get(pattern);
+    if (regex === undefined) {
+        regex = new RegExp(pattern, 'g');
+        compiledPatterns.set(pattern, regex);
+    }
+
+    return string.replace(regex, (matched) => replacePairs[matched].toString());
 }

--- a/src/Translator/assets/test/unit/utils.test.ts
+++ b/src/Translator/assets/test/unit/utils.test.ts
@@ -41,4 +41,12 @@ text & @()`,
     ])('strtr', (expected, string, replacePairs) => {
         expect(strtr(string, replacePairs)).toEqual(expected);
     });
+
+    test('strtr reuses its compiled pattern across calls', () => {
+        const replacePairs = { '%name%': 'Hugo', '%count%': '2' };
+
+        expect(strtr('%name% has %count% apples', replacePairs)).toEqual('Hugo has 2 apples');
+        expect(strtr('%name% has %count% apples', replacePairs)).toEqual('Hugo has 2 apples');
+        expect(strtr('%count% apples for %name%', replacePairs)).toEqual('2 apples for Hugo');
+    });
 });


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`strtr()` built and compiled a new `RegExp` on every call, and it is called once per `trans()` with parameters. The pattern only depends on the parameter names, which come from a fixed set in the source code.

Cache the compiled `RegExp` by pattern and hoist the escaping regex out of the mapping callback.

200k `trans()` calls: ~226 ms -> ~195 ms with parameters, ~214 ms -> ~189 ms with plural forms.

Browser-side JavaScript, so there is no Blackfire profile for this one. Benchmarked on node 22, after `pnpm --filter @symfony/ux-translator run build`, from the repository root with `node bench.mjs`:

```js
import { createTranslator } from './src/Translator/assets/dist/translator_controller.js';

const messages = {
    'app.greeting': { id: 'app.greeting', translations: { messages: { en: 'Hello %name%, you have %count% new messages' } } },
    'app.plural': { id: 'app.plural', translations: { messages: { en: '{0} No apples|one: One apple|more: %count% apples' } } },
};

const translator = createTranslator({ messages, locale: 'en' });
const n = 200000;

let start = process.hrtime.bigint();
for (let i = 0; i < n; i++) {
    translator.trans('app.greeting', { '%name%': 'Hugo', '%count%': i });
}
console.log(`simple  ${n} trans() -> ${Number(process.hrtime.bigint() - start) / 1e6} ms`);

start = process.hrtime.bigint();
for (let i = 0; i < n; i++) {
    translator.trans('app.plural', { '%count%': i % 7 });
}
console.log(`plural  ${n} trans() -> ${Number(process.hrtime.bigint() - start) / 1e6} ms`);
```

Analysis, implementation and benchmarks by Claude Opus 5.
