### PR TITLE
[Toolkit][Shadcn] Add form recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Shadcn] Add `slider` recipe
 - [Shadcn] Add `drawer` recipe
 - [Shadcn] Add `sheet` recipe
+- [Shadcn] Add `form` recipe
 - [Shadcn][Flowbite] Merge component classes with `attributes.defaults({ class: '...'|tailwind_classes })` instead of `tailwind_merge` (consumer classes now override component variants)
 - [Shadcn] Fix Field/Label, InputGroup and Pagination silently dropping their own base classes when forwarding to a child component (their checked/disabled/nested/dark styles now apply)
 - [Shadcn] Fix `dialog` opening on initial render when `open` is `false`

--- a/src/Toolkit/kits/shadcn/form/README.md
+++ b/src/Toolkit/kits/shadcn/form/README.md
@@ -1,0 +1,59 @@
+# Form
+
+A set of layout wrappers to build accessible forms with label, description and error-message slots.
+
+```twig {"preview":true}
+<twig:Form class="mx-auto w-full max-w-md">
+    <twig:Form:Item>
+        <twig:Form:Label for="form-email">Email</twig:Form:Label>
+        <twig:Input id="form-email" name="email" type="email" placeholder="you@example.com" />
+        <twig:Form:Description>We'll never share your email with anyone else.</twig:Form:Description>
+    </twig:Form:Item>
+    <twig:Form:Item>
+        <twig:Form:Label for="form-bio">Bio</twig:Form:Label>
+        <twig:Textarea id="form-bio" name="bio" placeholder="Tell us a bit about yourself" />
+        <twig:Form:Description>You can @mention other users and organizations.</twig:Form:Description>
+    </twig:Form:Item>
+    <div class="flex justify-end gap-2">
+        <twig:Button type="button" variant="outline">Cancel</twig:Button>
+        <twig:Button type="submit">Save</twig:Button>
+    </div>
+</twig:Form>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+```twig
+<twig:Form>
+    <twig:Form:Item>
+        <twig:Form:Label for="form-username">Username</twig:Form:Label>
+        <twig:Input id="form-username" name="username" placeholder="shadcn" />
+        <twig:Form:Description>This is your public display name.</twig:Form:Description>
+    </twig:Form:Item>
+    <twig:Button type="submit">Submit</twig:Button>
+</twig:Form>
+```
+
+## Examples
+
+### Validation
+
+When a `Form:Item` contains a `Form:Message`, its `Form:Label` switches to the destructive color.
+
+```twig {"preview":true}
+<twig:Form class="mx-auto w-full max-w-md">
+    <twig:Form:Item>
+        <twig:Form:Label for="form-validation-email">Email</twig:Form:Label>
+        <twig:Input id="form-validation-email" name="email" type="email" value="not-an-email" aria-invalid="true" />
+        <twig:Form:Message>Please enter a valid email address.</twig:Form:Message>
+    </twig:Form:Item>
+</twig:Form>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/shadcn/form/manifest.json
+++ b/src/Toolkit/kits/shadcn/form/manifest.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Form",
+    "version-added": "3.5",
+    "copy-files": {
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "composer": [
+            "twig/html-extra:^3.24.0",
+            "symfony/ux-twig-component:^3.5",
+            "tales-from-a-dev/twig-tailwind-extra:^1.3.0"
+        ]
+    }
+}

