### PR TITLE
[CalendarLink] Alias `IcsBuilder` so it can be autowired and decorated

### DIFF
--- a/src/CalendarLink/CHANGELOG.md
+++ b/src/CalendarLink/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.5.0
+
+- Add a class alias for `IcsBuilder` so it can be autowired and decorated
+
 ## 3.1
 
 - Add component

--- a/src/CalendarLink/config/services.php
+++ b/src/CalendarLink/config/services.php
@@ -27,6 +27,8 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set('ux_calendar_link.ics.builder', IcsBuilder::class);
 
+    $services->alias(IcsBuilder::class, 'ux_calendar_link.ics.builder');
+
     $services->set('ux_calendar_link.provider.google', GoogleCalendarLinkProvider::class)
         ->tag('ux_calendar_link.provider');
 

--- a/src/CalendarLink/tests/Integration/BundleIntegrationTest.php
+++ b/src/CalendarLink/tests/Integration/BundleIntegrationTest.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\CalendarLink\Tests\Integration;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\UX\CalendarLink\CalendarEvent;
+use Symfony\UX\CalendarLink\Ics\IcsBuilder;
 use Symfony\UX\CalendarLink\Provider\CalendarLinkProviderInterface;
 use Symfony\UX\CalendarLink\Registry\CalendarLinkProviderRegistry;
 
@@ -30,6 +31,11 @@ final class BundleIntegrationTest extends KernelTestCase
         foreach ($registry->all() as $provider) {
             $this->assertInstanceOf(CalendarLinkProviderInterface::class, $provider);
         }
+    }
+
+    public function testIcsBuilderIsAutowirable()
+    {
+        $this->assertInstanceOf(IcsBuilder::class, self::getContainer()->get(IcsBuilder::class));
     }
 
     public function testTwigRendersCalendarLink()


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3812 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

The registry got a class alias but the builder did not, leaving it reachable only by its string service id. Aliasing `IcsBuilder::class` makes it type-hintable and decoratable like the registry.
