### PR TITLE
[TwigComponent] Treat a prop explicitly passed as `null` as defined

### DIFF
--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit bootstrap, component button, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit bootstrap, component button, example 1__1.html
@@ -6,4 +6,4 @@
 <twig:Button :color="null">Base class</twig:Button>
 ```
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
-<button class="btn btn-primary" type="button">Base class</button>
+<button class="btn" type="button">Base class</button>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit bootstrap, component button, example 9__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit bootstrap, component button, example 9__1.html
@@ -29,11 +29,11 @@
 - Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
 <div class="d-flex flex-column align-items-start gap-3">
     <div class="d-inline-flex flex-wrap gap-1">
-        <button class="btn btn-primary" type="button" data-bs-toggle="button">Toggle button</button>        <button class="btn btn-primary active" type="button" data-bs-toggle="button" aria-pressed="true">Active toggle button</button>        <button class="btn btn-primary" type="button" disabled data-bs-toggle="button">Disabled toggle button</button>    </div>
+        <button class="btn" type="button" data-bs-toggle="button">Toggle button</button>        <button class="btn active" type="button" data-bs-toggle="button" aria-pressed="true">Active toggle button</button>        <button class="btn" type="button" disabled data-bs-toggle="button">Disabled toggle button</button>    </div>
     <div class="d-inline-flex flex-wrap gap-1">
         <button class="btn btn-primary" type="button" data-bs-toggle="button">Toggle button</button>        <button class="btn btn-primary active" type="button" data-bs-toggle="button" aria-pressed="true">Active toggle button</button>        <button class="btn btn-primary" type="button" disabled data-bs-toggle="button">Disabled toggle button</button>    </div>
     <div class="d-inline-flex flex-wrap gap-1">
-        <a class="btn btn-primary" role="button" href="#" data-bs-toggle="button">Toggle link</a>        <a class="btn btn-primary active" role="button" href="#" data-bs-toggle="button" aria-pressed="true">Active toggle link</a>        <a class="btn btn-primary disabled" role="button" aria-disabled="true" tabindex="-1" data-bs-toggle="button">Disabled toggle link</a>    </div>
+        <a class="btn" role="button" href="#" data-bs-toggle="button">Toggle link</a>        <a class="btn active" role="button" href="#" data-bs-toggle="button" aria-pressed="true">Active toggle link</a>        <a class="btn disabled" role="button" aria-disabled="true" tabindex="-1" data-bs-toggle="button">Disabled toggle link</a>    </div>
     <div class="d-inline-flex flex-wrap gap-1">
         <a class="btn btn-primary" role="button" href="#" data-bs-toggle="button">Toggle link</a>        <a class="btn btn-primary active" role="button" href="#" data-bs-toggle="button" aria-pressed="true">Active toggle link</a>        <a class="btn btn-primary disabled" role="button" aria-disabled="true" tabindex="-1" data-bs-toggle="button">Disabled toggle link</a>    </div>
 </div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit bootstrap, component navbar, example 6__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit bootstrap, component navbar, example 6__1.html
@@ -60,7 +60,7 @@
         </div>
     </nav>
 
-    <nav class="navbar bg-body-tertiary" data-bs-theme="light" style="background-color: #e3f2fd;"><div class="container-fluid">
+    <nav class="navbar" data-bs-theme="light" style="background-color: #e3f2fd;"><div class="container-fluid">
             <a class="navbar-brand" href="#">Navbar</a>
             <div class="navbar-nav flex-row gap-3">
                 <a class="nav-link active" aria-current="page" href="#">Home</a>

--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for `MergeableInterface` from `twig/html-extra` in `ComponentAttributes#defaults()`
 - Add support for dynamic component names in the HTML syntax using `<twig:component is="myComponent" ...`
 - Capture `## <description>` documentation comments written above props inside `{% props %}` (Twig 3.29+), exposed per prop via `PropsNode::getPropDocumentation()`
+- Fix `{% props %}` treating a prop explicitly passed as `null` as missing: a required prop no longer throws, and a prop declaring a default value now keeps the `null` it was given
 
 ## 3.4.0
 

