### PR TITLE
[LiveComponent] Use test stubs instead of mocks

### DIFF
--- a/src/LiveComponent/tests/Unit/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Unit/EventListener/LiveComponentSubscriberTest.php
@@ -21,7 +21,7 @@ class LiveComponentSubscriberTest extends TestCase
 {
     public function testDefaultConstructedSubscriberRejectsRequestWithoutAcceptHeader()
     {
-        $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class));
+        $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class));
 
         $request = new Request();
         $request->attributes->set('_live_component', 'some_component');
@@ -34,7 +34,7 @@ class LiveComponentSubscriberTest extends TestCase
 
     public function testDefaultConstructedSubscriberAcceptsRequestWithProperAcceptHeader()
     {
-        $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class));
+        $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class));
 
         $request = new Request();
         $request->attributes->set('_live_component', 'some_component');
@@ -46,7 +46,7 @@ class LiveComponentSubscriberTest extends TestCase
 
     public function testTestModeBypassesAcceptHeaderCheck()
     {
-        $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class), true);
+        $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class), true);
 
         $request = new Request();
         $request->attributes->set('_live_component', 'some_component');
@@ -67,7 +67,7 @@ class LiveComponentSubscriberTest extends TestCase
     #[DataProvider('provideProductionGateScenarios')]
     public function testProductionGateRequiresNonSafelistedHeader(array $headers, bool $expected)
     {
-        $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class), testMode: false);
+        $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class), testMode: false);
 
         $request = new Request();
         $request->attributes->set('_live_component', 'some-component');
@@ -111,7 +111,7 @@ class LiveComponentSubscriberTest extends TestCase
 
     public function testRequestWithoutLiveComponentAttributeIsRejected()
     {
-        $subscriber = new LiveComponentSubscriber($this->createMock(ContainerInterface::class), testMode: false);
+        $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class), testMode: false);
 
         $request = new Request();
         $request->headers->set('Accept', 'application/vnd.live-component+html');

--- a/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
+++ b/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
@@ -209,7 +209,7 @@ final class LiveCollectionTraitTest extends TestCase
 
     private function createComponent(array $postedFormData)
     {
-        $form = $this->createMock(FormInterface::class);
+        $form = $this->createStub(FormInterface::class);
         $component = new class($form) {
             use LiveCollectionTrait;
 

--- a/src/LiveComponent/tests/Unit/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Unit/LiveComponentHydratorTest.php
@@ -33,11 +33,11 @@ final class LiveComponentHydratorTest extends TestCase
 
         new LiveComponentHydrator(
             [],
-            $this->createMock(PropertyAccessorInterface::class),
-            $this->createMock(LiveComponentMetadataFactory::class),
-            $this->createMock(NormalizerInterface::class),
+            $this->createStub(PropertyAccessorInterface::class),
+            $this->createStub(LiveComponentMetadataFactory::class),
+            $this->createStub(NormalizerInterface::class),
             '',
-            $this->createMock(Environment::class),
+            $this->createStub(Environment::class),
         );
     }
 
@@ -47,11 +47,11 @@ final class LiveComponentHydratorTest extends TestCase
         if (!class_exists(Type::class)) {
             $hydrator = new LiveComponentHydrator(
                 [],
-                $this->createMock(PropertyAccessorInterface::class),
-                $this->createMock(LiveComponentMetadataFactory::class),
+                $this->createStub(PropertyAccessorInterface::class),
+                $this->createStub(LiveComponentMetadataFactory::class),
                 new Serializer(normalizers: [new ObjectNormalizer()]),
                 'foo',
-                $this->createMock(Environment::class),
+                $this->createStub(Environment::class),
             );
 
             $hydratedValue = $hydrator->hydrateValue(
@@ -64,11 +64,11 @@ final class LiveComponentHydratorTest extends TestCase
         } else {
             $hydrator = new LiveComponentHydrator(
                 [],
-                $this->createMock(PropertyAccessorInterface::class),
-                $this->createMock(LiveComponentMetadataFactory::class),
+                $this->createStub(PropertyAccessorInterface::class),
+                $this->createStub(LiveComponentMetadataFactory::class),
                 new Serializer(normalizers: [new ObjectNormalizer()]),
                 'foo',
-                $this->createMock(Environment::class),
+                $this->createStub(Environment::class),
             );
 
             $hydratedValue = $hydrator->hydrateValue(


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... 
| License        | MIT

PHPUnit 12 emits a notice for every mock object created without an expectation, since such
an object is a stub rather than a mock. The `LiveComponent` suite triggers 23 of them.

- Replaces 16 `createMock()` calls with `createStub()` across 3 test files
- None of them had `expects()`, `method()` or `willReturn()`: all were constructor fillers
- Notices drop from 23 to 4

`LiveCollectionTraitTest` still trigger 4 notices, but this must be fixed in symfony/form 
