### PR TITLE
[TwigComponent] Fix null-safe operator in component tag props

### DIFF
--- a/src/TwigComponent/CHANGELOG.md
+++ b/src/TwigComponent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for dynamic component names in the HTML syntax using `<twig:component is="myComponent" ...`
 - Capture `## <description>` documentation comments written above props inside `{% props %}` (Twig 3.29+), exposed per prop via `PropsNode::getPropDocumentation()`
 - Fix `{% props %}` treating a prop explicitly passed as `null` as missing: a required prop no longer throws, and a prop declaring a default value now keeps the `null` it was given
+- Fix HTML/`{% component %}` syntax failing when a prop uses the null-safe operator (`?.`)
 
 ## 3.4.0
 

--- a/src/TwigComponent/doc/index.rst
+++ b/src/TwigComponent/doc/index.rst
@@ -299,6 +299,9 @@ prefix the attribute with ``:`` or use the normal ``{{ }}`` syntax:
     // pass object, array, or anything you imagine
     <twig:Alert :foo="{col: ['foo', 'oof']}" />
 
+    // null-safe operator (Twig 3.23+)
+    <twig:Alert :title="user.profile?.displayName" />
+
 Boolean props are converted using PHP's type juggling rules. The
 string ``"false"`` is converted to the boolean ``true``.
 

--- a/src/TwigComponent/src/Twig/ComponentNode.php
+++ b/src/TwigComponent/src/Twig/ComponentNode.php
@@ -95,6 +95,15 @@ final class ComponentNode extends Node implements NodeOutputInterface
                 ->write("}\n");
         }
 
+        // Compile props once: Twig 3.24+ null-safe chains are stateful when compiled.
+        $props = $compiler->getVarName();
+        $compiler
+            ->write(\sprintf('$%s = ', $props))
+            ->raw('Twig\Extension\CoreExtension::toArray')
+            ->raw('(');
+        $this->writeProps($compiler)
+            ->raw(");\n");
+
         /*
          * Block 1) PreCreateForRender handling
          *
@@ -103,12 +112,7 @@ final class ComponentNode extends Node implements NodeOutputInterface
          */
         $compiler
             ->write(\sprintf('$preRendered = $%s->preRender(', $componentRuntime))
-            ->raw(\sprintf('$%s', $componentName))
-            ->raw(', ')
-            ->raw('Twig\Extension\CoreExtension::toArray')
-            ->raw('(');
-        $this->writeProps($compiler)
-            ->raw(')')
+            ->raw(\sprintf('$%s, $%s', $componentName, $props))
             ->raw(");\n");
 
         $compiler
@@ -135,12 +139,7 @@ final class ComponentNode extends Node implements NodeOutputInterface
          */
         $compiler
             ->write(\sprintf('$preRenderEvent = $%s->startEmbedComponent(', $componentRuntime))
-            ->raw(\sprintf('$%s', $componentName))
-            ->raw(', ')
-            ->raw('Twig\Extension\CoreExtension::toArray')
-            ->raw('(');
-        $this->writeProps($compiler)
-            ->raw('), ')
+            ->raw(\sprintf('$%s, $%s, ', $componentName, $props))
             ->raw($this->getAttribute('only') ? '[]' : '$context')
             ->raw(', ')
             ->string($this->getAttribute('embedded_template'))

--- a/src/TwigComponent/tests/Fixtures/templates/anonymous_component_nullsafe_props.html.twig
+++ b/src/TwigComponent/tests/Fixtures/templates/anonymous_component_nullsafe_props.html.twig
@@ -1,0 +1,5 @@
+<twig:Button :label="item.city?.organisation?.name ~ ' - ' ~ item.title">
+    unused
+</twig:Button>
+<twig:Button :label="item.city?.organisation?.name ~ ' - ' ~ item.title" />
+{{ component('Button', {label: item.city?.organisation?.name ~ ' - ' ~ item.title}) }}

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -382,6 +382,26 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('class variable defined? no', $output);
     }
 
+    public function testRenderComponentTagWithNullsafeProps()
+    {
+        if (Environment::VERSION_ID < 32300) {
+            $this->markTestSkipped('The "?." operator requires Twig 3.23+.');
+        }
+
+        $city = new \stdClass();
+        $city->organisation = null;
+
+        $item = new \stdClass();
+        $item->city = $city;
+        $item->title = 'Title';
+
+        $output = self::getContainer()->get(Environment::class)->render('anonymous_component_nullsafe_props.html.twig', [
+            'item' => $item,
+        ]);
+
+        $this->assertSame(3, substr_count($output, '- Title'));
+    }
+
     public function testComponentPropsOverwriteContextValue()
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_variable_already_in_context.html.twig');


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Fix #3704
| License        | MIT

`ComponentNode` subcompiles the props hash twice (`preRender()` then `startEmbedComponent()`). From Twig 3.24, compiling `?.` is stateful: the second pass drops the null guard and reads an unassigned temp variable, which blows up with "Impossible to access an attribute on a null variable" when the left-hand side is null.

Worth flagging for anyone bisecting this: it is not a `ComponentNode` regression between the versions in the report. That class is byte-identical from v2.32.0 to v2.36.2. `?.` landed in Twig 3.23 and its compilation became stateful in 3.24 (twigphp/Twig#4748); compiling the props twice is what drops the null guard.

This hits the HTML syntax (`<twig:Foo :bar="a?.b">`) and `{% component %}`, because both go through `ComponentNode`. `{{ component() }}` was already fine.

Fix is to evaluate props once and reuse the array. Same idea as #3738, retargeted to 3.x (2.x is security-only). Thanks @Amoifr for the original diagnosis.

The test covers the paired HTML tag, the self-closing HTML tag, and `{{ component() }}`. It fails without the patch (skipped below Twig 3.23).