--- a/src/TwigComponent/src/Twig/PropsNode.php
+++ b/src/TwigComponent/src/Twig/PropsNode.php
@@ -58,7 +58,7 @@ class PropsNode extends Node
 
         foreach ($this->getAttribute('names') as $name) {
             $compiler
-                ->write('if (isset($context[\'__props\'][\''.$name.'\'])) {')
+                ->write('if (array_key_exists(\''.$name.'\', $context[\'__props\'] ?? [])) {')
                 ->raw("\n")
                 ->indent()
                 ->write('$componentClass = isset($context[\'this\']) ? get_debug_type($context[\'this\']) : "";')
@@ -70,13 +70,13 @@ class PropsNode extends Node
                 ->raw("\n")
             ;
 
-            $compiler->write('if (!isset($context[\''.$name.'\'])) {');
+            $compiler->write('if (!array_key_exists(\''.$name.'\', $context)) {');
 
             if (!$this->hasNode($name)) {
                 $compiler
                     ->write("\n")
                     ->indent()
-                    ->write('throw new \Twig\Error\RuntimeError("'.$name.' should be defined for component '.$this->getTemplateName().'.");')
+                    ->write('throw new \Twig\Error\RuntimeError(\'Prop "'.$name.'" should be defined.\');')
                     ->write("\n")
                     ->outdent()
                     ->write('}')
@@ -98,7 +98,7 @@ class PropsNode extends Node
             // overwrite the context value if a props with a similar name and a default value exist
             if ($this->hasNode($name)) {
                 $compiler
-                    ->write('if (isset($context[\'__context\'][\''.$name.'\'])) {')
+                    ->write('if (array_key_exists(\''.$name.'\', $context[\'__context\'] ?? [])) {')
                     ->raw("\n")
                     ->indent()
                     ->write('$context[\''.$name.'\'] = ')

--- a/src/TwigComponent/tests/Fixtures/Component/NullableClassProps.php
+++ b/src/TwigComponent/tests/Fixtures/Component/NullableClassProps.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent]
+class NullableClassProps
+{
+    public ?string $property = 'default';
+    public ?string $mounted = null;
+
+    public function mount(?string $mounted = 'default')
+    {
+        $this->mounted = $mounted;
+    }
+}

--- a/src/TwigComponent/tests/Fixtures/Component/NullableConflict.php
+++ b/src/TwigComponent/tests/Fixtures/Component/NullableConflict.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Fixtures\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent]
+class NullableConflict
+{
+    public ?string $name = null;
+}

--- a/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_missing_required_prop.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_missing_required_prop.html.twig
@@ -1,0 +1,1 @@
+<twig:NullableProps />

--- a/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_null_props.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_null_props.html.twig
@@ -1,0 +1,1 @@
+<twig:NullableProps :required="null" :withDefault="null" />

--- a/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_null_variable_already_in_context.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/anonymous_component_with_null_variable_already_in_context.html.twig
@@ -1,0 +1,3 @@
+{% set withDefault = null %}
+
+<twig:NullableProps required="foo" />

--- a/src/TwigComponent/tests/Fixtures/templates/class_component_with_null_props.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/class_component_with_null_props.html.twig
@@ -1,0 +1,1 @@
+<twig:NullableClassProps :property="null" :mounted="null" />

--- a/src/TwigComponent/tests/Fixtures/templates/class_component_with_omitted_props.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/class_component_with_omitted_props.html.twig
@@ -1,0 +1,1 @@
+<twig:NullableClassProps />

--- a/src/TwigComponent/tests/Fixtures/templates/component_with_conflict_between_null_prop_from_template_and_class.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/component_with_conflict_between_null_prop_from_template_and_class.html.twig
@@ -1,0 +1,1 @@
+<twig:NullableConflict />

--- a/src/TwigComponent/tests/Fixtures/templates/components/NullableClassProps.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/NullableClassProps.html.twig
@@ -1,0 +1,2 @@
+<p>property: {{ property ?? 'NULL' }}</p>
+<p>mounted: {{ mounted ?? 'NULL' }}</p>

--- a/src/TwigComponent/tests/Fixtures/templates/components/NullableConflict.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/NullableConflict.html.twig
@@ -1,0 +1,3 @@
+{% props name %}
+
+<p>{{ name }}</p>

--- a/src/TwigComponent/tests/Fixtures/templates/components/NullableProps.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/components/NullableProps.html.twig
@@ -1,0 +1,4 @@
+{% props required, withDefault = 'default' %}
+
+<p>required: {{ required ?? 'NULL' }}</p>
+<p>withDefault: {{ withDefault ?? 'NULL' }}</p>

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -396,6 +396,51 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('<p>bar</p>', $output);
     }
 
