### PR TITLE
[CI] Unify unit test parallelism across Linux and Windows

### DIFF
--- a/.github/workflows/.utils.sh
+++ b/.github/workflows/.utils.sh
@@ -1,6 +1,6 @@
-# Create a non-exiting version of _run_task for sequential execution
-# This is used to run the tests sequentially on Windows
-# because parallel is not available on Windows.
+# Runs a single task ($1 = title, $2 = command) and buffers its output into one
+# grouped block. Returns the command's exit code instead of exiting, so it can be
+# reused both by the parallel pool (_run_package_tests) and by _run_task.
 _run_task_sequential() {
     local ok=0
     local title="$1"
@@ -28,3 +28,42 @@ _run_task() {
     exit $?
 }
 export -f _run_task
+
+# Run every package in $PACKAGES through its test command with bounded parallelism.
+# Output is buffered per package and printed once all have finished, so grouped logs
+# stay readable. Relies only on Bash job control, so it behaves the same on Linux and
+# on Windows (Git Bash) — unlike GNU parallel, which is missing from Windows runners.
+_run_package_tests() {
+    # Default matches the previous "parallel -j +3": as many jobs as CPUs, plus 3.
+    local max_jobs="${1:-$(( $(nproc 2>/dev/null || echo 4) + 3 ))}"
+    local logs
+    logs="$(mktemp -d)"
+    local pkg safe rc=0
+
+    for pkg in $PACKAGES; do
+        # Throttle: wait for a running job to finish before starting the next package.
+        while [ "$(jobs -rp | wc -l)" -ge "$max_jobs" ]; do wait -n; done
+        # Bridge packages carry slashes (e.g. Map/src/Bridge/Google), so flatten
+        # them into a single path segment for the temp file names.
+        safe="${pkg//\//_}"
+        # Run in the background, capturing the package's output and exit code to files
+        # so the parallel logs can be replayed in a stable order below.
+        {
+            _run_task_sequential "$pkg" \
+                "(cd src/$pkg && $COMPOSER_MIN_STAB && $COMPOSER_UP && $PHPUNIT)"
+            echo "$?" > "$logs/$safe.rc"
+        } > "$logs/$safe.log" 2>&1 &
+    done
+    wait
+
+    # Replay each package's log in order, failing the step if any package exited non-zero.
+    for pkg in $PACKAGES; do
+        safe="${pkg//\//_}"
+        cat "$logs/$safe.log"
+        [ "$(cat "$logs/$safe.rc" 2>/dev/null || echo 1)" = 0 ] || rc=1
+    done
+
+    rm -rf "$logs"
+    return "$rc"
+}
+export -f _run_package_tests

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -123,37 +123,10 @@ jobs:
             - name: Build root packages
               run: php .github/build-packages.php
 
-            - name: Run packages tests (Unix)
-              if: matrix.os != 'windows-latest'
+            - name: Run packages tests
               run: |
                   source .github/workflows/.utils.sh
-                  echo "$PACKAGES" | xargs -n1 | parallel -j +3 "_run_task {} \
-                    '(cd src/{} \
-                    && $COMPOSER_MIN_STAB \
-                    && $COMPOSER_UP \
-                    && $PHPUNIT)'"
-
-            - name: Run packages tests (Windows)
-              if: matrix.os == 'windows-latest'
-              run: |
-                  source .github/workflows/.utils.sh
-
-                  # parallel is not available on Windows, so we need to run the tests sequentially
-                  FAILED_PACKAGES=""
-                  for PACKAGE in $PACKAGES; do
-                    if ! PACKAGE="$PACKAGE" _run_task_sequential $PACKAGE \
-                      '(cd src/$PACKAGE \
-                      && $COMPOSER_MIN_STAB \
-                      && $COMPOSER_UP \
-                      && $PHPUNIT)'; then
-                      FAILED_PACKAGES="$FAILED_PACKAGES $PACKAGE"
-                    fi
-                  done
-
-                  if [ -n "$FAILED_PACKAGES" ]; then
-                    echo "The following packages failed:$FAILED_PACKAGES"
-                    exit 1
-                  fi
+                  _run_package_tests
     js:
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Alternative to https://github.com/symfony/ux/pull/2997

The "Unit Tests" workflow ran packages differently depending on the
OS: Linux used GNU `parallel`, Windows fell back to a sequential
loop because `parallel` isn't available there. That made the two
Windows jobs by far the slowest in the matrix (~326s and ~305s,
versus ~85-107s on Linux for the same suites).

Replace both code paths with a single portable Bash function,
`_run_package_tests`, that caps concurrency using only Bash job
control (background jobs, `wait -n`, `jobs -rp`). It behaves the
same on Linux and on Windows (Git Bash), needs no external tool,
and reuses the existing `_run_task_sequential` helper. This
supersedes the rust-parallel attempt from #2997, which had to be
abandoned because rust-parallel could not be forced to use bash on
Windows.

By comparing https://github.com/symfony/ux/actions/runs/32469165022?pr=3799 and https://github.com/symfony/ux/actions/runs/32528673415?pr=3800, tests are going from ~4m30s to ~1m30s-2m30s 🚀 