### PR TITLE
[Image] Add the UX Image package and its Glide, Cloudflare and KeyCDN bridges

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -7,6 +7,10 @@
         "ux-chartjs": "src/Chartjs",
         "ux-cropperjs": "src/Cropperjs",
         "ux-icons": "src/Icons",
+        "ux-image": { "prefixes": [{ "from": "src/Image", "to": "", "excludes": ["src/Bridge"] }] },
+        "ux-cloudflare-image": "src/Image/src/Bridge/Cloudflare",
+        "ux-glide-image": "src/Image/src/Bridge/Glide",
+        "ux-keycdn-image": "src/Image/src/Bridge/KeyCdn",
         "ux-live-component": "src/LiveComponent",
         "ux-map": {
             "prefixes": [{ "from": "src/Map", "to": "", "excludes": ["src/Bridge"] }]

--- a/src/Image/.gitattributes
+++ b/src/Image/.gitattributes
@@ -1,0 +1,5 @@
+/.git* export-ignore
+/.symfony.bundle.yaml export-ignore
+/doc export-ignore
+/phpunit.dist.xml export-ignore
+/tests export-ignore

--- a/src/Image/.gitignore
+++ b/src/Image/.gitignore
@@ -1,0 +1,7 @@
+/composer.lock
+/phpunit.xml
+/vendor/
+/.phpunit.cache/
+/var/
+/config/reference.php
+/config/schema.json

--- a/src/Image/.symfony.bundle.yaml
+++ b/src/Image/.symfony.bundle.yaml
@@ -1,0 +1,3 @@
+branches: ['3.x']
+maintained_branches: ['3.x']
+doc_dir: 'doc'

--- a/src/Image/CHANGELOG.md
+++ b/src/Image/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 3.6.0
+
+- Add the component

--- a/src/Image/LICENSE
+++ b/src/Image/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Image/README.md
+++ b/src/Image/README.md
@@ -1,0 +1,16 @@
+# Symfony UX Image
+
+**EXPERIMENTAL** This component is currently experimental and is
+likely to change, or even change drastically.
+
+Symfony UX Image renders responsive images in Symfony applications by delegating transformations to a URL-based image provider, like Glide, KeyCDN or Cloudflare.
+
+**This repository is a READ-ONLY sub-tree split**. See
+https://github.com/symfony/ux to create issues or submit pull requests.
+
+## Resources
+
+- [Documentation](https://symfony.com/bundles/ux-image/current/index.html)
+- [Report issues](https://github.com/symfony/ux/issues) and
+  [send Pull Requests](https://github.com/symfony/ux/pulls)
+  in the [main Symfony UX repository](https://github.com/symfony/ux)

--- a/src/Image/composer.json
+++ b/src/Image/composer.json
@@ -1,0 +1,56 @@
+{
+    "name": "symfony/ux-image",
+    "type": "symfony-bundle",
+    "description": "Responsive images for Symfony, delivered through URL-based image providers",
+    "keywords": [
+        "symfony-ux",
+        "image",
+        "responsive",
+        "cdn"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Hugo Alliaume",
+            "email": "hugo@alliau.me"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Symfony\\UX\\Image\\": "src/"
+        },
+        "exclude-from-classmap": []
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\UX\\Image\\Tests\\": "tests/"
+        }
+    },
+    "require": {
+        "php": ">=8.4",
+        "symfony/config": "^7.4|^8.0",
+        "symfony/dependency-injection": "^7.4|^8.0",
+        "symfony/http-kernel": "^7.4|^8.0",
+        "symfony/routing": "^7.4|^8.0",
+        "symfony/twig-bundle": "^7.4|^8.0",
+        "symfony/ux-twig-component": "^3.5",
+        "twig/html-extra": "^3.29"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^12.0",
+        "spatie/phpunit-snapshot-assertions": "^5.2.3",
+        "symfony/framework-bundle": "^7.4|^8.0"
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ux",
+            "url": "https://github.com/symfony/ux"
+        }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Image/config/routes/glide.php
+++ b/src/Image/config/routes/glide.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\UX\Image\Bridge\Glide\Controller\GlideController;
+
+return function (RoutingConfigurator $routes) {
+    $routes->add('ux_image_glide', '/{path}')
+        ->controller(GlideController::class)
+        ->requirements(['path' => '.+'])
+        ->methods(['GET', 'HEAD'])
+    ;
+};

--- a/src/Image/config/services.php
+++ b/src/Image/config/services.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\UX\Image\Provider\ProviderInterface;
+use Symfony\UX\Image\Provider\ProviderResolver;
+use Symfony\UX\Image\Renderer\ImageRenderer;
+use Symfony\UX\Image\Renderer\ImageRendererInterface;
+use Symfony\UX\Image\Renderer\LayoutResolver;
+use Symfony\UX\Image\Twig\ImageExtension;
+use Symfony\UX\Image\Twig\ImageRuntime;
+
+/*
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->set('ux_image.provider_resolver', ProviderResolver::class)
+            ->args([
+                tagged_iterator('ux_image.provider_factory'),
+            ])
+
+        ->set('ux_image.provider', ProviderInterface::class)
+            ->factory([service('ux_image.provider_resolver'), 'fromString'])
+            ->args([
+                abstract_arg('provider dsn'),
+            ])
+
+        ->set('ux_image.layout_resolver', LayoutResolver::class)
+            ->args([
+                abstract_arg('resolutions'),
+            ])
+
+        ->set('ux_image.renderer', ImageRenderer::class)
+            ->args([
+                service('ux_image.provider'),
+                service('ux_image.layout_resolver'),
+                abstract_arg('formats'),
+            ])
+
+        ->alias(ImageRendererInterface::class, 'ux_image.renderer')
+
+        ->set('ux_image.twig_extension', ImageExtension::class)
+            ->tag('twig.extension')
+
+        ->set('ux_image.twig_runtime', ImageRuntime::class)
+            ->args([
+                service('ux_image.renderer'),
+                service('twig'),
+            ])
+            ->tag('twig.runtime')
+    ;
+};

--- a/src/Image/config/twig_component.php
+++ b/src/Image/config/twig_component.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\UX\Image\Twig\Components\Image;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->set('.ux_image.twig_component.image', Image::class)
+            ->args([
+                service('ux_image.renderer'),
+            ])
+            ->tag('twig.component', ['key' => 'ux:image', 'template' => '@UXImage/components/Image.html.twig'])
+    ;
+};

--- a/src/Image/doc/index.rst
+++ b/src/Image/doc/index.rst
@@ -1,0 +1,473 @@
+Symfony UX Image
+================
+
+**EXPERIMENTAL** This component is currently experimental and is likely
+to change, or even change drastically.
+
+Symfony UX Image renders responsive images in Symfony applications by
+delegating every transformation to a URL-based image provider, such as
+`Glide`_, `KeyCDN`_ or `Cloudflare`_. It is part of
+`the Symfony UX initiative`_.
+
+The package never decodes, resizes or encodes an image itself. Every
+transformation is expressed as a URL, built by whichever provider is
+active; the package's own job is generating that URL, a ``srcset``, a
+``sizes`` attribute and a layout ``style``.
+
+Installation
+------------
+
+Install the bundle using Composer and Symfony Flex:
+
+.. code-block:: terminal
+
+    $ composer require symfony/ux-image
+
+Then install one of the provider bridges, for example `Glide`_:
+
+.. code-block:: terminal
+
+    $ composer require symfony/ux-glide-image
+
+Rendering an image
+------------------
+
+The ``<twig:ux:image>`` component renders a single image:
+
+.. code-block:: html+twig
+
+    <twig:ux:image src="/uploads/hero.jpg" alt="Hero" width="800" height="450" />
+
+The equivalent ``ux_image()`` Twig function is available for programmatic use,
+for example when the source path is only known inside a Twig macro:
+
+.. code-block:: twig
+
+    {{ ux_image('/uploads/hero.jpg', 'Hero', {width: 800, height: 450}) }}
+
+Both accept the same rendering options: the component exposes them as props,
+the function takes them as its third, associative-array argument, keyed by
+prop name in camelCase (``objectFit``, not ``object-fit``). An unknown key
+there throws an ``InvalidArgumentException``.
+
+HTML attributes are the component's alone. ``class``, ``data-*``, ``style``
+and ``sizes`` reach the rendered ``<img>`` when they are passed to
+``<twig:ux:image>``; ``ux_image()`` has no argument for them.
+
+Props
+~~~~~
+
+=============== ================================= ================================
+Prop            Type                              Default
+=============== ================================= ================================
+``src``         ``string``                        required
+``alt``         ``string``                        required
+``layout``      ``fixed|constrained|full-width``  ``constrained``
+``width``       ``int|null``                      ``null``
+``height``      ``int|null``                      ``null``
+``fit``         ``cover|contain|scale-down|null`` ``null``
+``format``      ``string|null``                   ``null``
+``quality``     ``int|null`` (1 to 100)           ``null``
+``priority``    ``bool``                          ``false``
+``object-fit``  ``string|null``                   the ``fit`` value
+``breakpoints`` ``int[]|null``                    the ``resolutions`` option
+``operations``  ``array<string, array>``          ``{}``
+=============== ================================= ================================
+
+``layout`` and its ``breakpoints``, ``sizes`` and generated ``style`` are
+covered under :ref:`Layout and rendering <image_layout_and_rendering>`.
+``priority`` sets ``loading="eager" fetchpriority="high"``; without it, an
+image gets ``loading="lazy" fetchpriority="auto"``.
+
+``fit`` decides how the provider reshapes the source image into the requested
+``width`` x ``height``. ``cover`` fills the box and crops the excess,
+``contain`` fits the whole image inside it, and ``scale-down`` behaves like
+``contain`` but never enlarges the image. It only has an effect when both
+``width`` and ``height`` are set, since without both there is no target box to
+fit into. And it only produces a visible difference when the source image's
+aspect ratio differs from the requested one: at equal ratios there is nothing
+to crop and nothing to letterbox, so the three modes come out identical.
+
+The generated ``object-fit`` follows ``fit`` (``cover`` -> ``cover``,
+``contain`` -> ``contain``, ``scale-down`` -> ``scale-down``), so the browser
+doesn't redo a crop the provider was asked to avoid. Without that, a
+``contain`` image would be cropped back to fill its box by CSS, and ``fit``
+would never be observable.
+
+``format`` pins the output format for this one image, in place of both the
+provider's own negotiation and the per-format ``<picture>`` fallbacks: a
+single ``<img>`` is rendered in that format. A format the active provider
+cannot produce throws an ``InvalidArgumentException`` naming its supported
+list.
+
+Any attribute not listed above (``class``, ``data-*``, a caller-supplied
+``style`` or ``sizes``, …) is passed through to the rendered ``<img>``. A
+caller-supplied ``style`` merges with the generated layout style instead of
+replacing it; a caller-supplied ``sizes`` replaces the generated value.
+
+.. _image_provider_operations:
+
+Provider-specific operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every provider accepts extra, provider-specific parameters beyond the common
+``width``/``height``/``fit``/``format``/``quality`` set (see
+:ref:`Providers <image_providers>` for the full list per bridge). Pass them
+through ``operations``, keyed by provider name:
+
+.. code-block:: html+twig
+
+    <twig:ux:image src="/uploads/hero.jpg" alt="Hero" width="800"
+        :operations="{cloudflare: {gravity: 'auto'}, glide: {crop: 'smart'}}" />
+
+At render time, only ``operations[activeProviderName]`` is read; the rest is
+ignored. Keying by provider name is deliberate: the active DSN changes
+between environments, and a flat, un-keyed ``gravity`` option would silently
+vanish the moment the application switched from Cloudflare to another
+provider. Passing an operation the active provider does not support throws
+an ``InvalidArgumentException`` naming the provider's supported list.
+
+Configuration
+-------------
+
+Configuration is done in your ``config/packages/ux_image.yaml`` file:
+
+.. code-block:: yaml
+
+    # config/packages/ux_image.yaml
+    ux_image:
+        provider: '%env(resolve:UX_IMAGE_DSN)%'
+        formats: ['avif', 'webp', 'jpeg']
+        resolutions: [6016, 5120, 4480, 3840, 3200, 2560, 2048, 1920, 1668, 1280, 1080, 960, 828, 750, 640]
+
+The ``resolve:`` processor is required: a DSN may reference container
+parameters such as ``%kernel.project_dir%``, and parameter resolution does not
+recurse into environment variable values on its own.
+
+The provider DSN
+~~~~~~~~~~~~~~~~
+
+The ``provider`` option is a DSN string that selects which bridge renders
+your images, and configures it. Define it in your ``.env`` files so it can
+change per environment:
+
+.. code-block:: bash
+
+    # .env
+    UX_IMAGE_DSN=glide://default/images?source=%kernel.project_dir%/public/uploads&cache=%kernel.project_dir%/var/glide-cache
+
+.. code-block:: bash
+
+    # .env.prod
+    UX_IMAGE_DSN=cloudflare://cdn.example.com
+
+Each bridge is only registered when its Composer package is actually
+installed. Install the one matching the scheme used in the DSN:
+
+============== ================================================ ===========================================
+Scheme         Install                                          DSN example
+============== ================================================ ===========================================
+``glide``      ``composer require symfony/ux-glide-image``      ``glide://default/images?source=…&cache=…``
+``keycdn``     ``composer require symfony/ux-keycdn-image``     ``keycdn://myzone.kxcdn.com``
+``cloudflare`` ``composer require symfony/ux-cloudflare-image`` ``cloudflare://cdn.example.com``
+============== ================================================ ===========================================
+
+See :ref:`Providers <image_providers>` for what each DSN option means and how
+transformation parameters map to that provider's own query string.
+
+The ``formats`` option
+~~~~~~~~~~~~~~~~~~~~~~
+
+``formats`` is the candidate output format list, in preference order. What it
+governs depends on the active provider:
+
+* for a provider that does not negotiate the format itself, it is intersected
+  with that provider's own supported formats (see
+  :ref:`Providers <image_providers>`) and each surviving entry becomes one
+  ``<source>`` of the rendered ``<picture>`` (see
+  :ref:`Layout and rendering <image_layout_and_rendering>`). An empty
+  intersection throws an exception naming both lists, so asking a provider
+  that cannot encode AVIF to serve only AVIF fails at first render rather
+  than serving the wrong format silently;
+* for `Glide`_, it narrows the candidates the bridge's controller will
+  negotiate ``fm=auto`` down to, with ``jpg`` as the last-resort fallback;
+* for `Cloudflare`_, it has no effect: the choice is made inside Cloudflare,
+  by its own ``format=auto``.
+
+The default is ``['avif', 'webp', 'jpeg']``. For the non-negotiating and
+`Glide`_ cases above, narrowing it is how an application whose image pipeline
+cannot encode AVIF keeps AVIF off the wire; on `Cloudflare`_, ``formats`` is
+ignored, so this does not apply there.
+
+The ``resolutions`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``resolutions`` is the resolution ladder the ``constrained`` and
+``full-width`` layouts draw their ``srcset`` candidates from (see
+:ref:`The resolution ladder <image_resolution_ladder>`). It defaults to
+``Symfony\UX\Image\Renderer\LayoutResolver::DEFAULT_RESOLUTIONS``, the common
+screen widths ported from `unpic`_.
+
+Narrow it when your images never reach those sizes, or when you want fewer
+candidates per ``srcset``; a component can still override it for one image
+through the ``breakpoints`` prop.
+
+.. _image_layout_and_rendering:
+
+Layout and rendering
+--------------------
+
+The ``layout`` prop
+~~~~~~~~~~~~~~~~~~~
+
+``layout`` decides the breakpoint ladder used to build ``srcset``, the
+``sizes`` attribute, and the generated ``style``. ``constrained`` is the
+default.
+
+``fixed``
+    Breakpoints: ``[width, 2 × width]``. ``sizes``: ``{width}px``. ``style``:
+    ``object-fit: cover; width: {width}px; height: {height}px``.
+
+``constrained`` (the default)
+    Breakpoints: ``[width, 2 × width, …ladder entries below 2 × width]``.
+    ``sizes``: ``(min-width: {width}px) {width}px, 100vw``. ``style``:
+    ``object-fit: cover; max-width: {width}px; max-height: {height}px;
+    aspect-ratio: {width/height}; width: 100%; height: auto``.
+
+``full-width``
+    Breakpoints: the full resolution ladder. ``sizes``: ``100vw``. With both
+    ``width`` and ``height`` given, ``style``: ``object-fit: cover; width:
+    100%; aspect-ratio: {width/height}; height: auto``. With only ``height``
+    (no derivable ratio), ``style``: ``object-fit: cover; width: 100%;
+    height: {height}px``.
+
+Both ``constrained`` and ``full-width`` (when a ratio applies) declare
+``height: auto`` alongside ``aspect-ratio``: the ``width``/``height`` HTML
+attributes on ``<img>`` become a definite CSS height through the browser's
+own presentational hint, which would otherwise make CSS ignore
+``aspect-ratio`` outright.
+
+``fixed`` and ``constrained`` require ``width``; ``full-width`` requires
+``height``. Passing neither throws an ``InvalidArgumentException``.
+
+``object-fit`` overrides the value derived from ``fit``. It defaults to the
+``fit`` value itself, or to ``cover`` when no ``fit`` applies.
+
+.. _image_resolution_ladder:
+
+The resolution ladder
+~~~~~~~~~~~~~~~~~~~~~
+
+Unless ``breakpoints`` is passed explicitly, candidates for ``constrained``
+and ``full-width`` are drawn from the ``resolutions`` option, which defaults
+to a descending ladder of common screen widths ported from `unpic`_:
+
+.. code-block:: text
+
+    6016, 5120, 4480, 3840, 3200, 2560, 2048, 1920, 1668, 1280, 1080, 960, 828, 750, 640
+
+``constrained`` keeps only the entries below twice the requested ``width``;
+``full-width`` keeps the whole ladder.
+
+``<img>`` or ``<picture>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The choice is the active provider's, unless the caller pins a ``format``: it
+follows ``supportsAutoFormat()`` (see :ref:`Providers <image_providers>`).
+
+* When the provider can pick the output format from the request itself (for
+  example through a native ``format=auto``, or a controller that negotiates
+  it), a single ``<img>`` is rendered with one ``srcset`` across the
+  breakpoints.
+* When it cannot, a ``<picture>`` is rendered with one ``<source
+  type="image/…" srcset="…">`` per entry of the ``formats`` option
+  intersected with the provider's supported formats, in that order, followed
+  by the ``<img>`` as the last-resort fallback.
+
+KeyCDN has no automatic format negotiation and cannot encode to AVIF, so
+``ux_image()`` always renders a ``<picture>`` for it, never a single
+``<img>``.
+
+This means the exact same template renders different markup depending on
+which provider is active: switching ``UX_IMAGE_DSN`` between a
+``<picture>``-based provider and an ``<img>``-based one changes the output
+without any template change. This is deliberate — an application configured
+for KeyCDN that emitted a single ``<img>`` would serve one hard-coded format
+to every browser, negotiation or not.
+
+A ``format`` prop short-circuits all of this: it names one format, so there is
+nothing left to fall back to and a single ``<img>`` is rendered whatever the
+provider supports.
+
+The ``<picture>`` emitted here only ever carries per-format fallbacks. It
+never carries a different crop per media query (art direction); that is out
+of scope for this version.
+
+.. _image_providers:
+
+Providers
+---------
+
+Parameter mapping
+~~~~~~~~~~~~~~~~~
+
+Every ``ImageTransformation`` property maps to a provider-specific query
+parameter:
+
+=========================== ============ ================== ==============
+``ImageTransformation``     `Glide`_     `Cloudflare`_      `KeyCDN`_
+=========================== ============ ================== ==============
+``width``                   ``w``        ``width``          ``width``
+``height``                  ``h``        ``height``         ``height``
+``format``                  ``fm``       ``format``         ``format``
+``quality``                 ``q``        ``quality``        ``quality``
+``fit``: ``Fit::Cover``     ``fit=crop`` ``fit=cover``      ``fit=cover``
+``fit``: ``Fit::ScaleDown`` ``fit=max``  ``fit=scale-down`` ``fit=inside``
+=========================== ============ ================== ==============
+
+``Fit::Contain`` maps to ``fit=contain`` on every provider.
+
+``operations`` (see
+:ref:`Provider-specific operations <image_provider_operations>`) is merged
+into the generated URL verbatim, once resolved for the active provider.
+
+Supported formats and negotiation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============= ================================================================== =========================
+Provider      Supported formats                                                  Negotiates automatically?
+============= ================================================================== =========================
+`Cloudflare`_ ``avif``, ``webp``, ``jpeg``, ``png``                              **Yes**
+`Glide`_      ``avif``, ``webp``, ``jpeg``, ``pjpg``, ``png``, ``gif``, ``heic`` **Yes**
+`KeyCDN`_     ``webp``, ``jpeg``, ``png``                                        **No**
+============= ================================================================== =========================
+
+Cloudflare negotiates natively, through its own ``format=auto``. Glide has no
+such native value — negotiation is done by the controller this bridge ships,
+which resolves ``fm=auto`` from the request's ``Accept`` header itself (see
+below). KeyCDN has no automatic format negotiation at all, and no AVIF
+support either, which is why ``ux_image()`` always renders a ``<picture>``
+with one ``<source>`` per configured format for it, never a single ``<img>``
+(see ``<img>`` or ``<picture>`` above).
+
+Glide
+~~~~~
+
+`Glide`_ is the local, no-CDN provider: images are resized and encoded
+on-the-fly by your own application through a controller this bridge ships,
+from a source directory you control, with results cached to disk.
+
+.. code-block:: terminal
+
+    $ composer require symfony/ux-glide-image
+
+.. code-block:: bash
+
+    # .env
+    UX_IMAGE_DSN=glide://default/images?source=%kernel.project_dir%/public/uploads&cache=%kernel.project_dir%/var/glide-cache&sign_key=s3cret
+
+The host (``default`` above) is always a placeholder — Glide has no remote
+endpoint, only a local source and cache — so what matters is the DSN's path
+and its query options:
+
+================== =======================================================================
+DSN part           Meaning
+================== =======================================================================
+path (``/images``) the URL prefix images are served under, e.g. ``/images/hero.jpg?w=800``
+``source``         absolute path to the directory holding your original images
+``cache``          absolute path to the directory Glide writes resized/encoded images to
+``sign_key``       optional; when set, every request must carry a valid ``s=`` signature
+``max_image_size`` optional; output pixel cap per image, ``25000000`` by default
+================== =======================================================================
+
+The bridge ships a controller but not a route with a fixed prefix. **The
+prefix your application imports it under must match the DSN's path
+exactly** — the bundle has no way to enforce this at compile time, and a
+drift between the two means ``ux_image()`` generates URLs your own route
+cannot match:
+
+.. code-block:: yaml
+
+    # config/routes/ux_image_glide.yaml
+    ux_image_glide:
+        resource: '@UXImageBundle/config/routes/glide.php'
+        prefix: /images
+
+When ``sign_key`` is set, the controller validates the ``s=`` signature
+**server-side** before doing anything else — it is not merely generated and
+left unchecked. An unsigned request against a signed setup gets a plain 403,
+with no signature or key echoed back.
+
+Setting a ``sign_key`` is **strongly recommended in production**. Without one
+the route resizes and caches whatever anyone asks it for, and every distinct
+parameter combination costs one encode and one new cache file.
+``max_image_size`` caps how large a single output can get — Glide scales an
+oversized request down to it rather than refusing — but only a signature stops
+the request from being served at all.
+
+Extra operations, forwarded as-is: ``crop``, ``or``, ``bri``, ``con``,
+``gam``, ``sharp``, ``blur``, ``pixel``, ``filt``, ``bg``, ``border``. See
+`Glide's own API reference`_ for what each one does.
+
+Cloudflare
+~~~~~~~~~~
+
+`Cloudflare Image Resizing`_ transforms images already served from your own
+origin, through the ``/cdn-cgi/image/`` URL path on a Cloudflare zone. No
+image-processing server of your own is needed.
+
+.. code-block:: terminal
+
+    $ composer require symfony/ux-cloudflare-image
+
+.. code-block:: bash
+
+    # .env.prod
+    UX_IMAGE_DSN=cloudflare://cdn.example.com
+
+The host is the domain proxied by your Cloudflare zone; it must be the
+domain your origin images are served from. Image transformations must be
+enabled on that zone before ``/cdn-cgi/image/`` URLs work — see
+`Enable transformations`_ in the Cloudflare docs.
+
+Extra operations, forwarded as-is: ``gravity``, ``dpr``, ``rotate``,
+``trim``, ``blur``, ``brightness``, ``contrast``, ``gamma``, ``saturation``,
+``sharpen``, ``background``, ``border``, ``anim``, ``metadata``,
+``onerror``, ``compression``. See `Cloudflare's own options reference`_ for
+what each one does.
+
+KeyCDN
+~~~~~~
+
+`KeyCDN Image Processing`_ transforms images already served from your own
+origin, through query string parameters appended to your zone's URL.
+
+.. code-block:: terminal
+
+    $ composer require symfony/ux-keycdn-image
+
+.. code-block:: bash
+
+    # .env.prod
+    UX_IMAGE_DSN=keycdn://myzone.kxcdn.com
+
+The host is your KeyCDN zone.
+
+Extra operations, forwarded as-is: ``position``, ``enlarge``, ``trim``,
+``crop``, ``bg``, ``rotate``, ``flip``, ``flop``, ``sharpen``, ``blur``,
+``gamma``, ``grayscale``, ``progressive``, ``lossless``, ``metadata``. See
+`KeyCDN's own parameter reference`_ for what each one does.
+
+The package supports PHP 8.4 or later and Symfony 7.4 or 8.x.
+
+.. _`the Symfony UX initiative`: https://ux.symfony.com/
+.. _`unpic`: https://github.com/ascorbic/unpic-img
+.. _`Glide`: https://github.com/symfony/ux/blob/3.x/src/Image/src/Bridge/Glide/README.md
+.. _`Glide's own API reference`: https://glide.thephpleague.com/4.0/api/quick-reference/
+.. _`Cloudflare`: https://github.com/symfony/ux/blob/3.x/src/Image/src/Bridge/Cloudflare/README.md
+.. _`Cloudflare Image Resizing`: https://developers.cloudflare.com/images/transform-images/
+.. _`Cloudflare's own options reference`: https://developers.cloudflare.com/images/transform-images/transform-via-url/#options
+.. _`Enable transformations`: https://developers.cloudflare.com/images/transform-images/#enable-transformations-via-dashboard
+.. _`KeyCDN`: https://github.com/symfony/ux/blob/3.x/src/Image/src/Bridge/KeyCdn/README.md
+.. _`KeyCDN Image Processing`: https://www.keycdn.com/support/image-processing
+.. _`KeyCDN's own parameter reference`: https://www.keycdn.com/support/image-processing

--- a/src/Image/phpunit.dist.xml
+++ b/src/Image/phpunit.dist.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+        failOnDeprecation="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UX Image Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source
+            ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/src/Image/src/Bridge/Cloudflare/.gitattributes
+++ b/src/Image/src/Bridge/Cloudflare/.gitattributes
@@ -1,0 +1,3 @@
+/.git* export-ignore
+/phpunit.dist.xml export-ignore
+/tests export-ignore

--- a/src/Image/src/Bridge/Cloudflare/.gitignore
+++ b/src/Image/src/Bridge/Cloudflare/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.cache

--- a/src/Image/src/Bridge/Cloudflare/CHANGELOG.md
+++ b/src/Image/src/Bridge/Cloudflare/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 3.6.0
+
+- Bridge added

--- a/src/Image/src/Bridge/Cloudflare/LICENSE
+++ b/src/Image/src/Bridge/Cloudflare/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Image/src/Bridge/Cloudflare/README.md
+++ b/src/Image/src/Bridge/Cloudflare/README.md
@@ -1,0 +1,61 @@
+# Symfony UX Image: Cloudflare
+
+**EXPERIMENTAL** This component is currently experimental and is
+likely to change, or even change drastically.
+
+[Cloudflare Image Resizing](https://developers.cloudflare.com/images/transform-images/) integration for Symfony UX Image, through the `/cdn-cgi/image/` URL path. Use this bridge to transform images already served from your own origin ("bring your own storage") behind a Cloudflare zone, without running any image-processing server yourself.
+
+> [!IMPORTANT]
+> Image transformations must be enabled on your Cloudflare zone before `/cdn-cgi/image/` URLs work. See [Enable transformations](https://developers.cloudflare.com/images/transform-images/#enable-transformations-via-dashboard) in the Cloudflare docs.
+
+## Installation
+
+Install the bridge using Composer and Symfony Flex:
+
+```shell
+composer require symfony/ux-cloudflare-image
+```
+
+## DSN example
+
+```dotenv
+UX_IMAGE_DSN=cloudflare://cdn.example.com
+```
+
+The host is the domain proxied by your Cloudflare zone; it must be the domain the origin images are served from.
+
+## Parameter mapping
+
+`ImageTransformation` properties are mapped to Cloudflare's [`options` URL segment](https://developers.cloudflare.com/images/transform-images/transform-via-url/#options):
+
+| `ImageTransformation` | Cloudflare option | Notes                                                                |
+| --------------------- | ----------------- | -------------------------------------------------------------------- |
+| `width`               | `width`           |                                                                      |
+| `height`              | `height`          |                                                                      |
+| `fit: Fit::Cover`     | `fit=cover`       |                                                                      |
+| `fit: Fit::Contain`   | `fit=contain`     |                                                                      |
+| `fit: Fit::ScaleDown` | `fit=scale-down`  |                                                                      |
+| `format`              | `format`          | `format: 'auto'` lets Cloudflare pick AVIF/WebP based on the request |
+| `quality`             | `quality`         |                                                                      |
+| `operations`          | _(as given)_      | merged in verbatim, see below                                        |
+
+## Supported operations
+
+Any of the following keys can be passed through `ImageTransformation::$operations` and are forwarded as-is to the Cloudflare URL:
+
+`gravity`, `dpr`, `rotate`, `trim`, `blur`, `brightness`, `contrast`, `gamma`, `saturation`, `sharpen`, `background`, `border`, `anim`, `metadata`, `onerror`, `compression`.
+
+See the [full options reference](https://developers.cloudflare.com/images/transform-images/transform-via-url/#options) for what each one does.
+
+## Supported formats
+
+`avif`, `webp`, `jpeg`, `png`.
+
+Cloudflare also supports `format=auto`, so this provider negotiates the best format for the requesting browser itself; `ux_image()` renders a single `<img>` rather than a `<picture>` with per-format `<source>` elements.
+
+## Resources
+
+- [Documentation](https://symfony.com/bundles/ux-image/current/index.html)
+- [Report issues](https://github.com/symfony/ux/issues) and
+  [send Pull Requests](https://github.com/symfony/ux/pulls)
+  in the [main Symfony UX repository](https://github.com/symfony/ux)

--- a/src/Image/src/Bridge/Cloudflare/composer.json
+++ b/src/Image/src/Bridge/Cloudflare/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "symfony/ux-cloudflare-image",
+    "type": "symfony-ux-image-bridge",
+    "description": "Symfony UX Image Cloudflare Bridge",
+    "keywords": ["symfony-ux", "cloudflare", "image", "responsive", "cdn"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        { "name": "Hugo Alliaume", "email": "hugo@alliau.me" },
+        { "name": "Symfony Community", "homepage": "https://symfony.com/contributors" }
+    ],
+    "require": {
+        "php": ">=8.4",
+        "symfony/ux-image": "^3.6"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^12.0",
+        "spatie/phpunit-snapshot-assertions": "^5.2.3"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\UX\\Image\\Bridge\\Cloudflare\\": "src/" },
+        "exclude-from-classmap": []
+    },
+    "autoload-dev": {
+        "psr-4": { "Symfony\\UX\\Image\\Bridge\\Cloudflare\\Tests\\": "tests/" }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Image/src/Bridge/Cloudflare/phpunit.dist.xml
+++ b/src/Image/src/Bridge/Cloudflare/phpunit.dist.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+        failOnDeprecation="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UX Image Cloudflare Bridge Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source
+            ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/src/Image/src/Bridge/Cloudflare/src/CloudflareProvider.php
+++ b/src/Image/src/Bridge/Cloudflare/src/CloudflareProvider.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Cloudflare;
+
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Provider\PathEncoder;
+use Symfony\UX\Image\Provider\ProviderInterface;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class CloudflareProvider implements ProviderInterface
+{
+    public function __construct(
+        private readonly string $host,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'cloudflare';
+    }
+
+    public function generateUrl(ImageTransformation $transformation): string
+    {
+        $options = array_filter([
+            'width' => $transformation->width,
+            'height' => $transformation->height,
+            'fit' => match ($transformation->fit) {
+                Fit::Cover => 'cover',
+                Fit::Contain => 'contain',
+                Fit::ScaleDown => 'scale-down',
+                null => null,
+            },
+            'format' => $transformation->format,
+            'quality' => $transformation->quality,
+        ], static fn (mixed $v): bool => null !== $v);
+
+        $options += $transformation->operations;
+
+        $path = PathEncoder::encode($transformation->path);
+
+        // An empty "/cdn-cgi/image//" segment isn't a URL Cloudflare serves, so skip it entirely and return the origin URL.
+        if ([] === $options) {
+            return \sprintf('https://%s/%s', $this->host, $path);
+        }
+
+        // PHP_QUERY_RFC3986 encodes each key/value: a raw "#", "/", "?" or space would otherwise end or escape this comma-joined segment.
+        // Values are cast to string first so a boolean false serializes as "" like (string) does, not as http_build_query's own "0".
+        $encodedOptions = http_build_query(array_map(static fn (mixed $v): string => (string) $v, $options), '', ',', \PHP_QUERY_RFC3986);
+
+        return \sprintf('https://%s/cdn-cgi/image/%s/%s', $this->host, $encodedOptions, $path);
+    }
+
+    public function getSupportedOperations(): array
+    {
+        return ['gravity', 'dpr', 'rotate', 'trim', 'blur', 'brightness', 'contrast', 'gamma', 'saturation', 'sharpen', 'background', 'border', 'anim', 'metadata', 'onerror', 'compression'];
+    }
+
+    public function getSupportedFormats(): array
+    {
+        return ['avif', 'webp', 'jpeg', 'png'];
+    }
+
+    public function supportsAutoFormat(): bool
+    {
+        return true;
+    }
+}

--- a/src/Image/src/Bridge/Cloudflare/src/CloudflareProviderFactory.php
+++ b/src/Image/src/Bridge/Cloudflare/src/CloudflareProviderFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Cloudflare;
+
+use Symfony\UX\Image\Exception\IncompleteDsnException;
+use Symfony\UX\Image\Provider\AbstractProviderFactory;
+use Symfony\UX\Image\Provider\Dsn;
+use Symfony\UX\Image\Provider\ProviderFactoryInterface;
+use Symfony\UX\Image\Provider\ProviderInterface;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class CloudflareProviderFactory extends AbstractProviderFactory implements ProviderFactoryInterface
+{
+    public function create(Dsn $dsn): ProviderInterface
+    {
+        if (null === $host = $dsn->getHost()) {
+            throw new IncompleteDsnException('The Cloudflare image provider requires a host, e.g. "cloudflare://cdn.example.com".');
+        }
+
+        return new CloudflareProvider($host);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['cloudflare'];
+    }
+}

--- a/src/Image/src/Bridge/Cloudflare/tests/CloudflareProviderTest.php
+++ b/src/Image/src/Bridge/Cloudflare/tests/CloudflareProviderTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Cloudflare\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Bridge\Cloudflare\CloudflareProvider;
+use Symfony\UX\Image\Bridge\Cloudflare\CloudflareProviderFactory;
+use Symfony\UX\Image\Exception\IncompleteDsnException;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Provider\Dsn;
+use Symfony\UX\Image\Renderer\RenderOptions;
+
+final class CloudflareProviderTest extends TestCase
+{
+    #[DataProvider('provideUrls')]
+    public function testItGeneratesTheExpectedUrl(ImageTransformation $transformation, string $expected)
+    {
+        self::assertSame($expected, new CloudflareProvider('cdn.example.com')->generateUrl($transformation));
+    }
+
+    public static function provideUrls(): iterable
+    {
+        yield 'width only' => [
+            new ImageTransformation('hero.jpg', width: 800),
+            'https://cdn.example.com/cdn-cgi/image/width=800/hero.jpg',
+        ];
+        yield 'every common parameter' => [
+            new ImageTransformation('a/hero.jpg', width: 800, height: 450, fit: Fit::Cover, format: 'auto', quality: 80),
+            'https://cdn.example.com/cdn-cgi/image/width=800,height=450,fit=cover,format=auto,quality=80/a/hero.jpg',
+        ];
+        yield 'scale down maps to scale-down' => [
+            new ImageTransformation('hero.jpg', width: 800, fit: Fit::ScaleDown),
+            'https://cdn.example.com/cdn-cgi/image/width=800,fit=scale-down/hero.jpg',
+        ];
+        yield 'provider operation' => [
+            new ImageTransformation('hero.jpg', width: 800, operations: ['gravity' => 'auto']),
+            'https://cdn.example.com/cdn-cgi/image/width=800,gravity=auto/hero.jpg',
+        ];
+        yield 'leading slash in the path is not doubled' => [
+            new ImageTransformation('/hero.jpg', width: 800),
+            'https://cdn.example.com/cdn-cgi/image/width=800/hero.jpg',
+        ];
+        yield 'a space in a path segment is percent-encoded' => [
+            new ImageTransformation('hero image.jpg', width: 800),
+            'https://cdn.example.com/cdn-cgi/image/width=800/hero%20image.jpg',
+        ];
+        yield 'a question mark in a path segment is encoded, not started as a query string' => [
+            new ImageTransformation('a?b=1/hero.jpg', width: 800),
+            'https://cdn.example.com/cdn-cgi/image/width=800/a%3Fb%3D1/hero.jpg',
+        ];
+        yield 'a hash in an operation value is encoded, not started as a fragment' => [
+            new ImageTransformation('hero.jpg', width: 800, operations: ['background' => '#ff0000']),
+            'https://cdn.example.com/cdn-cgi/image/width=800,background=%23ff0000/hero.jpg',
+        ];
+        yield 'a slash in an operation value is encoded, not ending the options segment' => [
+            new ImageTransformation('hero.jpg', width: 800, operations: ['onerror' => 'redirect/../../evil']),
+            'https://cdn.example.com/cdn-cgi/image/width=800,onerror=redirect%2F..%2F..%2Fevil/hero.jpg',
+        ];
+        yield 'a space in an operation value is encoded' => [
+            new ImageTransformation('hero.jpg', width: 800, operations: ['metadata' => 'a b']),
+            'https://cdn.example.com/cdn-cgi/image/width=800,metadata=a%20b/hero.jpg',
+        ];
+        yield 'no options at all falls back to the origin url, not an empty options segment' => [
+            new ImageTransformation('hero.jpg'),
+            'https://cdn.example.com/hero.jpg',
+        ];
+    }
+
+    public function testWidthAndHeightBothGivenDefaultToACroppingFit()
+    {
+        $options = new RenderOptions(width: 800, height: 450);
+
+        $url = new CloudflareProvider('cdn.example.com')->generateUrl(
+            new ImageTransformation('hero.jpg', $options->width, $options->height, $options->fit),
+        );
+
+        self::assertStringContainsString('fit=cover', $url);
+    }
+
+    public function testHeightOnlyWithNoWidthLeavesFitAndWidthUnsetForTheProvidersOwnDefault()
+    {
+        $options = new RenderOptions(layout: Layout::FullWidth, height: 450);
+
+        $url = new CloudflareProvider('cdn.example.com')->generateUrl(
+            new ImageTransformation('hero.jpg', $options->width, $options->height, $options->fit),
+        );
+
+        self::assertSame('https://cdn.example.com/cdn-cgi/image/height=450/hero.jpg', $url);
+    }
+
+    public function testItAdvertisesAutoFormatSupport()
+    {
+        self::assertTrue(new CloudflareProvider('cdn.example.com')->supportsAutoFormat());
+    }
+
+    public function testItAdvertisesItsSupportedOperations()
+    {
+        self::assertSame(
+            ['gravity', 'dpr', 'rotate', 'trim', 'blur', 'brightness', 'contrast', 'gamma', 'saturation', 'sharpen', 'background', 'border', 'anim', 'metadata', 'onerror', 'compression'],
+            new CloudflareProvider('cdn.example.com')->getSupportedOperations(),
+        );
+    }
+
+    public function testItAdvertisesItsSupportedFormats()
+    {
+        self::assertSame(['avif', 'webp', 'jpeg', 'png'], new CloudflareProvider('cdn.example.com')->getSupportedFormats());
+    }
+
+    public function testItAdvertisesItsName()
+    {
+        self::assertSame('cloudflare', new CloudflareProvider('cdn.example.com')->getName());
+    }
+
+    public function testTheFactoryRejectsAnotherScheme()
+    {
+        self::assertFalse(new CloudflareProviderFactory()->supports(new Dsn('keycdn://zone.kxcdn.com')));
+    }
+
+    public function testTheFactoryAcceptsItsOwnScheme()
+    {
+        self::assertTrue(new CloudflareProviderFactory()->supports(new Dsn('cloudflare://cdn.example.com')));
+    }
+
+    public function testTheFactoryRequiresAHost()
+    {
+        $this->expectException(IncompleteDsnException::class);
+        $this->expectExceptionMessage('The Cloudflare image provider requires a host, e.g. "cloudflare://cdn.example.com".');
+
+        new CloudflareProviderFactory()->create(new Dsn('cloudflare:'));
+    }
+
+    public function testAnEmptyAuthorityDsnFailsInDsnItselfNotInTheFactory()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The image provider DSN is invalid.');
+
+        new CloudflareProviderFactory()->create(new Dsn('cloudflare://'));
+    }
+
+    public function testTheFactoryCreatesAConfiguredProvider()
+    {
+        $provider = new CloudflareProviderFactory()->create(new Dsn('cloudflare://cdn.example.com'));
+
+        self::assertInstanceOf(CloudflareProvider::class, $provider);
+        self::assertSame(
+            'https://cdn.example.com/cdn-cgi/image/width=800/hero.jpg',
+            $provider->generateUrl(new ImageTransformation('hero.jpg', width: 800)),
+        );
+    }
+}

--- a/src/Image/src/Bridge/Cloudflare/tests/CloudflareRendererSnapshotTest.php
+++ b/src/Image/src/Bridge/Cloudflare/tests/CloudflareRendererSnapshotTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Cloudflare\Tests;
+
+use Symfony\UX\Image\Bridge\Cloudflare\CloudflareProvider;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Renderer\RenderOptions;
+use Symfony\UX\Image\Test\RendererSnapshotTestCase;
+
+/**
+ * Pins the URL matrix a real Cloudflare zone produces, complementing {@see CloudflareProviderTest}'s
+ * single-URL assertions with the full per-breakpoint srcset shape.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class CloudflareRendererSnapshotTest extends RendererSnapshotTestCase
+{
+    public static function provideOptions(): iterable
+    {
+        yield 'constrained layout, both dimensions' => [
+            new CloudflareProvider('cdn.example.com'),
+            new RenderOptions(layout: Layout::Constrained, width: 800, height: 450),
+        ];
+
+        yield 'full-width layout, both dimensions' => [
+            new CloudflareProvider('cdn.example.com'),
+            new RenderOptions(layout: Layout::FullWidth, width: 800, height: 450),
+        ];
+
+        yield 'a Cloudflare-specific operation' => [
+            new CloudflareProvider('cdn.example.com'),
+            new RenderOptions(layout: Layout::Constrained, width: 800, height: 450, operations: ['cloudflare' => ['gravity' => 'auto']]),
+        ];
+    }
+}

--- a/src/Image/src/Bridge/Cloudflare/tests/__snapshots__/CloudflareRendererSnapshotTest__testRenderedUrls with data set a Cloudflare-specific operation__1.txt
+++ b/src/Image/src/Bridge/Cloudflare/tests/__snapshots__/CloudflareRendererSnapshotTest__testRenderedUrls with data set a Cloudflare-specific operation__1.txt
@@ -1,0 +1,12 @@
+src:
+https://cdn.example.com/cdn-cgi/image/width=800,height=450,fit=cover,format=auto,gravity=auto/hero.jpg
+
+srcset:
+https://cdn.example.com/cdn-cgi/image/width=640,height=360,fit=cover,format=auto,gravity=auto/hero.jpg 640w
+https://cdn.example.com/cdn-cgi/image/width=750,height=422,fit=cover,format=auto,gravity=auto/hero.jpg 750w
+https://cdn.example.com/cdn-cgi/image/width=800,height=450,fit=cover,format=auto,gravity=auto/hero.jpg 800w
+https://cdn.example.com/cdn-cgi/image/width=828,height=466,fit=cover,format=auto,gravity=auto/hero.jpg 828w
+https://cdn.example.com/cdn-cgi/image/width=960,height=540,fit=cover,format=auto,gravity=auto/hero.jpg 960w
+https://cdn.example.com/cdn-cgi/image/width=1080,height=608,fit=cover,format=auto,gravity=auto/hero.jpg 1080w
+https://cdn.example.com/cdn-cgi/image/width=1280,height=720,fit=cover,format=auto,gravity=auto/hero.jpg 1280w
+https://cdn.example.com/cdn-cgi/image/width=1600,height=900,fit=cover,format=auto,gravity=auto/hero.jpg 1600w

--- a/src/Image/src/Bridge/Cloudflare/tests/__snapshots__/CloudflareRendererSnapshotTest__testRenderedUrls with data set constrained layout, both dimensions__1.txt
+++ b/src/Image/src/Bridge/Cloudflare/tests/__snapshots__/CloudflareRendererSnapshotTest__testRenderedUrls with data set constrained layout, both dimensions__1.txt
@@ -1,0 +1,12 @@
+src:
+https://cdn.example.com/cdn-cgi/image/width=800,height=450,fit=cover,format=auto/hero.jpg
+
+srcset:
+https://cdn.example.com/cdn-cgi/image/width=640,height=360,fit=cover,format=auto/hero.jpg 640w
+https://cdn.example.com/cdn-cgi/image/width=750,height=422,fit=cover,format=auto/hero.jpg 750w
+https://cdn.example.com/cdn-cgi/image/width=800,height=450,fit=cover,format=auto/hero.jpg 800w
+https://cdn.example.com/cdn-cgi/image/width=828,height=466,fit=cover,format=auto/hero.jpg 828w
+https://cdn.example.com/cdn-cgi/image/width=960,height=540,fit=cover,format=auto/hero.jpg 960w
+https://cdn.example.com/cdn-cgi/image/width=1080,height=608,fit=cover,format=auto/hero.jpg 1080w
+https://cdn.example.com/cdn-cgi/image/width=1280,height=720,fit=cover,format=auto/hero.jpg 1280w
+https://cdn.example.com/cdn-cgi/image/width=1600,height=900,fit=cover,format=auto/hero.jpg 1600w

--- a/src/Image/src/Bridge/Cloudflare/tests/__snapshots__/CloudflareRendererSnapshotTest__testRenderedUrls with data set full-width layout, both dimensions__1.txt
+++ b/src/Image/src/Bridge/Cloudflare/tests/__snapshots__/CloudflareRendererSnapshotTest__testRenderedUrls with data set full-width layout, both dimensions__1.txt
@@ -1,0 +1,19 @@
+src:
+https://cdn.example.com/cdn-cgi/image/width=800,height=450,fit=cover,format=auto/hero.jpg
+
+srcset:
+https://cdn.example.com/cdn-cgi/image/width=640,height=360,fit=cover,format=auto/hero.jpg 640w
+https://cdn.example.com/cdn-cgi/image/width=750,height=422,fit=cover,format=auto/hero.jpg 750w
+https://cdn.example.com/cdn-cgi/image/width=828,height=466,fit=cover,format=auto/hero.jpg 828w
+https://cdn.example.com/cdn-cgi/image/width=960,height=540,fit=cover,format=auto/hero.jpg 960w
+https://cdn.example.com/cdn-cgi/image/width=1080,height=608,fit=cover,format=auto/hero.jpg 1080w
+https://cdn.example.com/cdn-cgi/image/width=1280,height=720,fit=cover,format=auto/hero.jpg 1280w
+https://cdn.example.com/cdn-cgi/image/width=1668,height=938,fit=cover,format=auto/hero.jpg 1668w
+https://cdn.example.com/cdn-cgi/image/width=1920,height=1080,fit=cover,format=auto/hero.jpg 1920w
+https://cdn.example.com/cdn-cgi/image/width=2048,height=1152,fit=cover,format=auto/hero.jpg 2048w
+https://cdn.example.com/cdn-cgi/image/width=2560,height=1440,fit=cover,format=auto/hero.jpg 2560w
+https://cdn.example.com/cdn-cgi/image/width=3200,height=1800,fit=cover,format=auto/hero.jpg 3200w
+https://cdn.example.com/cdn-cgi/image/width=3840,height=2160,fit=cover,format=auto/hero.jpg 3840w
+https://cdn.example.com/cdn-cgi/image/width=4480,height=2520,fit=cover,format=auto/hero.jpg 4480w
+https://cdn.example.com/cdn-cgi/image/width=5120,height=2880,fit=cover,format=auto/hero.jpg 5120w
+https://cdn.example.com/cdn-cgi/image/width=6016,height=3384,fit=cover,format=auto/hero.jpg 6016w

--- a/src/Image/src/Bridge/Cloudflare/tests/bootstrap.php
+++ b/src/Image/src/Bridge/Cloudflare/tests/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once __DIR__.'/../vendor/autoload.php';

--- a/src/Image/src/Bridge/Glide/.gitattributes
+++ b/src/Image/src/Bridge/Glide/.gitattributes
@@ -1,0 +1,3 @@
+/.git* export-ignore
+/phpunit.dist.xml export-ignore
+/tests export-ignore

--- a/src/Image/src/Bridge/Glide/.gitignore
+++ b/src/Image/src/Bridge/Glide/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.cache

--- a/src/Image/src/Bridge/Glide/CHANGELOG.md
+++ b/src/Image/src/Bridge/Glide/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 3.6.0
+
+- Bridge added

--- a/src/Image/src/Bridge/Glide/LICENSE
+++ b/src/Image/src/Bridge/Glide/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Image/src/Bridge/Glide/README.md
+++ b/src/Image/src/Bridge/Glide/README.md
@@ -1,0 +1,94 @@
+# Symfony UX Image: Glide
+
+**EXPERIMENTAL** This component is currently experimental and is
+likely to change, or even change drastically.
+
+[Glide](https://glide.thephpleague.com/) integration for Symfony UX Image, through a controller served by your own application. This is the local, no-CDN provider: images are resized and encoded on-the-fly by your own server, from a source directory you control, with results cached to disk. Use this bridge when you don't want to depend on a third-party CDN or image service.
+
+## Installation
+
+Install the bridge using Composer and Symfony Flex:
+
+```shell
+composer require symfony/ux-glide-image
+```
+
+## DSN example
+
+```dotenv
+# .env
+UX_IMAGE_DSN=glide://default/images?source=%kernel.project_dir%/public/uploads&cache=%kernel.project_dir%/var/glide-cache&sign_key=s3cret
+```
+
+```yaml
+# config/packages/ux_image.yaml
+ux_image:
+    provider: '%env(resolve:UX_IMAGE_DSN)%'
+```
+
+The `resolve:` processor is required: without it Glide receives the literal `%kernel.project_dir%/public/uploads` as its source directory, since parameter resolution does not recurse into environment variable values on its own.
+
+The host (`default` above) is always a placeholder: Glide has no remote endpoint to point at, only a local source and cache. What matters is:
+
+| DSN part                    | Meaning                                                                                         |
+| --------------------------- | ----------------------------------------------------------------------------------------------- |
+| path (`/images`)            | the URL prefix images are served under, e.g. `/images/hero.jpg?w=800`                           |
+| `source`                    | absolute path to the directory holding your original images                                     |
+| `cache`                     | absolute path to the directory Glide writes resized/encoded images to                           |
+| `sign_key` (optional)       | secret used to sign generated URLs; when set, `s=<signature>` is required on every request      |
+| `max_image_size` (optional) | output pixel cap per image, `25000000` by default; Glide scales an oversized request down to it |
+
+Setting a `sign_key` is **strongly recommended in production**. Without one the route resizes and caches whatever anyone asks it for, and every distinct parameter combination costs one encode and one new cache file. `max_image_size` bounds how large a single output can get, but only a signature stops the request from being served at all.
+
+## Wiring the route
+
+This bridge ships a controller but not a route with a fixed prefix — the prefix must match the DSN's path exactly, so your application supplies it:
+
+```yaml
+# config/routes/ux_image_glide.yaml
+ux_image_glide:
+    resource: '@UXImageBundle/config/routes/glide.php'
+    prefix: /images
+```
+
+The `prefix` here and the path segment of `UX_IMAGE_DSN` (`/images` in the example above) must be the same string. If they drift apart, `ux_image()` generates URLs your route can't match.
+
+Importing this route without `symfony/ux-glide-image` installed fails with a plain "class not found" error, which is expected: the route references `GlideController` by its fully-qualified class name.
+
+## Parameter mapping
+
+`ImageTransformation` properties are mapped to [Glide's own query parameters](https://glide.thephpleague.com/4.0/api/quick-reference/):
+
+| `ImageTransformation` | Glide parameter | Notes                                                                                                                                                                  |
+| --------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `width`               | `w`             |                                                                                                                                                                        |
+| `height`              | `h`             |                                                                                                                                                                        |
+| `fit: Fit::Cover`     | `fit=crop`      |                                                                                                                                                                        |
+| `fit: Fit::Contain`   | `fit=contain`   |                                                                                                                                                                        |
+| `fit: Fit::ScaleDown` | `fit=max`       |                                                                                                                                                                        |
+| `format`              | `fm`            | `format: 'auto'` is resolved by `GlideController` from `Accept`, since Glide itself has no `auto`; `jpeg` is accepted and translated to `fm=jpg`, Glide's own spelling |
+| `quality`             | `q`             |                                                                                                                                                                        |
+| `operations`          | _(as given)_    | merged in verbatim, see below                                                                                                                                          |
+
+## Automatic format negotiation
+
+Unlike Cloudflare, Glide's `fm` parameter only accepts concrete formats. `GlideController` reads the request's `Accept` header, replaces `fm=auto` with the first format both it and the browser support (falling back to `jpg` otherwise, regardless of `getSupportedFormats()`'s content or order), and sets `Vary: Accept` on the response so caches don't mix up results for different browsers. The candidates it picks from are the application's own `ux_image.formats`, intersected with the list below. This is why `supportsAutoFormat()` returns `true` for this provider: it's the controller doing the negotiation, not Glide.
+
+## Supported operations
+
+Any of the following keys can be passed through `ImageTransformation::$operations` and are forwarded as-is to Glide:
+
+`crop`, `or`, `bri`, `con`, `gam`, `sharp`, `blur`, `pixel`, `filt`, `bg`, `border`.
+
+See the [full API reference](https://glide.thephpleague.com/4.0/api/quick-reference/) for what each one does.
+
+## Supported formats
+
+`avif`, `webp`, `jpeg`, `pjpg`, `png`, `gif`, `heic`.
+
+## Resources
+
+- [Documentation](https://symfony.com/bundles/ux-image/current/index.html)
+- [Report issues](https://github.com/symfony/ux/issues) and
+  [send Pull Requests](https://github.com/symfony/ux/pulls)
+  in the [main Symfony UX repository](https://github.com/symfony/ux)

--- a/src/Image/src/Bridge/Glide/composer.json
+++ b/src/Image/src/Bridge/Glide/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "symfony/ux-glide-image",
+    "type": "symfony-ux-image-bridge",
+    "description": "Symfony UX Image Glide Bridge",
+    "keywords": ["symfony-ux", "glide", "image", "responsive"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        { "name": "Hugo Alliaume", "email": "hugo@alliau.me" },
+        { "name": "Symfony Community", "homepage": "https://symfony.com/contributors" }
+    ],
+    "require": {
+        "php": ">=8.4",
+        "league/flysystem": "^3.0",
+        "league/glide": "^4.0",
+        "symfony/http-foundation": "^7.4|^8.0",
+        "symfony/http-kernel": "^7.4|^8.0",
+        "symfony/ux-image": "^3.6"
+    },
+    "require-dev": {
+        "ext-gd": "*",
+        "phpunit/phpunit": "^12.0",
+        "spatie/phpunit-snapshot-assertions": "^5.2.3",
+        "symfony/filesystem": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\UX\\Image\\Bridge\\Glide\\": "src/" },
+        "exclude-from-classmap": []
+    },
+    "autoload-dev": {
+        "psr-4": { "Symfony\\UX\\Image\\Bridge\\Glide\\Tests\\": "tests/" }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Image/src/Bridge/Glide/phpunit.dist.xml
+++ b/src/Image/src/Bridge/Glide/phpunit.dist.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+        failOnDeprecation="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UX Image Glide Bridge Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source
+            ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/src/Image/src/Bridge/Glide/src/Controller/GlideController.php
+++ b/src/Image/src/Bridge/Glide/src/Controller/GlideController.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide\Controller;
+
+use League\Glide\Filesystem\FileNotFoundException;
+use League\Glide\Server;
+use League\Glide\Signatures\SignatureException;
+use League\Glide\Signatures\SignatureInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\UX\Image\Bridge\Glide\FormatNegotiator;
+use Symfony\UX\Image\Bridge\Glide\GlideProvider;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class GlideController
+{
+    /** @var list<string> */
+    private readonly array $supportedFormats;
+
+    /**
+     * @param list<string> $supportedFormats the application's configured formats, in preference order
+     */
+    public function __construct(
+        private readonly Server $server,
+        private readonly FormatNegotiator $formatNegotiator = new FormatNegotiator(),
+        array $supportedFormats = GlideProvider::SUPPORTED_FORMATS,
+        private readonly ?SignatureInterface $signature = null,
+    ) {
+        $this->supportedFormats = array_values(array_intersect($supportedFormats, GlideProvider::SUPPORTED_FORMATS));
+    }
+
+    public function __invoke(Request $request, string $path): Response
+    {
+        $params = $request->query->all();
+
+        if (null !== $this->signature) {
+            // Must validate the full prefixed request path before "fm=auto" is rewritten below, or every signed URL 403s.
+            try {
+                $this->signature->validateRequest($request->getPathInfo(), $params);
+            } catch (SignatureException) {
+                $response = new Response('Forbidden', Response::HTTP_FORBIDDEN);
+                $response->headers->set('Vary', 'Accept');
+
+                return $response;
+            }
+        }
+
+        if ('auto' === ($params['fm'] ?? null)) {
+            $params['fm'] = GlideProvider::toGlideFormat(
+                $this->formatNegotiator->negotiate($request->headers->get('Accept'), $this->supportedFormats, 'jpeg'),
+            );
+        }
+
+        try {
+            $response = $this->server->getImageResponse($path, $params);
+        } catch (FileNotFoundException $e) {
+            throw new NotFoundHttpException(previous: $e, headers: ['Vary' => 'Accept']);
+        }
+
+        $response->headers->set('Vary', 'Accept');
+
+        return $response;
+    }
+}

--- a/src/Image/src/Bridge/Glide/src/FormatNegotiator.php
+++ b/src/Image/src/Bridge/Glide/src/FormatNegotiator.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class FormatNegotiator
+{
+    /**
+     * @param list<string> $supportedFormats
+     */
+    public function negotiate(?string $acceptHeader, array $supportedFormats, string $fallback = 'jpeg'): string
+    {
+        if (null !== $acceptHeader) {
+            foreach ($supportedFormats as $format) {
+                if (str_contains($acceptHeader, 'image/'.$format)) {
+                    return $format;
+                }
+            }
+        }
+
+        return $fallback;
+    }
+}

--- a/src/Image/src/Bridge/Glide/src/GlideProvider.php
+++ b/src/Image/src/Bridge/Glide/src/GlideProvider.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide;
+
+use League\Glide\Urls\UrlBuilder;
+use League\Glide\Urls\UrlBuilderFactory;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Provider\PathEncoder;
+use Symfony\UX\Image\Provider\ProviderInterface;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class GlideProvider implements ProviderInterface
+{
+    public const array SUPPORTED_OPERATIONS = ['crop', 'or', 'bri', 'con', 'gam', 'sharp', 'blur', 'pixel', 'filt', 'bg', 'border'];
+    public const array SUPPORTED_FORMATS = ['avif', 'webp', 'jpeg', 'pjpg', 'png', 'gif', 'heic'];
+
+    private readonly UrlBuilder $urlBuilder;
+
+    public function __construct(
+        private readonly string $urlPrefix,
+        private readonly ?string $signKey = null,
+    ) {
+        $this->urlBuilder = UrlBuilderFactory::create($this->urlPrefix, $this->signKey);
+    }
+
+    public function getName(): string
+    {
+        return 'glide';
+    }
+
+    public function generateUrl(ImageTransformation $transformation): string
+    {
+        $options = array_filter([
+            'w' => $transformation->width,
+            'h' => $transformation->height,
+            'fit' => match ($transformation->fit) {
+                Fit::Cover => 'crop',
+                Fit::Contain => 'contain',
+                Fit::ScaleDown => 'max',
+                null => null,
+            },
+            'fm' => null !== $transformation->format ? self::toGlideFormat($transformation->format) : null,
+            'q' => $transformation->quality,
+        ], static fn (mixed $v): bool => null !== $v);
+
+        $options += $transformation->operations;
+
+        $path = PathEncoder::encode($transformation->path);
+
+        return $this->urlBuilder->getUrl($path, $options);
+    }
+
+    public function getSupportedOperations(): array
+    {
+        return self::SUPPORTED_OPERATIONS;
+    }
+
+    public function getSupportedFormats(): array
+    {
+        return self::SUPPORTED_FORMATS;
+    }
+
+    public function supportsAutoFormat(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Translates the shared "jpeg" spelling (SUPPORTED_FORMATS, getSupportedFormats(), every other
+     * provider) to the one Glide's own "fm" parameter accepts -- League\Glide\Api\Encoder::supportedFormats()
+     * rejects "jpeg" outright. Every other format name, including "jpg" itself, is already Glide's own spelling.
+     */
+    public static function toGlideFormat(string $format): string
+    {
+        return 'jpeg' === $format ? 'jpg' : $format;
+    }
+}

--- a/src/Image/src/Bridge/Glide/src/GlideProviderFactory.php
+++ b/src/Image/src/Bridge/Glide/src/GlideProviderFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide;
+
+use Symfony\UX\Image\Exception\IncompleteDsnException;
+use Symfony\UX\Image\Provider\AbstractProviderFactory;
+use Symfony\UX\Image\Provider\Dsn;
+use Symfony\UX\Image\Provider\ProviderFactoryInterface;
+use Symfony\UX\Image\Provider\ProviderInterface;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class GlideProviderFactory extends AbstractProviderFactory implements ProviderFactoryInterface
+{
+    public function create(Dsn $dsn): ProviderInterface
+    {
+        // The host is just a placeholder (e.g. "default"); this provider needs the DSN's path as its URL prefix.
+        if (null === $urlPrefix = $dsn->getPath()) {
+            throw new IncompleteDsnException('The Glide image provider requires a URL prefix, e.g. "glide://default/images".');
+        }
+        foreach (['source', 'cache'] as $option) {
+            if (null === $dsn->getOption($option)) {
+                throw new IncompleteDsnException(\sprintf('The Glide image provider requires a "%s" directory, e.g. "glide://default/images?source=/app/public/uploads&cache=/app/var/glide-cache".', $option));
+            }
+        }
+
+        return new GlideProvider($urlPrefix, $dsn->getOption('sign_key'));
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['glide'];
+    }
+}

--- a/src/Image/src/Bridge/Glide/src/ServerFactory.php
+++ b/src/Image/src/Bridge/Glide/src/ServerFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide;
+
+use League\Glide\Server;
+use League\Glide\ServerFactory as LeagueServerFactory;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Provider\Dsn;
+
+/**
+ * Builds the League\Glide\Server from the provider DSN at service-instantiation time, not at
+ * container-compile time -- an "%env(...)%" DSN placeholder isn't a real "glide://" string yet then.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class ServerFactory
+{
+    // Bounds Glide's otherwise-unbounded resize endpoint; still covers the widest default breakpoint at common ratios.
+    public const int DEFAULT_MAX_IMAGE_SIZE = 25_000_000;
+
+    public static function createFromDsn(#[\SensitiveParameter] string $dsn): Server
+    {
+        $options = new Dsn($dsn);
+
+        return LeagueServerFactory::create([
+            'source' => $options->getOption('source'),
+            'cache' => $options->getOption('cache'),
+            'max_image_size' => self::maxImageSize($options),
+            'response' => new SymfonyResponseFactory(),
+        ]);
+    }
+
+    private static function maxImageSize(Dsn $dsn): int
+    {
+        if (null === $value = $dsn->getOption('max_image_size')) {
+            return self::DEFAULT_MAX_IMAGE_SIZE;
+        }
+
+        if (!ctype_digit((string) $value) || 0 === (int) $value) {
+            throw new InvalidArgumentException(\sprintf('The Glide "max_image_size" DSN option must be a positive number of output pixels, "%s" given.', $value));
+        }
+
+        return (int) $value;
+    }
+}

--- a/src/Image/src/Bridge/Glide/src/SignatureFactory.php
+++ b/src/Image/src/Bridge/Glide/src/SignatureFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide;
+
+use League\Glide\Signatures\SignatureFactory as LeagueSignatureFactory;
+use League\Glide\Signatures\SignatureInterface;
+use Symfony\UX\Image\Provider\Dsn;
+
+/**
+ * Builds the optional League\Glide\Signatures\Signature from the provider DSN at service-instantiation
+ * time, same reason as ServerFactory: an "%env(...)%" DSN placeholder resolves too late for compile time.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class SignatureFactory
+{
+    public static function createFromDsn(#[\SensitiveParameter] string $dsn): ?SignatureInterface
+    {
+        $signKey = new Dsn($dsn)->getOption('sign_key');
+
+        return null !== $signKey ? LeagueSignatureFactory::create($signKey) : null;
+    }
+}

--- a/src/Image/src/Bridge/Glide/src/SymfonyResponseFactory.php
+++ b/src/Image/src/Bridge/Glide/src/SymfonyResponseFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide;
+
+use League\Flysystem\FilesystemOperator;
+use League\Glide\Responses\ResponseFactoryInterface;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Turns a cached Glide image into an HttpFoundation response, since league/glide only ships a PSR-7 factory.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class SymfonyResponseFactory implements ResponseFactoryInterface
+{
+    public function create(FilesystemOperator $cache, string $path): StreamedResponse
+    {
+        return new StreamedResponse(static function () use ($cache, $path) {
+            $stream = $cache->readStream($path);
+            fpassthru($stream);
+            fclose($stream);
+        }, 200, [
+            'Content-Type' => $cache->mimeType($path),
+            'Content-Length' => (string) $cache->fileSize($path),
+            'Cache-Control' => 'max-age=31536000, public',
+            'Expires' => date_create('+1 years')->format('D, d M Y H:i:s').' GMT',
+        ]);
+    }
+}

--- a/src/Image/src/Bridge/Glide/tests/Controller/GlideControllerTest.php
+++ b/src/Image/src/Bridge/Glide/tests/Controller/GlideControllerTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide\Tests\Controller;
+
+use League\Glide\ServerFactory;
+use League\Glide\Signatures\SignatureFactory;
+use League\Glide\Signatures\SignatureInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\UX\Image\Bridge\Glide\Controller\GlideController;
+use Symfony\UX\Image\Bridge\Glide\GlideProvider;
+use Symfony\UX\Image\Bridge\Glide\SymfonyResponseFactory;
+use Symfony\UX\Image\ImageTransformation;
+
+final class GlideControllerTest extends TestCase
+{
+    private const string SIGN_KEY = 's3cret';
+
+    private string $source;
+    private string $cache;
+
+    protected function setUp(): void
+    {
+        $this->source = sys_get_temp_dir().'/ux_image_glide_test_'.bin2hex(random_bytes(8));
+        $this->cache = $this->source.'/cache';
+        mkdir($this->source, recursive: true);
+        mkdir($this->cache, recursive: true);
+
+        $image = imagecreatetruecolor(20, 20);
+        imagefill($image, 0, 0, imagecolorallocate($image, 255, 0, 0));
+        imagejpeg($image, $this->source.'/hero.jpg', 90);
+        imagedestroy($image);
+    }
+
+    protected function tearDown(): void
+    {
+        new Filesystem()->remove($this->source);
+    }
+
+    public function testTheControllerSetsVaryAccept()
+    {
+        $request = Request::create('/images/hero.jpg?w=10&fm=auto');
+        $request->headers->set('Accept', 'image/avif,image/webp,*/*');
+
+        $response = $this->controller()->__invoke($request, 'hero.jpg');
+
+        self::assertStringContainsString('Accept', $response->headers->get('Vary'));
+    }
+
+    public function testFmAutoIsReplacedWithANegotiatedFormatBeforeGlideSeesIt()
+    {
+        $request = Request::create('/images/hero.jpg?w=10&fm=auto');
+        $request->headers->set('Accept', 'image/webp,*/*');
+
+        $response = $this->controller()->__invoke($request, 'hero.jpg');
+
+        self::assertSame('image/webp', $response->headers->get('Content-Type'));
+    }
+
+    public function testFmAutoWithoutAnAcceptHeaderFallsBackToJpgNotHeic()
+    {
+        $response = $this->controller()->__invoke(Request::create('/images/hero.jpg?w=10&fm=auto'), 'hero.jpg');
+
+        self::assertSame('image/jpeg', $response->headers->get('Content-Type'));
+    }
+
+    public function testFmAutoWithAWildcardAcceptFallsBackToJpgNotHeic()
+    {
+        $request = Request::create('/images/hero.jpg?w=10&fm=auto');
+        $request->headers->set('Accept', '*/*');
+
+        $response = $this->controller()->__invoke($request, 'hero.jpg');
+
+        self::assertSame('image/jpeg', $response->headers->get('Content-Type'));
+    }
+
+    public function testFmAutoWithAnImageWildcardAcceptFallsBackToJpgNotHeic()
+    {
+        $request = Request::create('/images/hero.jpg?w=10&fm=auto');
+        $request->headers->set('Accept', 'image/*');
+
+        $response = $this->controller()->__invoke($request, 'hero.jpg');
+
+        self::assertSame('image/jpeg', $response->headers->get('Content-Type'));
+    }
+
+    public function testAConfiguredFormatGlideCannotEncodeIsNeverNegotiated()
+    {
+        $request = Request::create('/images/hero.jpg?w=10&fm=auto');
+        $request->headers->set('Accept', 'image/tiff,*/*');
+
+        $response = $this->controller(supportedFormats: ['tiff', 'webp'])->__invoke($request, 'hero.jpg');
+
+        self::assertSame('image/jpeg', $response->headers->get('Content-Type'));
+    }
+
+    public function testAConfiguredFormatGlideCanEncodeIsStillNegotiated()
+    {
+        $request = Request::create('/images/hero.jpg?w=10&fm=auto');
+        $request->headers->set('Accept', 'image/webp,*/*');
+
+        $response = $this->controller(supportedFormats: ['tiff', 'webp'])->__invoke($request, 'hero.jpg');
+
+        self::assertSame('image/webp', $response->headers->get('Content-Type'));
+    }
+
+    public function testAConcreteFormatIsPassedThroughUnchanged()
+    {
+        $response = $this->controller()->__invoke(Request::create('/images/hero.jpg?w=10&fm=png'), 'hero.jpg');
+
+        self::assertSame('image/png', $response->headers->get('Content-Type'));
+    }
+
+    public function testUnsignedModeIsUnaffectedByARequestWithoutASignature()
+    {
+        $response = $this->controller()->__invoke(Request::create('/images/hero.jpg?w=10&fm=png'), 'hero.jpg');
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testAValidSignaturePasses()
+    {
+        $url = new GlideProvider('/images', self::SIGN_KEY)->generateUrl(new ImageTransformation('hero.jpg', width: 10, format: 'png'));
+
+        $response = $this->controller(signature: SignatureFactory::create(self::SIGN_KEY))->__invoke(Request::create($url), 'hero.jpg');
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testATamperedParameterGives403()
+    {
+        $url = new GlideProvider('/images', self::SIGN_KEY)->generateUrl(new ImageTransformation('hero.jpg', width: 10, format: 'png'));
+        $tampered = str_replace('w=10', 'w=9999', $url);
+
+        $response = $this->controller(signature: SignatureFactory::create(self::SIGN_KEY))->__invoke(Request::create($tampered), 'hero.jpg');
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testAMissingSignatureGives403WhenAKeyIsConfigured()
+    {
+        $response = $this->controller(signature: SignatureFactory::create(self::SIGN_KEY))
+            ->__invoke(Request::create('/images/hero.jpg?w=10&fm=png'), 'hero.jpg');
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testASignedFmAutoRequestStillValidatesAndStillNegotiates()
+    {
+        $url = new GlideProvider('/images', self::SIGN_KEY)->generateUrl(new ImageTransformation('hero.jpg', width: 10, format: 'auto'));
+
+        self::assertStringContainsString('fm=auto', $url);
+
+        $request = Request::create($url);
+        $request->headers->set('Accept', 'image/webp,*/*');
+
+        $response = $this->controller(signature: SignatureFactory::create(self::SIGN_KEY))->__invoke($request, 'hero.jpg');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/webp', $response->headers->get('Content-Type'));
+    }
+
+    public function testAMissingImageThrowsNotFoundNotAServerError()
+    {
+        try {
+            $this->controller()->__invoke(Request::create('/images/missing.jpg?w=10'), 'missing.jpg');
+            self::fail('Expected a NotFoundHttpException.');
+        } catch (NotFoundHttpException $e) {
+            self::assertSame(404, $e->getStatusCode());
+            self::assertSame(['Vary' => 'Accept'], $e->getHeaders());
+        }
+    }
+
+    /**
+     * @param list<string>|null $supportedFormats
+     */
+    private function controller(?SignatureInterface $signature = null, ?array $supportedFormats = null): GlideController
+    {
+        $server = ServerFactory::create([
+            'source' => $this->source,
+            'cache' => $this->cache,
+            'response' => new SymfonyResponseFactory(),
+        ]);
+
+        return null === $supportedFormats
+            ? new GlideController($server, signature: $signature)
+            : new GlideController($server, supportedFormats: $supportedFormats, signature: $signature);
+    }
+}

--- a/src/Image/src/Bridge/Glide/tests/FormatNegotiatorTest.php
+++ b/src/Image/src/Bridge/Glide/tests/FormatNegotiatorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Bridge\Glide\FormatNegotiator;
+use Symfony\UX\Image\Bridge\Glide\GlideProvider;
+
+final class FormatNegotiatorTest extends TestCase
+{
+    #[DataProvider('provideAcceptHeaders')]
+    public function testFormatNegotiation(?string $accept, string $expected)
+    {
+        self::assertSame($expected, new FormatNegotiator()->negotiate($accept, ['avif', 'webp', 'jpeg'], 'jpeg'));
+    }
+
+    public static function provideAcceptHeaders(): iterable
+    {
+        yield 'avif preferred' => ['image/avif,image/webp,*/*', 'avif'];
+        yield 'webp only' => ['image/webp,*/*', 'webp'];
+        yield 'neither' => ['text/html,*/*', 'jpeg'];
+        yield 'no header' => [null, 'jpeg'];
+    }
+
+    public function testAnUnmatchedAcceptFallsBackToTheExplicitFallbackNotTheLastListElement()
+    {
+        self::assertSame('jpeg', new FormatNegotiator()->negotiate('text/html,*/*', GlideProvider::SUPPORTED_FORMATS, 'jpeg'));
+    }
+
+    public function testANullAcceptFallsBackToTheExplicitFallback()
+    {
+        self::assertSame('jpeg', new FormatNegotiator()->negotiate(null, GlideProvider::SUPPORTED_FORMATS, 'jpeg'));
+    }
+
+    public function testHeicIsReturnedOnlyWhenTheClientActuallyAsksForIt()
+    {
+        self::assertSame('heic', new FormatNegotiator()->negotiate('image/heic,*/*', GlideProvider::SUPPORTED_FORMATS, 'jpeg'));
+    }
+
+    public function testTheFallbackIsHonouredIndependentlyOfListOrder()
+    {
+        self::assertSame('webp', new FormatNegotiator()->negotiate('text/html,*/*', ['avif', 'webp', 'jpeg'], 'webp'));
+    }
+}

--- a/src/Image/src/Bridge/Glide/tests/GlideProviderTest.php
+++ b/src/Image/src/Bridge/Glide/tests/GlideProviderTest.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Bridge\Glide\GlideProvider;
+use Symfony\UX\Image\Bridge\Glide\GlideProviderFactory;
+use Symfony\UX\Image\Exception\IncompleteDsnException;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Provider\Dsn;
+use Symfony\UX\Image\Renderer\ImageRenderer;
+use Symfony\UX\Image\Renderer\LayoutResolver;
+use Symfony\UX\Image\Renderer\RenderOptions;
+
+final class GlideProviderTest extends TestCase
+{
+    private const string DSN = 'glide://default/images?source=/tmp/source&cache=/tmp/cache';
+
+    #[DataProvider('provideUrls')]
+    public function testItGeneratesTheExpectedUrl(ImageTransformation $transformation, string $expected)
+    {
+        self::assertSame($expected, new GlideProvider('/images')->generateUrl($transformation));
+    }
+
+    public static function provideUrls(): iterable
+    {
+        yield 'width only' => [
+            new ImageTransformation('hero.jpg', width: 800),
+            '/images/hero.jpg?w=800',
+        ];
+        yield 'every common parameter' => [
+            new ImageTransformation('hero.jpg', width: 800, height: 450, fit: Fit::Cover, format: 'webp', quality: 80),
+            '/images/hero.jpg?w=800&h=450&fit=crop&fm=webp&q=80',
+        ];
+        yield 'a pinned "jpeg" becomes Glide\'s own "jpg"' => [
+            new ImageTransformation('hero.jpg', width: 800, format: 'jpeg'),
+            '/images/hero.jpg?w=800&fm=jpg',
+        ];
+        yield 'a pinned "jpg" is passed through' => [
+            new ImageTransformation('hero.jpg', width: 800, format: 'jpg'),
+            '/images/hero.jpg?w=800&fm=jpg',
+        ];
+        yield 'contain maps to contain' => [
+            new ImageTransformation('a.jpg', width: 10, fit: Fit::Contain),
+            '/images/a.jpg?w=10&fit=contain',
+        ];
+        yield 'scale down maps to max' => [
+            new ImageTransformation('a.jpg', width: 10, fit: Fit::ScaleDown),
+            '/images/a.jpg?w=10&fit=max',
+        ];
+        yield 'provider operation' => [
+            new ImageTransformation('hero.jpg', width: 800, operations: ['blur' => 25]),
+            '/images/hero.jpg?w=800&blur=25',
+        ];
+        yield 'leading slash in the path is not doubled' => [
+            new ImageTransformation('/hero.jpg', width: 800),
+            '/images/hero.jpg?w=800',
+        ];
+        yield 'a space in a path segment is percent-encoded' => [
+            new ImageTransformation('hero image.jpg', width: 800),
+            '/images/hero%20image.jpg?w=800',
+        ];
+        yield 'a question mark in a path segment is encoded, not started as a query string' => [
+            new ImageTransformation('a?b=1/hero.jpg', width: 800),
+            '/images/a%3Fb%3D1/hero.jpg?w=800',
+        ];
+    }
+
+    public function testItGeneratesAUrlUnderTheConfiguredPrefix()
+    {
+        $provider = new GlideProvider('/images');
+
+        self::assertSame(
+            '/images/hero.jpg?w=800&h=450&fit=crop&fm=webp&q=80',
+            $provider->generateUrl(new ImageTransformation('hero.jpg', width: 800, height: 450, fit: Fit::Cover, format: 'webp', quality: 80)),
+        );
+    }
+
+    public function testCoverMapsToCropAndScaleDownToMax()
+    {
+        $provider = new GlideProvider('/images');
+
+        self::assertStringContainsString('fit=crop', $provider->generateUrl(new ImageTransformation('a.jpg', width: 10, fit: Fit::Cover)));
+        self::assertStringContainsString('fit=max', $provider->generateUrl(new ImageTransformation('a.jpg', width: 10, fit: Fit::ScaleDown)));
+    }
+
+    public function testWidthAndHeightBothGivenDefaultToACroppingFit()
+    {
+        $options = new RenderOptions(width: 800, height: 450);
+
+        $url = new GlideProvider('/images')->generateUrl(
+            new ImageTransformation('hero.jpg', $options->width, $options->height, $options->fit),
+        );
+
+        self::assertStringContainsString('fit=crop', $url);
+    }
+
+    public function testHeightOnlyWithNoWidthLeavesFitAndWidthUnsetForTheProvidersOwnDefault()
+    {
+        $options = new RenderOptions(layout: Layout::FullWidth, height: 450);
+
+        $url = new GlideProvider('/images')->generateUrl(
+            new ImageTransformation('hero.jpg', $options->width, $options->height, $options->fit),
+        );
+
+        self::assertSame('/images/hero.jpg?h=450', $url);
+    }
+
+    public function testItAppendsASignatureWhenASignKeyIsConfigured()
+    {
+        $unsigned = new GlideProvider('/images')->generateUrl(new ImageTransformation('hero.jpg', width: 800));
+        $signed = new GlideProvider('/images', 's3cret')->generateUrl(new ImageTransformation('hero.jpg', width: 800));
+
+        self::assertSame('/images/hero.jpg?w=800', $unsigned);
+        self::assertMatchesRegularExpression('#^/images/hero\.jpg\?w=800&s=[0-9a-f]{32}$#', $signed);
+    }
+
+    public function testItSupportsAutoFormatBecauseTheControllerNegotiates()
+    {
+        self::assertTrue(new GlideProvider('/images')->supportsAutoFormat());
+    }
+
+    public function testItAdvertisesItsSupportedOperations()
+    {
+        self::assertSame(
+            ['crop', 'or', 'bri', 'con', 'gam', 'sharp', 'blur', 'pixel', 'filt', 'bg', 'border'],
+            new GlideProvider('/images')->getSupportedOperations(),
+        );
+    }
+
+    public function testItAdvertisesItsSupportedFormats()
+    {
+        self::assertSame(['avif', 'webp', 'jpeg', 'pjpg', 'png', 'gif', 'heic'], new GlideProvider('/images')->getSupportedFormats());
+    }
+
+    public function testToGlideFormatTranslatesJpegAndLeavesEveryOtherFormatUnchanged()
+    {
+        self::assertSame('jpg', GlideProvider::toGlideFormat('jpeg'));
+        self::assertSame('jpg', GlideProvider::toGlideFormat('jpg'));
+        self::assertSame('avif', GlideProvider::toGlideFormat('avif'));
+        self::assertSame('auto', GlideProvider::toGlideFormat('auto'));
+    }
+
+    public function testAPinnedJpegFormatIsAcceptedByImageRendererAndReachesTheGeneratedUrlAsFmJpg()
+    {
+        $renderer = new ImageRenderer(new GlideProvider('/images'), new LayoutResolver());
+
+        $rendered = $renderer->render('hero.jpg', 'Hero', new RenderOptions(layout: Layout::Fixed, width: 800, format: 'jpeg'));
+
+        self::assertStringContainsString('fm=jpg', $rendered->imgAttributes['src']);
+        self::assertStringContainsString('fm=jpg', $rendered->imgAttributes['srcset']);
+    }
+
+    public function testItAdvertisesItsName()
+    {
+        self::assertSame('glide', new GlideProvider('/images')->getName());
+    }
+
+    public function testTheFactoryRejectsAnotherScheme()
+    {
+        self::assertFalse(new GlideProviderFactory()->supports(new Dsn('cloudflare://cdn.example.com')));
+    }
+
+    public function testTheFactoryAcceptsItsOwnScheme()
+    {
+        self::assertTrue(new GlideProviderFactory()->supports(new Dsn('glide://default/images')));
+    }
+
+    public function testTheFactoryRequiresAUrlPrefix()
+    {
+        $this->expectException(IncompleteDsnException::class);
+        $this->expectExceptionMessage('The Glide image provider requires a URL prefix, e.g. "glide://default/images".');
+
+        new GlideProviderFactory()->create(new Dsn('glide:'));
+    }
+
+    public function testTheFactoryRequiresAUrlPrefixEvenWhenAHostIsPresent()
+    {
+        $this->expectException(IncompleteDsnException::class);
+        $this->expectExceptionMessage('The Glide image provider requires a URL prefix, e.g. "glide://default/images".');
+
+        new GlideProviderFactory()->create(new Dsn('glide://default'));
+    }
+
+    public function testAnEmptyAuthorityDsnFailsInDsnItselfNotInTheFactory()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The image provider DSN is invalid.');
+
+        new GlideProviderFactory()->create(new Dsn('glide://'));
+    }
+
+    public function testTheFactoryRequiresASourceDirectory()
+    {
+        $this->expectException(IncompleteDsnException::class);
+        $this->expectExceptionMessage('The Glide image provider requires a "source" directory, e.g. "glide://default/images?source=/app/public/uploads&cache=/app/var/glide-cache".');
+
+        new GlideProviderFactory()->create(new Dsn('glide://default/images?cache=/tmp/cache'));
+    }
+
+    public function testTheFactoryRequiresACacheDirectory()
+    {
+        $this->expectException(IncompleteDsnException::class);
+        $this->expectExceptionMessage('The Glide image provider requires a "cache" directory, e.g. "glide://default/images?source=/app/public/uploads&cache=/app/var/glide-cache".');
+
+        new GlideProviderFactory()->create(new Dsn('glide://default/images?source=/tmp/source'));
+    }
+
+    public function testTheFactoryCreatesAConfiguredProvider()
+    {
+        $provider = new GlideProviderFactory()->create(new Dsn(self::DSN));
+
+        self::assertInstanceOf(GlideProvider::class, $provider);
+        self::assertSame(
+            '/images/hero.jpg?w=800',
+            $provider->generateUrl(new ImageTransformation('hero.jpg', width: 800)),
+        );
+    }
+
+    public function testTheFactoryReadsTheSignKeyFromTheDsn()
+    {
+        $provider = new GlideProviderFactory()->create(new Dsn(self::DSN.'&sign_key=s3cret'));
+
+        self::assertMatchesRegularExpression(
+            '#^/images/hero\.jpg\?w=800&s=[0-9a-f]{32}$#',
+            $provider->generateUrl(new ImageTransformation('hero.jpg', width: 800)),
+        );
+    }
+}

--- a/src/Image/src/Bridge/Glide/tests/GlideRendererSnapshotTest.php
+++ b/src/Image/src/Bridge/Glide/tests/GlideRendererSnapshotTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide\Tests;
+
+use Symfony\UX\Image\Bridge\Glide\GlideProvider;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Renderer\RenderOptions;
+use Symfony\UX\Image\Test\RendererSnapshotTestCase;
+
+/**
+ * Pins the URL matrix a real Glide server produces, complementing {@see GlideProviderTest}'s
+ * single-URL assertions with the full per-breakpoint srcset shape.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class GlideRendererSnapshotTest extends RendererSnapshotTestCase
+{
+    public static function provideOptions(): iterable
+    {
+        yield 'constrained layout, both dimensions' => [
+            new GlideProvider('/images'),
+            new RenderOptions(layout: Layout::Constrained, width: 800, height: 450),
+        ];
+
+        yield 'full-width layout, both dimensions' => [
+            new GlideProvider('/images'),
+            new RenderOptions(layout: Layout::FullWidth, width: 800, height: 450),
+        ];
+
+        yield 'a signed DSN adds the "s" signature parameter' => [
+            new GlideProvider('/images', 's3cret'),
+            new RenderOptions(layout: Layout::Constrained, width: 800, height: 450),
+        ];
+    }
+}

--- a/src/Image/src/Bridge/Glide/tests/Integration/BundleInitializationTest.php
+++ b/src/Image/src/Bridge/Glide/tests/Integration/BundleInitializationTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\UX\Image\Bridge\Glide\Controller\GlideController;
+use Symfony\UX\Image\Bridge\Glide\GlideProvider;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\UXImageBundle;
+
+/**
+ * Only testable from this package, where "symfony/ux-image" and "league/glide" are both actually
+ * Composer-installed side by side; a bare, uncompiled ContainerBuilder won't resolve "%env(...)%".
+ */
+final class BundleInitializationTest extends TestCase
+{
+    private string $source;
+    private string $cache;
+
+    protected function setUp(): void
+    {
+        $this->source = sys_get_temp_dir().'/ux_image_glide_bundle_init_'.bin2hex(random_bytes(8));
+        $this->cache = $this->source.'/cache';
+        mkdir($this->source, recursive: true);
+        mkdir($this->cache, recursive: true);
+
+        $image = imagecreatetruecolor(10, 10);
+        imagefill($image, 0, 0, imagecolorallocate($image, 0, 0, 255));
+        imagejpeg($image, $this->source.'/hero.jpg', 90);
+        imagedestroy($image);
+    }
+
+    protected function tearDown(): void
+    {
+        new Filesystem()->remove($this->source);
+
+        putenv('UX_IMAGE_DSN');
+        unset($_ENV['UX_IMAGE_DSN'], $_SERVER['UX_IMAGE_DSN']);
+    }
+
+    public function testGlideControllerResolvesAndServesARequestWhenTheDsnIsAnUnresolvedEnvPlaceholder()
+    {
+        $this->setDsnEnvVar($this->dsn());
+
+        $controller = $this->compileAndGetGlideController(['provider' => '%env(UX_IMAGE_DSN)%']);
+
+        $response = $controller(Request::create('/images/hero.jpg?w=5'), 'hero.jpg');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/jpeg', $response->headers->get('Content-Type'));
+    }
+
+    public function testASignKeyCarriedByTheEnvPlaceholderDsnIsValidatedServerSide()
+    {
+        $signKey = 's3cret';
+        $this->setDsnEnvVar(\sprintf('glide://default/images?source=%s&cache=%s&sign_key=%s', $this->source, $this->cache, $signKey));
+
+        $controller = $this->compileAndGetGlideController(['provider' => '%env(UX_IMAGE_DSN)%']);
+
+        $unsigned = $controller(Request::create('/images/hero.jpg?w=5'), 'hero.jpg');
+        self::assertSame(403, $unsigned->getStatusCode());
+
+        $signedUrl = new GlideProvider('/images', $signKey)->generateUrl(new ImageTransformation('hero.jpg', width: 5));
+        $signed = $controller(Request::create($signedUrl), 'hero.jpg');
+        self::assertSame(200, $signed->getStatusCode());
+    }
+
+    public function testAContainerParameterInsideTheDsnReachesGlideExpanded()
+    {
+        // Needs "%env(resolve:UX_IMAGE_DSN)%", not "%env(UX_IMAGE_DSN)%": parameter resolution doesn't recurse into env values.
+        $this->setDsnEnvVar('glide://default/images?source=%kernel.project_dir%&cache=%kernel.project_dir%/cache');
+
+        $controller = $this->compileAndGetGlideController(['provider' => '%env(resolve:UX_IMAGE_DSN)%']);
+
+        $response = $controller(Request::create('/images/hero.jpg?w=5'), 'hero.jpg');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/jpeg', $response->headers->get('Content-Type'));
+    }
+
+    public function testTheConfiguredFormatsBecomeTheControllerNegotiationCandidates()
+    {
+        $this->setDsnEnvVar($this->dsn());
+
+        $request = Request::create('/images/hero.jpg?w=5&fm=auto');
+        $request->headers->set('Accept', 'image/webp,*/*');
+
+        $wide = $this->compileAndGetGlideController(['provider' => '%env(UX_IMAGE_DSN)%']);
+        self::assertSame('image/webp', $wide($request, 'hero.jpg')->headers->get('Content-Type'));
+    }
+
+    public function testAConfiguredJpegCandidateIsActuallyNegotiatedNotJustFallenBackTo()
+    {
+        $this->setDsnEnvVar($this->dsn());
+
+        $request = Request::create('/images/hero.jpg?w=5&fm=auto');
+        $request->headers->set('Accept', 'image/jpeg,image/avif,*/*');
+
+        $controller = $this->compileAndGetGlideController(['provider' => '%env(UX_IMAGE_DSN)%', 'formats' => ['jpeg', 'avif']]);
+
+        self::assertSame('image/jpeg', $controller($request, 'hero.jpg')->headers->get('Content-Type'));
+    }
+
+    private function dsn(): string
+    {
+        return \sprintf('glide://default/images?source=%s&cache=%s', $this->source, $this->cache);
+    }
+
+    private function setDsnEnvVar(string $dsn): void
+    {
+        putenv('UX_IMAGE_DSN='.$dsn);
+        $_ENV['UX_IMAGE_DSN'] = $dsn;
+        $_SERVER['UX_IMAGE_DSN'] = $dsn;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function compileAndGetGlideController(array $config): GlideController
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', $this->source);
+
+        new UXImageBundle()->getContainerExtension()->load([$config], $container);
+
+        $container->getDefinition(GlideController::class)->setPublic(true);
+
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $class = 'GlideBundleInitializationTestContainer'.bin2hex(random_bytes(8));
+        eval(preg_replace('/^<\?php\s*/', '', $dumper->dump(['class' => $class])));
+
+        $compiled = new $class();
+
+        return $compiled->get(GlideController::class);
+    }
+}

--- a/src/Image/src/Bridge/Glide/tests/ServerFactoryTest.php
+++ b/src/Image/src/Bridge/Glide/tests/ServerFactoryTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\Glide\Tests;
+
+use League\Glide\Api\Api;
+use League\Glide\Manipulators\Size;
+use League\Glide\Server;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\UX\Image\Bridge\Glide\Controller\GlideController;
+use Symfony\UX\Image\Bridge\Glide\ServerFactory;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+
+final class ServerFactoryTest extends TestCase
+{
+    private string $source;
+    private string $cache;
+
+    protected function setUp(): void
+    {
+        $this->source = sys_get_temp_dir().'/ux_image_glide_server_factory_'.bin2hex(random_bytes(8));
+        $this->cache = $this->source.'/cache';
+        mkdir($this->source, recursive: true);
+        mkdir($this->cache, recursive: true);
+
+        $image = imagecreatetruecolor(20, 20);
+        imagefill($image, 0, 0, imagecolorallocate($image, 0, 128, 0));
+        imagejpeg($image, $this->source.'/hero.jpg', 90);
+        imagedestroy($image);
+    }
+
+    protected function tearDown(): void
+    {
+        new Filesystem()->remove($this->source);
+    }
+
+    public function testAnUnconfiguredDsnStillCapsTheOutputSize()
+    {
+        self::assertSame(ServerFactory::DEFAULT_MAX_IMAGE_SIZE, $this->maxImageSizeOf($this->server()));
+    }
+
+    public function testTheDsnCanRaiseOrLowerTheCap()
+    {
+        self::assertSame(10_000, $this->maxImageSizeOf($this->server('&max_image_size=10000')));
+    }
+
+    public function testAnOversizedRequestIsScaledDownToTheCap()
+    {
+        $response = new GlideController($this->server('&max_image_size=10000'))(Request::create('/images/hero.jpg?w=2000&h=2000'), 'hero.jpg');
+
+        ob_start();
+        $response->sendContent();
+        $body = ob_get_clean();
+
+        self::assertSame([100, 100], \array_slice(getimagesizefromstring($body), 0, 2));
+    }
+
+    public function testANonNumericCapIsRejected()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The Glide "max_image_size" DSN option must be a positive number of output pixels, "lots" given.');
+
+        $this->server('&max_image_size=lots');
+    }
+
+    public function testAZeroCapIsRejectedRatherThanMeaningUnlimited()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The Glide "max_image_size" DSN option must be a positive number of output pixels, "0" given.');
+
+        $this->server('&max_image_size=0');
+    }
+
+    private function server(string $extraOptions = ''): Server
+    {
+        return ServerFactory::createFromDsn(\sprintf('glide://default/images?source=%s&cache=%s%s', $this->source, $this->cache, $extraOptions));
+    }
+
+    private function maxImageSizeOf(Server $server): ?int
+    {
+        $api = $server->getApi();
+        self::assertInstanceOf(Api::class, $api);
+
+        foreach ($api->getManipulators() as $manipulator) {
+            if ($manipulator instanceof Size) {
+                return $manipulator->getMaxImageSize();
+            }
+        }
+
+        self::fail('The Glide server has no Size manipulator.');
+    }
+}

--- a/src/Image/src/Bridge/Glide/tests/__snapshots__/GlideRendererSnapshotTest__testRenderedUrls with data set a signed DSN adds the s signature parameter__1.txt
+++ b/src/Image/src/Bridge/Glide/tests/__snapshots__/GlideRendererSnapshotTest__testRenderedUrls with data set a signed DSN adds the s signature parameter__1.txt
@@ -1,0 +1,12 @@
+src:
+/images/hero.jpg?w=800&h=450&fit=crop&fm=auto&s=176a6f966546fb8b9db0f7ff4f6ea23c
+
+srcset:
+/images/hero.jpg?w=640&h=360&fit=crop&fm=auto&s=1d73e494cbd5deb6578e52317cb23ef1 640w
+/images/hero.jpg?w=750&h=422&fit=crop&fm=auto&s=12a4e9c3d4cec454a15802f5eaa16edb 750w
+/images/hero.jpg?w=800&h=450&fit=crop&fm=auto&s=176a6f966546fb8b9db0f7ff4f6ea23c 800w
+/images/hero.jpg?w=828&h=466&fit=crop&fm=auto&s=5ce519b188ee2d169f5db430392a8638 828w
+/images/hero.jpg?w=960&h=540&fit=crop&fm=auto&s=035133f54b6c01666668d00ba79b7fcc 960w
+/images/hero.jpg?w=1080&h=608&fit=crop&fm=auto&s=d5a5cb5de8a54ff50bd5946518371edd 1080w
+/images/hero.jpg?w=1280&h=720&fit=crop&fm=auto&s=1c418a53bd1e3cc39c51e784f3c2d7ea 1280w
+/images/hero.jpg?w=1600&h=900&fit=crop&fm=auto&s=5bafe683c489a78e745374bdc278e88d 1600w

--- a/src/Image/src/Bridge/Glide/tests/__snapshots__/GlideRendererSnapshotTest__testRenderedUrls with data set constrained layout, both dimensions__1.txt
+++ b/src/Image/src/Bridge/Glide/tests/__snapshots__/GlideRendererSnapshotTest__testRenderedUrls with data set constrained layout, both dimensions__1.txt
@@ -1,0 +1,12 @@
+src:
+/images/hero.jpg?w=800&h=450&fit=crop&fm=auto
+
+srcset:
+/images/hero.jpg?w=640&h=360&fit=crop&fm=auto 640w
+/images/hero.jpg?w=750&h=422&fit=crop&fm=auto 750w
+/images/hero.jpg?w=800&h=450&fit=crop&fm=auto 800w
+/images/hero.jpg?w=828&h=466&fit=crop&fm=auto 828w
+/images/hero.jpg?w=960&h=540&fit=crop&fm=auto 960w
+/images/hero.jpg?w=1080&h=608&fit=crop&fm=auto 1080w
+/images/hero.jpg?w=1280&h=720&fit=crop&fm=auto 1280w
+/images/hero.jpg?w=1600&h=900&fit=crop&fm=auto 1600w

--- a/src/Image/src/Bridge/Glide/tests/__snapshots__/GlideRendererSnapshotTest__testRenderedUrls with data set full-width layout, both dimensions__1.txt
+++ b/src/Image/src/Bridge/Glide/tests/__snapshots__/GlideRendererSnapshotTest__testRenderedUrls with data set full-width layout, both dimensions__1.txt
@@ -1,0 +1,19 @@
+src:
+/images/hero.jpg?w=800&h=450&fit=crop&fm=auto
+
+srcset:
+/images/hero.jpg?w=640&h=360&fit=crop&fm=auto 640w
+/images/hero.jpg?w=750&h=422&fit=crop&fm=auto 750w
+/images/hero.jpg?w=828&h=466&fit=crop&fm=auto 828w
+/images/hero.jpg?w=960&h=540&fit=crop&fm=auto 960w
+/images/hero.jpg?w=1080&h=608&fit=crop&fm=auto 1080w
+/images/hero.jpg?w=1280&h=720&fit=crop&fm=auto 1280w
+/images/hero.jpg?w=1668&h=938&fit=crop&fm=auto 1668w
+/images/hero.jpg?w=1920&h=1080&fit=crop&fm=auto 1920w
+/images/hero.jpg?w=2048&h=1152&fit=crop&fm=auto 2048w
+/images/hero.jpg?w=2560&h=1440&fit=crop&fm=auto 2560w
+/images/hero.jpg?w=3200&h=1800&fit=crop&fm=auto 3200w
+/images/hero.jpg?w=3840&h=2160&fit=crop&fm=auto 3840w
+/images/hero.jpg?w=4480&h=2520&fit=crop&fm=auto 4480w
+/images/hero.jpg?w=5120&h=2880&fit=crop&fm=auto 5120w
+/images/hero.jpg?w=6016&h=3384&fit=crop&fm=auto 6016w

--- a/src/Image/src/Bridge/Glide/tests/bootstrap.php
+++ b/src/Image/src/Bridge/Glide/tests/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once __DIR__.'/../vendor/autoload.php';

--- a/src/Image/src/Bridge/KeyCdn/.gitattributes
+++ b/src/Image/src/Bridge/KeyCdn/.gitattributes
@@ -1,0 +1,3 @@
+/.git* export-ignore
+/phpunit.dist.xml export-ignore
+/tests export-ignore

--- a/src/Image/src/Bridge/KeyCdn/.gitignore
+++ b/src/Image/src/Bridge/KeyCdn/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/composer.lock
+/phpunit.xml
+/.phpunit.cache

--- a/src/Image/src/Bridge/KeyCdn/CHANGELOG.md
+++ b/src/Image/src/Bridge/KeyCdn/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 3.6.0
+
+- Bridge added

--- a/src/Image/src/Bridge/KeyCdn/LICENSE
+++ b/src/Image/src/Bridge/KeyCdn/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Image/src/Bridge/KeyCdn/README.md
+++ b/src/Image/src/Bridge/KeyCdn/README.md
@@ -1,0 +1,58 @@
+# Symfony UX Image: KeyCDN
+
+**EXPERIMENTAL** This component is currently experimental and is
+likely to change, or even change drastically.
+
+[KeyCDN Image Processing](https://www.keycdn.com/support/image-processing) integration for Symfony UX Image, through query string parameters appended to your zone's URL. Use this bridge to transform images already served from your own origin ("bring your own storage") behind a KeyCDN zone, without running any image-processing server yourself.
+
+## Installation
+
+Install the bridge using Composer and Symfony Flex:
+
+```shell
+composer require symfony/ux-keycdn-image
+```
+
+## DSN example
+
+```dotenv
+UX_IMAGE_DSN=keycdn://myzone.kxcdn.com
+```
+
+The host is your KeyCDN zone.
+
+## Parameter mapping
+
+`ImageTransformation` properties are mapped to KeyCDN's [image processing query parameters](https://www.keycdn.com/support/image-processing):
+
+| `ImageTransformation` | KeyCDN parameter | Notes                         |
+| --------------------- | ---------------- | ----------------------------- |
+| `width`               | `width`          |                               |
+| `height`              | `height`         |                               |
+| `fit: Fit::Cover`     | `fit=cover`      |                               |
+| `fit: Fit::Contain`   | `fit=contain`    |                               |
+| `fit: Fit::ScaleDown` | `fit=inside`     |                               |
+| `format`              | `format`         |                               |
+| `quality`             | `quality`        |                               |
+| `operations`          | _(as given)_     | merged in verbatim, see below |
+
+## Supported operations
+
+Any of the following keys can be passed through `ImageTransformation::$operations` and are forwarded as-is as query parameters:
+
+`position`, `enlarge`, `trim`, `crop`, `bg`, `rotate`, `flip`, `flop`, `sharpen`, `blur`, `gamma`, `grayscale`, `progressive`, `lossless`, `metadata`.
+
+See the [full parameter reference](https://www.keycdn.com/support/image-processing) for what each one does.
+
+## Supported formats
+
+`webp`, `jpeg`, `png`.
+
+Unlike Cloudflare, KeyCDN has no `format=auto` equivalent: there is no automatic format negotiation, and AVIF is not among the formats it can encode to. Because of this, `ux_image()` renders a `<picture>` element with one `<source type>` per configured format instead of a single `<img>`.
+
+## Resources
+
+- [Documentation](https://symfony.com/bundles/ux-image/current/index.html)
+- [Report issues](https://github.com/symfony/ux/issues) and
+  [send Pull Requests](https://github.com/symfony/ux/pulls)
+  in the [main Symfony UX repository](https://github.com/symfony/ux)

--- a/src/Image/src/Bridge/KeyCdn/composer.json
+++ b/src/Image/src/Bridge/KeyCdn/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "symfony/ux-keycdn-image",
+    "type": "symfony-ux-image-bridge",
+    "description": "Symfony UX Image KeyCDN Bridge",
+    "keywords": ["symfony-ux", "keycdn", "image", "responsive", "cdn"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        { "name": "Hugo Alliaume", "email": "hugo@alliau.me" },
+        { "name": "Symfony Community", "homepage": "https://symfony.com/contributors" }
+    ],
+    "require": {
+        "php": ">=8.4",
+        "symfony/ux-image": "^3.6"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^12.0",
+        "spatie/phpunit-snapshot-assertions": "^5.2.3"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\UX\\Image\\Bridge\\KeyCdn\\": "src/" },
+        "exclude-from-classmap": []
+    },
+    "autoload-dev": {
+        "psr-4": { "Symfony\\UX\\Image\\Bridge\\KeyCdn\\Tests\\": "tests/" }
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Image/src/Bridge/KeyCdn/phpunit.dist.xml
+++ b/src/Image/src/Bridge/KeyCdn/phpunit.dist.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+        failOnDeprecation="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UX Image KeyCdn Bridge Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source
+            ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/src/Image/src/Bridge/KeyCdn/src/KeyCdnProvider.php
+++ b/src/Image/src/Bridge/KeyCdn/src/KeyCdnProvider.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\KeyCdn;
+
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Provider\PathEncoder;
+use Symfony\UX\Image\Provider\ProviderInterface;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class KeyCdnProvider implements ProviderInterface
+{
+    public function __construct(
+        private readonly string $host,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'keycdn';
+    }
+
+    public function generateUrl(ImageTransformation $transformation): string
+    {
+        $options = array_filter([
+            'width' => $transformation->width,
+            'height' => $transformation->height,
+            'fit' => match ($transformation->fit) {
+                Fit::Cover => 'cover',
+                Fit::Contain => 'contain',
+                Fit::ScaleDown => 'inside',
+                null => null,
+            },
+            'format' => $transformation->format,
+            'quality' => $transformation->quality,
+        ], static fn (mixed $v): bool => null !== $v);
+
+        $options += $transformation->operations;
+
+        $path = PathEncoder::encode($transformation->path);
+
+        return \sprintf('https://%s/%s?%s', $this->host, $path, http_build_query($options));
+    }
+
+    public function getSupportedOperations(): array
+    {
+        return ['position', 'enlarge', 'trim', 'crop', 'bg', 'rotate', 'flip', 'flop', 'sharpen', 'blur', 'gamma', 'grayscale', 'progressive', 'lossless', 'metadata'];
+    }
+
+    public function getSupportedFormats(): array
+    {
+        return ['webp', 'jpeg', 'png'];
+    }
+
+    public function supportsAutoFormat(): bool
+    {
+        return false;
+    }
+}

--- a/src/Image/src/Bridge/KeyCdn/src/KeyCdnProviderFactory.php
+++ b/src/Image/src/Bridge/KeyCdn/src/KeyCdnProviderFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\KeyCdn;
+
+use Symfony\UX\Image\Exception\IncompleteDsnException;
+use Symfony\UX\Image\Provider\AbstractProviderFactory;
+use Symfony\UX\Image\Provider\Dsn;
+use Symfony\UX\Image\Provider\ProviderFactoryInterface;
+use Symfony\UX\Image\Provider\ProviderInterface;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class KeyCdnProviderFactory extends AbstractProviderFactory implements ProviderFactoryInterface
+{
+    public function create(Dsn $dsn): ProviderInterface
+    {
+        if (null === $host = $dsn->getHost()) {
+            throw new IncompleteDsnException('The KeyCDN image provider requires a host, e.g. "keycdn://myzone.kxcdn.com".');
+        }
+
+        return new KeyCdnProvider($host);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['keycdn'];
+    }
+}

--- a/src/Image/src/Bridge/KeyCdn/tests/KeyCdnProviderTest.php
+++ b/src/Image/src/Bridge/KeyCdn/tests/KeyCdnProviderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\KeyCdn\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Bridge\KeyCdn\KeyCdnProvider;
+use Symfony\UX\Image\Bridge\KeyCdn\KeyCdnProviderFactory;
+use Symfony\UX\Image\Exception\IncompleteDsnException;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Provider\Dsn;
+use Symfony\UX\Image\Renderer\RenderOptions;
+
+final class KeyCdnProviderTest extends TestCase
+{
+    #[DataProvider('provideUrls')]
+    public function testItGeneratesTheExpectedUrl(ImageTransformation $transformation, string $expected)
+    {
+        self::assertSame($expected, new KeyCdnProvider('zone.kxcdn.com')->generateUrl($transformation));
+    }
+
+    public static function provideUrls(): iterable
+    {
+        yield 'width only' => [
+            new ImageTransformation('hero.jpg', width: 800),
+            'https://zone.kxcdn.com/hero.jpg?width=800',
+        ];
+        yield 'every common parameter' => [
+            new ImageTransformation('a/hero.jpg', width: 800, height: 450, fit: Fit::Cover, format: 'webp', quality: 80),
+            'https://zone.kxcdn.com/a/hero.jpg?width=800&height=450&fit=cover&format=webp&quality=80',
+        ];
+        yield 'scale down maps to inside' => [
+            new ImageTransformation('hero.jpg', width: 800, fit: Fit::ScaleDown),
+            'https://zone.kxcdn.com/hero.jpg?width=800&fit=inside',
+        ];
+        yield 'provider operation' => [
+            new ImageTransformation('hero.jpg', width: 800, operations: ['grayscale' => 1]),
+            'https://zone.kxcdn.com/hero.jpg?width=800&grayscale=1',
+        ];
+        yield 'leading slash in the path is not doubled' => [
+            new ImageTransformation('/hero.jpg', width: 800),
+            'https://zone.kxcdn.com/hero.jpg?width=800',
+        ];
+        yield 'a space in a path segment is percent-encoded' => [
+            new ImageTransformation('hero image.jpg', width: 800),
+            'https://zone.kxcdn.com/hero%20image.jpg?width=800',
+        ];
+        yield 'a question mark in a path segment is encoded, not started as a query string' => [
+            new ImageTransformation('a?b=1/hero.jpg', width: 800),
+            'https://zone.kxcdn.com/a%3Fb%3D1/hero.jpg?width=800',
+        ];
+    }
+
+    public function testWidthAndHeightBothGivenDefaultToACroppingFit()
+    {
+        $options = new RenderOptions(width: 800, height: 450);
+
+        $url = new KeyCdnProvider('zone.kxcdn.com')->generateUrl(
+            new ImageTransformation('hero.jpg', $options->width, $options->height, $options->fit),
+        );
+
+        self::assertStringContainsString('fit=cover', $url);
+    }
+
+    public function testHeightOnlyWithNoWidthLeavesFitAndWidthUnsetForTheProvidersOwnDefault()
+    {
+        $options = new RenderOptions(layout: Layout::FullWidth, height: 450);
+
+        $url = new KeyCdnProvider('zone.kxcdn.com')->generateUrl(
+            new ImageTransformation('hero.jpg', $options->width, $options->height, $options->fit),
+        );
+
+        self::assertSame('https://zone.kxcdn.com/hero.jpg?height=450', $url);
+    }
+
+    public function testItDoesNotSupportAutoFormat()
+    {
+        self::assertFalse(new KeyCdnProvider('zone.kxcdn.com')->supportsAutoFormat());
+    }
+
+    public function testItDoesNotAdvertiseAvif()
+    {
+        self::assertNotContains('avif', new KeyCdnProvider('zone.kxcdn.com')->getSupportedFormats());
+    }
+
+    public function testItAdvertisesItsSupportedOperations()
+    {
+        self::assertSame(
+            ['position', 'enlarge', 'trim', 'crop', 'bg', 'rotate', 'flip', 'flop', 'sharpen', 'blur', 'gamma', 'grayscale', 'progressive', 'lossless', 'metadata'],
+            new KeyCdnProvider('zone.kxcdn.com')->getSupportedOperations(),
+        );
+    }
+
+    public function testItAdvertisesItsSupportedFormats()
+    {
+        self::assertSame(['webp', 'jpeg', 'png'], new KeyCdnProvider('zone.kxcdn.com')->getSupportedFormats());
+    }
+
+    public function testItAdvertisesItsName()
+    {
+        self::assertSame('keycdn', new KeyCdnProvider('zone.kxcdn.com')->getName());
+    }
+
+    public function testTheFactoryRejectsAnotherScheme()
+    {
+        self::assertFalse(new KeyCdnProviderFactory()->supports(new Dsn('cloudflare://cdn.example.com')));
+    }
+
+    public function testTheFactoryAcceptsItsOwnScheme()
+    {
+        self::assertTrue(new KeyCdnProviderFactory()->supports(new Dsn('keycdn://zone.kxcdn.com')));
+    }
+
+    public function testTheFactoryRequiresAHost()
+    {
+        $this->expectException(IncompleteDsnException::class);
+        $this->expectExceptionMessage('The KeyCDN image provider requires a host, e.g. "keycdn://myzone.kxcdn.com".');
+
+        new KeyCdnProviderFactory()->create(new Dsn('keycdn:'));
+    }
+
+    public function testAnEmptyAuthorityDsnFailsInDsnItselfNotInTheFactory()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The image provider DSN is invalid.');
+
+        new KeyCdnProviderFactory()->create(new Dsn('keycdn://'));
+    }
+
+    public function testTheFactoryCreatesAConfiguredProvider()
+    {
+        $provider = new KeyCdnProviderFactory()->create(new Dsn('keycdn://zone.kxcdn.com'));
+
+        self::assertInstanceOf(KeyCdnProvider::class, $provider);
+        self::assertSame(
+            'https://zone.kxcdn.com/hero.jpg?width=800',
+            $provider->generateUrl(new ImageTransformation('hero.jpg', width: 800)),
+        );
+    }
+}

--- a/src/Image/src/Bridge/KeyCdn/tests/KeyCdnRendererSnapshotTest.php
+++ b/src/Image/src/Bridge/KeyCdn/tests/KeyCdnRendererSnapshotTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Bridge\KeyCdn\Tests;
+
+use Symfony\UX\Image\Bridge\KeyCdn\KeyCdnProvider;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Renderer\RenderOptions;
+use Symfony\UX\Image\Test\RendererSnapshotTestCase;
+
+/**
+ * Pins the URL matrix a real KeyCDN zone produces, complementing {@see KeyCdnProviderTest}'s
+ * single-URL assertions with the full per-breakpoint srcset shape. KeyCDN never negotiates a
+ * format itself, so every case below produces a <picture> with one <source> per configured
+ * format, not a plain <img>.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class KeyCdnRendererSnapshotTest extends RendererSnapshotTestCase
+{
+    public static function provideOptions(): iterable
+    {
+        yield 'constrained layout, both dimensions' => [
+            new KeyCdnProvider('zone.kxcdn.com'),
+            new RenderOptions(layout: Layout::Constrained, width: 800, height: 450),
+        ];
+
+        yield 'full-width layout, both dimensions' => [
+            new KeyCdnProvider('zone.kxcdn.com'),
+            new RenderOptions(layout: Layout::FullWidth, width: 800, height: 450),
+        ];
+
+        yield 'fixed layout, the <picture> sources at their most readable' => [
+            new KeyCdnProvider('zone.kxcdn.com'),
+            new RenderOptions(layout: Layout::Fixed, width: 400),
+        ];
+    }
+}

--- a/src/Image/src/Bridge/KeyCdn/tests/__snapshots__/KeyCdnRendererSnapshotTest__testRenderedUrls with data set constrained layout, both dimensions__1.txt
+++ b/src/Image/src/Bridge/KeyCdn/tests/__snapshots__/KeyCdnRendererSnapshotTest__testRenderedUrls with data set constrained layout, both dimensions__1.txt
@@ -1,0 +1,32 @@
+src:
+https://zone.kxcdn.com/hero.jpg?width=800&height=450&fit=cover&format=jpeg
+
+srcset:
+https://zone.kxcdn.com/hero.jpg?width=640&height=360&fit=cover&format=jpeg 640w
+https://zone.kxcdn.com/hero.jpg?width=750&height=422&fit=cover&format=jpeg 750w
+https://zone.kxcdn.com/hero.jpg?width=800&height=450&fit=cover&format=jpeg 800w
+https://zone.kxcdn.com/hero.jpg?width=828&height=466&fit=cover&format=jpeg 828w
+https://zone.kxcdn.com/hero.jpg?width=960&height=540&fit=cover&format=jpeg 960w
+https://zone.kxcdn.com/hero.jpg?width=1080&height=608&fit=cover&format=jpeg 1080w
+https://zone.kxcdn.com/hero.jpg?width=1280&height=720&fit=cover&format=jpeg 1280w
+https://zone.kxcdn.com/hero.jpg?width=1600&height=900&fit=cover&format=jpeg 1600w
+
+source (image/webp):
+https://zone.kxcdn.com/hero.jpg?width=640&height=360&fit=cover&format=webp 640w
+https://zone.kxcdn.com/hero.jpg?width=750&height=422&fit=cover&format=webp 750w
+https://zone.kxcdn.com/hero.jpg?width=800&height=450&fit=cover&format=webp 800w
+https://zone.kxcdn.com/hero.jpg?width=828&height=466&fit=cover&format=webp 828w
+https://zone.kxcdn.com/hero.jpg?width=960&height=540&fit=cover&format=webp 960w
+https://zone.kxcdn.com/hero.jpg?width=1080&height=608&fit=cover&format=webp 1080w
+https://zone.kxcdn.com/hero.jpg?width=1280&height=720&fit=cover&format=webp 1280w
+https://zone.kxcdn.com/hero.jpg?width=1600&height=900&fit=cover&format=webp 1600w
+
+source (image/jpeg):
+https://zone.kxcdn.com/hero.jpg?width=640&height=360&fit=cover&format=jpeg 640w
+https://zone.kxcdn.com/hero.jpg?width=750&height=422&fit=cover&format=jpeg 750w
+https://zone.kxcdn.com/hero.jpg?width=800&height=450&fit=cover&format=jpeg 800w
+https://zone.kxcdn.com/hero.jpg?width=828&height=466&fit=cover&format=jpeg 828w
+https://zone.kxcdn.com/hero.jpg?width=960&height=540&fit=cover&format=jpeg 960w
+https://zone.kxcdn.com/hero.jpg?width=1080&height=608&fit=cover&format=jpeg 1080w
+https://zone.kxcdn.com/hero.jpg?width=1280&height=720&fit=cover&format=jpeg 1280w
+https://zone.kxcdn.com/hero.jpg?width=1600&height=900&fit=cover&format=jpeg 1600w

--- a/src/Image/src/Bridge/KeyCdn/tests/__snapshots__/KeyCdnRendererSnapshotTest__testRenderedUrls with data set fixed layout, the picture sources at their most readable__1.txt
+++ b/src/Image/src/Bridge/KeyCdn/tests/__snapshots__/KeyCdnRendererSnapshotTest__testRenderedUrls with data set fixed layout, the picture sources at their most readable__1.txt
@@ -1,0 +1,14 @@
+src:
+https://zone.kxcdn.com/hero.jpg?width=400&format=jpeg
+
+srcset:
+https://zone.kxcdn.com/hero.jpg?width=400&format=jpeg 400w
+https://zone.kxcdn.com/hero.jpg?width=800&format=jpeg 800w
+
+source (image/webp):
+https://zone.kxcdn.com/hero.jpg?width=400&format=webp 400w
+https://zone.kxcdn.com/hero.jpg?width=800&format=webp 800w
+
+source (image/jpeg):
+https://zone.kxcdn.com/hero.jpg?width=400&format=jpeg 400w
+https://zone.kxcdn.com/hero.jpg?width=800&format=jpeg 800w

--- a/src/Image/src/Bridge/KeyCdn/tests/__snapshots__/KeyCdnRendererSnapshotTest__testRenderedUrls with data set full-width layout, both dimensions__1.txt
+++ b/src/Image/src/Bridge/KeyCdn/tests/__snapshots__/KeyCdnRendererSnapshotTest__testRenderedUrls with data set full-width layout, both dimensions__1.txt
@@ -1,0 +1,53 @@
+src:
+https://zone.kxcdn.com/hero.jpg?width=800&height=450&fit=cover&format=jpeg
+
+srcset:
+https://zone.kxcdn.com/hero.jpg?width=640&height=360&fit=cover&format=jpeg 640w
+https://zone.kxcdn.com/hero.jpg?width=750&height=422&fit=cover&format=jpeg 750w
+https://zone.kxcdn.com/hero.jpg?width=828&height=466&fit=cover&format=jpeg 828w
+https://zone.kxcdn.com/hero.jpg?width=960&height=540&fit=cover&format=jpeg 960w
+https://zone.kxcdn.com/hero.jpg?width=1080&height=608&fit=cover&format=jpeg 1080w
+https://zone.kxcdn.com/hero.jpg?width=1280&height=720&fit=cover&format=jpeg 1280w
+https://zone.kxcdn.com/hero.jpg?width=1668&height=938&fit=cover&format=jpeg 1668w
+https://zone.kxcdn.com/hero.jpg?width=1920&height=1080&fit=cover&format=jpeg 1920w
+https://zone.kxcdn.com/hero.jpg?width=2048&height=1152&fit=cover&format=jpeg 2048w
+https://zone.kxcdn.com/hero.jpg?width=2560&height=1440&fit=cover&format=jpeg 2560w
+https://zone.kxcdn.com/hero.jpg?width=3200&height=1800&fit=cover&format=jpeg 3200w
+https://zone.kxcdn.com/hero.jpg?width=3840&height=2160&fit=cover&format=jpeg 3840w
+https://zone.kxcdn.com/hero.jpg?width=4480&height=2520&fit=cover&format=jpeg 4480w
+https://zone.kxcdn.com/hero.jpg?width=5120&height=2880&fit=cover&format=jpeg 5120w
+https://zone.kxcdn.com/hero.jpg?width=6016&height=3384&fit=cover&format=jpeg 6016w
+
+source (image/webp):
+https://zone.kxcdn.com/hero.jpg?width=640&height=360&fit=cover&format=webp 640w
+https://zone.kxcdn.com/hero.jpg?width=750&height=422&fit=cover&format=webp 750w
+https://zone.kxcdn.com/hero.jpg?width=828&height=466&fit=cover&format=webp 828w
+https://zone.kxcdn.com/hero.jpg?width=960&height=540&fit=cover&format=webp 960w
+https://zone.kxcdn.com/hero.jpg?width=1080&height=608&fit=cover&format=webp 1080w
+https://zone.kxcdn.com/hero.jpg?width=1280&height=720&fit=cover&format=webp 1280w
+https://zone.kxcdn.com/hero.jpg?width=1668&height=938&fit=cover&format=webp 1668w
+https://zone.kxcdn.com/hero.jpg?width=1920&height=1080&fit=cover&format=webp 1920w
+https://zone.kxcdn.com/hero.jpg?width=2048&height=1152&fit=cover&format=webp 2048w
+https://zone.kxcdn.com/hero.jpg?width=2560&height=1440&fit=cover&format=webp 2560w
+https://zone.kxcdn.com/hero.jpg?width=3200&height=1800&fit=cover&format=webp 3200w
+https://zone.kxcdn.com/hero.jpg?width=3840&height=2160&fit=cover&format=webp 3840w
+https://zone.kxcdn.com/hero.jpg?width=4480&height=2520&fit=cover&format=webp 4480w
+https://zone.kxcdn.com/hero.jpg?width=5120&height=2880&fit=cover&format=webp 5120w
+https://zone.kxcdn.com/hero.jpg?width=6016&height=3384&fit=cover&format=webp 6016w
+
+source (image/jpeg):
+https://zone.kxcdn.com/hero.jpg?width=640&height=360&fit=cover&format=jpeg 640w
+https://zone.kxcdn.com/hero.jpg?width=750&height=422&fit=cover&format=jpeg 750w
+https://zone.kxcdn.com/hero.jpg?width=828&height=466&fit=cover&format=jpeg 828w
+https://zone.kxcdn.com/hero.jpg?width=960&height=540&fit=cover&format=jpeg 960w
+https://zone.kxcdn.com/hero.jpg?width=1080&height=608&fit=cover&format=jpeg 1080w
+https://zone.kxcdn.com/hero.jpg?width=1280&height=720&fit=cover&format=jpeg 1280w
+https://zone.kxcdn.com/hero.jpg?width=1668&height=938&fit=cover&format=jpeg 1668w
+https://zone.kxcdn.com/hero.jpg?width=1920&height=1080&fit=cover&format=jpeg 1920w
+https://zone.kxcdn.com/hero.jpg?width=2048&height=1152&fit=cover&format=jpeg 2048w
+https://zone.kxcdn.com/hero.jpg?width=2560&height=1440&fit=cover&format=jpeg 2560w
+https://zone.kxcdn.com/hero.jpg?width=3200&height=1800&fit=cover&format=jpeg 3200w
+https://zone.kxcdn.com/hero.jpg?width=3840&height=2160&fit=cover&format=jpeg 3840w
+https://zone.kxcdn.com/hero.jpg?width=4480&height=2520&fit=cover&format=jpeg 4480w
+https://zone.kxcdn.com/hero.jpg?width=5120&height=2880&fit=cover&format=jpeg 5120w
+https://zone.kxcdn.com/hero.jpg?width=6016&height=3384&fit=cover&format=jpeg 6016w

--- a/src/Image/src/Bridge/KeyCdn/tests/bootstrap.php
+++ b/src/Image/src/Bridge/KeyCdn/tests/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once __DIR__.'/../vendor/autoload.php';

--- a/src/Image/src/Exception/ExceptionInterface.php
+++ b/src/Image/src/Exception/ExceptionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Exception;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Image/src/Exception/IncompleteDsnException.php
+++ b/src/Image/src/Exception/IncompleteDsnException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Exception;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class IncompleteDsnException extends InvalidArgumentException
+{
+}

--- a/src/Image/src/Exception/InvalidArgumentException.php
+++ b/src/Image/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Exception;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Image/src/Exception/LogicException.php
+++ b/src/Image/src/Exception/LogicException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Exception;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Image/src/Exception/UnsupportedSchemeException.php
+++ b/src/Image/src/Exception/UnsupportedSchemeException.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Exception;
+
+use Symfony\UX\Image\Provider\Dsn;
+use Symfony\UX\Image\UXImageBundle;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class UnsupportedSchemeException extends InvalidArgumentException
+{
+    public function __construct(Dsn $dsn, ?\Throwable $previous = null)
+    {
+        $provider = $dsn->getScheme();
+        $bridge = UXImageBundle::$bridges[$provider] ?? null;
+        if ($bridge && !class_exists($bridge['factory'])) {
+            parent::__construct(\sprintf('Unable to generate images via "%s" as the bridge is not installed. Try running "composer require symfony/ux-%s-image".', $provider, $provider));
+
+            return;
+        }
+
+        parent::__construct(
+            \sprintf('The image provider "%s" is not supported.', $dsn->getScheme()),
+            0,
+            $previous
+        );
+    }
+}

--- a/src/Image/src/Fit.php
+++ b/src/Image/src/Fit.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image;
+
+/**
+ * The resize behaviours every supported provider implements.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+enum Fit: string
+{
+    case Cover = 'cover';
+    case Contain = 'contain';
+    case ScaleDown = 'scale-down';
+}

--- a/src/Image/src/ImageTransformation.php
+++ b/src/Image/src/ImageTransformation.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image;
+
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+
+/**
+ * A single image output, normalised across providers.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class ImageTransformation
+{
+    /**
+     * @param array<string, scalar> $operations provider-specific extras
+     */
+    public function __construct(
+        public readonly string $path,
+        public readonly ?int $width = null,
+        public readonly ?int $height = null,
+        public readonly ?Fit $fit = null,
+        public readonly ?string $format = null,
+        public readonly ?int $quality = null,
+        public readonly array $operations = [],
+    ) {
+        if ('' === trim($path)) {
+            throw new InvalidArgumentException('The image path must not be empty.');
+        }
+        foreach (explode('/', $path) as $segment) {
+            if ('.' === $segment || '..' === $segment) {
+                throw new InvalidArgumentException(\sprintf('The image path "%s" must not contain a "." or ".." segment.', $path));
+            }
+        }
+        if (null !== $width && $width < 1) {
+            throw new InvalidArgumentException(\sprintf('The image width must be a positive integer, %d given.', $width));
+        }
+        if (null !== $height && $height < 1) {
+            throw new InvalidArgumentException(\sprintf('The image height must be a positive integer, %d given.', $height));
+        }
+        if (null !== $quality && ($quality < 1 || $quality > 100)) {
+            throw new InvalidArgumentException(\sprintf('The image quality must be between 1 and 100, %d given.', $quality));
+        }
+    }
+}

--- a/src/Image/src/Layout.php
+++ b/src/Image/src/Layout.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+enum Layout: string
+{
+    case Fixed = 'fixed';
+    case Constrained = 'constrained';
+    case FullWidth = 'full-width';
+}

--- a/src/Image/src/Provider/AbstractProviderFactory.php
+++ b/src/Image/src/Provider/AbstractProviderFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+abstract class AbstractProviderFactory
+{
+    public function supports(Dsn $dsn): bool
+    {
+        return \in_array($dsn->getScheme(), $this->getSupportedSchemes(), true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    abstract protected function getSupportedSchemes(): array;
+}

--- a/src/Image/src/Provider/Dsn.php
+++ b/src/Image/src/Provider/Dsn.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class Dsn
+{
+    private readonly string $scheme;
+    private readonly ?string $host;
+    private readonly ?string $path;
+    private readonly array $options;
+    private readonly string $originalDsn;
+
+    public function __construct(#[\SensitiveParameter] string $dsn)
+    {
+        $this->originalDsn = $dsn;
+
+        if (false === $params = parse_url($dsn)) {
+            throw new InvalidArgumentException('The image provider DSN is invalid.');
+        }
+        if (!isset($params['scheme'])) {
+            throw new InvalidArgumentException('The image provider DSN must contain a scheme.');
+        }
+
+        $this->scheme = $params['scheme'];
+        $this->host = '' !== ($params['host'] ?? '') ? $params['host'] : null;
+        $this->path = '' !== ($params['path'] ?? '') ? $params['path'] : null;
+
+        $options = [];
+        parse_str($params['query'] ?? '', $options);
+        $this->options = $options;
+    }
+
+    public function getScheme(): string
+    {
+        return $this->scheme;
+    }
+
+    public function getHost(): ?string
+    {
+        return $this->host;
+    }
+
+    public function getPath(): ?string
+    {
+        return $this->path;
+    }
+
+    public function getOption(string $key, mixed $default = null): mixed
+    {
+        return $this->options[$key] ?? $default;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function getOriginalDsn(): string
+    {
+        return $this->originalDsn;
+    }
+}

--- a/src/Image/src/Provider/NullProvider.php
+++ b/src/Image/src/Provider/NullProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+use Symfony\UX\Image\Exception\LogicException;
+use Symfony\UX\Image\ImageTransformation;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class NullProvider implements ProviderInterface
+{
+    public function getName(): string
+    {
+        return 'null';
+    }
+
+    public function generateUrl(ImageTransformation $transformation): string
+    {
+        throw new LogicException('No image provider is configured. Install a bridge such as "symfony/ux-glide-image", "symfony/ux-keycdn-image" or "symfony/ux-cloudflare-image".');
+    }
+
+    public function getSupportedOperations(): array
+    {
+        return [];
+    }
+
+    public function getSupportedFormats(): array
+    {
+        return [];
+    }
+
+    public function supportsAutoFormat(): bool
+    {
+        return true;
+    }
+}

--- a/src/Image/src/Provider/NullProviderFactory.php
+++ b/src/Image/src/Provider/NullProviderFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class NullProviderFactory extends AbstractProviderFactory implements ProviderFactoryInterface
+{
+    public function create(Dsn $dsn): ProviderInterface
+    {
+        return new NullProvider();
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['null'];
+    }
+}

--- a/src/Image/src/Provider/PathEncoder.php
+++ b/src/Image/src/Provider/PathEncoder.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class PathEncoder
+{
+    /**
+     * Encodes a path for safe URL transmission.
+     *
+     * Each segment is rawurlencode'd individually, which keeps a "?", "#" or space inside a
+     * filename from being read as a query string, a fragment or a segment break. It does NOT
+     * neutralize dot-segments -- rawurlencode('..') is '..' -- so this is only half of the
+     * path-safety invariant: {@see \Symfony\UX\Image\ImageTransformation} rejects "." and ".."
+     * segments up front, and every provider must keep relying on it.
+     */
+    public static function encode(string $path): string
+    {
+        $segments = explode('/', ltrim($path, '/'));
+
+        return implode('/', array_map(rawurlencode(...), $segments));
+    }
+}

--- a/src/Image/src/Provider/ProviderFactoryInterface.php
+++ b/src/Image/src/Provider/ProviderFactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+interface ProviderFactoryInterface
+{
+    public function create(Dsn $dsn): ProviderInterface;
+
+    public function supports(Dsn $dsn): bool;
+}

--- a/src/Image/src/Provider/ProviderInterface.php
+++ b/src/Image/src/Provider/ProviderInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+use Symfony\UX\Image\ImageTransformation;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+interface ProviderInterface
+{
+    /**
+     * The DSN scheme this provider answers to, also the key used in the
+     * component's "operations" map.
+     */
+    public function getName(): string;
+
+    public function generateUrl(ImageTransformation $transformation): string;
+
+    /**
+     * @return list<string> operation names accepted in ImageTransformation::$operations
+     */
+    public function getSupportedOperations(): array;
+
+    /**
+     * @return list<string> output formats this provider can encode to
+     */
+    public function getSupportedFormats(): array;
+
+    /**
+     * Whether the provider picks the output format from the request itself.
+     *
+     * True lets the renderer emit a single <img>; false makes it emit a <picture>
+     * with one <source type> per format.
+     */
+    public function supportsAutoFormat(): bool;
+}

--- a/src/Image/src/Provider/ProviderResolver.php
+++ b/src/Image/src/Provider/ProviderResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Provider;
+
+use Symfony\UX\Image\Exception\UnsupportedSchemeException;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class ProviderResolver
+{
+    /**
+     * @param iterable<ProviderFactoryInterface> $factories
+     */
+    public function __construct(private readonly iterable $factories)
+    {
+    }
+
+    public function fromString(#[\SensitiveParameter] ?string $dsn): ProviderInterface
+    {
+        // A "%env(default::UX_IMAGE_DSN)%" provider resolves to null at runtime, long after the bundle applied its compile-time default.
+        $parsed = new Dsn($dsn ?: 'null://null');
+
+        foreach ($this->factories as $factory) {
+            if ($factory->supports($parsed)) {
+                return $factory->create($parsed);
+            }
+        }
+
+        throw new UnsupportedSchemeException($parsed);
+    }
+}

--- a/src/Image/src/Renderer/ImageRenderer.php
+++ b/src/Image/src/Renderer/ImageRenderer.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Renderer;
+
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Exception\LogicException;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Provider\ProviderInterface;
+use Twig\Extra\Html\HtmlAttr\InlineStyle;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class ImageRenderer implements ImageRendererInterface
+{
+    /**
+     * @param list<string> $formats
+     */
+    public function __construct(
+        private readonly ProviderInterface $provider,
+        private readonly LayoutResolver $layoutResolver,
+        private readonly array $formats = ['avif', 'webp', 'jpeg'],
+    ) {
+    }
+
+    public function render(string $src, string $alt, RenderOptions $options): RenderedImage
+    {
+        $operations = $this->resolveOperations($options->operations);
+        $breakpoints = $options->breakpoints ?? $this->layoutResolver->breakpoints($options->layout, $options->width);
+        $ratio = $this->resolveRatio($options);
+
+        $pinned = $options->format;
+        if (null !== $pinned) {
+            $this->assertSupportedFormat($pinned);
+        }
+
+        $auto = null === $pinned && $this->provider->supportsAutoFormat();
+        $formats = match (true) {
+            null !== $pinned => [$pinned],
+            $auto => ['auto'],
+            default => $this->resolveFormats(),
+        };
+
+        $sources = [];
+        $fallbackSrcset = null;
+        if (null === $pinned && !$auto) {
+            foreach ($formats as $format) {
+                $fallbackSrcset = $this->buildSrcset($src, $breakpoints, $format, $options, $operations, $ratio);
+                $sources[] = [
+                    'type' => 'image/'.$format,
+                    'srcset' => $fallbackSrcset,
+                ];
+            }
+        }
+
+        $fallbackFormat = $formats[\count($formats) - 1];
+        $fallbackSrcset ??= $this->buildSrcset($src, $breakpoints, $fallbackFormat, $options, $operations, $ratio);
+
+        $attributes = [
+            'src' => $this->provider->generateUrl(
+                // "src" must match the srcset candidates for bots/crawlers that ignore srcset: no width fallback, no height without a known ratio.
+                new ImageTransformation($src, $options->width, null !== $ratio ? $options->height : null, $options->fit, $fallbackFormat, $options->quality, $operations),
+            ),
+            'alt' => $alt,
+            'srcset' => $fallbackSrcset,
+            'loading' => $options->priority ? 'eager' : 'lazy',
+            'fetchpriority' => $options->priority ? 'high' : 'auto',
+            'decoding' => 'async',
+        ];
+
+        if (null !== $sizes = $this->layoutResolver->sizes($options->layout, $options->width)) {
+            $attributes['sizes'] = $sizes;
+        }
+        if (null !== $options->width) {
+            $attributes['width'] = (string) $options->width;
+        }
+        if (null !== $options->height) {
+            $attributes['height'] = (string) $options->height;
+        }
+        $attributes['style'] = new InlineStyle($this->layoutResolver->style($options->layout, $options->width, $options->height, $options->objectFit ?? $options->fit?->value ?? 'cover'));
+
+        return new RenderedImage($sources, $attributes);
+    }
+
+    private function assertSupportedFormat(string $format): void
+    {
+        $supported = $this->provider->getSupportedFormats();
+
+        // Empty means an unconfigured NullProvider, not "supports nothing"; the real error surfaces from generateUrl() below.
+        if ([] === $supported) {
+            return;
+        }
+
+        if (!\in_array($format, $supported, true)) {
+            throw new InvalidArgumentException(\sprintf('The image format "%s" is not supported by the "%s" provider (supported: "%s").', $format, $this->provider->getName(), implode('", "', $supported)));
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveFormats(): array
+    {
+        $supported = $this->provider->getSupportedFormats();
+        $formats = array_values(array_intersect($this->formats, $supported));
+
+        if ([] === $formats) {
+            throw new LogicException(\sprintf('None of the configured formats ("%s") are supported by the "%s" provider (supported: "%s").', implode('", "', $this->formats), $this->provider->getName(), implode('", "', $supported)));
+        }
+
+        return $formats;
+    }
+
+    /**
+     * @param list<int>             $breakpoints
+     * @param array<string, scalar> $operations
+     */
+    private function buildSrcset(string $src, array $breakpoints, string $format, RenderOptions $options, array $operations, ?float $ratio): string
+    {
+        // Browsers always fetch from srcset over src, so a height-less candidate would make "fit" a no-op here.
+        $entries = [];
+        foreach ($breakpoints as $breakpoint) {
+            $height = null !== $ratio ? max(1, (int) round($breakpoint * $ratio)) : null;
+            $url = $this->provider->generateUrl(
+                new ImageTransformation($src, $breakpoint, $height, $options->fit, $format, $options->quality, $operations),
+            );
+            $entries[] = $url.' '.$breakpoint.'w';
+        }
+
+        return implode(', ', $entries);
+    }
+
+    private function resolveRatio(RenderOptions $options): ?float
+    {
+        return null !== $options->width && null !== $options->height ? $options->height / $options->width : null;
+    }
+
+    /**
+     * @param array<string, array<string, scalar>> $operations
+     *
+     * @return array<string, scalar>
+     */
+    private function resolveOperations(array $operations): array
+    {
+        $resolved = $operations[$this->provider->getName()] ?? [];
+        $supported = $this->provider->getSupportedOperations();
+
+        foreach (array_keys($resolved) as $name) {
+            if (!\in_array($name, $supported, true)) {
+                throw new InvalidArgumentException(\sprintf('The image operation "%s" is not supported by the "%s" provider (supported: "%s").', $name, $this->provider->getName(), implode('", "', $supported)));
+            }
+        }
+
+        return $resolved;
+    }
+}

--- a/src/Image/src/Renderer/ImageRendererInterface.php
+++ b/src/Image/src/Renderer/ImageRendererInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Renderer;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+interface ImageRendererInterface
+{
+    public function render(string $src, string $alt, RenderOptions $options): RenderedImage;
+}

--- a/src/Image/src/Renderer/LayoutResolver.php
+++ b/src/Image/src/Renderer/LayoutResolver.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Renderer;
+
+use Symfony\UX\Image\Layout;
+
+/**
+ * Derives the srcset candidates, the sizes attribute and the layout styles.
+ *
+ * Ported from unpic (packages/core/src/base.ts).
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class LayoutResolver
+{
+    /**
+     * Common screen widths. These will be filtered according to the image size and layout.
+     *
+     * @var list<int>
+     */
+    public const DEFAULT_RESOLUTIONS = [
+        6016, // 6K
+        5120, // 5K
+        4480, // 4.5K
+        3840, // 4K
+        3200, // QHD+
+        2560, // WQXGA
+        2048, // QXGA
+        1920, // 1080p
+        1668, // Various iPads
+        1280, // 720p
+        1080, // iPhone 6-8 Plus
+        960, // older horizontal phones
+        828, // iPhone XR/11
+        750, // iPhone 6-8
+        640, // older and lower-end phones
+    ];
+
+    /**
+     * @param list<int> $resolutions
+     */
+    public function __construct(
+        private readonly array $resolutions = self::DEFAULT_RESOLUTIONS,
+    ) {
+    }
+
+    /**
+     * @return list<int> ascending, deduplicated
+     */
+    public function breakpoints(Layout $layout, ?int $width): array
+    {
+        if (Layout::FullWidth === $layout) {
+            $candidates = $this->resolutions;
+        } elseif (null === $width) {
+            return [];
+        } elseif (Layout::Fixed === $layout) {
+            $candidates = [$width, $width * 2];
+        } else {
+            $doubled = $width * 2;
+            $candidates = [$width, $doubled, ...array_filter($this->resolutions, static fn (int $w): bool => $w < $doubled)];
+        }
+
+        $candidates = array_values(array_unique($candidates));
+        sort($candidates);
+
+        return $candidates;
+    }
+
+    public function sizes(Layout $layout, ?int $width): ?string
+    {
+        if (Layout::FullWidth === $layout) {
+            return '100vw';
+        }
+        if (null === $width) {
+            return null;
+        }
+
+        return match ($layout) {
+            Layout::Fixed => \sprintf('%dpx', $width),
+            Layout::Constrained => \sprintf('(min-width: %1$dpx) %1$dpx, 100vw', $width),
+        };
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function style(Layout $layout, ?int $width, ?int $height, string $objectFit = 'cover'): array
+    {
+        $style = ['object-fit' => $objectFit];
+        $ratio = null !== $width && null !== $height ? \sprintf('%d / %d', $width, $height) : null;
+
+        switch ($layout) {
+            case Layout::Fixed:
+                $style += array_filter([
+                    'width' => null !== $width ? $width.'px' : null,
+                    'height' => null !== $height ? $height.'px' : null,
+                ]);
+                break;
+
+            case Layout::Constrained:
+                $style += array_filter([
+                    'max-width' => null !== $width ? $width.'px' : null,
+                    'max-height' => null !== $height ? $height.'px' : null,
+                    'aspect-ratio' => $ratio,
+                ]);
+                $style['width'] = '100%';
+                // width/height attrs imply a fixed CSS height (browser hint); "height: auto" restores aspect-ratio.
+                if (null !== $ratio) {
+                    $style['height'] = 'auto';
+                }
+                break;
+
+            case Layout::FullWidth:
+                $style['width'] = '100%';
+                if (null !== $ratio) {
+                    $style['aspect-ratio'] = $ratio;
+                    $style['height'] = 'auto';
+                } elseif (null !== $height) {
+                    $style['height'] = $height.'px';
+                }
+                break;
+        }
+
+        return $style;
+    }
+}

--- a/src/Image/src/Renderer/RenderOptions.php
+++ b/src/Image/src/Renderer/RenderOptions.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Renderer;
+
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\Layout;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class RenderOptions
+{
+    public readonly ?Fit $fit;
+
+    /**
+     * @param list<int>|null                       $breakpoints
+     * @param array<string, array<string, scalar>> $operations
+     */
+    public function __construct(
+        public readonly Layout $layout = Layout::Constrained,
+        public readonly ?int $width = null,
+        public readonly ?int $height = null,
+        ?Fit $fit = null,
+        public readonly ?string $format = null,
+        public readonly ?int $quality = null,
+        public readonly bool $priority = false,
+        public readonly ?string $objectFit = null,
+        public readonly ?array $breakpoints = null,
+        public readonly array $operations = [],
+    ) {
+        if (null === $width && \in_array($layout, [Layout::Fixed, Layout::Constrained], true)) {
+            throw new InvalidArgumentException(\sprintf('The "%s" layout requires a width.', $layout->value));
+        }
+        if (null === $height && Layout::FullWidth === $layout) {
+            throw new InvalidArgumentException(\sprintf('The "%s" layout requires a height.', $layout->value));
+        }
+
+        // Both dimensions given signals an intended ratio (already asserted in the generated CSS), so default to cropping to it.
+        $this->fit = $fit ?? (null !== $width && null !== $height ? Fit::Cover : null);
+    }
+}

--- a/src/Image/src/Renderer/RenderedImage.php
+++ b/src/Image/src/Renderer/RenderedImage.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Renderer;
+
+use Twig\Extra\Html\HtmlAttr\InlineStyle;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class RenderedImage
+{
+    /**
+     * @param list<array{type: string, srcset: string}> $sources       empty means a plain <img>
+     * @param array<string, string|InlineStyle>         $imgAttributes
+     */
+    public function __construct(
+        public readonly array $sources,
+        public readonly array $imgAttributes,
+    ) {
+    }
+}

--- a/src/Image/src/Test/RendererSnapshotTestCase.php
+++ b/src/Image/src/Test/RendererSnapshotTestCase.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Test;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Spatie\Snapshots\Drivers\TextDriver;
+use Spatie\Snapshots\MatchesSnapshots;
+use Symfony\UX\Image\Provider\ProviderInterface;
+use Symfony\UX\Image\Renderer\ImageRenderer;
+use Symfony\UX\Image\Renderer\LayoutResolver;
+use Symfony\UX\Image\Renderer\RenderedImage;
+use Symfony\UX\Image\Renderer\RenderOptions;
+
+/**
+ * A test case to ease snapshot-testing a provider's rendered URL matrix.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+abstract class RendererSnapshotTestCase extends TestCase
+{
+    use MatchesSnapshots;
+
+    /**
+     * @return iterable<string, array{0: ProviderInterface, 1: RenderOptions}>
+     */
+    abstract public static function provideOptions(): iterable;
+
+    #[DataProvider('provideOptions')]
+    public function testRenderedUrls(ProviderInterface $provider, RenderOptions $options)
+    {
+        $rendered = new ImageRenderer($provider, new LayoutResolver())->render('/hero.jpg', 'Hero', $options);
+
+        $this->assertMatchesSnapshot($this->format($rendered), new TextDriver());
+    }
+
+    private function format(RenderedImage $rendered): string
+    {
+        $lines = ['src:', $rendered->imgAttributes['src'], '', 'srcset:'];
+
+        foreach (explode(', ', $rendered->imgAttributes['srcset']) as $candidate) {
+            $lines[] = $candidate;
+        }
+
+        foreach ($rendered->sources as $source) {
+            $lines[] = '';
+            $lines[] = \sprintf('source (%s):', $source['type']);
+            foreach (explode(', ', $source['srcset']) as $candidate) {
+                $lines[] = $candidate;
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/src/Image/src/Twig/Components/Image.php
+++ b/src/Image/src/Twig/Components/Image.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig\Components;
+
+use Symfony\UX\Image\Renderer\ImageRendererInterface;
+use Symfony\UX\Image\Renderer\RenderedImage;
+use Symfony\UX\Image\Twig\RenderOptionsFactory;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+use Symfony\UX\TwigComponent\Attribute\PostMount;
+use Twig\Extra\Html\HtmlAttr\InlineStyle;
+
+/**
+ * Backs the <twig:ux:image> component.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class Image
+{
+    public string $src;
+
+    public string $alt;
+
+    public string $layout = 'constrained';
+
+    public ?int $width = null;
+
+    public ?int $height = null;
+
+    public ?string $fit = null;
+
+    public ?string $format = null;
+
+    public ?int $quality = null;
+
+    public bool $priority = false;
+
+    public ?string $objectFit = null;
+
+    /**
+     * @var list<int>|null
+     */
+    public ?array $breakpoints = null;
+
+    /**
+     * @var array<string, array<string, scalar>>
+     */
+    public array $operations = [];
+
+    public function __construct(
+        private readonly ImageRendererInterface $renderer,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     *
+     * @return array<string, mixed>
+     */
+    #[PostMount]
+    public function normalizeStyleAttribute(array $attributes): array
+    {
+        $style = $attributes['style'] ?? null;
+
+        if (is_iterable($style)) {
+            // ComponentAttributes renders scalars and AttributeValueInterface values, never a raw array.
+            $attributes['style'] = new InlineStyle($style);
+        } elseif (null !== $style) {
+            // InlineStyle refuses a plain string; wrap it as a one-element list, which getValue() treats as a pre-formed CSS chunk.
+            $attributes['style'] = new InlineStyle([$style]);
+        }
+
+        return $attributes;
+    }
+
+    #[ExposeInTemplate]
+    public function getRendered(): RenderedImage
+    {
+        $options = RenderOptionsFactory::create(
+            layout: $this->layout,
+            width: $this->width,
+            height: $this->height,
+            fit: $this->fit,
+            format: $this->format,
+            quality: $this->quality,
+            priority: $this->priority,
+            objectFit: $this->objectFit,
+            breakpoints: $this->breakpoints,
+            operations: $this->operations,
+        );
+
+        return $this->renderer->render($this->src, $this->alt, $options);
+    }
+}

--- a/src/Image/src/Twig/ImageExtension.php
+++ b/src/Image/src/Twig/ImageExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class ImageExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('ux_image', [ImageRuntime::class, 'renderImage'], ['is_safe' => ['html']]),
+        ];
+    }
+}

--- a/src/Image/src/Twig/ImageRuntime.php
+++ b/src/Image/src/Twig/ImageRuntime.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+use Symfony\UX\Image\Renderer\ImageRendererInterface;
+use Symfony\UX\TwigComponent\ComponentAttributes;
+use Twig\Environment;
+use Twig\Extension\RuntimeExtensionInterface;
+use Twig\Runtime\EscaperRuntime;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class ImageRuntime implements RuntimeExtensionInterface
+{
+    public function __construct(
+        private readonly ImageRendererInterface $renderer,
+        private readonly Environment $twig,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function renderImage(string $src, string $alt, array $options = []): string
+    {
+        $rendered = $this->renderer->render($src, $alt, RenderOptionsFactory::createFromArray($options));
+
+        return $this->twig->render('@UXImage/components/Image.html.twig', [
+            'rendered' => $rendered,
+            'attributes' => new ComponentAttributes([], $this->twig->getRuntime(EscaperRuntime::class)),
+        ]);
+    }
+}

--- a/src/Image/src/Twig/RenderOptionsFactory.php
+++ b/src/Image/src/Twig/RenderOptionsFactory.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Twig;
+
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Renderer\RenderOptions;
+
+/**
+ * Converts the loose, string-typed values coming from Twig (the component's
+ * props or the ux_image() options array) into a {@see RenderOptions}.
+ *
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class RenderOptionsFactory
+{
+    /**
+     * Spreading an unvetted array over {@see create()} would raise a raw PHP "Unknown named
+     * parameter" Error, so ux_image()'s options array goes through here first.
+     *
+     * @param array<string, mixed> $options
+     */
+    public static function createFromArray(array $options): RenderOptions
+    {
+        static $known;
+        $known ??= array_column(new \ReflectionMethod(self::class, 'create')->getParameters(), 'name');
+
+        if ([] !== $unknown = array_diff(array_keys($options), $known)) {
+            throw new InvalidArgumentException(\sprintf('Unknown image option "%s": expected one of "%s".', implode('", "', $unknown), implode('", "', $known)));
+        }
+
+        return self::create(...$options);
+    }
+
+    /**
+     * @param list<int>|null                       $breakpoints
+     * @param array<string, array<string, scalar>> $operations
+     */
+    public static function create(
+        string $layout = 'constrained',
+        ?int $width = null,
+        ?int $height = null,
+        ?string $fit = null,
+        ?string $format = null,
+        ?int $quality = null,
+        bool $priority = false,
+        ?string $objectFit = null,
+        ?array $breakpoints = null,
+        array $operations = [],
+    ): RenderOptions {
+        return new RenderOptions(
+            layout: self::layout($layout),
+            width: $width,
+            height: $height,
+            fit: null !== $fit ? self::fit($fit) : null,
+            format: $format,
+            quality: $quality,
+            priority: $priority,
+            objectFit: $objectFit,
+            breakpoints: $breakpoints,
+            operations: $operations,
+        );
+    }
+
+    private static function layout(string $layout): Layout
+    {
+        return Layout::tryFrom($layout) ?? throw new InvalidArgumentException(\sprintf('Invalid "layout" value "%s": expected one of "%s".', $layout, implode('", "', array_column(Layout::cases(), 'value'))));
+    }
+
+    private static function fit(string $fit): Fit
+    {
+        return Fit::tryFrom($fit) ?? throw new InvalidArgumentException(\sprintf('Invalid "fit" value "%s": expected one of "%s".', $fit, implode('", "', array_column(Fit::cases(), 'value'))));
+    }
+}

--- a/src/Image/src/UXImageBundle.php
+++ b/src/Image/src/UXImageBundle.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image;
+
+use League\Glide\Server;
+use League\Glide\Signatures\SignatureInterface;
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use Symfony\UX\Image\Bridge\Cloudflare\CloudflareProviderFactory;
+use Symfony\UX\Image\Bridge\Glide\Controller\GlideController;
+use Symfony\UX\Image\Bridge\Glide\GlideProviderFactory;
+use Symfony\UX\Image\Bridge\Glide\ServerFactory as GlideServerFactory;
+use Symfony\UX\Image\Bridge\Glide\SignatureFactory as GlideSignatureFactory;
+use Symfony\UX\Image\Bridge\KeyCdn\KeyCdnProviderFactory;
+use Symfony\UX\Image\Provider\NullProviderFactory;
+use Symfony\UX\Image\Renderer\LayoutResolver;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
+final class UXImageBundle extends AbstractBundle
+{
+    protected string $extensionAlias = 'ux_image';
+
+    /**
+     * @var array<string, array{factory: class-string}>
+     *
+     * @internal
+     */
+    public static array $bridges = [
+        'cloudflare' => ['factory' => CloudflareProviderFactory::class],
+        'glide' => ['factory' => GlideProviderFactory::class],
+        'keycdn' => ['factory' => KeyCdnProviderFactory::class],
+    ];
+
+    public function getPath(): string
+    {
+        return \dirname(__DIR__);
+    }
+
+    public function configure(DefinitionConfigurator $definition): void
+    {
+        $definition->rootNode()
+            ->children()
+                ->scalarNode('provider')->defaultNull()->end()
+                ->arrayNode('formats')
+                    ->scalarPrototype()->end()
+                    ->defaultValue(['avif', 'webp', 'jpeg'])
+                ->end()
+                ->arrayNode('resolutions')
+                    ->integerPrototype()->end()
+                    ->defaultValue(LayoutResolver::DEFAULT_RESOLUTIONS)
+                ->end()
+            ->end()
+        ;
+    }
+
+    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $container->import('../config/services.php');
+        $container->import('../config/twig_component.php');
+
+        $config['provider'] ??= 'null://null';
+
+        $container->services()
+            ->set('ux_image.provider_factory.null', NullProviderFactory::class)
+            ->tag('ux_image.provider_factory');
+
+        // Not a "glide://" prefix check: the documented DSN is an unresolved %env() placeholder at compile time.
+        if (ContainerBuilder::willBeAvailable('symfony/ux-glide-image', GlideController::class, ['symfony/ux-image'])) {
+            $container->services()
+                ->set('ux_image.glide.server', Server::class)
+                    ->factory([GlideServerFactory::class, 'createFromDsn'])
+                    ->args([$config['provider']])
+
+                ->set('ux_image.glide.signature', SignatureInterface::class)
+                    ->factory([GlideSignatureFactory::class, 'createFromDsn'])
+                    ->args([$config['provider']])
+
+                ->set(GlideController::class)
+                    ->args([
+                        '$server' => new Reference('ux_image.glide.server'),
+                        '$signature' => new Reference('ux_image.glide.signature'),
+                        '$supportedFormats' => $config['formats'],
+                    ])
+                    ->tag('controller.service_arguments')
+            ;
+        }
+
+        $container->services()->get('ux_image.provider')->arg(0, $config['provider']);
+        $container->services()->get('ux_image.renderer')->arg(2, $config['formats']);
+        $container->services()->get('ux_image.layout_resolver')->arg(0, $config['resolutions']);
+
+        foreach (self::$bridges as $name => $bridge) {
+            if (ContainerBuilder::willBeAvailable('symfony/ux-'.$name.'-image', $bridge['factory'], ['symfony/ux-image'])) {
+                $container->services()
+                    ->set('ux_image.provider_factory.'.$name, $bridge['factory'])
+                    ->tag('ux_image.provider_factory');
+            }
+        }
+    }
+}

--- a/src/Image/templates/components/Image.html.twig
+++ b/src/Image/templates/components/Image.html.twig
@@ -1,0 +1,12 @@
+{%- set imgAttributes = attributes.defaults(rendered.imgAttributes) -%}
+{%- set resolvedSizes = attributes.all().sizes ?? rendered.imgAttributes.sizes ?? null -%}
+{%- if rendered.sources is empty -%}
+    <img{{ imgAttributes }} />
+{%- else -%}
+    <picture>
+        {%- for source in rendered.sources -%}
+            <source type="{{ source.type }}" srcset="{{ source.srcset }}"{% if resolvedSizes is not null %} sizes="{{ resolvedSizes }}"{% endif %} />
+        {%- endfor -%}
+        <img{{ imgAttributes }} />
+    </picture>
+{%- endif -%}

--- a/src/Image/tests/DependencyInjection/UXImageExtensionTest.php
+++ b/src/Image/tests/DependencyInjection/UXImageExtensionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\UX\Image\Provider\NullProviderFactory;
+use Symfony\UX\Image\Renderer\ImageRendererInterface;
+use Symfony\UX\Image\Renderer\LayoutResolver;
+use Symfony\UX\Image\Tests\Fixtures\FakeProviderFactory;
+use Symfony\UX\Image\UXImageBundle;
+
+final class UXImageExtensionTest extends TestCase
+{
+    private array $originalBridges;
+
+    protected function setUp(): void
+    {
+        $this->originalBridges = UXImageBundle::$bridges;
+    }
+
+    protected function tearDown(): void
+    {
+        UXImageBundle::$bridges = $this->originalBridges;
+    }
+
+    public function testItRegistersTheRendererWithTheConfiguredFormats()
+    {
+        $container = $this->buildContainer(['provider' => 'fake://default', 'formats' => ['webp', 'jpeg']]);
+
+        self::assertTrue($container->hasDefinition('ux_image.renderer'));
+        self::assertSame(['webp', 'jpeg'], $container->getDefinition('ux_image.renderer')->getArgument(2));
+    }
+
+    public function testTheDefaultFormatsAreAvifWebpJpeg()
+    {
+        self::assertSame(['avif', 'webp', 'jpeg'], $this->buildContainer([])->getDefinition('ux_image.renderer')->getArgument(2));
+    }
+
+    public function testItRegistersTheLayoutResolverWithTheConfiguredResolutions()
+    {
+        $container = $this->buildContainer(['provider' => 'fake://default', 'resolutions' => [1600, 800, 400]]);
+
+        self::assertTrue($container->hasDefinition('ux_image.layout_resolver'));
+        self::assertSame([1600, 800, 400], $container->getDefinition('ux_image.layout_resolver')->getArgument(0));
+    }
+
+    public function testTheDefaultResolutionsAreTheUnpicLadder()
+    {
+        self::assertSame(LayoutResolver::DEFAULT_RESOLUTIONS, $this->buildContainer([])->getDefinition('ux_image.layout_resolver')->getArgument(0));
+    }
+
+    public function testItFallsBackToTheNullProviderWhenNoDsnIsConfigured()
+    {
+        $container = $this->buildContainer([]);
+
+        self::assertTrue($container->hasDefinition('ux_image.provider_factory.null'));
+        self::assertSame(NullProviderFactory::class, $container->getDefinition('ux_image.provider_factory.null')->getClass());
+        self::assertTrue($container->getDefinition('ux_image.provider_factory.null')->hasTag('ux_image.provider_factory'));
+    }
+
+    public function testItRegistersTheNullProviderEvenWhenADsnIsConfigured()
+    {
+        $container = $this->buildContainer(['provider' => 'fake://default']);
+
+        self::assertTrue($container->hasDefinition('ux_image.provider_factory.null'));
+    }
+
+    public function testTheDefaultDsnReachesTheProviderService()
+    {
+        $container = $this->buildContainer([]);
+
+        self::assertSame('null://null', $container->getDefinition('ux_image.provider')->getArgument(0));
+    }
+
+    public function testTheConfiguredDsnReachesTheProviderService()
+    {
+        $container = $this->buildContainer(['provider' => 'fake://default']);
+
+        self::assertSame('fake://default', $container->getDefinition('ux_image.provider')->getArgument(0));
+    }
+
+    public function testTheRendererInterfaceIsAliasedToTheRendererService()
+    {
+        $container = $this->buildContainer([]);
+
+        self::assertTrue($container->hasAlias(ImageRendererInterface::class));
+        self::assertSame('ux_image.renderer', (string) $container->getAlias(ImageRendererInterface::class));
+    }
+
+    public function testItRegistersATaggedProviderFactoryForEachAvailableBridge()
+    {
+        UXImageBundle::$bridges = ['fake' => ['factory' => FakeProviderFactory::class]];
+
+        $container = $this->buildContainer([]);
+
+        self::assertTrue($container->hasDefinition('ux_image.provider_factory.fake'));
+        self::assertSame(FakeProviderFactory::class, $container->getDefinition('ux_image.provider_factory.fake')->getClass());
+        self::assertTrue($container->getDefinition('ux_image.provider_factory.fake')->hasTag('ux_image.provider_factory'));
+    }
+
+    private function buildContainer(array $config): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+
+        $bundle = new UXImageBundle();
+        $bundle->getContainerExtension()->load([$config], $container);
+
+        return $container;
+    }
+}

--- a/src/Image/tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Image/tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Exception\UnsupportedSchemeException;
+use Symfony\UX\Image\Provider\Dsn;
+use Symfony\UX\Image\UXImageBundle;
+
+final class UnsupportedSchemeExceptionTest extends TestCase
+{
+    private array $originalBridges;
+
+    protected function setUp(): void
+    {
+        $this->originalBridges = UXImageBundle::$bridges;
+    }
+
+    protected function tearDown(): void
+    {
+        UXImageBundle::$bridges = $this->originalBridges;
+    }
+
+    public function testMessageWhenSchemeIsUnknown()
+    {
+        UXImageBundle::$bridges = [];
+
+        $exception = new UnsupportedSchemeException(new Dsn('cloudflare://cdn.example.com'));
+
+        self::assertSame('The image provider "cloudflare" is not supported.', $exception->getMessage());
+    }
+
+    public function testMessageWhenBridgeIsKnownButFactoryClassIsMissing()
+    {
+        UXImageBundle::$bridges = [
+            'glide' => ['factory' => 'Symfony\UX\Image\Bridge\Glide\NotInstalledFactory'],
+        ];
+
+        $exception = new UnsupportedSchemeException(new Dsn('glide://default/images'));
+
+        self::assertSame('Unable to generate images via "glide" as the bridge is not installed. Try running "composer require symfony/ux-glide-image".', $exception->getMessage());
+    }
+}

--- a/src/Image/tests/Fixtures/FakeProvider.php
+++ b/src/Image/tests/Fixtures/FakeProvider.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Fixtures;
+
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Provider\PathEncoder;
+use Symfony\UX\Image\Provider\ProviderInterface;
+
+final class FakeProvider implements ProviderInterface
+{
+    public function __construct(private readonly bool $autoFormat = true)
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'fake';
+    }
+
+    public function generateUrl(ImageTransformation $transformation): string
+    {
+        $path = PathEncoder::encode($transformation->path);
+        $params = [];
+
+        if (null !== $transformation->width) {
+            $params[] = 'w='.$transformation->width;
+        }
+        $params[] = 'fm='.($transformation->format ?? '');
+        if (null !== $transformation->height) {
+            $params[] = 'h='.$transformation->height;
+        }
+
+        foreach ($transformation->operations as $key => $value) {
+            $params[] = \sprintf('%s=%s', $key, $value);
+        }
+
+        return \sprintf('/%s?%s', $path, implode('&', $params));
+    }
+
+    public function getSupportedOperations(): array
+    {
+        return ['sharpen'];
+    }
+
+    public function getSupportedFormats(): array
+    {
+        return ['avif', 'webp', 'jpeg'];
+    }
+
+    public function supportsAutoFormat(): bool
+    {
+        return $this->autoFormat;
+    }
+}

--- a/src/Image/tests/Fixtures/FakeProviderFactory.php
+++ b/src/Image/tests/Fixtures/FakeProviderFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Fixtures;
+
+use Symfony\UX\Image\Provider\AbstractProviderFactory;
+use Symfony\UX\Image\Provider\Dsn;
+use Symfony\UX\Image\Provider\ProviderFactoryInterface;
+use Symfony\UX\Image\Provider\ProviderInterface;
+
+final class FakeProviderFactory extends AbstractProviderFactory implements ProviderFactoryInterface
+{
+    public function create(Dsn $dsn): ProviderInterface
+    {
+        return new FakeProvider(autoFormat: (bool) $dsn->getOption('auto_format', true));
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['fake'];
+    }
+}

--- a/src/Image/tests/Fixtures/TestKernel.php
+++ b/src/Image/tests/Fixtures/TestKernel.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Fixtures;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\UX\Image\UXImageBundle;
+use Symfony\UX\TwigComponent\TwigComponentBundle;
+
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ *
+ * @internal
+ */
+final class TestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        yield new FrameworkBundle();
+        yield new TwigBundle();
+        yield new TwigComponentBundle();
+        yield new UXImageBundle();
+    }
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->extension('framework', [
+            'secret' => 'S3CRET',
+            'test' => true,
+            'http_method_override' => false,
+            'php_errors' => ['log' => true],
+            ...(self::VERSION_ID >= 60200 ? ['handle_all_throwables' => true] : []),
+        ]);
+
+        $container->extension('twig', [
+            'default_path' => __DIR__.'/templates',
+            'strict_variables' => true,
+        ]);
+
+        $container->extension('twig_component', [
+            'defaults' => [],
+            'anonymous_template_directory' => 'components',
+        ]);
+
+        $container->extension('ux_image', match ($this->environment) {
+            'no_auto_format' => ['provider' => 'fake://default?auto_format=0'],
+            'bare' => [],
+            'env_placeholder' => ['provider' => '%env(UX_IMAGE_DSN)%'],
+            'default_placeholder' => ['provider' => '%env(resolve:default::UX_IMAGE_DSN)%'],
+            default => ['provider' => 'fake://default'],
+        });
+
+        if ('bare' !== $this->environment) {
+            $container->services()
+                ->set('test.ux_image.provider_factory.fake', FakeProviderFactory::class)
+                    ->tag('ux_image.provider_factory')
+            ;
+        }
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir().'/ux_image_bundle/cache/'.self::VERSION_ID.'/'.$this->environment;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir().'/ux_image_bundle/log/'.self::VERSION_ID;
+    }
+}

--- a/src/Image/tests/ImageTransformationTest.php
+++ b/src/Image/tests/ImageTransformationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\ImageTransformation;
+
+final class ImageTransformationTest extends TestCase
+{
+    public function testItKeepsTheGivenValues()
+    {
+        $t = new ImageTransformation('hero.jpg', width: 800, height: 450, fit: Fit::Cover, format: 'webp', quality: 80);
+
+        self::assertSame('hero.jpg', $t->path);
+        self::assertSame(800, $t->width);
+        self::assertSame(450, $t->height);
+        self::assertSame(Fit::Cover, $t->fit);
+        self::assertSame('webp', $t->format);
+        self::assertSame(80, $t->quality);
+        self::assertSame([], $t->operations);
+    }
+
+    public function testItRejectsAnEmptyPath()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The image path must not be empty.');
+
+        new ImageTransformation('');
+    }
+
+    #[DataProvider('provideDotSegmentPaths')]
+    public function testItRejectsADotSegmentPath(string $path)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ImageTransformation($path);
+    }
+
+    public static function provideDotSegmentPaths(): iterable
+    {
+        yield 'parent segment at the start' => ['../a.jpg'];
+        yield 'parent segment in the middle' => ['a/../b.jpg'];
+        yield 'current segment at the start' => ['./a.jpg'];
+    }
+
+    public function testItAcceptsAPathSegmentThatOnlyLooksLikeADotSegment()
+    {
+        $t = new ImageTransformation('a..b/c.jpg');
+
+        self::assertSame('a..b/c.jpg', $t->path);
+    }
+
+    #[DataProvider('provideInvalidDimensions')]
+    public function testItRejectsNonPositiveDimensions(?int $width, ?int $height)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ImageTransformation('hero.jpg', width: $width, height: $height);
+    }
+
+    public static function provideInvalidDimensions(): iterable
+    {
+        yield 'zero width' => [0, null];
+        yield 'negative width' => [-1, null];
+        yield 'zero height' => [null, 0];
+    }
+
+    public function testItRejectsAQualityOutsideOneToHundred()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ImageTransformation('hero.jpg', quality: 101);
+    }
+}

--- a/src/Image/tests/Integration/BundleInitializationTest.php
+++ b/src/Image/tests/Integration/BundleInitializationTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Loader\PhpFileLoader;
+use Symfony\UX\Image\Bridge\Glide\Controller\GlideController;
+use Symfony\UX\Image\Exception\LogicException;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Provider\ProviderInterface;
+use Symfony\UX\Image\Tests\Fixtures\TestKernel;
+
+/**
+ * Boots a real, compiled and dumped container via {@see KernelTestCase}: a bare ContainerBuilder
+ * hands "%env(...)%" placeholders an internal token, not the real value.
+ *
+ * GlideController is referenced here only by class name -- never autoloaded, since this package
+ * never Composer-requires a bridge. The Glide bridge's own DI wiring is tested in its own suite.
+ */
+final class BundleInitializationTest extends KernelTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        putenv('UX_IMAGE_DSN');
+        unset($_ENV['UX_IMAGE_DSN'], $_SERVER['UX_IMAGE_DSN']);
+    }
+
+    public function testTheContainerCompilesWithNoBridgeInstalledAndTheNullProviderIsActive()
+    {
+        self::bootKernel(['environment' => 'bare']);
+
+        /** @var ProviderInterface $provider */
+        $provider = self::getContainer()->get('ux_image.provider');
+
+        self::assertSame('null', $provider->getName());
+
+        try {
+            $provider->generateUrl(new ImageTransformation('hero.jpg'));
+            self::fail('Expected a LogicException.');
+        } catch (LogicException $e) {
+            self::assertStringContainsString('symfony/ux-glide-image', $e->getMessage());
+            self::assertStringContainsString('symfony/ux-keycdn-image', $e->getMessage());
+            self::assertStringContainsString('symfony/ux-cloudflare-image', $e->getMessage());
+        }
+
+        self::assertFalse(self::getContainer()->has('ux_image.provider_factory.cloudflare'));
+        self::assertFalse(self::getContainer()->has('ux_image.provider_factory.glide'));
+        self::assertFalse(self::getContainer()->has('ux_image.provider_factory.keycdn'));
+        self::assertFalse(self::getContainer()->has(GlideController::class));
+    }
+
+    public function testTheContainerCompilesWithABridgeAvailableAndItsProviderBecomesActive()
+    {
+        self::bootKernel(['environment' => 'test']);
+
+        /** @var ProviderInterface $provider */
+        $provider = self::getContainer()->get('ux_image.provider');
+
+        self::assertSame('fake', $provider->getName());
+    }
+
+    public function testAnEnvPlaceholderDsnResolvingToTheNullSchemeStillReachesTheNullProvider()
+    {
+        putenv('UX_IMAGE_DSN=null://null');
+        $_ENV['UX_IMAGE_DSN'] = 'null://null';
+        $_SERVER['UX_IMAGE_DSN'] = 'null://null';
+
+        self::bootKernel(['environment' => 'env_placeholder']);
+
+        /** @var ProviderInterface $provider */
+        $provider = self::getContainer()->get('ux_image.provider');
+
+        self::assertSame('null', $provider->getName());
+    }
+
+    public function testAnUnsetDefaultingEnvPlaceholderDsnFallsBackToTheNullProviderAtRuntime()
+    {
+        self::bootKernel(['environment' => 'default_placeholder']);
+
+        /** @var ProviderInterface $provider */
+        $provider = self::getContainer()->get('ux_image.provider');
+
+        self::assertSame('null', $provider->getName());
+
+        $this->expectException(LogicException::class);
+        $provider->generateUrl(new ImageTransformation('hero.jpg'));
+    }
+
+    public function testAnUnresolvedEnvPlaceholderDsnStillResolvesTheActiveProviderAtRuntime()
+    {
+        putenv('UX_IMAGE_DSN=fake://default');
+        $_ENV['UX_IMAGE_DSN'] = 'fake://default';
+        $_SERVER['UX_IMAGE_DSN'] = 'fake://default';
+
+        self::bootKernel(['environment' => 'env_placeholder']);
+
+        /** @var ProviderInterface $provider */
+        $provider = self::getContainer()->get('ux_image.provider');
+
+        self::assertSame('fake', $provider->getName());
+    }
+
+    public function testTheGlideRouteFileIsImportableWithoutTheGlideBridgeInstalled()
+    {
+        $loader = new PhpFileLoader(new FileLocator(\dirname(__DIR__, 2).'/config/routes'));
+        $routes = $loader->load('glide.php');
+
+        $route = $routes->get('ux_image_glide');
+
+        self::assertNotNull($route);
+        self::assertSame('/{path}', $route->getPath());
+        self::assertSame(GlideController::class, $route->getDefault('_controller'));
+        self::assertSame('.+', $route->getRequirement('path'));
+        self::assertSame(['GET', 'HEAD'], $route->getMethods());
+    }
+}

--- a/src/Image/tests/Provider/DsnTest.php
+++ b/src/Image/tests/Provider/DsnTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Provider\Dsn;
+
+final class DsnTest extends TestCase
+{
+    public function testItParsesAHostOnlyDsn()
+    {
+        $dsn = new Dsn('cloudflare://cdn.example.com');
+
+        self::assertSame('cloudflare', $dsn->getScheme());
+        self::assertSame('cdn.example.com', $dsn->getHost());
+        self::assertNull($dsn->getPath());
+    }
+
+    public function testItParsesADsnWithAPlaceholderHostAPathAndOptions()
+    {
+        $dsn = new Dsn('glide://default/images?source=/app/public/uploads&sign_key=s3cret');
+
+        self::assertSame('glide', $dsn->getScheme());
+        self::assertSame('default', $dsn->getHost());
+        self::assertSame('/images', $dsn->getPath());
+        self::assertSame('/app/public/uploads', $dsn->getOption('source'));
+        self::assertSame('s3cret', $dsn->getOption('sign_key'));
+        self::assertNull($dsn->getOption('cache'));
+        self::assertSame('fallback', $dsn->getOption('cache', 'fallback'));
+    }
+
+    public function testItRejectsADsnWithoutAScheme()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The image provider DSN must contain a scheme.');
+
+        new Dsn('cdn.example.com');
+    }
+
+    public function testItKeepsTheOriginalDsn()
+    {
+        self::assertSame('keycdn://zone.kxcdn.com', new Dsn('keycdn://zone.kxcdn.com')->getOriginalDsn());
+    }
+
+    public function testItParsesASchemeOnlyDsnWithoutAHost()
+    {
+        $dsn = new Dsn('cloudflare:');
+
+        self::assertSame('cloudflare', $dsn->getScheme());
+        self::assertNull($dsn->getHost());
+        self::assertNull($dsn->getPath());
+    }
+
+    public function testItRejectsAnEmptyAuthorityDsn()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The image provider DSN is invalid.');
+
+        new Dsn('glide:///images');
+    }
+}

--- a/src/Image/tests/Provider/NullProviderTest.php
+++ b/src/Image/tests/Provider/NullProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Exception\LogicException;
+use Symfony\UX\Image\ImageTransformation;
+use Symfony\UX\Image\Provider\NullProvider;
+
+final class NullProviderTest extends TestCase
+{
+    public function testGenerateUrlThrowsAndNamesTheInstallableBridges()
+    {
+        $provider = new NullProvider();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('symfony/ux-glide-image');
+        $this->expectExceptionMessageMatches('/symfony\/ux-keycdn-image/');
+        $this->expectExceptionMessageMatches('/symfony\/ux-cloudflare-image/');
+
+        $provider->generateUrl(new ImageTransformation('/foo.png'));
+    }
+}

--- a/src/Image/tests/Provider/PathEncoderTest.php
+++ b/src/Image/tests/Provider/PathEncoderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Provider\PathEncoder;
+
+final class PathEncoderTest extends TestCase
+{
+    #[DataProvider('providePaths')]
+    public function testEncode(string $input, string $expected)
+    {
+        $this->assertSame($expected, PathEncoder::encode($input));
+    }
+
+    public static function providePaths(): iterable
+    {
+        yield 'plain path' => ['hero.jpg', 'hero.jpg'];
+        yield 'path with subdirectory' => ['images/hero.jpg', 'images/hero.jpg'];
+        yield 'path with space' => ['hero image.jpg', 'hero%20image.jpg'];
+        yield 'path segment with question mark' => ['a?b=1/hero.jpg', 'a%3Fb%3D1/hero.jpg'];
+        yield 'leading slash is stripped' => ['/hero.jpg', 'hero.jpg'];
+        yield 'multiple leading slashes' => ['///hero.jpg', 'hero.jpg'];
+        yield 'leading slash with space' => ['/hero image.jpg', 'hero%20image.jpg'];
+    }
+}

--- a/src/Image/tests/Provider/ProviderResolverTest.php
+++ b/src/Image/tests/Provider/ProviderResolverTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Exception\UnsupportedSchemeException;
+use Symfony\UX\Image\Provider\ProviderResolver;
+use Symfony\UX\Image\Tests\Fixtures\FakeProvider;
+use Symfony\UX\Image\Tests\Fixtures\FakeProviderFactory;
+
+final class ProviderResolverTest extends TestCase
+{
+    public function testItResolvesADsnToTheMatchingProvider()
+    {
+        $resolver = new ProviderResolver([new FakeProviderFactory()]);
+
+        self::assertInstanceOf(FakeProvider::class, $resolver->fromString('fake://default'));
+    }
+
+    public function testItThrowsWhenNoFactorySupportsTheScheme()
+    {
+        $resolver = new ProviderResolver([new FakeProviderFactory()]);
+
+        $this->expectException(UnsupportedSchemeException::class);
+
+        $resolver->fromString('unknown://default');
+    }
+}

--- a/src/Image/tests/Renderer/ImageRendererTest.php
+++ b/src/Image/tests/Renderer/ImageRendererTest.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Exception\LogicException;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Provider\NullProvider;
+use Symfony\UX\Image\Renderer\ImageRenderer;
+use Symfony\UX\Image\Renderer\LayoutResolver;
+use Symfony\UX\Image\Renderer\RenderOptions;
+use Symfony\UX\Image\Tests\Fixtures\FakeProvider;
+
+final class ImageRendererTest extends TestCase
+{
+    public function testAnAutoFormatProviderProducesNoSources()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', 'Hero', new RenderOptions(width: 400, height: 300));
+
+        self::assertSame([], $rendered->sources);
+        self::assertSame('Hero', $rendered->imgAttributes['alt']);
+    }
+
+    public function testItBuildsASrcsetFromTheDerivedBreakpoints()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::Fixed, width: 400));
+
+        self::assertSame('/hero.jpg?w=400&fm=auto 400w, /hero.jpg?w=800&fm=auto 800w', $rendered->imgAttributes['srcset']);
+    }
+
+    public function testSrcsetEntriesCarryAPerBreakpointHeightWhenTheRatioIsKnown()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::Fixed, width: 800, height: 450));
+
+        self::assertSame(
+            '/hero.jpg?w=800&fm=auto&h=450 800w, /hero.jpg?w=1600&fm=auto&h=900 1600w',
+            $rendered->imgAttributes['srcset'],
+        );
+    }
+
+    public function testSrcsetEntriesCarryNoHeightWhenTheRatioIsUnknown()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::FullWidth, height: 600));
+
+        self::assertStringNotContainsString('&h=', $rendered->imgAttributes['srcset']);
+    }
+
+    public function testSrcAndSrcsetAgreeOnCarryingNoHeightWhenTheRatioIsUnknown()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::FullWidth, height: 600));
+
+        self::assertStringNotContainsString('h=', $rendered->imgAttributes['src']);
+        self::assertStringNotContainsString('&h=', $rendered->imgAttributes['srcset']);
+    }
+
+    public function testItCarriesTheLayoutSizesAndStyle()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(width: 800, height: 450));
+
+        self::assertSame('(min-width: 800px) 800px, 100vw', $rendered->imgAttributes['sizes']);
+        self::assertStringContainsString('aspect-ratio: 800 / 450', $rendered->imgAttributes['style']->getValue());
+    }
+
+    public function testTheCssObjectFitMirrorsTheRequestedFitSoTheProviderCropIsNotRedoneByTheBrowser()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(width: 400, height: 400, fit: Fit::Contain));
+
+        self::assertStringContainsString('object-fit: contain', $rendered->imgAttributes['style']->getValue());
+    }
+
+    public function testScaleDownAlsoReachesTheCss()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(width: 400, height: 400, fit: Fit::ScaleDown));
+
+        self::assertStringContainsString('object-fit: scale-down', $rendered->imgAttributes['style']->getValue());
+    }
+
+    public function testAnExplicitObjectFitStillWinsOverTheOneDerivedFromFit()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(width: 400, height: 400, fit: Fit::Contain, objectFit: 'none'));
+
+        self::assertStringContainsString('object-fit: none', $rendered->imgAttributes['style']->getValue());
+        self::assertStringNotContainsString('object-fit: contain', $rendered->imgAttributes['style']->getValue());
+    }
+
+    public function testWithoutAFitTheCssStillDefaultsToCover()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::FullWidth, height: 600));
+
+        self::assertStringContainsString('object-fit: cover', $rendered->imgAttributes['style']->getValue());
+    }
+
+    public function testPriorityFlipsTheLoadingHints()
+    {
+        $lazy = $this->renderer()->render('hero.jpg', '', new RenderOptions(width: 800));
+        $eager = $this->renderer()->render('hero.jpg', '', new RenderOptions(width: 800, priority: true));
+
+        self::assertSame('lazy', $lazy->imgAttributes['loading']);
+        self::assertSame('auto', $lazy->imgAttributes['fetchpriority']);
+        self::assertSame('eager', $eager->imgAttributes['loading']);
+        self::assertSame('high', $eager->imgAttributes['fetchpriority']);
+    }
+
+    public function testAProviderWithoutAutoFormatProducesOneSourcePerFormat()
+    {
+        $renderer = new ImageRenderer(new FakeProvider(autoFormat: false), new LayoutResolver(), ['avif', 'webp', 'jpeg']);
+
+        $rendered = $renderer->render('hero.jpg', '', new RenderOptions(layout: Layout::Fixed, width: 400));
+
+        self::assertCount(3, $rendered->sources);
+        self::assertSame('image/avif', $rendered->sources[0]['type']);
+        self::assertSame('image/webp', $rendered->sources[1]['type']);
+        self::assertSame('image/jpeg', $rendered->sources[2]['type']);
+        self::assertStringContainsString('fm=avif', $rendered->sources[0]['srcset']);
+        self::assertStringContainsString('fm=jpeg', $rendered->imgAttributes['src']);
+        self::assertStringContainsString('fm=jpeg', $rendered->imgAttributes['srcset']);
+    }
+
+    public function testFormatsAreIntersectedWithWhatTheProviderSupports()
+    {
+        $renderer = new ImageRenderer(new FakeProvider(autoFormat: false), new LayoutResolver(), ['avif', 'tiff', 'jpeg']);
+
+        $rendered = $renderer->render('hero.jpg', '', new RenderOptions(layout: Layout::Fixed, width: 400));
+
+        self::assertCount(2, $rendered->sources);
+    }
+
+    public function testTheSourceOrderComesFromTheConfiguredFormatsNotTheProvider()
+    {
+        $renderer = new ImageRenderer(new FakeProvider(autoFormat: false), new LayoutResolver(), ['jpeg', 'avif']);
+
+        $rendered = $renderer->render('hero.jpg', '', new RenderOptions(layout: Layout::Fixed, width: 400));
+
+        self::assertSame(['image/jpeg', 'image/avif'], array_column($rendered->sources, 'type'));
+        self::assertStringContainsString('fm=avif', $rendered->imgAttributes['src']);
+    }
+
+    public function testItThrowsWhenTheConfiguredFormatsAndTheProviderShareNothing()
+    {
+        $renderer = new ImageRenderer(new FakeProvider(autoFormat: false), new LayoutResolver(), ['tiff', 'heic']);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('None of the configured formats ("tiff", "heic") are supported by the "fake" provider (supported: "avif", "webp", "jpeg").');
+
+        $renderer->render('hero.jpg', '', new RenderOptions(layout: Layout::Fixed, width: 400));
+    }
+
+    public function testAnExplicitFormatPinsTheOutputAndSuppressesTheAutoFormat()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::Fixed, width: 400, format: 'webp'));
+
+        self::assertSame([], $rendered->sources);
+        self::assertStringContainsString('fm=webp', $rendered->imgAttributes['src']);
+        self::assertStringContainsString('fm=webp', $rendered->imgAttributes['srcset']);
+        self::assertStringNotContainsString('fm=auto', $rendered->imgAttributes['srcset']);
+    }
+
+    public function testAnExplicitFormatSuppressesThePictureSourcesToo()
+    {
+        $renderer = new ImageRenderer(new FakeProvider(autoFormat: false), new LayoutResolver(), ['avif', 'webp', 'jpeg']);
+
+        $rendered = $renderer->render('hero.jpg', '', new RenderOptions(layout: Layout::Fixed, width: 400, format: 'jpeg'));
+
+        self::assertSame([], $rendered->sources);
+        self::assertStringContainsString('fm=jpeg', $rendered->imgAttributes['src']);
+    }
+
+    public function testItRejectsAnExplicitFormatTheProviderCannotProduce()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The image format "tiff" is not supported by the "fake" provider (supported: "avif", "webp", "jpeg").');
+
+        $this->renderer()->render('hero.jpg', '', new RenderOptions(width: 400, format: 'tiff'));
+    }
+
+    public function testAPinnedFormatOnAnUnconfiguredProviderFailsWithTheInstallABridgeMessageNotAFormatMismatch()
+    {
+        $renderer = new ImageRenderer(new NullProvider(), new LayoutResolver());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('No image provider is configured. Install a bridge such as "symfony/ux-glide-image", "symfony/ux-keycdn-image" or "symfony/ux-cloudflare-image".');
+
+        $renderer->render('hero.jpg', '', new RenderOptions(width: 400, format: 'webp'));
+    }
+
+    public function testItPassesOnlyTheActiveProviderOperations()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(
+            layout: Layout::Fixed,
+            width: 400,
+            operations: ['fake' => ['sharpen' => 3], 'cloudflare' => ['gravity' => 'auto']],
+        ));
+
+        self::assertStringContainsString('sharpen=3', $rendered->imgAttributes['src']);
+        self::assertStringNotContainsString('gravity', $rendered->imgAttributes['src']);
+    }
+
+    public function testItRejectsAnUnknownOperationForTheActiveProvider()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The image operation "gravity" is not supported by the "fake" provider (supported: "sharpen").');
+
+        $this->renderer()->render('hero.jpg', '', new RenderOptions(width: 400, operations: ['fake' => ['gravity' => 'auto']]));
+    }
+
+    public function testItRejectsAFixedLayoutWithoutAWidth()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "fixed" layout requires a width.');
+
+        new RenderOptions(layout: Layout::Fixed);
+    }
+
+    public function testItRejectsAConstrainedLayoutWithoutAWidth()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "constrained" layout requires a width.');
+
+        new RenderOptions(layout: Layout::Constrained);
+    }
+
+    public function testItRejectsAFullWidthLayoutWithoutAHeight()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "full-width" layout requires a height.');
+
+        new RenderOptions(layout: Layout::FullWidth);
+    }
+
+    public function testFullWidthLayoutDoesNotRequireAWidth()
+    {
+        $options = new RenderOptions(layout: Layout::FullWidth, height: 600);
+
+        self::assertNull($options->width);
+    }
+
+    public function testFullWidthRendersWithoutAWidth()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::FullWidth, height: 600));
+
+        self::assertNotSame('', $rendered->imgAttributes['srcset']);
+        self::assertStringContainsString('6016w', $rendered->imgAttributes['srcset']);
+        self::assertSame('100vw', $rendered->imgAttributes['sizes']);
+        self::assertArrayNotHasKey('width', $rendered->imgAttributes);
+        self::assertStringContainsString('height: 600px', $rendered->imgAttributes['style']->getValue());
+    }
+
+    public function testFullWidthSrcDoesNotFallBackToTheTopOfTheResolutionLadder()
+    {
+        $rendered = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::FullWidth, height: 600, format: 'webp'));
+
+        self::assertStringNotContainsString('w=', $rendered->imgAttributes['src']);
+        self::assertSame('/hero.jpg?fm=webp', $rendered->imgAttributes['src']);
+    }
+
+    public function testFixedAndConstrainedSrcKeepTheirOwnWidthRegardlessOfTheFullWidthFallback()
+    {
+        $fixed = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::Fixed, width: 400));
+        $constrained = $this->renderer()->render('hero.jpg', '', new RenderOptions(layout: Layout::Constrained, width: 400));
+
+        self::assertStringContainsString('w=400', $fixed->imgAttributes['src']);
+        self::assertStringContainsString('w=400', $constrained->imgAttributes['src']);
+    }
+
+    private function renderer(): ImageRenderer
+    {
+        return new ImageRenderer(new FakeProvider(), new LayoutResolver(), ['avif', 'webp', 'jpeg']);
+    }
+}

