### PR TITLE
[Toolkit][Shadcn] Add navigation-menu recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Shadcn] Add the `login-01` and `login-02` login blocks
 - [Shadcn] Add `input-otp` recipe
 - [Shadcn] Add `menubar` recipe
+- [Shadcn] Add `navigation-menu` recipe
 - [Shadcn] Add `popover` recipe
 - [Shadcn] Add `dropdown-menu` recipe
 - [Shadcn][Flowbite] Merge component classes with `attributes.defaults({ class: '...'|tailwind_classes })` instead of `tailwind_merge` (consumer classes now override component variants)

--- a/src/Toolkit/kits/shadcn/navigation-menu/README.md
+++ b/src/Toolkit/kits/shadcn/navigation-menu/README.md
@@ -1,0 +1,199 @@
+# Navigation Menu
+
+A collection of navigation links with optional hover-triggered submenus.
+
+```twig {"preview":true,"height":"340px"}
+<div class="flex items-start justify-center" style="min-height: 320px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>Getting started</twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid w-96 gap-1">
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                <div class="text-sm font-medium leading-none">Introduction</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Reusable components built with Tailwind CSS.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                <div class="text-sm font-medium leading-none">Installation</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">How to install dependencies and structure your app.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                <div class="text-sm font-medium leading-none">Typography</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Styles for headings, paragraphs, lists, and more.</p>
+                            </a>
+                        </li>
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>Components</twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid w-[500px] grid-cols-2 gap-2">
+                        {% set components = [
+                            {title: 'Alert Dialog', href: '/docs/primitives/alert-dialog', description: 'A modal dialog that interrupts the user with important content and expects a response.'},
+                            {title: 'Hover Card', href: '/docs/primitives/hover-card', description: 'For sighted users to preview content available behind a link.'},
+                            {title: 'Progress', href: '/docs/primitives/progress', description: 'Displays an indicator showing the completion progress of a task.'},
+                            {title: 'Scroll Area', href: '/docs/primitives/scroll-area', description: 'Visually or semantically separates content.'},
+                            {title: 'Tabs', href: '/docs/primitives/tabs', description: 'Layered sections of content displayed one panel at a time.'},
+                            {title: 'Tooltip', href: '/docs/primitives/tooltip', description: 'A popup that displays information related to an element on hover or focus.'},
+                        ] %}
+                        {% for component in components %}
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="{{ component.href }}">
+                                    <div class="text-sm font-medium leading-none">{{ component.title }}</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">{{ component.description }}</p>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>Resources</twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid w-[500px] grid-cols-2 gap-2">
+                        {% set resources = [
+                            {title: 'Blog', href: '/blog', description: 'Read the latest news and articles from the team.'},
+                            {title: 'Changelog', href: '/changelog', description: 'See what shipped in every release.'},
+                            {title: 'Support', href: '/support', description: 'Get help from the community and the maintainers.'},
+                            {title: 'Roadmap', href: '/roadmap', description: 'Discover what we are planning to build next.'},
+                        ] %}
+                        {% for resource in resources %}
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="{{ resource.href }}">
+                                    <div class="text-sm font-medium leading-none">{{ resource.title }}</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">{{ resource.description }}</p>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+```twig
+<twig:NavigationMenu>
+    <twig:NavigationMenu:List>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Link href="/">Home</twig:NavigationMenu:Link>
+        </twig:NavigationMenu:Item>
+        <twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+        </twig:NavigationMenu:Item>
+    </twig:NavigationMenu:List>
+</twig:NavigationMenu>
+```
+
+## Examples
+
+### Simple
+
+A menu of plain links, without any submenu.
+
+```twig {"preview":true,"height":"120px"}
+<div class="flex items-start justify-center" style="min-height: 100px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/">Home</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/pricing">Pricing</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+```twig {"preview":true,"height":"340px"}
+<div class="flex flex-col items-center gap-16 py-8" style="min-height: 320px">
+    {# Arabic #}
+    <div dir="rtl">
+        <twig:NavigationMenu>
+            <twig:NavigationMenu:List>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>ابدأ</twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid w-96 gap-1">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">مقدمة</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">مكونات قابلة لإعادة الاستخدام مبنية باستخدام Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">التثبيت</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">كيفية تثبيت التبعيات وتنظيم تطبيقك.</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Link href="/docs">التوثيق</twig:NavigationMenu:Link>
+                </twig:NavigationMenu:Item>
+            </twig:NavigationMenu:List>
+        </twig:NavigationMenu>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl">
+        <twig:NavigationMenu>
+            <twig:NavigationMenu:List>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>תחילת העבודה</twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid w-96 gap-1">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">מבוא</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">רכיבים לשימוש חוזר הבנויים עם Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">התקנה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">כיצד להתקין תלויות ולבנות את האפליקציה שלך.</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Link href="/docs">תיעוד</twig:NavigationMenu:Link>
+                </twig:NavigationMenu:Item>
+            </twig:NavigationMenu:List>
+        </twig:NavigationMenu>
+    </div>
+</div>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/shadcn/navigation-menu/assets/controllers/navigation_menu_controller.js
+++ b/src/Toolkit/kits/shadcn/navigation-menu/assets/controllers/navigation_menu_controller.js
@@ -1,0 +1,181 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['item', 'trigger', 'content', 'viewport', 'viewportPositioner'];
+    static values = {
+        openDelay: { type: Number, default: 200 },
+        closeDelay: { type: Number, default: 300 },
+    };
+
+    connect() {
+        this.activeIndex = null;
+        this.openTimeout = null;
+        this.closeTimeout = null;
+        this.contentByItem = new Map();
+        this.triggerByItem = new Map();
+
+        this.triggerTargets.forEach((trigger) => {
+            const item = trigger.closest('[data-navigation-menu-target="item"]');
+            if (item) {
+                this.triggerByItem.set(item, trigger);
+            }
+        });
+
+        this.contentTargets.forEach((content) => {
+            const item = content.closest('[data-navigation-menu-target="item"]');
+            if (item) {
+                this.contentByItem.set(item, content);
+            }
+            this.viewportTarget.appendChild(content);
+        });
+    }
+
+    disconnect() {
+        this.#clearTimeouts();
+    }
+
+    open(event) {
+        const item = event.currentTarget;
+        const content = this.contentByItem.get(item);
+        this.#clearTimeouts();
+
+        if (!content) {
+            this.scheduleClose();
+
+            return;
+        }
+
+        const delay = this.activeIndex === null ? this.openDelayValue : 0;
+        this.openTimeout = setTimeout(() => {
+            this.#activate(item, content);
+            this.openTimeout = null;
+        }, delay);
+    }
+
+    scheduleClose() {
+        this.#clearTimeouts();
+        this.closeTimeout = setTimeout(() => {
+            this.#setOpen(false);
+            this.closeTimeout = null;
+        }, this.closeDelayValue);
+    }
+
+    cancelClose() {
+        this.#clearCloseTimeout();
+    }
+
+    onFocusIn(event) {
+        const trigger = event.target.closest('[data-navigation-menu-target="trigger"]');
+        if (!trigger) {
+            return;
+        }
+
+        const item = trigger.closest('[data-navigation-menu-target="item"]');
+        const content = item && this.contentByItem.get(item);
+        this.#clearTimeouts();
+
+        if (content) {
+            this.#activate(item, content);
+        }
+    }
+
+    onFocusOut(event) {
+        if (!this.element.contains(event.relatedTarget)) {
+            this.#setOpen(false);
+        }
+    }
+
+    #activate(item, content) {
+        const newIndex = this.itemTargets.indexOf(item);
+        const motion =
+            this.activeIndex === null || newIndex === this.activeIndex
+                ? null
+                : newIndex > this.activeIndex
+                  ? 'from-end'
+                  : 'from-start';
+
+        this.contentTargets.forEach((candidate) => {
+            if (candidate !== content) {
+                delete candidate.dataset.active;
+                delete candidate.dataset.motion;
+            }
+        });
+
+        // Read layout before writing styles so the writes below don't force extra reflows.
+        const width = content.offsetWidth;
+        const height = content.offsetHeight;
+        const navRect = this.element.getBoundingClientRect();
+        const itemRect = item.getBoundingClientRect();
+        const rtl = getComputedStyle(this.element).direction === 'rtl';
+        const inlineStart = this.#viewportInlineStart(navRect, itemRect, width, rtl);
+
+        this.viewportTarget.style.setProperty('--navigation-menu-viewport-width', `${width}px`);
+        this.viewportTarget.style.setProperty('--navigation-menu-viewport-height', `${height}px`);
+        this.viewportPositionerTarget.style.insetInlineStart = `${inlineStart}px`;
+
+        if (motion) {
+            content.dataset.motion = motion;
+            // Commit the off-screen start position before activating, so the switch transitions.
+            void content.offsetWidth;
+            delete content.dataset.motion;
+        }
+        content.dataset.active = '';
+
+        this.activeIndex = newIndex;
+        this.#setOpen(true, item);
+    }
+
+    // Anchor to the trigger's inline-start, but shift so the content never overflows the viewport.
+    #viewportInlineStart(navRect, itemRect, width, rtl) {
+        const margin = 8;
+        if (rtl) {
+            const right = Math.max(width + margin, Math.min(itemRect.right, window.innerWidth - margin));
+
+            return navRect.right - right;
+        }
+
+        const left = Math.max(margin, Math.min(itemRect.left, window.innerWidth - margin - width));
+
+        return left - navRect.left;
+    }
+
+    #setOpen(open, activeItem = null) {
+        this.viewportTarget.dataset.state = open ? 'open' : 'closed';
+
+        if (!open) {
+            this.activeIndex = null;
+            this.contentTargets.forEach((content) => {
+                delete content.dataset.active;
+                delete content.dataset.motion;
+            });
+        }
+
+        this.itemTargets.forEach((item) => {
+            const isActive = open && item === activeItem;
+            item.dataset.state = isActive ? 'open' : 'closed';
+            const trigger = this.triggerByItem.get(item);
+            if (trigger) {
+                trigger.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+            }
+        });
+    }
+
+    #clearTimeouts() {
+        this.#clearOpenTimeout();
+        this.#clearCloseTimeout();
+    }
+
+    #clearOpenTimeout() {
+        if (this.openTimeout) {
+            clearTimeout(this.openTimeout);
+            this.openTimeout = null;
+        }
+    }
+
+    #clearCloseTimeout() {
+        if (this.closeTimeout) {
+            clearTimeout(this.closeTimeout);
+            this.closeTimeout = null;
+        }
+    }
+}

