### PR TITLE
[LiveComponent] Index TemplateMap instead of scanning it on every child component

### DIFF
--- a/src/LiveComponent/src/Twig/TemplateMap.php
+++ b/src/LiveComponent/src/Twig/TemplateMap.php
@@ -26,6 +26,11 @@ final class TemplateMap
      */
     private readonly array $map;
 
+    /**
+     * @var array<string, string>|null Map of <template name> => <obscured name>
+     */
+    private ?array $reverseMap = null;
+
     public function __construct(string $cacheFile)
     {
         $this->map = PhpArrayAdapter::create($cacheFile, new NullAdapter())->getItem('map')->get();
@@ -38,10 +43,9 @@ final class TemplateMap
 
     public function obscuredName(string $templateName): string
     {
-        if (false === $obscuredName = array_search($templateName, $this->map, true)) {
-            throw new \RuntimeException(\sprintf('Cannot find a match for template "%s". Cache may be corrupt.', $templateName));
-        }
-
-        return $obscuredName;
+        // This runs for every embedded child component, and scanning the whole map
+        // each time made it cost more the more templates an application has.
+        return ($this->reverseMap ??= array_flip($this->map))[$templateName]
+            ?? throw new \RuntimeException(\sprintf('Cannot find a match for template "%s". Cache may be corrupt.', $templateName));
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`TemplateMap::obscuredName()` resolved a template name through `array_search($templateName, $this->map, true)`, a linear scan of the whole map. It runs once per embedded child component render, via `LiveControllerAttributesCreator` setting `data-host-template`, so the cost grew with the number of templates in the application rather than with the page being rendered.

Flip the map once, on first use. `TemplateCacheWarmer` builds it as `hash('xxh128', $name.$secret) => $name`, so the key is a pure function of the value and no two keys can share one: `array_flip()` is therefore exactly equivalent to the first match `array_search()` returned. Applications that never render an embedded child component never build the reverse map.

Reusing the flipped map across many lookups, 2000 lookups against a 1000-template map: ~5.36 ms -> ~0.17 ms, flip included. That's the amortized case though, and it hides what a single request looks like, since `TemplateMap` is built fresh each time and the flip itself has a cost. Measured against a 1000-template map with one fresh `TemplateMap` per request:

    1 lookup     2.4 us  ->  9.2 us   (slower)
    3 lookups    6.5 us  ->  9.2 us   (slower)
    5 lookups   10.6 us  ->  9.4 us   (break-even)
    10 lookups  20.7 us  ->  9.8 us
    20 lookups  41.2 us  -> 10.5 us
    50 lookups 103.4 us  -> 12.7 us

`obscuredName()` is called once per embedded child component, so a page with fewer than about five of them pays a few extra microseconds for the flip. Past that it wins, and it wins outright under a worker runtime (Swoole, FrankenPHP worker mode) where the flip is amortized across requests instead of redone on every one.

Benchmarked from the repository root with `blackfire run symfony php bench.php`:

```php
<?php
require __DIR__.'/src/LiveComponent/vendor/autoload.php';

use Symfony\UX\LiveComponent\Twig\TemplateMap;

$size = 1000;
$map = [];
for ($i = 0; $i < $size; ++$i) {
    $map[hash('xxh3', 'template-'.$i)] = 'components/Some/Nested/Template'.$i.'.html.twig';
}

// TemplateMap reads its map from a PhpArrayAdapter cache file, so inject it directly.
$templateMap = new ReflectionClass(TemplateMap::class)->newInstanceWithoutConstructor();
new ReflectionProperty(TemplateMap::class, 'map')->setValue($templateMap, $map);

$names = array_values($map);

$start = hrtime(true);
for ($i = 0; $i < 2000; ++$i) {
    $templateMap->obscuredName($names[$i % $size]);
}
printf("%d templates, 2000 obscuredName() -> %.2f ms\n", $size, (hrtime(true) - $start) / 1e6);
```

Blackfire:

- before (26ms wall / 19ms CPU): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/9b527dfe-ce30-4f8d-a5e0-df0ef79fed11/graph
- after (11ms wall / 11ms CPU): https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/f44635d7-2b33-40b8-844b-c202a85d88a6/graph
- diff: https://app.blackfire.io/envs/5f4f9a62-eaa0-45ee-b7b3-a1b879f550e9/profiles/compare/9b527dfe-ce30-4f8d-a5e0-df0ef79fed11...f44635d7-2b33-40b8-844b-c202a85d88a6/graph

Analysis, implementation and benchmarks by Claude Opus 5.