--- a/src/Image/tests/Renderer/LayoutResolverTest.php
+++ b/src/Image/tests/Renderer/LayoutResolverTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Renderer;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Renderer\LayoutResolver;
+
+final class LayoutResolverTest extends TestCase
+{
+    public function testFixedGivesOneAndTwoTimesTheWidth()
+    {
+        self::assertSame([400, 800], new LayoutResolver()->breakpoints(Layout::Fixed, 400));
+    }
+
+    public function testConstrainedAddsTheLadderEntriesBelowTwiceTheWidth()
+    {
+        self::assertSame(
+            [640, 750, 800, 828, 960, 1080, 1280, 1600],
+            new LayoutResolver()->breakpoints(Layout::Constrained, 800),
+        );
+    }
+
+    public function testFullWidthGivesTheWholeLadderAscending()
+    {
+        $breakpoints = new LayoutResolver()->breakpoints(Layout::FullWidth, null);
+
+        self::assertSame(640, $breakpoints[0]);
+        self::assertSame(6016, $breakpoints[\count($breakpoints) - 1]);
+        self::assertCount(\count(LayoutResolver::DEFAULT_RESOLUTIONS), $breakpoints);
+    }
+
+    public function testFullWidthUsesTheInjectedResolutionsInsteadOfTheDefaultLadder()
+    {
+        self::assertSame([400, 800, 1600], new LayoutResolver([1600, 800, 400])->breakpoints(Layout::FullWidth, null));
+    }
+
+    public function testConstrainedFiltersTheInjectedResolutions()
+    {
+        self::assertSame([400, 500, 800, 1000], new LayoutResolver([1600, 800, 500, 400])->breakpoints(Layout::Constrained, 500));
+    }
+
+    public function testFixedIgnoresTheInjectedResolutions()
+    {
+        self::assertSame([400, 800], new LayoutResolver([1600, 1200])->breakpoints(Layout::Fixed, 400));
+    }
+
+    public function testConstrainedWithoutAWidthGivesNothing()
+    {
+        self::assertSame([], new LayoutResolver()->breakpoints(Layout::Constrained, null));
+    }
+
+    #[DataProvider('provideSizes')]
+    public function testSizes(Layout $layout, ?int $width, ?string $expected)
+    {
+        self::assertSame($expected, new LayoutResolver()->sizes($layout, $width));
+    }
+
+    public static function provideSizes(): iterable
+    {
+        yield 'fixed' => [Layout::Fixed, 400, '400px'];
+        yield 'constrained' => [Layout::Constrained, 800, '(min-width: 800px) 800px, 100vw'];
+        yield 'full width' => [Layout::FullWidth, null, '100vw'];
+        yield 'constrained without width' => [Layout::Constrained, null, null];
+    }
+
+    public function testFixedStyle()
+    {
+        self::assertSame(
+            ['object-fit' => 'cover', 'width' => '120px', 'height' => '40px'],
+            new LayoutResolver()->style(Layout::Fixed, 120, 40),
+        );
+    }
+
+    public function testConstrainedStyle()
+    {
+        self::assertSame(
+            [
+                'object-fit' => 'cover',
+                'max-width' => '800px',
+                'max-height' => '450px',
+                'aspect-ratio' => '800 / 450',
+                'width' => '100%',
+                'height' => 'auto',
+            ],
+            new LayoutResolver()->style(Layout::Constrained, 800, 450),
+        );
+    }
+
+    public function testFullWidthStyleWithADerivableRatioEmitsTheRatioAndAnAutoHeight()
+    {
+        self::assertSame(
+            ['object-fit' => 'cover', 'width' => '100%', 'aspect-ratio' => '800 / 450', 'height' => 'auto'],
+            new LayoutResolver()->style(Layout::FullWidth, 800, 450),
+        );
+    }
+
+    public function testFullWidthStyleWithOnlyAHeightEmitsTheHeightAndNoRatio()
+    {
+        self::assertSame(
+            ['object-fit' => 'cover', 'width' => '100%', 'height' => '450px'],
+            new LayoutResolver()->style(Layout::FullWidth, null, 450),
+        );
+    }
+
+    public function testStyleOmitsAspectRatioWhenADimensionIsMissing()
+    {
+        self::assertArrayNotHasKey('aspect-ratio', new LayoutResolver()->style(Layout::Constrained, 800, null));
+    }
+
+    #[DataProvider('provideLayoutsWithARatio')]
+    public function testAnyStyleWithAnAspectRatioAlsoDeclaresAnAutoHeight(Layout $layout)
+    {
+        $style = new LayoutResolver()->style($layout, 800, 450);
+
+        self::assertArrayHasKey('aspect-ratio', $style);
+        self::assertSame('auto', $style['height'] ?? null);
+    }
+
+    public static function provideLayoutsWithARatio(): iterable
+    {
+        yield 'constrained' => [Layout::Constrained];
+        yield 'full width' => [Layout::FullWidth];
+    }
+
+    public function testObjectFitIsOverridable()
+    {
+        self::assertSame('contain', new LayoutResolver()->style(Layout::Fixed, 120, 40, 'contain')['object-fit']);
+    }
+}

