### PR TITLE
[Icons] Update docs about using underscores in icon names

### DIFF
--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -67,7 +67,10 @@ The icon ``name`` is the same as the file name without the file extension (e.g. 
 
 .. caution::
 
-    The name must match a standard ``slug`` format: ``[a-z0-9-]+(-[a-z0-9])+``.
+    The ``prefix`` and the ``name`` must be *slugs*: only lowercase letters, digits
+    and hyphens are allowed (e.g. ``user-profile``). Underscores and uppercase letters
+    are not allowed, not even in the names of the directories inside ``assets/icons/``.
+    Icons with an invalid name are reported as not found (see `Errors`_).
 
 Depending on your `configuration`_, the ``prefix`` can be the name of an icon set, a directory
 where the icon is located, or a combination of both.
@@ -234,8 +237,8 @@ Local SVG Icons
 
 If you already have the SVG icon files to use in your project, store them in the
 ``assets/icons/`` directory and commit them. The name of the file is used as the
-*name* of the icon (``icon_name.svg`` will be named ``icon_name``). If located in
-a subdirectory, the *name* will be ``subdirectory:icon_name``.
+*name* of the icon (``icon-name.svg`` will be named ``icon-name``). If located in
+a subdirectory, the *name* will be ``subdirectory:icon-name``.
 
 .. code-block:: text
 
@@ -252,6 +255,13 @@ a subdirectory, the *name* will be ``subdirectory:icon_name``.
     │     ├─ menu.svg
     │     └─ ...
     └─ ...
+
+.. caution::
+
+    Directory and file names must be *slugs* (lowercase letters, digits and hyphens).
+    An icon stored in ``assets/icons/user_menu/close.svg`` cannot be loaded because
+    of the underscore in the directory name; rename it to ``user-menu/`` and use
+    ``user-menu:close`` instead. See `Icon Names`_ for details.
 
 On-Demand Icons
 ~~~~~~~~~~~~~~~
@@ -367,7 +377,7 @@ Twig Function
     {# includes the contents of the 'assets/icons/user-profile.svg' file in the template #}
     {{ ux_icon('user-profile') }}
 
-    {# icons stored in subdirectories must use the 'subdirectory_name:file_name' syntax
+    {# icons stored in subdirectories must use the 'subdirectory-name:file-name' syntax
        (e.g. this includes 'assets/icons/admin/user-profile.svg') #}
     {{ ux_icon('admin:user-profile') }}
 

--- a/src/Icons/tests/Fixtures/icons/sub_dir/check.svg
+++ b/src/Icons/tests/Fixtures/icons/sub_dir/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+  <path fill-rule="evenodd" d="M19.916 4.626a.75.75 0 0 1 .208 1.04l-9 13.5a.75.75 0 0 1-1.154.114l-6-6a.75.75 0 0 1 1.06-1.06l5.353 5.353 8.493-12.74a.75.75 0 0 1 1.04-.207Z" clip-rule="evenodd" />
+</svg>

--- a/src/Icons/tests/Integration/RenderIconsInTwigTest.php
+++ b/src/Icons/tests/Integration/RenderIconsInTwigTest.php
@@ -12,7 +12,9 @@
 namespace Symfony\UX\Icons\Tests\Integration;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\Icons\Exception\IconNotFoundException;
 use Twig\Environment;
+use Twig\Error\RuntimeError;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -52,5 +54,18 @@ final class RenderIconsInTwigTest extends KernelTestCase
         $expected = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L17.94 6M18 18L6.06 6"/></svg>';
         $this->assertSame($outputIcon, $expected);
         $this->assertSame($outputIcon, $outputAlias);
+    }
+
+    public function testIconInDirectoryWithUnderscoreIsNotFound()
+    {
+        $this->assertFileExists(__DIR__.'/../Fixtures/icons/sub_dir/check.svg');
+
+        try {
+            self::getContainer()->get(Environment::class)->createTemplate("{{ ux_icon('sub_dir:check') }}")->render();
+            $this->fail('An IconNotFoundException should have been thrown.');
+        } catch (RuntimeError $e) {
+            $this->assertInstanceOf(IconNotFoundException::class, $e->getPrevious());
+            $this->assertSame('The icon name "sub_dir:check" is not valid.', $e->getPrevious()->getMessage());
+        }
     }
 }

--- a/src/Icons/tests/Unit/IconTest.php
+++ b/src/Icons/tests/Unit/IconTest.php
@@ -136,6 +136,7 @@ final class IconTest extends TestCase
             ['foo--bar'],
             ['foo--bar-baz'],
             ['foo-bar--baz'],
+            ['foo-bar--baz-qux'],
         ];
     }
 
@@ -146,6 +147,8 @@ final class IconTest extends TestCase
             ['foo:'],
             [':foo'],
             ['foo::bar'],
+            ['foo_bar--baz'],
+            ['foo--bar_baz'],
         ];
     }
 
@@ -155,6 +158,8 @@ final class IconTest extends TestCase
         yield from [
             ['foo:bar-baz'],
             ['foo:bar'],
+            ['foo:bar:baz'],
+            ['foo-bar:baz-qux'],
         ];
     }
 
@@ -169,6 +174,9 @@ final class IconTest extends TestCase
             ['foo::'],
             ['::foo'],
             ['foo--bar'],
+            ['foo_bar:baz'],
+            ['foo:bar_baz'],
+            ['foo_bar:baz_qux'],
         ];
     }
 

--- a/src/Icons/tests/Unit/Registry/CacheIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/CacheIconRegistryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Icons\Tests\Unit\Registry;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\UX\Icons\Exception\IconNotFoundException;
+use Symfony\UX\Icons\Icon;
+use Symfony\UX\Icons\Registry\CacheIconRegistry;
+use Symfony\UX\Icons\Tests\Util\InMemoryIconRegistry;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class CacheIconRegistryTest extends TestCase
+{
+    #[DataProvider('provideInvalidNames')]
+    public function testInvalidNameIsRejectedEvenIfInnerRegistryHasIt(string $name)
+    {
+        $inner = new InMemoryIconRegistry([$name => new Icon('<path d="M0 0h24v24H0z"/>')]);
+        $registry = new CacheIconRegistry($inner, new ArrayAdapter());
+
+        $this->expectException(IconNotFoundException::class);
+        $this->expectExceptionMessage(\sprintf('The icon name "%s" is not valid.', $name));
+
+        $registry->get($name);
+    }
+
+    public function testValidNameIsResolvedAndCached()
+    {
+        $icon = new Icon('<path d="M0 0h24v24H0z"/>');
+        $cache = new ArrayAdapter();
+        $registry = new CacheIconRegistry(new InMemoryIconRegistry(['foo-bar:baz' => $icon]), $cache);
+
+        $this->assertSame($icon->getInnerSvg(), $registry->get('foo-bar:baz')->getInnerSvg());
+        $this->assertTrue($cache->hasItem('foo-bar--baz'));
+        $this->assertSame($icon->getInnerSvg(), $registry->get('foo-bar:baz')->getInnerSvg());
+    }
+
+    public static function provideInvalidNames(): iterable
+    {
+        yield 'underscore_in_prefix' => ['foo_bar:baz'];
+        yield 'underscore_in_name' => ['foo:bar_baz'];
+        yield 'underscore_in_prefix_and_name' => ['foo_bar:baz_qux'];
+        yield 'uppercase_prefix' => ['FOO:bar'];
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

You can't use underscores in icon paths (icon names and/or icon dirs + subdirs). Let's fix some examples in the docs and let's explain more clearly this limitation.

I also added a test that verifies this behavior ... but I can remove it if you think this is unnecessary.