### PR TITLE
[Toolkit][Shadcn] Focus the first form field when a dialog opens

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Shadcn][Flowbite] Merge component classes with `attributes.defaults({ class: '...'|tailwind_classes })` instead of `tailwind_merge` (consumer classes now override component variants)
 - [Shadcn] Fix Field/Label, InputGroup and Pagination silently dropping their own base classes when forwarding to a child component (their checked/disabled/nested/dark styles now apply)
 - [Shadcn] Fix `dialog` opening on initial render when `open` is `false`
+- [Shadcn] Focus the first form field (or the `[autofocus]` element) when a `dialog` opens
 - [Shadcn] Remove `typography` recipe
 - Remove the now-obsolete `ClassMergeSpacingChecker` linter
 

--- a/src/Toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js
+++ b/src/Toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js
@@ -15,6 +15,7 @@ export default class extends Controller {
 
     open() {
         this.dialogTarget.showModal();
+        this._focusInitialElement();
 
         if (this.hasTriggerTarget) {
             if (this.dialogTarget.getAnimations().length > 0) {
@@ -35,6 +36,19 @@ export default class extends Controller {
         if (target === this.dialogTarget) {
             this.close();
         }
+    }
+
+    _focusInitialElement() {
+        // showModal() already focuses an [autofocus] target or the first focusable element;
+        // when the author did not opt into autofocus, prefer the first form field instead.
+        if (this.dialogTarget.querySelector('[autofocus]')) {
+            return;
+        }
+
+        const field = this.dialogTarget.querySelector(
+            'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled])'
+        );
+        field?.focus();
     }
 
     close() {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

When a `dialog` opens, it now focuses the first form field (`input`, `textarea` or `select`) inside it, or the element marked `[autofocus]` if present, instead of relying on the browser's default behavior, which focuses the first focusable element (often the close button). This improves the `dialog` recipe itself and the new `sheet` and `drawer` recipes, which reuse the `dialog` recipe's Stimulus controller.

Part of #3233.