--- a/src/Image/tests/Renderer/RenderOptionsTest.php
+++ b/src/Image/tests/Renderer/RenderOptionsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Renderer\RenderOptions;
+
+final class RenderOptionsTest extends TestCase
+{
+    public function testBothDimensionsDefaultFitToCover()
+    {
+        $options = new RenderOptions(width: 800, height: 450);
+
+        self::assertSame(Fit::Cover, $options->fit);
+    }
+
+    public function testOnlyAWidthLeavesFitNull()
+    {
+        $options = new RenderOptions(layout: Layout::Fixed, width: 800);
+
+        self::assertNull($options->fit);
+    }
+
+    public function testOnlyAHeightLeavesFitNull()
+    {
+        $options = new RenderOptions(layout: Layout::FullWidth, height: 450);
+
+        self::assertNull($options->fit);
+    }
+
+    public function testAnExplicitFitIsNeverOverridden()
+    {
+        $options = new RenderOptions(width: 800, height: 450, fit: Fit::Contain);
+
+        self::assertSame(Fit::Contain, $options->fit);
+    }
+}

--- a/src/Image/tests/Twig/ImageComponentTest.php
+++ b/src/Image/tests/Twig/ImageComponentTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Twig;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Tests\Fixtures\TestKernel;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
+
+final class ImageComponentTest extends KernelTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    public function testItRendersASingleImgForAnAutoFormatProvider()
+    {
+        $html = $this->renderComponent(['src' => '/hero.jpg', 'alt' => 'Hero', 'width' => 800, 'height' => 450]);
+
+        self::assertStringStartsWith('<img ', $html);
+        self::assertStringContainsString('alt="Hero"', $html);
+        self::assertStringContainsString('aspect-ratio: 800 / 450', $html);
+    }
+
+    public function testItRendersAPictureForAProviderWithoutAutoFormat()
+    {
+        $html = $this->renderComponent(['src' => '/hero.jpg', 'alt' => '', 'width' => 800], autoFormat: false);
+
+        self::assertStringStartsWith('<picture>', $html);
+        self::assertStringContainsString('<source type="image/avif"', $html);
+        self::assertStringContainsString('<source type="image/webp"', $html);
+        self::assertStringContainsString('<source type="image/jpeg"', $html);
+        self::assertStringContainsString('</picture>', $html);
+    }
+
+    public function testAnExplicitFormatPropRendersASingleImgInsteadOfAPicture()
+    {
+        $html = $this->renderComponent(['src' => '/hero.jpg', 'alt' => '', 'width' => 800, 'format' => 'webp'], autoFormat: false);
+
+        self::assertStringStartsWith('<img ', $html);
+        self::assertStringNotContainsString('<source', $html);
+        self::assertStringNotContainsString('format="webp"', $html);
+        self::assertStringContainsString('fm=webp', $html);
+    }
+
+    public function testCallerAttributesAreRendered()
+    {
+        $html = $this->renderComponent(['src' => '/hero.jpg', 'alt' => '', 'width' => 800, 'class' => 'rounded', 'data-test' => '1']);
+
+        self::assertStringContainsString('class="rounded"', $html);
+        self::assertStringContainsString('data-test="1"', $html);
+    }
+
+    public function testACallerStyleMergesIntoTheLayoutStyle()
+    {
+        $html = $this->renderComponent(['src' => '/hero.jpg', 'alt' => '', 'width' => 800, 'height' => 450, 'style' => ['border-radius' => '8px']]);
+
+        self::assertStringContainsString('aspect-ratio: 800 / 450', $html);
+        self::assertStringContainsString('border-radius: 8px', $html);
+    }
+
+    public function testACallerStringStyleMergesIntoTheLayoutStyle()
+    {
+        $html = $this->renderComponent(['src' => '/hero.jpg', 'alt' => '', 'width' => 800, 'height' => 450, 'style' => 'border-radius: 8px']);
+
+        self::assertStringContainsString('aspect-ratio: 800 / 450', $html);
+        self::assertStringContainsString('border-radius: 8px', $html);
+    }
+
+    public function testACallerSizesOverridesEverySourceAndTheImgInThePictureBranch()
+    {
+        $html = $this->renderComponent(['src' => '/hero.jpg', 'alt' => '', 'width' => 800, 'sizes' => '50vw'], autoFormat: false);
+
+        self::assertSame(4, substr_count($html, 'sizes="50vw"'));
+        self::assertStringNotContainsString('100vw', $html);
+    }
+
+    public function testAnInvalidLayoutFailsClearly()
+    {
+        try {
+            $this->renderComponent(['src' => '/hero.jpg', 'alt' => '', 'width' => 800, 'layout' => 'not-a-layout']);
+            self::fail('Expected a RuntimeError to be thrown.');
+        } catch (RuntimeError $e) {
+            self::assertInstanceOf(InvalidArgumentException::class, $e->getPrevious());
+            self::assertSame('Invalid "layout" value "not-a-layout": expected one of "fixed", "constrained", "full-width".', $e->getPrevious()->getMessage());
+        }
+    }
+
+    private function renderComponent(array $props, bool $autoFormat = true): string
+    {
+        self::bootKernel(['environment' => $autoFormat ? 'test' : 'no_auto_format']);
+
+        /** @var Environment $twig */
+        $twig = self::getContainer()->get('twig');
+
+        return trim($twig->createTemplate('{{ component("ux:image", props) }}')->render(['props' => $props]));
+    }
+}

