### PR TITLE
[StimulusBundle] Document chaining different stimulus_* helpers

### DIFF
--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -342,6 +342,34 @@ You can also retrieve the generated attributes as an array, which can be helpful
 
     {{ form_row(form.password, { attr: stimulus_target('hello-controller', 'myTarget').toArray() }) }}
 
+Chaining Different Helpers
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``stimulus_controller``, ``stimulus_action`` and ``stimulus_target``
+filters can be mixed freely to render all the attributes of an element at
+once, whichever function the chain started with:
+
+.. code-block:: html+twig
+
+    <div {{ stimulus_controller('first-controller')
+        |stimulus_target('second-controller', 'anotherTarget')
+        |stimulus_target('third-controller', 'foo')
+        |stimulus_action('first-controller', 'test')
+        |stimulus_controller('fourth-controller')
+        |stimulus_action('fourth-controller', 'onClick') }}
+    >
+        Hello
+    </div>
+
+    <!-- would render -->
+    <div data-controller="first-controller fourth-controller"
+        data-action="first-controller#test fourth-controller#onClick"
+        data-second-controller-target="anotherTarget"
+        data-third-controller-target="foo"
+    >
+        Hello
+    </div>
+
 .. _configuration:
 
 Configuration

--- a/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
+++ b/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
@@ -250,4 +250,20 @@ final class StimulusTwigExtensionTest extends TestCase
             (string) $extension->appendStimulusTarget($dto, '@symfony/ux-dropzone/dropzone', 'anotherTarget fooTarget')
         );
     }
+
+    public function testAppendDifferentStimulusHelpers()
+    {
+        $extension = new StimulusTwigExtension(new StimulusHelper($this->twig));
+        $dto = $extension->renderStimulusController('first-controller');
+        $dto = $extension->appendStimulusTarget($dto, 'second-controller', 'anotherTarget');
+        $dto = $extension->appendStimulusTarget($dto, 'third-controller', 'foo');
+        $dto = $extension->appendStimulusAction($dto, 'first-controller', 'test');
+        $dto = $extension->appendStimulusController($dto, 'fourth-controller');
+        $dto = $extension->appendStimulusAction($dto, 'fourth-controller', 'onClick');
+
+        $this->assertSame(
+            'data-controller="first-controller fourth-controller" data-action="first-controller#test fourth-controller#onClick" data-second-controller-target="anotherTarget" data-third-controller-target="foo"',
+            (string) $dto
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | Fix #3794
| License       | MIT

The docs already show chaining the `stimulus_controller`, `stimulus_action` and `stimulus_target` filters with themselves, but not that they can be mixed freely to build all the attributes of an element in one chain, as suggested in #3794. This adds a short section with the example (rendered output verified against the actual helpers) and a unit test covering mixed chaining, which no test exercised before.
