### PR TITLE
[TwigComponent] Capture prop documentation comments

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for `MergeableInterface` from `twig/html-extra` in `ComponentAttributes#defaults()`
 - Add support for dynamic component names in the HTML syntax using `<twig:component is="myComponent" ...`
+- Capture `## <description>` documentation comments written above props inside `{% props %}` (Twig 3.29+), exposed per prop via `PropsNode::getPropDocumentation()`
 
 ## 3.4.0
 

--- a/src/TwigComponent/src/Twig/PropsNode.php
+++ b/src/TwigComponent/src/Twig/PropsNode.php
@@ -23,9 +23,20 @@ use Twig\Node\Node;
 #[YieldReady]
 class PropsNode extends Node
 {
-    public function __construct(array $propsNames, array $values, $lineno = 0)
+    /**
+     * @param array<string, string> $documentations The `## ...` documentation of each documented prop, keyed by name
+     */
+    public function __construct(array $propsNames, array $values, array $documentations = [], $lineno = 0)
     {
-        parent::__construct($values, ['names' => $propsNames], $lineno);
+        parent::__construct($values, ['names' => $propsNames, 'documentations' => $documentations], $lineno);
+    }
+
+    /**
+     * The `## ...` documentation attached to the given prop, or null when it is undocumented.
+     */
+    public function getPropDocumentation(string $name): ?string
+    {
+        return $this->getAttribute('documentations')[$name] ?? null;
     }
 
     public function compile(Compiler $compiler): void

--- a/src/TwigComponent/src/Twig/PropsTokenParser.php
+++ b/src/TwigComponent/src/Twig/PropsTokenParser.php
@@ -29,8 +29,15 @@ class PropsTokenParser extends AbstractTokenParser
 
         $names = [];
         $values = [];
+        $documentations = [];
         while (!$stream->nextIf(Token::BLOCK_END_TYPE)) {
-            $name = $stream->expect(Token::NAME_TYPE)->getValue();
+            $nameToken = $stream->expect(Token::NAME_TYPE);
+            $name = $nameToken->getValue();
+
+            // Since Twig 3.29, a `## ...` comment above a prop is attached to its name token.
+            if (method_exists($nameToken, 'getDocumentation') && null !== $documentation = $nameToken->getDocumentation()) {
+                $documentations[$name] = $documentation;
+            }
 
             if ($stream->nextIf(Token::OPERATOR_TYPE, '=')) {
                 if (method_exists($parser, 'parseExpression')) {
@@ -49,7 +56,7 @@ class PropsTokenParser extends AbstractTokenParser
             }
         }
 
-        return new PropsNode($names, $values, $token->getLine());
+        return new PropsNode($names, $values, $documentations, $token->getLine());
     }
 
     public function getTag(): string

--- a/src/TwigComponent/tests/Integration/Twig/ComponentPropsParserTest.php
+++ b/src/TwigComponent/tests/Integration/Twig/ComponentPropsParserTest.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\TwigComponent\Twig\PropsNode;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use Twig\Node\Node;
 use Twig\Node\TextNode;
 use Twig\Source;
 
@@ -60,6 +61,48 @@ class ComponentPropsParserTest extends KernelTestCase
         $this->assertInstanceOf(TextNode::class, $body->getNode(1));
         $this->assertTrue($body->getNode(1)->hasAttribute('data'));
         $this->assertSame($text, $body->getNode(1)->getAttribute('data'));
+    }
+
+    public function testPropDocumentationIsCaptured()
+    {
+        if (!method_exists(\Twig\Token::class, 'getDocumentation')) {
+            $this->markTestSkipped('Documentation comments require twig/twig >= 3.29.');
+        }
+
+        $template = <<<'TWIG'
+            {%- props
+                ## string Unique identifier.
+                id,
+                ## 'default'|'secondary' The visual style variant.
+                variant = 'default',
+                open = false
+            -%}
+            TWIG;
+
+        /** @var Environment $twig */
+        $twig = self::getContainer()->get(Environment::class);
+        $twig->setLoader(new ArrayLoader(['template' => $template]));
+
+        $propsNode = $this->findPropsNode($twig->parse($twig->tokenize(new Source($template, 'template'))));
+
+        $this->assertInstanceOf(PropsNode::class, $propsNode);
+        $this->assertSame('string Unique identifier.', $propsNode->getPropDocumentation('id'));
+        $this->assertSame("'default'|'secondary' The visual style variant.", $propsNode->getPropDocumentation('variant'));
+        $this->assertNull($propsNode->getPropDocumentation('open'));
+    }
+
+    private function findPropsNode(Node $node): ?PropsNode
+    {
+        if ($node instanceof PropsNode) {
+            return $node;
+        }
+        foreach ($node as $child) {
+            if ($child instanceof Node && null !== $found = $this->findPropsNode($child)) {
+                return $found;
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Twig 3.29 ([twigphp/Twig#4871](https://github.com/twigphp/Twig/pull/4871)) introduces documentation comments: a `## <description>` comment written inside a tag, or a `{## ... #}` comment, gets attached to the following node and can be read back through `Node::getDocumentation()` / `Token::getDocumentation()`.

This PR teaches the `{% props %}` tag to pick these up. A `## <description>` comment written above a prop is captured from the prop's name token and exposed per prop through a new `PropsNode::getPropDocumentation()` method.

It's fully backward compatible. The read is guarded with `method_exists()`, so the props tag keeps working exactly the same on Twig < 3.29, documentation just isn't available there. The `twig/twig` requirement is unchanged, and documentation is only ever captured when running on Twig >= 3.29.