+    public function testComponentPropWithoutDefaultAcceptsNullValue()
+    {
+        $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_null_props.html.twig');
+
+        $this->assertStringContainsString('<p>required: NULL</p>', $output);
+    }
+
+    public function testComponentPropWithoutDefaultAndWithoutValueThrows()
+    {
+        $this->expectException(RuntimeError::class);
+        $this->expectExceptionMessage('Prop "required" should be defined in "components/NullableProps.html.twig" at line 1.');
+
+        self::getContainer()->get(Environment::class)->render('anonymous_component_with_missing_required_prop.html.twig');
+    }
+
+    public function testComponentPropWithDefaultKeepsNullValueExplicitlyPassed()
+    {
+        $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_null_props.html.twig');
+
+        $this->assertStringContainsString('<p>withDefault: NULL</p>', $output);
+    }
+
+    public function testComponentPropWithDefaultIgnoresNullValueFromContext()
+    {
+        $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_null_variable_already_in_context.html.twig');
+
+        $this->assertStringContainsString('<p>withDefault: default</p>', $output);
+    }
+
+    public function testComponentClassPropertyWithDefaultKeepsNullValueExplicitlyPassed()
+    {
+        $output = self::getContainer()->get(Environment::class)->render('class_component_with_null_props.html.twig');
+
+        $this->assertStringContainsString('<p>property: NULL</p>', $output);
+        $this->assertStringContainsString('<p>mounted: NULL</p>', $output);
+    }
+
+    public function testComponentClassPropertyWithDefaultKeepsItWhenPropIsNotPassed()
+    {
+        $output = self::getContainer()->get(Environment::class)->render('class_component_with_omitted_props.html.twig');
+
+        $this->assertStringContainsString('<p>property: default</p>', $output);
+        $this->assertStringContainsString('<p>mounted: default</p>', $output);
+    }
+
     public function testComponentPropsWithTrailingComma()
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_props_trailing_comma.html.twig');
@@ -594,6 +639,14 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->expectExceptionMessage('Cannot define prop "name" in template "components/Conflict.html.twig". Property already defined in component class "Symfony\UX\TwigComponent\Tests\Fixtures\Component\Conflict"');
 
         self::getContainer()->get(Environment::class)->render('component_with_conflict_between_props_from_template_and_class.html.twig');
+    }
+
+    public function testComponentWithConflictBetweenNullPropFromTemplateAndClass()
+    {
+        $this->expectException(RuntimeError::class);
+        $this->expectExceptionMessage('Cannot define prop "name" in template "components/NullableConflict.html.twig". Property already defined in component class "Symfony\\UX\\TwigComponent\\Tests\\Fixtures\\Component\\NullableConflict"');
+
+        self::getContainer()->get(Environment::class)->render('component_with_conflict_between_null_prop_from_template_and_class.html.twig');
     }
 
     public function testComponentWithEmptyProps()


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Found at work during a Twig template refactorisation, but having a component `EditorialPartant` like that:
```twig
{# @prop chevalCourse Cheval_Course Le partant commenté #}
{# @prop texte string|null Le contenu éditorial (HTML), tel que saisi en back-office #}
{%- props chevalCourse, texte -%}
{# ... #}
```

Calling `<twig:EditorialPartant chevalCourse="{{ chevalCourse }}" texte="{{ texte }}" />` where `texte` is nullable and so, can be `null`, throws the following exception:
```
Uncaught PHP Exception Twig\Error\RuntimeError:
"texte should be defined for component components/EditorialPartant.html.twig
in "components/EditorialPartant.html.twig" at line 3."
at EditorialPartant.html.twig line 3
```

It's because we use `isset()` in `if (!isset($context[\''.$name.'\'])) {` , `isset()` will returns `false` even if the property (with `null` value) is passed.  It's not the case of `array_key_exists`, which correctly evaluate if a prop exists or not, whatever its value.

I also modified the exception message, the file name and line number are redundant.