### PR TITLE
[Toolkit][Shadcn] popover: honor [autofocus] and skip hidden inputs when focusing content

### DIFF
--- a/src/Toolkit/kits/shadcn/popover/assets/controllers/popover_controller.js
+++ b/src/Toolkit/kits/shadcn/popover/assets/controllers/popover_controller.js
@@ -89,9 +89,11 @@ export default class extends Controller {
 
     #focusContent() {
         const content = this.contentTargets[0];
-        const focusable = content?.querySelector(
-            'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
-        );
+        const focusable =
+            content?.querySelector('[autofocus]:not([disabled])') ??
+            content?.querySelector(
+                'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
+            );
         if (!focusable) {
             return;
         }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | no
| License        | MIT

Related to #3803

When a `popover` moves focus into its content on open, it now honors an `[autofocus]` element if present, and skips hidden inputs (`input[type="hidden"]`) so focus lands on a genuinely focusable field. This aligns the popover's focus-target selection with the `dialog` controller.
