### PR TITLE
[Toolkit][Shadcn] Fix the hover-card usage example crashing on a plain HTML trigger

### DIFF
--- a/src/Toolkit/kits/shadcn/hover-card/README.md
+++ b/src/Toolkit/kits/shadcn/hover-card/README.md
@@ -26,7 +26,7 @@ For sighted users to preview content available behind a link.
 ```twig
 <twig:HoverCard>
     <twig:HoverCard:Trigger>
-        <a href="#" class="underline" {{ ...hover_card_trigger_attrs }}>@symfony</a>
+        <a href="#" class="underline" {{ html_attr(hover_card_trigger_attrs) }}>@symfony</a>
     </twig:HoverCard:Trigger>
     <twig:HoverCard:Content>
         The Symfony PHP framework — official organization on GitHub.


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | n/a
| License        | MIT

The "Usage" snippet of the Shadcn `hover-card` recipe puts the trigger attributes on a plain `<a>` with the `{{ ...hover_card_trigger_attrs }}` spread. That spread is a Twig Components feature and only works on `<twig:...>` tags; on a plain HTML element it reaches Twig as-is and fails at compile time with `Cannot use positional argument after argument unpacking` (a PHP fatal, not even a catchable Twig error).

The snippet is not caught by the rendering snapshots because only the `## Examples` blocks are rendered, not `## Usage`.

This switches it to `{{ html_attr(hover_card_trigger_attrs) }}`, which is the right way to render the attributes on a plain element. I verified the updated snippet renders `<a href="#" class="underline" data-slot="hover-card-trigger" tabindex="0" data-action="focus->hover-card#show blur->hover-card#hide">` through the kit context runner. Found while answering a user report on #3469, where the same mistake is an easy one to make.
