### PR TITLE
[CalendarLink] Derive a stable ICS UID from the event content

### DIFF
--- a/src/CalendarLink/CHANGELOG.md
+++ b/src/CalendarLink/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Make `IcsBuilder` internal
 - Serialize timed events in a named time zone with `;TZID=` and a matching `VTIMEZONE`, so recurring events no longer drift by an hour across DST
 - Accept an optional `ClockInterface` in `IcsBuilder` so `DTSTAMP` is deterministic and testable
+- Add an optional `uid` to `CalendarEvent`, and derive the ICS `UID` from the event content by default instead of a random value, so re-adding the same event no longer duplicates it
 
 ## 3.1
 

--- a/src/CalendarLink/src/CalendarEvent.php
+++ b/src/CalendarLink/src/CalendarEvent.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\UX\CalendarLink;
 
+use Symfony\Component\Uid\Uuid;
 use Symfony\UX\CalendarLink\Exception\InvalidArgumentException;
 
 /**
@@ -23,6 +24,7 @@ final class CalendarEvent
 
     /**
      * @param list<CalendarReminder> $reminders
+     * @param Uuid|null              $uid       A stable UID reused across builds so clients update the event instead of duplicating it; derived from the event content when null
      */
     public function __construct(
         public readonly string $title,
@@ -34,6 +36,7 @@ final class CalendarEvent
         public readonly ?string $url = null,
         public readonly ?CalendarRecurrence $recurrence = null,
         public readonly array $reminders = [],
+        public readonly ?Uuid $uid = null,
     ) {
         if ('' === trim($title)) {
             throw new InvalidArgumentException('Event title must not be empty.');

--- a/src/CalendarLink/src/Ics/IcsBuilder.php
+++ b/src/CalendarLink/src/Ics/IcsBuilder.php
@@ -27,6 +27,8 @@ final class IcsBuilder
     private const CRLF = "\r\n";
     private const PRODID = '-//Symfony//UX Calendar Link//EN';
     private const TWO_YEARS = 63072000;
+    // Uuid::v5(NAMESPACE_DNS, 'ux.symfony.com'), frozen: changing it changes every derived UID.
+    private const UID_NAMESPACE = 'c7762b19-6d40-547b-9037-e90ffec34fb2';
 
     private readonly UuidFactory $uuidFactory;
 
@@ -47,7 +49,7 @@ final class IcsBuilder
             'METHOD:PUBLISH',
             ...$this->formatVtimezones($event),
             'BEGIN:VEVENT',
-            'UID:'.$this->uuidFactory->create()->toRfc4122(),
+            'UID:'.$this->uid($event),
             'DTSTAMP:'.$this->formatUtc($this->clock->now()),
             ...$this->formatDateLines($event),
             'SUMMARY:'.$this->escape($event->title),
@@ -79,6 +81,24 @@ final class IcsBuilder
         $folded = array_map([$this, 'fold'], $lines);
 
         return implode(self::CRLF, $folded).self::CRLF;
+    }
+
+    private function uid(CalendarEvent $event): string
+    {
+        if (null !== $event->uid) {
+            return $event->uid->toRfc4122();
+        }
+
+        // Derive a stable UUIDv5 from the event identity, so the same event always
+        // serializes to the same UID instead of a random one clients treat as a new event.
+        $identity = implode('|', [
+            $event->title,
+            $event->start->format(\DateTimeInterface::ATOM),
+            $event->end->format(\DateTimeInterface::ATOM),
+            $event->location ?? '',
+        ]);
+
+        return $this->uuidFactory->nameBased(self::UID_NAMESPACE)->create($identity)->toRfc4122();
     }
 
     /**

--- a/src/CalendarLink/tests/Ics/IcsBuilderTest.php
+++ b/src/CalendarLink/tests/Ics/IcsBuilderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Uid\Factory\MockUuidFactory;
+use Symfony\Component\Uid\Uuid;
 use Symfony\UX\CalendarLink\CalendarEvent;
 use Symfony\UX\CalendarLink\CalendarRecurrence;
 use Symfony\UX\CalendarLink\CalendarReminder;
@@ -27,8 +28,7 @@ final class IcsBuilderTest extends TestCase
     protected function setUp(): void
     {
         $this->builder = new IcsBuilder(
-            new MockUuidFactory(['0192a5d2-7c6f-7000-8000-000000000000']),
-            new MockClock(new \DateTimeImmutable('2026-05-14 08:30:00', new \DateTimeZone('UTC'))),
+            clock: new MockClock(new \DateTimeImmutable('2026-05-14 08:30:00', new \DateTimeZone('UTC'))),
         );
     }
 
@@ -43,20 +43,57 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("DTSTAMP:20260514T083000Z\r\n", $this->builder->build($event));
     }
 
-    public function testUidIsUniquePerBuild()
+    public function testUidIsStableForTheSameEvent()
     {
-        $builder = new IcsBuilder();
-
         $event = new CalendarEvent(
             title: 'Demo',
             start: new \DateTimeImmutable('2026-05-14 09:00', new \DateTimeZone('UTC')),
             end: new \DateTimeImmutable('2026-05-14 10:00', new \DateTimeZone('UTC')),
         );
 
-        preg_match('/^UID:(.+)$/m', $builder->build($event), $first);
-        preg_match('/^UID:(.+)$/m', $builder->build($event), $second);
+        preg_match('/^UID:(.+)$/m', $this->builder->build($event), $first);
+        preg_match('/^UID:(.+)$/m', $this->builder->build($event), $second);
+
+        $this->assertSame($first[1], $second[1]);
+    }
+
+    public function testDifferentEventsGetDifferentUids()
+    {
+        $start = new \DateTimeImmutable('2026-05-14 09:00', new \DateTimeZone('UTC'));
+        $end = new \DateTimeImmutable('2026-05-14 10:00', new \DateTimeZone('UTC'));
+
+        preg_match('/^UID:(.+)$/m', $this->builder->build(new CalendarEvent('Demo', $start, $end)), $first);
+        preg_match('/^UID:(.+)$/m', $this->builder->build(new CalendarEvent('Other', $start, $end)), $second);
 
         $this->assertNotSame($first[1], $second[1]);
+    }
+
+    public function testUidIsDerivedThroughTheInjectedUuidFactory()
+    {
+        // MockUuidFactory::nameBased() throws unless the UID matches the v5 it recomputes,
+        // which pins both the namespace and the identity string the UID is derived from.
+        $builder = new IcsBuilder(new MockUuidFactory(['66da134f-b0c7-54b1-924b-afa4fbe3f952']));
+
+        $event = new CalendarEvent(
+            title: 'Demo',
+            start: new \DateTimeImmutable('2026-05-14 09:00', new \DateTimeZone('UTC')),
+            end: new \DateTimeImmutable('2026-05-14 10:00', new \DateTimeZone('UTC')),
+            location: 'Paris',
+        );
+
+        $this->assertStringContainsString("UID:66da134f-b0c7-54b1-924b-afa4fbe3f952\r\n", $builder->build($event));
+    }
+
+    public function testExplicitUidTakesPrecedence()
+    {
+        $event = new CalendarEvent(
+            title: 'Demo',
+            start: new \DateTimeImmutable('2026-05-14 09:00', new \DateTimeZone('UTC')),
+            end: new \DateTimeImmutable('2026-05-14 10:00', new \DateTimeZone('UTC')),
+            uid: Uuid::fromString('5fc53010-1267-4f8e-bc28-1d7ae55a7c99'),
+        );
+
+        $this->assertStringContainsString("UID:5fc53010-1267-4f8e-bc28-1d7ae55a7c99\r\n", $this->builder->build($event));
     }
 
     public function testMinimalTimedEventStructure()


### PR DESCRIPTION

| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3810 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

`IcsBuilder` minted a random UID on every build, so the same CalendarEvent serialized to a different identity each time and calendar clients created duplicates on re-add. 

Add an optional `uid` on CalendarEvent for an application-supplied key, and default to a UUIDv5 derived from the event content (title, start, end, location).