--- a/src/Toolkit/kits/shadcn/navigation-menu/manifest.json
+++ b/src/Toolkit/kits/shadcn/navigation-menu/manifest.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Navigation Menu",
+    "version-added": "3.5",
+    "copy-files": {
+        "assets/": "assets/",
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": [
+            "twig/html-extra:^3.24.0",
+            "symfony/ux-icons",
+            "symfony/ux-twig-component:^3.5",
+            "tales-from-a-dev/twig-tailwind-extra:^1.3.0"
+        ]
+    }
+}

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu.html.twig
@@ -1,0 +1,30 @@
+{# @prop ariaLabel string The accessible name for the navigation landmark. #}
+{# @prop openDelay number Delay in milliseconds before opening a menu on hover. #}
+{# @prop closeDelay number Delay in milliseconds before closing the menu once the pointer leaves. #}
+{# @block content A `NavigationMenu:List` containing `NavigationMenu:Item` children. #}
+{%- props ariaLabel = 'Main', openDelay = 200, closeDelay = 300 -%}
+<nav
+    data-slot="navigation-menu"
+    aria-label="{{ ariaLabel }}"
+    data-navigation-menu-open-delay-value="{{ openDelay }}"
+    data-navigation-menu-close-delay-value="{{ closeDelay }}"
+    {{ attributes.defaults({
+        class: 'relative flex max-w-max flex-1 items-center justify-center'|tailwind_classes,
+        'data-controller': 'navigation-menu',
+        'data-action': 'mouseleave->navigation-menu#scheduleClose focusin->navigation-menu#onFocusIn focusout->navigation-menu#onFocusOut',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+    <div
+        data-navigation-menu-target="viewportPositioner"
+        class="absolute start-0 top-full isolate z-50 transition-[inset-inline-start] duration-150 ease-out"
+        data-action="mouseenter->navigation-menu#cancelClose mouseleave->navigation-menu#scheduleClose"
+    >
+        <div
+            data-slot="navigation-menu-viewport"
+            data-navigation-menu-target="viewport"
+            data-state="closed"
+            class="invisible relative mt-1.5 h-[var(--navigation-menu-viewport-height)] w-[var(--navigation-menu-viewport-width)] max-w-[calc(100vw-2rem)] origin-top scale-95 overflow-hidden rounded-md border bg-popover text-popover-foreground opacity-0 shadow-md transition-[opacity,scale,width,height,visibility] duration-150 ease-out data-[state=open]:visible data-[state=open]:scale-100 data-[state=open]:opacity-100"
+        ></div>
+    </div>
+</nav>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Content.html.twig
@@ -1,0 +1,10 @@
+{# @block content The submenu revealed inside the shared viewport on hover or focus. #}
+<div
+    data-slot="navigation-menu-content"
+    data-navigation-menu-target="content"
+    {{ attributes.defaults({
+        class: 'invisible absolute start-0 top-0 w-max p-2 opacity-0 transition-[opacity,translate,visibility] duration-200 ease-out data-[active]:visible data-[active]:translate-x-0 data-[active]:opacity-100 data-[motion=from-end]:translate-x-8 data-[motion=from-start]:-translate-x-8'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Item.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Item.html.twig
@@ -1,0 +1,11 @@
+{# @block content The `NavigationMenu:Trigger` and its optional `NavigationMenu:Content`. #}
+<li
+    data-slot="navigation-menu-item"
+    data-navigation-menu-target="item"
+    {{ attributes.defaults({
+        class: 'group/navigation-menu-item relative'|tailwind_classes,
+        'data-action': 'mouseenter->navigation-menu#open',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</li>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Link.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Link.html.twig
@@ -1,0 +1,12 @@
+{# @prop href string The target URL. #}
+{# @block content The link label. #}
+{%- props href -%}
+<a
+    href="{{ href }}"
+    data-slot="navigation-menu-link"
+    {{ attributes.defaults({
+        class: 'inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</a>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/List.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/List.html.twig
@@ -1,0 +1,9 @@
+{# @block content The `NavigationMenu:Item` children. #}
+<ul
+    data-slot="navigation-menu-list"
+    {{ attributes.defaults({
+        class: 'flex flex-1 list-none items-center justify-center gap-1'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</ul>

--- a/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Trigger.html.twig
+++ b/src/Toolkit/kits/shadcn/navigation-menu/templates/components/NavigationMenu/Trigger.html.twig
@@ -1,0 +1,14 @@
+{# @block content The trigger label. #}
+<button
+    type="button"
+    data-slot="navigation-menu-trigger"
+    data-navigation-menu-target="trigger"
+    aria-haspopup="menu"
+    aria-expanded="false"
+    {{ attributes.defaults({
+        class: 'inline-flex h-9 w-max items-center justify-center gap-1 rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+    <twig:ux:icon name="lucide:chevron-down" class="relative top-px size-3 transition-transform duration-200 group-data-[state=open]/navigation-menu-item:rotate-180" aria-hidden="true" />
+</button>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 0__1.html
@@ -1,0 +1,198 @@
+<!--
+- Kit: Shadcn UI
+- Component: Navigation Menu
+- Code:
+```twig
+<div class="flex items-start justify-center" style="min-height: 320px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>Getting started</twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid w-96 gap-1">
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                <div class="text-sm font-medium leading-none">Introduction</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Reusable components built with Tailwind CSS.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                <div class="text-sm font-medium leading-none">Installation</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">How to install dependencies and structure your app.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                <div class="text-sm font-medium leading-none">Typography</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Styles for headings, paragraphs, lists, and more.</p>
+                            </a>
+                        </li>
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>Components</twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid w-[500px] grid-cols-2 gap-2">
+                        {% set components = [
+                            {title: 'Alert Dialog', href: '/docs/primitives/alert-dialog', description: 'A modal dialog that interrupts the user with important content and expects a response.'},
+                            {title: 'Hover Card', href: '/docs/primitives/hover-card', description: 'For sighted users to preview content available behind a link.'},
+                            {title: 'Progress', href: '/docs/primitives/progress', description: 'Displays an indicator showing the completion progress of a task.'},
+                            {title: 'Scroll Area', href: '/docs/primitives/scroll-area', description: 'Visually or semantically separates content.'},
+                            {title: 'Tabs', href: '/docs/primitives/tabs', description: 'Layered sections of content displayed one panel at a time.'},
+                            {title: 'Tooltip', href: '/docs/primitives/tooltip', description: 'A popup that displays information related to an element on hover or focus.'},
+                        ] %}
+                        {% for component in components %}
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="{{ component.href }}">
+                                    <div class="text-sm font-medium leading-none">{{ component.title }}</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">{{ component.description }}</p>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Trigger>Resources</twig:NavigationMenu:Trigger>
+                <twig:NavigationMenu:Content>
+                    <ul class="grid w-[500px] grid-cols-2 gap-2">
+                        {% set resources = [
+                            {title: 'Blog', href: '/blog', description: 'Read the latest news and articles from the team.'},
+                            {title: 'Changelog', href: '/changelog', description: 'See what shipped in every release.'},
+                            {title: 'Support', href: '/support', description: 'Get help from the community and the maintainers.'},
+                            {title: 'Roadmap', href: '/roadmap', description: 'Discover what we are planning to build next.'},
+                        ] %}
+                        {% for resource in resources %}
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="{{ resource.href }}">
+                                    <div class="text-sm font-medium leading-none">{{ resource.title }}</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">{{ resource.description }}</p>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </twig:NavigationMenu:Content>
+            </twig:NavigationMenu:Item>
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex items-start justify-center" style="min-height: 320px">
+    <nav data-slot="navigation-menu" aria-label="Main" data-navigation-menu-open-delay-value="200" data-navigation-menu-close-delay-value="300" class="relative flex max-w-max flex-1 items-center justify-center" data-controller="navigation-menu" data-action="mouseleave-&gt;navigation-menu#scheduleClose focusin-&gt;navigation-menu#onFocusIn focusout-&gt;navigation-menu#onFocusOut"><ul data-slot="navigation-menu-list" class="flex flex-1 list-none items-center justify-center gap-1">
+<li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<button type="button" data-slot="navigation-menu-trigger" data-navigation-menu-target="trigger" aria-haspopup="menu" aria-expanded="false" class="inline-flex h-9 w-max items-center justify-center gap-1 rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">Getting started<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 group-data-[state=open]/navigation-menu-item:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</button>
+                <div data-slot="navigation-menu-content" data-navigation-menu-target="content" class="invisible absolute start-0 top-0 w-max p-2 opacity-0 transition-[opacity,translate,visibility] duration-200 ease-out data-[active]:visible data-[active]:translate-x-0 data-[active]:opacity-100 data-[motion=from-end]:translate-x-8 data-[motion=from-start]:-translate-x-8">
+<ul class="grid w-96 gap-1">
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                <div class="text-sm font-medium leading-none">Introduction</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Reusable components built with Tailwind CSS.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                <div class="text-sm font-medium leading-none">Installation</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">How to install dependencies and structure your app.</p>
+                            </a>
+                        </li>
+                        <li>
+                            <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/typography">
+                                <div class="text-sm font-medium leading-none">Typography</div>
+                                <p class="line-clamp-2 text-sm text-muted-foreground">Styles for headings, paragraphs, lists, and more.</p>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+            <li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<button type="button" data-slot="navigation-menu-trigger" data-navigation-menu-target="trigger" aria-haspopup="menu" aria-expanded="false" class="inline-flex h-9 w-max items-center justify-center gap-1 rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">Components<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 group-data-[state=open]/navigation-menu-item:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</button>
+                <div data-slot="navigation-menu-content" data-navigation-menu-target="content" class="invisible absolute start-0 top-0 w-max p-2 opacity-0 transition-[opacity,translate,visibility] duration-200 ease-out data-[active]:visible data-[active]:translate-x-0 data-[active]:opacity-100 data-[motion=from-end]:translate-x-8 data-[motion=from-start]:-translate-x-8">
+<ul class="grid w-[500px] grid-cols-2 gap-2">
+                                                                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/alert-dialog">
+                                    <div class="text-sm font-medium leading-none">Alert Dialog</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">A modal dialog that interrupts the user with important content and expects a response.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/hover-card">
+                                    <div class="text-sm font-medium leading-none">Hover Card</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">For sighted users to preview content available behind a link.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/progress">
+                                    <div class="text-sm font-medium leading-none">Progress</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Displays an indicator showing the completion progress of a task.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/scroll-area">
+                                    <div class="text-sm font-medium leading-none">Scroll Area</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Visually or semantically separates content.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tabs">
+                                    <div class="text-sm font-medium leading-none">Tabs</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Layered sections of content displayed one panel at a time.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/primitives/tooltip">
+                                    <div class="text-sm font-medium leading-none">Tooltip</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">A popup that displays information related to an element on hover or focus.</p>
+                                </a>
+                            </li>
+                                            </ul>
+                </div>
+            </li>
+            <li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<a href="/docs" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">Docs</a>
+            </li>
+            <li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<button type="button" data-slot="navigation-menu-trigger" data-navigation-menu-target="trigger" aria-haspopup="menu" aria-expanded="false" class="inline-flex h-9 w-max items-center justify-center gap-1 rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">Resources<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 group-data-[state=open]/navigation-menu-item:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</button>
+                <div data-slot="navigation-menu-content" data-navigation-menu-target="content" class="invisible absolute start-0 top-0 w-max p-2 opacity-0 transition-[opacity,translate,visibility] duration-200 ease-out data-[active]:visible data-[active]:translate-x-0 data-[active]:opacity-100 data-[motion=from-end]:translate-x-8 data-[motion=from-start]:-translate-x-8">
+<ul class="grid w-[500px] grid-cols-2 gap-2">
+                                                                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/blog">
+                                    <div class="text-sm font-medium leading-none">Blog</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Read the latest news and articles from the team.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/changelog">
+                                    <div class="text-sm font-medium leading-none">Changelog</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">See what shipped in every release.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/support">
+                                    <div class="text-sm font-medium leading-none">Support</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Get help from the community and the maintainers.</p>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/roadmap">
+                                    <div class="text-sm font-medium leading-none">Roadmap</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">Discover what we are planning to build next.</p>
+                                </a>
+                            </li>
+                                            </ul>
+                </div>
+            </li>
+        </ul>
+    <div data-navigation-menu-target="viewportPositioner" class="absolute start-0 top-full isolate z-50 transition-[inset-inline-start] duration-150 ease-out" data-action="mouseenter-&gt;navigation-menu#cancelClose mouseleave-&gt;navigation-menu#scheduleClose">
+        <div data-slot="navigation-menu-viewport" data-navigation-menu-target="viewport" data-state="closed" class="invisible relative mt-1.5 h-[var(--navigation-menu-viewport-height)] w-[var(--navigation-menu-viewport-width)] max-w-[calc(100vw-2rem)] origin-top scale-95 overflow-hidden rounded-md border bg-popover text-popover-foreground opacity-0 shadow-md transition-[opacity,scale,width,height,visibility] duration-150 ease-out data-[state=open]:visible data-[state=open]:scale-100 data-[state=open]:opacity-100"></div>
+    </div>
+</nav>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 1__1.html
@@ -1,0 +1,39 @@
+<!--
+- Kit: Shadcn UI
+- Component: Navigation Menu
+- Code:
+```twig
+<div class="flex items-start justify-center" style="min-height: 100px">
+    <twig:NavigationMenu>
+        <twig:NavigationMenu:List>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/">Home</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/docs">Docs</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+            <twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Link href="/pricing">Pricing</twig:NavigationMenu:Link>
+            </twig:NavigationMenu:Item>
+        </twig:NavigationMenu:List>
+    </twig:NavigationMenu>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex items-start justify-center" style="min-height: 100px">
+    <nav data-slot="navigation-menu" aria-label="Main" data-navigation-menu-open-delay-value="200" data-navigation-menu-close-delay-value="300" class="relative flex max-w-max flex-1 items-center justify-center" data-controller="navigation-menu" data-action="mouseleave-&gt;navigation-menu#scheduleClose focusin-&gt;navigation-menu#onFocusIn focusout-&gt;navigation-menu#onFocusOut"><ul data-slot="navigation-menu-list" class="flex flex-1 list-none items-center justify-center gap-1">
+<li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<a href="/" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">Home</a>
+            </li>
+            <li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<a href="/docs" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">Docs</a>
+            </li>
+            <li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<a href="/pricing" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">Pricing</a>
+            </li>
+        </ul>
+    <div data-navigation-menu-target="viewportPositioner" class="absolute start-0 top-full isolate z-50 transition-[inset-inline-start] duration-150 ease-out" data-action="mouseenter-&gt;navigation-menu#cancelClose mouseleave-&gt;navigation-menu#scheduleClose">
+        <div data-slot="navigation-menu-viewport" data-navigation-menu-target="viewport" data-state="closed" class="invisible relative mt-1.5 h-[var(--navigation-menu-viewport-height)] w-[var(--navigation-menu-viewport-width)] max-w-[calc(100vw-2rem)] origin-top scale-95 overflow-hidden rounded-md border bg-popover text-popover-foreground opacity-0 shadow-md transition-[opacity,scale,width,height,visibility] duration-150 ease-out data-[state=open]:visible data-[state=open]:scale-100 data-[state=open]:opacity-100"></div>
+    </div>
+</nav>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component navigation-menu, example 2__1.html
@@ -1,0 +1,133 @@
+<!--
+- Kit: Shadcn UI
+- Component: Navigation Menu
+- Code:
+```twig
+<div class="flex flex-col items-center gap-16 py-8" style="min-height: 320px">
+    {# Arabic #}
+    <div dir="rtl">
+        <twig:NavigationMenu>
+            <twig:NavigationMenu:List>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>ابدأ</twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid w-96 gap-1">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">مقدمة</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">مكونات قابلة لإعادة الاستخدام مبنية باستخدام Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">التثبيت</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">كيفية تثبيت التبعيات وتنظيم تطبيقك.</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Link href="/docs">التوثيق</twig:NavigationMenu:Link>
+                </twig:NavigationMenu:Item>
+            </twig:NavigationMenu:List>
+        </twig:NavigationMenu>
+    </div>
+
+    {# Hebrew #}
+    <div dir="rtl">
+        <twig:NavigationMenu>
+            <twig:NavigationMenu:List>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Trigger>תחילת העבודה</twig:NavigationMenu:Trigger>
+                    <twig:NavigationMenu:Content>
+                        <ul class="grid w-96 gap-1">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">מבוא</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">רכיבים לשימוש חוזר הבנויים עם Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">התקנה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">כיצד להתקין תלויות ולבנות את האפליקציה שלך.</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </twig:NavigationMenu:Content>
+                </twig:NavigationMenu:Item>
+                <twig:NavigationMenu:Item>
+                    <twig:NavigationMenu:Link href="/docs">תיעוד</twig:NavigationMenu:Link>
+                </twig:NavigationMenu:Item>
+            </twig:NavigationMenu:List>
+        </twig:NavigationMenu>
+    </div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col items-center gap-16 py-8" style="min-height: 320px">
+        <div dir="rtl">
+        <nav data-slot="navigation-menu" aria-label="Main" data-navigation-menu-open-delay-value="200" data-navigation-menu-close-delay-value="300" class="relative flex max-w-max flex-1 items-center justify-center" data-controller="navigation-menu" data-action="mouseleave-&gt;navigation-menu#scheduleClose focusin-&gt;navigation-menu#onFocusIn focusout-&gt;navigation-menu#onFocusOut"><ul data-slot="navigation-menu-list" class="flex flex-1 list-none items-center justify-center gap-1">
+<li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<button type="button" data-slot="navigation-menu-trigger" data-navigation-menu-target="trigger" aria-haspopup="menu" aria-expanded="false" class="inline-flex h-9 w-max items-center justify-center gap-1 rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">ابدأ<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 group-data-[state=open]/navigation-menu-item:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</button>
+                    <div data-slot="navigation-menu-content" data-navigation-menu-target="content" class="invisible absolute start-0 top-0 w-max p-2 opacity-0 transition-[opacity,translate,visibility] duration-200 ease-out data-[active]:visible data-[active]:translate-x-0 data-[active]:opacity-100 data-[motion=from-end]:translate-x-8 data-[motion=from-start]:-translate-x-8">
+<ul class="grid w-96 gap-1">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">مقدمة</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">مكونات قابلة لإعادة الاستخدام مبنية باستخدام Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">التثبيت</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">كيفية تثبيت التبعيات وتنظيم تطبيقك.</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+                <li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<a href="/docs" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">التوثيق</a>
+                </li>
+            </ul>
+        <div data-navigation-menu-target="viewportPositioner" class="absolute start-0 top-full isolate z-50 transition-[inset-inline-start] duration-150 ease-out" data-action="mouseenter-&gt;navigation-menu#cancelClose mouseleave-&gt;navigation-menu#scheduleClose">
+        <div data-slot="navigation-menu-viewport" data-navigation-menu-target="viewport" data-state="closed" class="invisible relative mt-1.5 h-[var(--navigation-menu-viewport-height)] w-[var(--navigation-menu-viewport-width)] max-w-[calc(100vw-2rem)] origin-top scale-95 overflow-hidden rounded-md border bg-popover text-popover-foreground opacity-0 shadow-md transition-[opacity,scale,width,height,visibility] duration-150 ease-out data-[state=open]:visible data-[state=open]:scale-100 data-[state=open]:opacity-100"></div>
+    </div>
+</nav>
+    </div>
+
+        <div dir="rtl">
+        <nav data-slot="navigation-menu" aria-label="Main" data-navigation-menu-open-delay-value="200" data-navigation-menu-close-delay-value="300" class="relative flex max-w-max flex-1 items-center justify-center" data-controller="navigation-menu" data-action="mouseleave-&gt;navigation-menu#scheduleClose focusin-&gt;navigation-menu#onFocusIn focusout-&gt;navigation-menu#onFocusOut"><ul data-slot="navigation-menu-list" class="flex flex-1 list-none items-center justify-center gap-1">
+<li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<button type="button" data-slot="navigation-menu-trigger" data-navigation-menu-target="trigger" aria-haspopup="menu" aria-expanded="false" class="inline-flex h-9 w-max items-center justify-center gap-1 rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">תחילת העבודה<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="relative top-px size-3 transition-transform duration-200 group-data-[state=open]/navigation-menu-item:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"></path></svg>
+</button>
+                    <div data-slot="navigation-menu-content" data-navigation-menu-target="content" class="invisible absolute start-0 top-0 w-max p-2 opacity-0 transition-[opacity,translate,visibility] duration-200 ease-out data-[active]:visible data-[active]:translate-x-0 data-[active]:opacity-100 data-[motion=from-end]:translate-x-8 data-[motion=from-start]:-translate-x-8">
+<ul class="grid w-96 gap-1">
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs">
+                                    <div class="text-sm font-medium leading-none">מבוא</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">רכיבים לשימוש חוזר הבנויים עם Tailwind CSS.</p>
+                                </a>
+                            </li>
+                            <li>
+                                <a class="block rounded-md p-3 hover:bg-accent" href="/docs/installation">
+                                    <div class="text-sm font-medium leading-none">התקנה</div>
+                                    <p class="line-clamp-2 text-sm text-muted-foreground">כיצד להתקין תלויות ולבנות את האפליקציה שלך.</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+                <li data-slot="navigation-menu-item" data-navigation-menu-target="item" class="group/navigation-menu-item relative" data-action="mouseenter-&gt;navigation-menu#open">
+<a href="/docs" data-slot="navigation-menu-link" class="inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50">תיעוד</a>
+                </li>
+            </ul>
+        <div data-navigation-menu-target="viewportPositioner" class="absolute start-0 top-full isolate z-50 transition-[inset-inline-start] duration-150 ease-out" data-action="mouseenter-&gt;navigation-menu#cancelClose mouseleave-&gt;navigation-menu#scheduleClose">
+        <div data-slot="navigation-menu-viewport" data-navigation-menu-target="viewport" data-state="closed" class="invisible relative mt-1.5 h-[var(--navigation-menu-viewport-height)] w-[var(--navigation-menu-viewport-width)] max-w-[calc(100vw-2rem)] origin-top scale-95 overflow-hidden rounded-md border bg-popover text-popover-foreground opacity-0 shadow-md transition-[opacity,scale,width,height,visibility] duration-150 ease-out data-[state=open]:visible data-[state=open]:scale-100 data-[state=open]:opacity-100"></div>
+    </div>
+</nav>
+    </div>
+</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Part of #3233, replaces #3484
| License       | MIT

Adds the `navigation-menu` recipe to the Shadcn kit, superseding #3484 (thanks @Amoifr): same component, reworked on top of current `3.x` and aligned with the kit's current conventions.

https://github.com/user-attachments/assets/2d61acb0-ae9b-449d-850e-79a9153e5a53


Highlights:

- Shadcn-style shared viewport: one Stimulus controller on the root `<nav>`, content panels moved into a single viewport that morphs between triggers (the "swipe"), positioned under the active trigger and clamped to stay within the viewport (LTR + RTL).
- `NavigationMenu:Trigger` renders its own styled `<button>` + chevron (shadcn's `navigationMenuTriggerStyle`), so menu triggers and top-level links share the same height.
- Keyboard: `focusin` / `focusout` keep the menu open while focus is inside it, and `aria-expanded` stays in sync.
- Modern kit conventions: `README.md` inline live previews, `tailwind_classes` in `attributes.defaults()`, literal `data-slot` / value attributes, canonical manifest deps, `version-added` 3.5.

Snapshots regenerated; kit-lint, PHPUnit, oxlint and oxfmt all pass.