--- a/src/Image/tests/Twig/ImageRuntimeTest.php
+++ b/src/Image/tests/Twig/ImageRuntimeTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Twig;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Tests\Fixtures\TestKernel;
+use Symfony\UX\Image\Twig\ImageExtension;
+use Symfony\UX\Image\Twig\ImageRuntime;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
+
+final class ImageRuntimeTest extends KernelTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    public function testTheExtensionAndRuntimeAreRegistered()
+    {
+        self::bootKernel();
+
+        /** @var Environment $twig */
+        $twig = self::getContainer()->get('twig');
+
+        self::assertTrue($twig->hasExtension(ImageExtension::class));
+        self::assertInstanceOf(ImageRuntime::class, $twig->getRuntime(ImageRuntime::class));
+    }
+
+    public function testItDoesNotRegisterAGlobalHtmlAttrTypeFilter()
+    {
+        // The layout style is built as an InlineStyle in PHP, so we don't need to publish twig/html-extra's filter into every app.
+        self::bootKernel();
+
+        /** @var Environment $twig */
+        $twig = self::getContainer()->get('twig');
+
+        self::assertArrayNotHasKey('html_attr_type', $twig->getFilters());
+    }
+
+    public function testItRendersASingleImgForAnAutoFormatProvider()
+    {
+        $html = $this->renderFunction('/hero.jpg', 'Hero', ['width' => 800, 'height' => 450]);
+
+        self::assertStringStartsWith('<img ', $html);
+        self::assertStringContainsString('alt="Hero"', $html);
+        self::assertStringContainsString('aspect-ratio: 800 / 450', $html);
+    }
+
+    public function testItRendersAPictureForAProviderWithoutAutoFormat()
+    {
+        $html = $this->renderFunction('/hero.jpg', '', ['width' => 800], autoFormat: false);
+
+        self::assertStringStartsWith('<picture>', $html);
+        self::assertStringContainsString('<source type="image/avif"', $html);
+    }
+
+    public function testAnExplicitFormatOptionIsAccepted()
+    {
+        $html = $this->renderFunction('/hero.jpg', '', ['width' => 800, 'format' => 'webp'], autoFormat: false);
+
+        self::assertStringStartsWith('<img ', $html);
+        self::assertStringContainsString('fm=webp', $html);
+    }
+
+    public function testAnUnknownOptionFailsClearlyInsteadOfARawPhpError()
+    {
+        try {
+            $this->renderFunction('/hero.jpg', '', ['width' => 800, 'class' => 'rounded']);
+            self::fail('Expected a RuntimeError to be thrown.');
+        } catch (RuntimeError $e) {
+            self::assertInstanceOf(InvalidArgumentException::class, $e->getPrevious());
+            self::assertStringStartsWith('Unknown image option "class": expected one of "layout"', $e->getPrevious()->getMessage());
+        }
+    }
+
+    public function testAnInvalidLayoutFailsClearly()
+    {
+        try {
+            $this->renderFunction('/hero.jpg', '', ['layout' => 'not-a-layout']);
+            self::fail('Expected a RuntimeError to be thrown.');
+        } catch (RuntimeError $e) {
+            self::assertInstanceOf(InvalidArgumentException::class, $e->getPrevious());
+            self::assertSame('Invalid "layout" value "not-a-layout": expected one of "fixed", "constrained", "full-width".', $e->getPrevious()->getMessage());
+        }
+    }
+
+    private function renderFunction(string $src, string $alt, array $options = [], bool $autoFormat = true): string
+    {
+        self::bootKernel(['environment' => $autoFormat ? 'test' : 'no_auto_format']);
+
+        /** @var Environment $twig */
+        $twig = self::getContainer()->get('twig');
+
+        return trim($twig->createTemplate('{{ ux_image(src, alt, options) }}')->render([
+            'src' => $src,
+            'alt' => $alt,
+            'options' => $options,
+        ]));
+    }
+}

