### PR TITLE
[TwigComponent] Fix ComponentNode emitting `echo` on Twig 4

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -49,7 +49,13 @@ final class ComponentNode extends Node implements NodeOutputInterface
     {
         $compiler->addDebugInfo($this);
 
-        $useYield = method_exists(Environment::class, 'useYield') && $compiler->getEnvironment()->useYield();
+        // Twig 4 removed Environment::useYield(): yield is no longer opt-in, it is the only
+        // compilation mode. Probing for the method therefore reports "no yield support" on
+        // Twig 4 and selects the legacy echo/display path, which Twig 4 rejects outright --
+        // so every template containing a component fails to compile.
+        $isTwig4 = Environment::MAJOR_VERSION >= 4;
+        $canYield = $isTwig4 || method_exists(Environment::class, 'useYield');
+        $useYield = $isTwig4 || ($canYield && $compiler->getEnvironment()->useYield());
 
         $componentRuntime = $compiler->getVarName();
         $compiler
@@ -115,7 +121,10 @@ final class ComponentNode extends Node implements NodeOutputInterface
             ->write('if (null !== $preRendered) {')
             ->raw("\n")
             ->indent();
-        if (method_exists(Environment::class, 'useYield')) {
+        // This node is #[YieldReady], so on any Twig that understands yield it emits yield even
+        // when the environment is still in legacy mode -- hence $canYield rather than $useYield,
+        // preserving the existing method_exists() behaviour on Twig 3.
+        if ($canYield) {
             $compiler->write('yield $preRendered; ');
         } else {
             $compiler->write('echo $preRendered; ');

--- a/src/TwigComponent/tests/Unit/ComponentNodeTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentNodeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\TwigComponent\Twig\ComponentNode;
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Node\Expression\ConstantExpression;
+
+final class ComponentNodeTest extends TestCase
+{
+    /**
+     * Twig 4 removed Environment::useYield() because yield stopped being optional. Probing for
+     * that method to decide whether yield is available therefore reports "no" on Twig 4 and
+     * selects the legacy echo/display path, which Twig 4 rejects with
+     * 'Using "echo" is not supported; use "yield" instead' -- making every template that
+     * contains a component fail to compile.
+     */
+    public function testCompilesToYieldWhenTheEnvironmentOnlySupportsYield()
+    {
+        if (Environment::MAJOR_VERSION < 4) {
+            $this->markTestSkipped('Only Twig 4+ drops useYield() entirely.');
+        }
+
+        $source = self::compile();
+
+        $this->assertStringContainsString('yield $preRendered;', $source);
+        $this->assertStringNotContainsString('echo $preRendered;', $source);
+        $this->assertStringContainsString('yield from ', $source);
+        $this->assertStringNotContainsString('->display(', $source);
+    }
+
+    public function testCompilesToYieldWhenYieldIsEnabledOnTwig3()
+    {
+        if (Environment::MAJOR_VERSION >= 4) {
+            $this->markTestSkipped('Twig 3 only: Twig 4 has no use_yield option to toggle.');
+        }
+
+        $source = self::compile(['use_yield' => true]);
+
+        $this->assertStringContainsString('yield $preRendered;', $source);
+        $this->assertStringContainsString('yield from ', $source);
+        $this->assertStringNotContainsString('->display(', $source);
+    }
+
+    /**
+     * The node is #[YieldReady], so it emits `yield $preRendered` even in legacy mode -- but the
+     * template it embeds is still loaded through display(). Pinned so the Twig 4 fix cannot
+     * quietly change what Twig 3 emits.
+     */
+    public function testKeepsTheLegacyDisplayPathWhenYieldIsDisabledOnTwig3()
+    {
+        if (Environment::MAJOR_VERSION >= 4) {
+            $this->markTestSkipped('Twig 3 only: Twig 4 has no legacy path.');
+        }
+
+        $source = self::compile(['use_yield' => false]);
+
+        $this->assertStringContainsString('->display(', $source);
+        $this->assertStringNotContainsString('yield from ', $source);
+    }
+
+    private static function compile(array $options = []): string
+    {
+        $compiler = new Compiler(new Environment(new ArrayLoader([]), $options));
+
+        $compiler->compile(new ComponentNode(
+            new ConstantExpression('Alert', 1),
+            'embedded_template',
+            0,
+            null,
+            false,
+            1,
+        ));
+
+        return $compiler->getSource();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | –
| License       | MIT

`ComponentNode` decides whether it may emit `yield` by probing for `Environment::useYield()`:

```php
$useYield = method_exists(Environment::class, 'useYield') && $compiler->getEnvironment()->useYield();
```

Twig 4 **removed** `useYield()` — not because yield went away, but because it stopped being optional and became the only compilation mode. The probe therefore reports "yield is not supported", the compiler takes the legacy `echo` / `->display()` path, and Twig 4 rejects it:

```
Using "echo" is not supported; use "yield" instead in "Symfony\UX\TwigComponent\Twig\ComponentNode".
```

This happens at **compile** time, so it is not a partial degradation: every template containing a component fails, and an app using TwigComponent cannot render any page that has a `<twig:…>` on it.

Minimal reproduction, no Symfony kernel needed:

```php
$compiler = new Compiler(new Environment(new ArrayLoader([])));
$compiler->compile(new ComponentNode(new ConstantExpression('Alert', 1), 'embedded_template', 0, null, false, 1));
// Twig 4: LogicException: Using "echo" is not supported; use "yield" instead
```

### The fix

Treat Twig >= 4 as always-yield:

```php
$isTwig4  = Environment::MAJOR_VERSION >= 4;
$canYield = $isTwig4 || method_exists(Environment::class, 'useYield');
$useYield = $isTwig4 || ($canYield && $compiler->getEnvironment()->useYield());
```

Two distinct flags, because the existing code uses two distinct conditions and I did not want to collapse them:

* `$canYield` replaces the bare `method_exists()` guard on `yield $preRendered`. That node is `#[YieldReady]`, so it emits `yield` even when the environment is still in legacy mode — existing Twig 3 behaviour, preserved exactly.
* `$useYield` replaces the environment-value check that picks `yield from … ->unwrap()->yield(` over `->display(`.

### On Twig 3, nothing changes

I dumped `Compiler::getSource()` for a `ComponentNode` before and after the patch under Twig 3.28, in both modes, and diffed:

| environment | stock vs patched |
| --- | --- |
| Twig 3.28, `use_yield => false` | byte-identical |
| Twig 3.28, `use_yield => true`  | byte-identical |

(The two Twig 3 modes differ from *each other*, so the comparison is actually discriminating.)

### Tests

Added `tests/Unit/ComponentNodeTest.php`, covering all three environments and skipping the ones that do not apply to the installed Twig. On Twig 4 the new test fails with the exact `LogicException` above without this patch and passes with it. The full `TwigComponent` suite is green on Twig 3 (382 tests, 898 assertions).

### Scope

I deliberately did **not** widen `"twig/twig": "^3.10.3"` to include `^4.0`. This fixes the one incompatibility I hit and verified; claiming full Twig 4 support for the package is a separate call for a maintainer who can validate the rest of it. With this patch applied, Twig 4 works for my app.

Found while running a Symfony 8 / Twig 4.0.0-alpha1 app in production.
