### PR TITLE
[TwigComponent] Read the call stack through a growing window in BlockStack

### DIFF
--- a/src/TwigComponent/src/BlockStack.php
+++ b/src/TwigComponent/src/BlockStack.php
@@ -24,6 +24,14 @@ final class BlockStack
     public const OUTER_BLOCK_FALLBACK_NAME = self::OUTER_BLOCK_PREFIX.'block_fallback';
 
     /**
+     * debug_backtrace() materializes every frame of the call stack, which is deep
+     * during a request. The frames looked at below sit near the top, so the stack
+     * is read through a growing window instead of all at once. The last entry is
+     * unbounded, so the outcome is always the same as scanning the whole stack.
+     */
+    private const BACKTRACE_LIMITS = [16, 64, 0];
+
+    /**
      * @var array<string, array<int, array<int, string>>>
      */
     private array $stack;
@@ -65,82 +73,99 @@ final class BlockStack
 
     public function __call(string $name, array $arguments)
     {
-        $callingEmbeddedTemplateIndex = $this->findCallingEmbeddedTemplateIndex();
-        $hostEmbeddedTemplateIndex = $this->findHostEmbeddedTemplateIndexFromCaller();
+        [$callingEmbeddedTemplateIndex, $hostEmbeddedTemplateIndex] = $this->findCallerIndexes();
 
         return $this->stack[$name][$callingEmbeddedTemplateIndex][$hostEmbeddedTemplateIndex] ?? self::OUTER_BLOCK_FALLBACK_NAME;
     }
 
     private function findHostEmbeddedTemplateIndex(): int
     {
-        $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS | \DEBUG_BACKTRACE_PROVIDE_OBJECT);
+        foreach (self::BACKTRACE_LIMITS as $limit) {
+            $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS | \DEBUG_BACKTRACE_PROVIDE_OBJECT, $limit);
 
-        foreach ($backtrace as $trace) {
-            if (isset($trace['object']) && $trace['object'] instanceof Template) {
-                $classname = $trace['object']::class;
-                $templateIndex = self::getTemplateIndexFromTemplateClassname($classname);
-                if ($templateIndex) {
-                    // If there's no template index, then we're in a component template
-                    // and we need to go up until we find the embedded template
-                    // (which will have the block definitions).
-                    return $templateIndex;
+            foreach ($backtrace as $trace) {
+                if (isset($trace['object']) && $trace['object'] instanceof Template) {
+                    $classname = $trace['object']::class;
+                    $templateIndex = self::getTemplateIndexFromTemplateClassname($classname);
+                    if ($templateIndex) {
+                        // If there's no template index, then we're in a component template
+                        // and we need to go up until we find the embedded template
+                        // (which will have the block definitions).
+                        return $templateIndex;
+                    }
                 }
+            }
+
+            if (self::isWholeStack($backtrace, $limit)) {
+                break;
             }
         }
 
         return 0;
     }
 
-    private function findCallingEmbeddedTemplateIndex(): int
+    /**
+     * Both indexes come from the same frames, so the stack is read once.
+     *
+     * @return array{int, int} the calling embedded template index, then the host one
+     */
+    private function findCallerIndexes(): array
     {
-        $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS | \DEBUG_BACKTRACE_PROVIDE_OBJECT);
+        $calling = null;
 
-        foreach ($backtrace as $trace) {
-            if (isset($trace['object']) && $trace['object'] instanceof Template) {
-                return self::getTemplateIndexFromTemplateClassname($trace['object']::class);
-            }
-        }
-    }
+        foreach (self::BACKTRACE_LIMITS as $limit) {
+            $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS | \DEBUG_BACKTRACE_PROVIDE_OBJECT, $limit);
 
-    private function findHostEmbeddedTemplateIndexFromCaller(): int
-    {
-        $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS | \DEBUG_BACKTRACE_PROVIDE_OBJECT);
+            $blockCallerStack = [];
+            $renderer = null;
 
