### PR TITLE
[CalendarLink] Make `DTSTAMP` deterministic via the Clock component

### DIFF
--- a/src/CalendarLink/CHANGELOG.md
+++ b/src/CalendarLink/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Make `IcsBuilder` internal
 - Serialize timed events in a named time zone with `;TZID=` and a matching `VTIMEZONE`, so recurring events no longer drift by an hour across DST
+- Accept an optional `ClockInterface` in `IcsBuilder` so `DTSTAMP` is deterministic and testable
 
 ## 3.1
 

--- a/src/CalendarLink/composer.json
+++ b/src/CalendarLink/composer.json
@@ -35,6 +35,7 @@
     },
     "require": {
         "php": ">=8.4",
+        "symfony/clock": "^7.4|^8.0",
         "symfony/framework-bundle": "^7.4|^8.0",
         "symfony/twig-bundle": "^7.4|^8.0",
         "symfony/uid": "^7.4|^8.0"

--- a/src/CalendarLink/config/services.php
+++ b/src/CalendarLink/config/services.php
@@ -25,7 +25,8 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_it
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('ux_calendar_link.ics.builder', IcsBuilder::class);
+    $services->set('ux_calendar_link.ics.builder', IcsBuilder::class)
+        ->arg('$clock', service('clock'));
 
     $services->set('ux_calendar_link.provider.google', GoogleCalendarLinkProvider::class)
         ->tag('ux_calendar_link.provider');

--- a/src/CalendarLink/src/Ics/IcsBuilder.php
+++ b/src/CalendarLink/src/Ics/IcsBuilder.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\UX\CalendarLink\Ics;
 
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\UX\CalendarLink\CalendarEvent;
 use Symfony\UX\CalendarLink\CalendarReminder;
@@ -28,8 +30,10 @@ final class IcsBuilder
 
     private readonly UuidFactory $uuidFactory;
 
-    public function __construct(?UuidFactory $uuidFactory = null)
-    {
+    public function __construct(
+        ?UuidFactory $uuidFactory = null,
+        private readonly ClockInterface $clock = new NativeClock(),
+    ) {
         $this->uuidFactory = $uuidFactory ?? new UuidFactory();
     }
 
@@ -44,7 +48,7 @@ final class IcsBuilder
             ...$this->formatVtimezones($event),
             'BEGIN:VEVENT',
             'UID:'.$this->uuidFactory->create()->toRfc4122(),
-            'DTSTAMP:'.$this->formatUtc(new \DateTimeImmutable('now', new \DateTimeZone('UTC'))),
+            'DTSTAMP:'.$this->formatUtc($this->clock->now()),
             ...$this->formatDateLines($event),
             'SUMMARY:'.$this->escape($event->title),
         ];

--- a/src/CalendarLink/tests/Ics/IcsBuilderTest.php
+++ b/src/CalendarLink/tests/Ics/IcsBuilderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\UX\CalendarLink\Tests\Ics;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Uid\Factory\MockUuidFactory;
 use Symfony\UX\CalendarLink\CalendarEvent;
 use Symfony\UX\CalendarLink\CalendarRecurrence;
@@ -25,7 +26,21 @@ final class IcsBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->builder = new IcsBuilder(new MockUuidFactory(['0192a5d2-7c6f-7000-8000-000000000000']));
+        $this->builder = new IcsBuilder(
+            new MockUuidFactory(['0192a5d2-7c6f-7000-8000-000000000000']),
+            new MockClock(new \DateTimeImmutable('2026-05-14 08:30:00', new \DateTimeZone('UTC'))),
+        );
+    }
+
+    public function testDtstampUsesTheInjectedClock()
+    {
+        $event = new CalendarEvent(
+            title: 'Demo',
+            start: new \DateTimeImmutable('2026-05-14 09:00', new \DateTimeZone('UTC')),
+            end: new \DateTimeImmutable('2026-05-14 10:00', new \DateTimeZone('UTC')),
+        );
+
+        $this->assertStringContainsString("DTSTAMP:20260514T083000Z\r\n", $this->builder->build($event));
     }
 
     public function testUidIsUniquePerBuild()

--- a/src/CalendarLink/tests/Integration/BundleIntegrationTest.php
+++ b/src/CalendarLink/tests/Integration/BundleIntegrationTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\UX\CalendarLink\Tests\Integration;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Clock\MockClock;
 use Symfony\UX\CalendarLink\CalendarEvent;
 use Symfony\UX\CalendarLink\Provider\CalendarLinkProviderInterface;
 use Symfony\UX\CalendarLink\Registry\CalendarLinkProviderRegistry;
@@ -30,6 +31,20 @@ final class BundleIntegrationTest extends KernelTestCase
         foreach ($registry->all() as $provider) {
             $this->assertInstanceOf(CalendarLinkProviderInterface::class, $provider);
         }
+    }
+
+    public function testDtstampUsesTheContainerClock()
+    {
+        $container = self::getContainer();
+        $container->set('clock', new MockClock(new \DateTimeImmutable('2026-05-14 08:30:00', new \DateTimeZone('UTC'))));
+
+        $ics = $container->get('ux_calendar_link.ics.builder')->build(new CalendarEvent(
+            title: 'Demo',
+            start: new \DateTimeImmutable('2026-05-14 09:00', new \DateTimeZone('UTC')),
+            end: new \DateTimeImmutable('2026-05-14 10:00', new \DateTimeZone('UTC')),
+        ));
+
+        $this->assertStringContainsString("DTSTAMP:20260514T083000Z\r\n", $ics);
     }
 
     public function testTwigRendersCalendarLink()


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3813 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

`IcsBuilder` read the wall clock directly for DTSTAMP, so no test could assert on a complete .ics payload. 
Inject an optional `ClockInterface` (defaulting to `NativeClock`), mirroring the existing `UuidFactory` seam.