--- a/src/Image/tests/Twig/RenderOptionsFactoryTest.php
+++ b/src/Image/tests/Twig/RenderOptionsFactoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\Exception\InvalidArgumentException;
+use Symfony\UX\Image\Fit;
+use Symfony\UX\Image\Layout;
+use Symfony\UX\Image\Twig\RenderOptionsFactory;
+
+final class RenderOptionsFactoryTest extends TestCase
+{
+    public function testItConvertsTheLayoutAndFitStringsToEnums()
+    {
+        $options = RenderOptionsFactory::create(layout: 'fixed', width: 400, fit: 'contain');
+
+        self::assertSame(Layout::Fixed, $options->layout);
+        self::assertSame(Fit::Contain, $options->fit);
+    }
+
+    public function testFitStaysNullWhenNotProvided()
+    {
+        $options = RenderOptionsFactory::create(width: 400);
+
+        self::assertNull($options->fit);
+    }
+
+    public function testItCarriesAnExplicitFormat()
+    {
+        self::assertSame('webp', RenderOptionsFactory::create(width: 400, format: 'webp')->format);
+    }
+
+    public function testAnUnknownOptionKeyFailsClearly()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown image option "class": expected one of "layout", "width", "height", "fit", "format", "quality", "priority", "objectFit", "breakpoints", "operations".');
+
+        RenderOptionsFactory::createFromArray(['width' => 400, 'class' => 'rounded']);
+    }
+
+    public function testAnInvalidLayoutFailsClearly()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "layout" value "not-a-layout": expected one of "fixed", "constrained", "full-width".');
+
+        RenderOptionsFactory::create(layout: 'not-a-layout', width: 400);
+    }
+
+    public function testAnInvalidFitFailsClearly()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "fit" value "not-a-fit": expected one of "cover", "contain", "scale-down".');
+
+        RenderOptionsFactory::create(width: 400, fit: 'not-a-fit');
+    }
+}

