### PR TITLE
[LiveComponent] Fix proxy turning "toJSON" and "then" protocol probes into server actions

### DIFF
--- a/src/LiveComponent/assets/dist/live_controller.js
+++ b/src/LiveComponent/assets/dist/live_controller.js
@@ -1663,6 +1663,7 @@ function proxifyComponent(component) {
 				return Reflect.get(component, prop);
 			}
 			if (component.valueStore.has(prop)) return component.getData(prop);
+			if ("toJSON" === prop || "then" === prop) return;
 			return (args) => {
 				return component.action.apply(component, [prop, args]);
 			};

--- a/src/LiveComponent/assets/src/Component/index.ts
+++ b/src/LiveComponent/assets/src/Component/index.ts
@@ -588,6 +588,14 @@ export function proxifyComponent(component: Component): Component {
                 return component.getData(prop);
             }
 
+            // protocol probes performed implicitly by JSON.stringify() ("toJSON") and
+            // by promise assimilation ("then", e.g. `await component`) must not be
+            // mistaken for actions: returning a callable would let those protocols
+            // invoke it, queueing a real server action of that name
+            if ('toJSON' === prop || 'then' === prop) {
+                return undefined;
+            }
+
             // try to call an action
             return (args: string[]) => {
                 return component.action.apply(component, [prop, args]);

--- a/src/LiveComponent/assets/test/unit/Component/index.test.ts
+++ b/src/LiveComponent/assets/test/unit/Component/index.test.ts
@@ -130,5 +130,54 @@ describe('Component class', () => {
             expect(backend.actions[0].name).toBe('save');
             expect(backend.actions[0].args).toEqual({ foo: 'bar', secondArg: 'secondValue' });
         });
+
+        it('does not turn the toJSON protocol probe of JSON.stringify() into an action', async () => {
+            const { proxy, backend } = makeDummyComponent();
+
+            // @ts-expect-error
+            expect(proxy.toJSON).toBeUndefined();
+
+            try {
+                JSON.stringify(proxy);
+            } catch {
+                // the component graph is circular, so stringify throws exactly like
+                // it does on the unproxied component; all that matters here is that
+                // the "toJSON" probe did not queue a server action
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            expect(backend.actions).toHaveLength(0);
+        });
+
+        it('does not turn the then protocol probe of promise assimilation into an action', async () => {
+            const { proxy, backend } = makeDummyComponent();
+
+            // if "then" returned a callable, the proxy would be treated as a
+            // thenable and this promise would never resolve to the proxy itself
+            const resolved = await Promise.resolve(proxy);
+
+            expect(resolved).toBe(proxy);
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            expect(backend.actions).toHaveLength(0);
+        });
+
+        it('still exposes models named like protocol probes', () => {
+            const { backend } = makeTestComponent();
+            const component = new Component(
+                document.createElement('div'),
+                'test-component',
+                { toJSON: 'model value', then: 'other value' },
+                [],
+                null,
+                backend,
+                new noopElementDriver()
+            );
+            const proxy = proxifyComponent(component);
+
+            // @ts-expect-error
+            expect(proxy.toJSON).toBe('model value');
+            // @ts-expect-error
+            expect(proxy.then).toBe('other value');
+        });
     });
 });

--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -925,6 +925,12 @@ initialized:
     const component = document.getElementById('id-of-your-element').__component;
     component.mode = 'editing';
 
+.. note::
+
+    An action cannot be named ``then`` or ``toJSON``: these names are reserved
+    so that ``await`` and ``JSON.stringify()`` keep working on the ``Component``
+    object.
+
 .. _javascript-manual-element-change:
 
 Finally, you can also set the value of a model field directly. However,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #3752
| License       | MIT

The component proxy treats any unknown property read as a server action. `JSON.stringify()` probes `toJSON`, and promise assimilation (e.g. `await component`, or returning the proxy from an async function) probes `then`: both received a callable and invoked it, queueing a phantom server action named `toJSON` or `then`.

This PR returns `undefined` for these two protocol probes. The guard sits after the model lookup, so a model actually named `toJSON` or `then` keeps priority; only the "unknown name = action" fallback is skipped. Same family of fix as #2537, which stopped `JSON.stringify()` from serializing `__component`.

Tests cover both probes (no action queued, `await` resolves to the proxy itself) and the model-priority case.
