### PR TITLE
[LiveComponent] Skip the bracket pipeline for plain model names

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -262,6 +262,7 @@ function trimAll(str) {
 	return str.replace(/[\s]+/g, " ").trim();
 }
 function normalizeModelName(model) {
+	if (!model.includes("[") && !model.includes("]")) return model;
 	return model.replace(/\[]$/, "").split("[").map((s) => s.replace("]", "")).join(".");
 }
 function getValueFromElement(element, valueStore) {

--- a/src/LiveComponent/assets/src/string_utils.ts
+++ b/src/LiveComponent/assets/src/string_utils.ts
@@ -31,6 +31,12 @@ export function trimAll(str: string) {
  * For example: "user[firstName]" becomes "user.firstName"
  */
 export function normalizeModelName(model: string): string {
+    // Most model names are plain (e.g. "query"), and the pipeline below is a
+    // no-op for them. ValueStore also normalizes already-normalized names.
+    if (!model.includes('[') && !model.includes(']')) {
+        return model;
+    }
+
     return (
         model
             // Names ending in "[]" represent arrays in HTML.

--- a/src/LiveComponent/assets/test/unit/string_utils.test.ts
+++ b/src/LiveComponent/assets/test/unit/string_utils.test.ts
@@ -30,4 +30,8 @@ describe('normalizeModelName', () => {
     it('can normalize a string ending in []', () => {
         expect(normalizeModelName('user[mailing][]')).toEqual('user.mailing');
     });
+
+    it('strips a stray closing bracket', () => {
+        expect(normalizeModelName('weird]name')).toEqual('weirdname');
+    });
 });


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

`normalizeModelName()` ran a `replace()`, a `split()`, a `map()` with a
second `replace()` per part and a `join()` on every call, even for a plain
name like `query` where the whole pipeline is a no-op.

It runs on every input event through `getValueFromElement()`, and twice per
`ValueStore.set()` since `set()` normalizes and then calls `get()`, which
normalizes again.

Return the name untouched when it contains neither `[` nor `]`. Names that
do use the bracket syntax take the same path as before.

400k calls: plain names ~45 ms -> ~12 ms, a realistic 80/20 mix ~43 ms ->
~17 ms, bracketed names unchanged (~84 ms). These are micro-seconds per
event in absolute terms, but the change is three lines and output is
identical.

Browser-side JavaScript, so there is no Blackfire profile for this one.
Benchmarked on node 22 with `node bench.mjs`, comparing both
implementations side by side:

```js
function current(model) {
    return model.replace(/\[]$/, '').split('[').map((s) => s.replace(']', '')).join('.');
}

function candidate(model) {
    if (!model.includes('[') && !model.includes(']')) {
        return model;
    }

    return model.replace(/\[]$/, '').split('[').map((s) => s.replace(']', '')).join('.');
}

const plain = ['firstName', 'email', 'query', 'isEnabled', 'selectedId'];
const bracketed = ['user[firstName]', 'user[mailing][]', 'form[items][0][label]'];

for (const [label, names] of [
    ['plain only', plain],
    ['bracketed only', bracketed],
    ['mixed 80/20', [...plain, ...plain, ...plain, ...plain, ...bracketed]],
]) {
    for (const [impl, fn] of [['current', current], ['candidate', candidate]]) {
        for (const n of names) fn(n); // warm up

        const start = process.hrtime.bigint();
        for (let i = 0; i < 400000; i++) {
            fn(names[i % names.length]);
        }
        console.log(`${label} ${impl} -> ${(Number(process.hrtime.bigint() - start) / 1e6).toFixed(2)} ms`);
    }
}
```

A stray `]` with no `[` was the one input where the fast path could have
diverged, so it is now covered by a unit test.

Analysis, implementation and benchmarks by Claude Opus 5.