--- a/src/Image/tests/UXImageBundleTest.php
+++ b/src/Image/tests/UXImageBundleTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\Image\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\Image\UXImageBundle;
+
+final class UXImageBundleTest extends TestCase
+{
+    public function testBundleHasTheExpectedExtensionAlias()
+    {
+        self::assertSame('ux_image', new UXImageBundle()->getContainerExtension()->getAlias());
+    }
+}

--- a/src/Image/tests/bootstrap.php
+++ b/src/Image/tests/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | yes <!-- required for new features, or documentation updates -->
| Issues         | Fix #3834 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Implements https://github.com/symfony/ux/issues/3834, replaces #3188, #3549, #3765, #3768. The RFC has the prior art and the reasoning; this is the implementation.

UX Image renders responsive images by delegating every transformation to a URL-driven provider, so the package itself never decodes, resizes or encodes an image. 
A DSN picks the provider at runtime, the way `symfony/ux-map` picks a renderer, which turns "local in dev, CDN in prod" into an environment variable rather than a code change.

```yaml
ux_image:
    provider: '%env(resolve:UX_IMAGE_DSN)%'
```

```twig
<twig:ux:image src="/uploads/hero.jpg" alt="Hero" width="800" height="450" />
```

## How it fits together

```mermaid
flowchart TD
    A["Template<br/>#60;twig:ux:image src alt width height layout /#62;"] --> B["Image component"]
    B --> C["RenderOptions"]
    C --> D["ImageRenderer"]
    L["LayoutResolver<br/>resolutions, sizes, inline style"] --> D
    D -- "path, width, height, fit, format, quality" --> E["Provider"]
    S["ux_image.provider DSN"] --> R["ProviderResolver"]
    R --> F["Glide, Cloudflare or KeyCDN bridge"]
    F -- "builds" --> E
    E -- "one URL per breakpoint and per format" --> G["RenderedImage"]
    G --> H["Image.html.twig"]
    H -- "provider negotiates the format" --> I["#60;img#62; + srcset + sizes"]
    H -- "it does not" --> J["#60;picture#62; + one #60;source#62; per format"]
```

`<twig:ux:image>` (or the `ux_image()` Twig function) collects its props into a `RenderOptions` object and hands it to `ImageRenderer`. `LayoutResolver` turns the layout into a breakpoint ladder, a `sizes` attribute and the inline `style`. The renderer asks the provider for one URL per breakpoint and per format, and returns a `RenderedImage` the template prints as `<img>`, or as `<picture>` when the provider can't negotiate the format on its own. `ComponentAttributes` and `twig/html-extra` write the attributes out, so the package has no `htmlspecialchars()` call of its own.

The provider itself is built once from the DSN: `ProviderResolver` walks the registered `ProviderFactoryInterface` services and the first one that recognizes the scheme wins. That factory is the whole surface a bridge has to implement.

Three bridges ship with it: `symfony/ux-glide-image` for local, no-CDN use, plus `symfony/ux-cloudflare-image` and `symfony/ux-keycdn-image` for CDN uses. 

---

Opened Recipes PR: https://github.com/symfony/recipes/pull/1571