--- a/src/Toolkit/kits/shadcn/form/templates/components/Form.html.twig
+++ b/src/Toolkit/kits/shadcn/form/templates/components/Form.html.twig
@@ -1,0 +1,9 @@
+{# @block content The form fields, typically a list of `Form:Item`. #}
+<form
+    data-slot="form"
+    {{ attributes.defaults({
+        class: 'space-y-6'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</form>

--- a/src/Toolkit/kits/shadcn/form/templates/components/Form/Description.html.twig
+++ b/src/Toolkit/kits/shadcn/form/templates/components/Form/Description.html.twig
@@ -1,0 +1,9 @@
+{# @block content The help text. #}
+<p
+    data-slot="form-description"
+    {{ attributes.defaults({
+        class: 'text-sm text-muted-foreground'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</p>

--- a/src/Toolkit/kits/shadcn/form/templates/components/Form/Item.html.twig
+++ b/src/Toolkit/kits/shadcn/form/templates/components/Form/Item.html.twig
@@ -1,0 +1,9 @@
+{# @block content A `Form:Label`, a form control, an optional `Form:Description` and an optional `Form:Message`. #}
+<div
+    data-slot="form-item"
+    {{ attributes.defaults({
+        class: 'group/form-item grid gap-2'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/form/templates/components/Form/Label.html.twig
+++ b/src/Toolkit/kits/shadcn/form/templates/components/Form/Label.html.twig
@@ -1,0 +1,9 @@
+{# @block content The label text. #}
+<label
+    data-slot="form-label"
+    {{ attributes.defaults({
+        class: 'flex items-center gap-2 text-sm font-medium leading-none select-none group-has-[[data-slot=form-message]]/form-item:text-destructive'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</label>

--- a/src/Toolkit/kits/shadcn/form/templates/components/Form/Message.html.twig
+++ b/src/Toolkit/kits/shadcn/form/templates/components/Form/Message.html.twig
@@ -1,0 +1,9 @@
+{# @block content The validation error message. #}
+<p
+    data-slot="form-message"
+    {{ attributes.defaults({
+        class: 'text-sm text-destructive'|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</p>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component form, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component form, example 0__1.html
@@ -1,0 +1,41 @@
+<!--
+- Kit: Shadcn UI
+- Component: Form
+- Code:
+```twig
+<twig:Form class="mx-auto w-full max-w-md">
+    <twig:Form:Item>
+        <twig:Form:Label for="form-email">Email</twig:Form:Label>
+        <twig:Input id="form-email" name="email" type="email" placeholder="you@example.com" />
+        <twig:Form:Description>We'll never share your email with anyone else.</twig:Form:Description>
+    </twig:Form:Item>
+    <twig:Form:Item>
+        <twig:Form:Label for="form-bio">Bio</twig:Form:Label>
+        <twig:Textarea id="form-bio" name="bio" placeholder="Tell us a bit about yourself" />
+        <twig:Form:Description>You can @mention other users and organizations.</twig:Form:Description>
+    </twig:Form:Item>
+    <div class="flex justify-end gap-2">
+        <twig:Button type="button" variant="outline">Cancel</twig:Button>
+        <twig:Button type="submit">Save</twig:Button>
+    </div>
+</twig:Form>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<form data-slot="form" class="space-y-6 mx-auto w-full max-w-md">
+<div data-slot="form-item" class="group/form-item grid gap-2">
+<label data-slot="form-label" class="flex items-center gap-2 text-sm font-medium leading-none select-none group-has-[[data-slot=form-message]]/form-item:text-destructive" for="form-email">Email</label>
+        <input data-slot="input" class="h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40" id="form-email" name="email" type="email" placeholder="you@example.com">
+
+        <p data-slot="form-description" class="text-sm text-muted-foreground">We'll never share your email with anyone else.</p>
+    </div>
+    <div data-slot="form-item" class="group/form-item grid gap-2">
+<label data-slot="form-label" class="flex items-center gap-2 text-sm font-medium leading-none select-none group-has-[[data-slot=form-message]]/form-item:text-destructive" for="form-bio">Bio</label>
+        <textarea data-slot="textarea" class="flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40" id="form-bio" name="bio" placeholder="Tell us a bit about yourself"></textarea>
+
+        <p data-slot="form-description" class="text-sm text-muted-foreground">You can @mention other users and organizations.</p>
+    </div>
+    <div class="flex justify-end gap-2">
+        <button data-slot="button" data-size="default" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center rounded-lg border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-8 gap-1.5 px-2.5 ltr:has-data-[icon=inline-end]:pr-2 rtl:has-data-[icon=inline-end]:pe-2 ltr:has-data-[icon=inline-start]:pl-2 rtl:has-data-[icon=inline-start]:ps-2" type="button">Cancel</button>
+        <button data-slot="button" data-size="default" data-variant="default" class="group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 bg-primary text-primary-foreground [a]:hover:bg-primary/80 h-8 gap-1.5 px-2.5 ltr:has-data-[icon=inline-end]:pr-2 rtl:has-data-[icon=inline-end]:pe-2 ltr:has-data-[icon=inline-start]:pl-2 rtl:has-data-[icon=inline-start]:ps-2" type="submit">Save</button>
+    </div>
+</form>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component form, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component form, example 1__1.html
@@ -1,0 +1,22 @@
+<!--
+- Kit: Shadcn UI
+- Component: Form
+- Code:
+```twig
+<twig:Form class="mx-auto w-full max-w-md">
+    <twig:Form:Item>
+        <twig:Form:Label for="form-validation-email">Email</twig:Form:Label>
+        <twig:Input id="form-validation-email" name="email" type="email" value="not-an-email" aria-invalid="true" />
+        <twig:Form:Message>Please enter a valid email address.</twig:Form:Message>
+    </twig:Form:Item>
+</twig:Form>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<form data-slot="form" class="space-y-6 mx-auto w-full max-w-md">
+<div data-slot="form-item" class="group/form-item grid gap-2">
+<label data-slot="form-label" class="flex items-center gap-2 text-sm font-medium leading-none select-none group-has-[[data-slot=form-message]]/form-item:text-destructive" for="form-validation-email">Email</label>
+        <input data-slot="input" class="h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40" id="form-validation-email" name="email" type="email" value="not-an-email" aria-invalid="true">
+
+        <p data-slot="form-message" class="text-sm text-destructive">Please enter a valid email address.</p>
+    </div>
+</form>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| Issues         | Part of #3233
| License        | MIT

Adds the `form` recipe to the Shadcn kit: a set of accessible layout wrappers (`Form`, `Form:Item`, `Form:Label`, `Form:Description`, `Form:Message`) for building forms around Symfony form fields. It's pure Twig and CSS, no Stimulus controller involved.

When a `Form:Item` contains a `Form:Message`, its `Form:Label` automatically switches to the destructive color. This is handled entirely in CSS via a `group-has` selector, no client-side state needed.

Split out of #3473 (closed in favor of this PR and its two siblings for `sheet` and `drawer`), itself part of #3233.