-        $blockCallerStack = [];
-        $renderer = null;
-
-        foreach ($backtrace as $trace) {
-            if (isset($trace['object']) && $trace['object'] instanceof Template) {
-                $classname = $trace['object']::class;
-                $templateIndex = self::getTemplateIndexFromTemplateClassname($classname);
-                if (null === $renderer) {
-                    if ($templateIndex) {
-                        // This class is an embedded template.
-                        // Next class is either the renderer or a previous template that's passing blocks through.
-                        $blockCallerStack[$classname] = $classname;
+            foreach ($backtrace as $trace) {
+                if (isset($trace['object']) && $trace['object'] instanceof Template) {
+                    $classname = $trace['object']::class;
+                    $templateIndex = self::getTemplateIndexFromTemplateClassname($classname);
+                    // The first template frame is the one calling the block.
+                    $calling ??= $templateIndex;
+                    if (null === $renderer) {
+                        if ($templateIndex) {
+                            // This class is an embedded template.
+                            // Next class is either the renderer or a previous template that's passing blocks through.
+                            $blockCallerStack[$classname] = $classname;
+                            continue;
+                        }
+                        // If it's not an embedded template anymore, we've reached the renderer.
+                        // From now on we'll travel back up the hierarchy.
+                        $renderer = $classname;
                         continue;
                     }
-                    // If it's not an embedded template anymore, we've reached the renderer.
-                    // From now on we'll travel back up the hierarchy.
-                    $renderer = $classname;
-                    continue;
-                }
-                if ($classname === $renderer || isset($blockCallerStack[$classname])) {
-                    continue;
-                }
+                    if ($classname === $renderer || isset($blockCallerStack[$classname])) {
+                        continue;
+                    }
 
-                if (!$templateIndex) {
-                    continue;
-                }
+                    if (!$templateIndex) {
+                        continue;
+                    }
 
-                // This is the first template that's not part of the callstack,
-                // so it's the template that has the outer block definition.
-                return $templateIndex;
+                    // This is the first template that's not part of the callstack,
+                    // so it's the template that has the outer block definition.
+                    return [$calling, $templateIndex];
+                }
+            }
+
+            if (self::isWholeStack($backtrace, $limit)) {
+                break;
             }
         }
 
         // If the component is not an embedded one, just return 0, so the fallback content (aka nothing) is used.
-        return 0;
+        return [$calling ?? 0, 0];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $backtrace
+     */
+    private static function isWholeStack(array $backtrace, int $limit): bool
+    {
+        return 0 === $limit || \count($backtrace) < $limit;
     }
 
     private static function getTemplateIndexFromTemplateClassname(string $classname): int


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`BlockStack` locates the embedded template it is rendering from by scanning the call stack. It did so with three unbounded `debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS | DEBUG_BACKTRACE_PROVIDE_OBJECT)` calls: one per `convert()`, and two more per `__call()`, which runs on every `outerBlocks.*` access in a template.

The frames of interest sit near the top of the stack, so read it through a growing window (16, then 64, then unbounded). The last window is unbounded, so the outcome is identical to scanning the whole stack; only the common case gets cheaper. Rendered output was compared byte for byte on the three `outer_blocks` fixtures.

Rendering `embedded_component_blocks_outer_blocks.html.twig` 3000 times from a call stack 40 frames deep: ~265 ms -> ~184 ms (means of 3+ runs).

Benchmarked from the repository root with `symfony php bench.php`:

```php
<?php
require __DIR__.'/src/TwigComponent/vendor/autoload.php';
require __DIR__.'/src/TwigComponent/tests/Fixtures/Kernel.php';

use Symfony\UX\TwigComponent\Tests\Fixtures\Kernel;
use Twig\Environment;

$kernel = new Kernel('test', true);
$kernel->boot();

$twig = $kernel->getContainer()->get('test.service_container')->get(Environment::class);
$template = 'embedded_component_blocks_outer_blocks.html.twig';

// Warm up: compile the templates once, outside the measurement.
$twig->render($template);

// Emulate the depth of a real Symfony request (kernel, controller, listeners...).
$deep = static function (int $depth, callable $fn) use (&$deep) {
    return $depth > 0 ? $deep($depth - 1, $fn) : $fn();
};

$start = hrtime(true);
for ($i = 0; $i < 3000; ++$i) {
    $deep(40, static fn () => $twig->render($template));
}
printf("%d renders -> %.2f ms\n", 3000, (hrtime(true) - $start) / 1e6);
```

Blackfire:

- before (2.9s wall / 2.9s CPU / 93MB): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/1d4252d4-1228-43ff-8627-2093aa7672b6/graph
- after (2.8s wall / 2.8s CPU / 91MB): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/aa82ef75-8b61-4985-9652-16f49c77c168/graph
- diff: https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/compare/1d4252d4-1228-43ff-8627-2093aa7672b6...aa82ef75-8b61-4985-9652-16f49c77c168/graph

Analysis, implementation and benchmarks by Claude Opus 5.
