### PR TITLE
[Map] Skip performance tests on Windows

### DIFF
--- a/src/Map/tests/Cluster/ClusteringPerformanceTest.php
+++ b/src/Map/tests/Cluster/ClusteringPerformanceTest.php
@@ -12,12 +12,14 @@
 namespace Symfony\UX\Map\Tests\Cluster;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\Map\Cluster\ClusteringAlgorithmInterface;
 use Symfony\UX\Map\Cluster\GridClusteringAlgorithm;
 use Symfony\UX\Map\Cluster\MortonClusteringAlgorithm;
 use Symfony\UX\Map\Point;
 
+#[RequiresOperatingSystem('^(?!WIN)')]
 class ClusteringPerformanceTest extends TestCase
 {
     /**


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #... 
| License        | MIT

CI often fails on Windows map performance non-regression tests, due to their anemic hardware. 

Simplest solution is to not run them on windows platforms. 

