### PR TITLE
[CI] Add void return type to PHPUnit test methods

### DIFF
--- a/.github/workflows/fabbot.yaml
+++ b/.github/workflows/fabbot.yaml
@@ -10,7 +10,8 @@ jobs:
         name: Fabbot
         permissions:
             contents: read
-        uses: symfony-tools/fabbot/.github/workflows/fabbot.yml@ad55ed5ac95aaa9794c60473178a007b342a73b4 # main
+        uses: symfony-tools/fabbot/.github/workflows/fabbot.yml@93bbf91e340fd0b35d12e412c82a3a927465050e # main
         with:
             package: Symfony UX
             check_license: true
+            check_test_return_type: false

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -51,21 +51,11 @@ return (new PhpCsFixer\Config())
         {
             return [
                 'void_return' => static function (SplFileInfo $file) {
-                    // temporary hack due to bug: https://github.com/symfony/symfony/issues/62734
-                    if (!$file instanceof Symfony\Component\Finder\SplFileInfo) {
-                        return false;
-                    }
+                    // parallel workers pass a plain SplFileInfo, which has no getRelativePathname()
+                    $pathname = str_replace('\\', '/', $file->getPathname());
 
-                    $relativePathname = $file->getRelativePathname();
-
-                    if (
-                        str_contains($relativePathname, '/tests/') // don't touch test files, as massive change with little benefit - as outside of public contract anyway
-                        || str_contains($relativePathname, '/Test/') // public namespace not following the rule, do not mistake it with `/Tests/`
-                    ) {
-                        return false;
-                    }
-
-                    return true;
+                    // `src/*/src/Test/` ships test helpers meant to be extended by users, adding a native return type there would break their subclasses
+                    return !str_contains($pathname, '/src/Test/');
                 },
             ];
         }

--- a/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
+++ b/src/Autocomplete/tests/Functional/AutocompleteFormRenderingTest.php
@@ -25,7 +25,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
     use HasBrowser;
     use ResetDatabase;
 
-    public function testFieldsRenderWithStimulusController()
+    public function testFieldsRenderWithStimulusController(): void
     {
         $this->browser()
             ->throwExceptions()
@@ -44,7 +44,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
         ;
     }
 
-    public function testCategoryFieldSubmitsCorrectly()
+    public function testCategoryFieldSubmitsCorrectly(): void
     {
         $firstCat = CategoryFactory::createOne(['name' => 'First cat']);
         CategoryFactory::createOne(['name' => 'in space']);
@@ -78,7 +78,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
         ;
     }
 
-    public function testProperlyLoadsChoicesWithIdValueObjects()
+    public function testProperlyLoadsChoicesWithIdValueObjects(): void
     {
         $ingredient1 = IngredientFactory::createOne(['name' => 'Flour']);
         $ingredient2 = IngredientFactory::createOne(['name' => 'Sugar']);
@@ -106,7 +106,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
         ;
     }
 
-    public function testMultipleDoesNotFailWithoutSelectedChoices()
+    public function testMultipleDoesNotFailWithoutSelectedChoices(): void
     {
         $this->browser()
             ->throwExceptions()
@@ -127,7 +127,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
         ;
     }
 
-    public function testItUsesPassedExtraOptions()
+    public function testItUsesPassedExtraOptions(): void
     {
         $ingredient1 = IngredientFactory::createOne(['name' => 'Flour']);
         $ingredient2 = IngredientFactory::createOne(['name' => 'Sugar']);
@@ -160,7 +160,7 @@ class AutocompleteFormRenderingTest extends KernelTestCase
         ;
     }
 
-    public function testItReturnsErrorWhenSendingMalformedExtraOptions()
+    public function testItReturnsErrorWhenSendingMalformedExtraOptions(): void
     {
         $extraOptionsWithoutChecksum = $this->encodeData(['foo' => 'bar']);
         $extraOptionsWithInvalidChecksum = $this->encodeData(['foo' => 'bar', '@checksum' => 'invalid']);

--- a/src/Autocomplete/tests/Functional/CustomAutocompleterTest.php
+++ b/src/Autocomplete/tests/Functional/CustomAutocompleterTest.php
@@ -25,7 +25,7 @@ class CustomAutocompleterTest extends KernelTestCase
     use HasBrowser;
     use ResetDatabase;
 
-    public function testItReturnsBasicResults()
+    public function testItReturnsBasicResults(): void
     {
         $product = ProductFactory::createOne(['name' => 'foo']);
         ProductFactory::createOne(['name' => 'bar']);
@@ -43,7 +43,7 @@ class CustomAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItUsesTheCustomQuery()
+    public function testItUsesTheCustomQuery(): void
     {
         ProductFactory::createOne(['name' => 'foo']);
         ProductFactory::new(['name' => 'foo and bar'])
@@ -59,7 +59,7 @@ class CustomAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItOnlySearchedOnSearchableFields()
+    public function testItOnlySearchedOnSearchableFields(): void
     {
         ProductFactory::createOne(['name' => 'foo', 'price' => 50]);
         ProductFactory::createOne(['name' => 'bar', 'description' => 'foo 50', 'price' => 55]);
@@ -77,7 +77,7 @@ class CustomAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItEnforcesSecurity()
+    public function testItEnforcesSecurity(): void
     {
         ProductFactory::createMany(3);
 
@@ -97,7 +97,7 @@ class CustomAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItReturns404OnBadAlias()
+    public function testItReturns404OnBadAlias(): void
     {
         $this->browser()
             ->get('/test/autocomplete/not_real')
@@ -105,7 +105,7 @@ class CustomAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItWorksWithCustomRoute()
+    public function testItWorksWithCustomRoute(): void
     {
         $product = ProductFactory::createOne(['name' => 'foo']);
         ProductFactory::createOne(['name' => 'bar']);

--- a/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
+++ b/src/Autocomplete/tests/Functional/FieldAutocompleterTest.php
@@ -27,7 +27,7 @@ class FieldAutocompleterTest extends KernelTestCase
     use HasBrowser;
     use ResetDatabase;
 
-    public function testItReturnsBasicResults()
+    public function testItReturnsBasicResults(): void
     {
         $category = CategoryFactory::createOne(['name' => 'foo and baz']);
         CategoryFactory::createOne(['name' => 'foo and bar']);
@@ -44,7 +44,7 @@ class FieldAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItUsesTheCustomQuery()
+    public function testItUsesTheCustomQuery(): void
     {
         CategoryFactory::createOne(['name' => 'foo and bar']);
         CategoryFactory::createOne(['name' => 'baz and bar']);
@@ -59,7 +59,7 @@ class FieldAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItEnforcesSecurity()
+    public function testItEnforcesSecurity(): void
     {
         CategoryFactory::createMany(3, [
             'name' => 'foo so that it matches custom query',
@@ -81,7 +81,7 @@ class FieldAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItCheckMaxResultsOption()
+    public function testItCheckMaxResultsOption(): void
     {
         CategoryFactory::createMany(30, ['name' => 'foo']);
 
@@ -93,7 +93,7 @@ class FieldAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItWorksWithoutAChoiceLabel()
+    public function testItWorksWithoutAChoiceLabel(): void
     {
         CategoryFactory::createMany(5, ['name' => 'foo']);
 
@@ -105,7 +105,7 @@ class FieldAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItUsesTheCustomStringValue()
+    public function testItUsesTheCustomStringValue(): void
     {
         $category = CategoryFactory::createOne(['code' => 'foo']);
 
@@ -118,7 +118,7 @@ class FieldAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItUsesTheCustomCallbackValue()
+    public function testItUsesTheCustomCallbackValue(): void
     {
         $category = CategoryFactory::createOne(['code' => 'foo']);
 
@@ -131,7 +131,7 @@ class FieldAutocompleterTest extends KernelTestCase
         ;
     }
 
-    public function testItSearchesByTags()
+    public function testItSearchesByTags(): void
     {
         $productTag = ProductTagFactory::createOne(['name' => 'technology']);
         $categoryTag = CategoryTagFactory::createOne(['name' => 'home appliances']);

--- a/src/Autocomplete/tests/Integration/AutocompleteResultsExecutorTest.php
+++ b/src/Autocomplete/tests/Integration/AutocompleteResultsExecutorTest.php
@@ -24,7 +24,7 @@ class AutocompleteResultsExecutorTest extends KernelTestCase
     use Factories;
     use ResetDatabase;
 
-    public function testItReturnsExtraAttributes()
+    public function testItReturnsExtraAttributes(): void
     {
         $kernel = new Kernel('test', true);
         $kernel->disableForms();

--- a/src/Autocomplete/tests/Integration/Doctrine/EntityMetadataFactoryTest.php
+++ b/src/Autocomplete/tests/Integration/Doctrine/EntityMetadataFactoryTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\Autocomplete\Tests\Fixtures\Entity\Product;
 
 class EntityMetadataFactoryTest extends KernelTestCase
 {
-    public function testItSuccessfullyCreatesMetadata()
+    public function testItSuccessfullyCreatesMetadata(): void
     {
         /** @var EntityMetadataFactory $factory */
         $factory = self::getContainer()->get('ux.autocomplete.entity_metadata_factory');

--- a/src/Autocomplete/tests/Integration/Doctrine/EntityMetadataTest.php
+++ b/src/Autocomplete/tests/Integration/Doctrine/EntityMetadataTest.php
@@ -25,7 +25,7 @@ class EntityMetadataTest extends KernelTestCase
     use Factories;
     use ResetDatabase;
 
-    public function testGetAllPropertyNames()
+    public function testGetAllPropertyNames(): void
     {
         $this->assertSame(
             ['id', 'name', 'description', 'price', 'isEnabled'],
@@ -33,20 +33,20 @@ class EntityMetadataTest extends KernelTestCase
         );
     }
 
-    public function testIsAssociation()
+    public function testIsAssociation(): void
     {
         $metadata = $this->getMetadata();
         $this->assertFalse($metadata->isAssociation('name'));
         $this->assertTrue($metadata->isAssociation('category'));
     }
 
-    public function testGetIdValue()
+    public function testGetIdValue(): void
     {
         $product = ProductFactory::createOne();
         $this->assertEquals($product->getId(), $this->getMetadata()->getIdValue($product));
     }
 
-    public function testGetPropertyDataType()
+    public function testGetPropertyDataType(): void
     {
         $metadata = $this->getMetadata();
         $this->assertSame(Types::STRING, $metadata->getPropertyDataType('name'));
@@ -55,7 +55,7 @@ class EntityMetadataTest extends KernelTestCase
         $this->assertEquals(2, $metadata->getPropertyDataType('category'));
     }
 
-    public function testGetFieldMetadata()
+    public function testGetFieldMetadata(): void
     {
         $metadata = $this->getMetadata();
         $nameMetadata = $metadata->getFieldMetadata('name');
@@ -75,7 +75,7 @@ class EntityMetadataTest extends KernelTestCase
         }
     }
 
-    public function testGetAssociationMetadata()
+    public function testGetAssociationMetadata(): void
     {
         $metadata = $this->getMetadata();
         $expected = [
@@ -132,7 +132,7 @@ class EntityMetadataTest extends KernelTestCase
         }
     }
 
-    public function testIsEmbeddedClassProperty()
+    public function testIsEmbeddedClassProperty(): void
     {
         // TODO
         $this->markTestIncomplete();

--- a/src/Autocomplete/tests/Integration/Doctrine/EntitySearchUtilTest.php
+++ b/src/Autocomplete/tests/Integration/Doctrine/EntitySearchUtilTest.php
@@ -26,7 +26,7 @@ class EntitySearchUtilTest extends KernelTestCase
     use Factories;
     use ResetDatabase;
 
-    public function testItCreatesBasicStringSearchQuery()
+    public function testItCreatesBasicStringSearchQuery(): void
     {
         $prod1 = ProductFactory::createOne(['name' => 'bar prod1']);
         $prod2 = ProductFactory::createOne(['name' => 'foo prod2']);
@@ -37,7 +37,7 @@ class EntitySearchUtilTest extends KernelTestCase
         $this->assertSame([$prod1, $prod2, $prod4], $results);
     }
 
-    public function testItSearchesOnCorrectFields()
+    public function testItSearchesOnCorrectFields(): void
     {
         $prod1 = ProductFactory::createOne(['name' => 'bar prod1']);
         ProductFactory::createOne(['description' => 'foo prod2']);
@@ -46,7 +46,7 @@ class EntitySearchUtilTest extends KernelTestCase
         $this->assertSame([$prod1], $results);
     }
 
-    public function testItCanSearchOnRelationFields()
+    public function testItCanSearchOnRelationFields(): void
     {
         $category1 = CategoryFactory::createOne(['name' => 'foods']);
         $category2 = CategoryFactory::createOne(['name' => 'toys']);
@@ -58,7 +58,7 @@ class EntitySearchUtilTest extends KernelTestCase
         $this->assertSame([$prod1, $prod2], $results);
     }
 
-    public function testItEscapesLikeWildcardsInTheQuery()
+    public function testItEscapesLikeWildcardsInTheQuery(): void
     {
         $percent = ProductFactory::createOne(['name' => '100% legit']);
         $underscore = ProductFactory::createOne(['name' => 'foo_bar']);

--- a/src/Autocomplete/tests/Integration/WiringTest.php
+++ b/src/Autocomplete/tests/Integration/WiringTest.php
@@ -35,7 +35,7 @@ class WiringTest extends KernelTestCase
         return $kernel;
     }
 
-    public function testWiringWithoutForm()
+    public function testWiringWithoutForm(): void
     {
         $kernel = new Kernel('test', true);
         $kernel->disableForms();
@@ -51,7 +51,7 @@ class WiringTest extends KernelTestCase
         $this->assertFalse($data->hasNextPage);
     }
 
-    public function testWiringWithManyResults()
+    public function testWiringWithManyResults(): void
     {
         $kernel = new Kernel('test', true);
         $kernel->disableForms();
@@ -76,7 +76,7 @@ class WiringTest extends KernelTestCase
         $this->assertFalse($data->hasNextPage);
     }
 
-    public function testWiringWithoutFormAndGroupByOption()
+    public function testWiringWithoutFormAndGroupByOption(): void
     {
         $kernel = new Kernel('test', true);
         $kernel->disableForms();

--- a/src/Autocomplete/tests/Unit/AutocompleteResultsExecutorTest.php
+++ b/src/Autocomplete/tests/Unit/AutocompleteResultsExecutorTest.php
@@ -21,7 +21,7 @@ use Symfony\UX\Autocomplete\EntityAutocompleterInterface;
 
 class AutocompleteResultsExecutorTest extends TestCase
 {
-    public function testItExecutesSecurity()
+    public function testItExecutesSecurity(): void
     {
         $doctrineRegistry = $this->createMock(DoctrineRegistryWrapper::class);
 

--- a/src/Autocomplete/tests/Unit/Calculator/ChecksumCalculatorTest.php
+++ b/src/Autocomplete/tests/Unit/Calculator/ChecksumCalculatorTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Autocomplete\Checksum\ChecksumCalculator;
 
 final class ChecksumCalculatorTest extends TestCase
 {
-    public function testCalculateChecksumForArray()
+    public function testCalculateChecksumForArray(): void
     {
         $this->assertSame(
             'tZ34YQKgpttqybzPws0YJCOHV1QtMjQeuyy+rszdhXU=',
@@ -24,7 +24,7 @@ final class ChecksumCalculatorTest extends TestCase
         );
     }
 
-    public function testCalculateTheSameChecksumForTheSameArrayButInDifferentOrder()
+    public function testCalculateTheSameChecksumForTheSameArrayButInDifferentOrder(): void
     {
         $this->assertSame(
             $this->createTestSubject()->calculateForArray(['test' => 'test', 'test2' => 'test2']),

--- a/src/Autocomplete/tests/Unit/Form/AsEntityAutocompleteFieldTest.php
+++ b/src/Autocomplete/tests/Unit/Form/AsEntityAutocompleteFieldTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Autocomplete\Tests\Fixtures\Form\ProductType;
 class AsEntityAutocompleteFieldTest extends TestCase
 {
     #[DataProvider('provideClassNames')]
-    public function testShortName(string $shortName, string $className)
+    public function testShortName(string $shortName, string $className): void
     {
         $this->assertEquals($shortName, AsEntityAutocompleteField::shortName($className));
     }

--- a/src/CalendarLink/tests/CalendarEventTest.php
+++ b/src/CalendarLink/tests/CalendarEventTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\CalendarLink\Exception\InvalidArgumentException;
 
 final class CalendarEventTest extends TestCase
 {
-    public function testRejectsEmptyTitle()
+    public function testRejectsEmptyTitle(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -28,7 +28,7 @@ final class CalendarEventTest extends TestCase
         );
     }
 
-    public function testRejectsEndBeforeStart()
+    public function testRejectsEndBeforeStart(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/src/CalendarLink/tests/CalendarRecurrenceTest.php
+++ b/src/CalendarLink/tests/CalendarRecurrenceTest.php
@@ -34,12 +34,12 @@ final class CalendarRecurrenceTest extends TestCase
     }
 
     #[DataProvider('factoryProvider')]
-    public function testFactoriesProduceExpectedRrule(CalendarRecurrence $recurrence, string $expected)
+    public function testFactoriesProduceExpectedRrule(CalendarRecurrence $recurrence, string $expected): void
     {
         $this->assertSame($expected, $recurrence->rrule);
     }
 
-    public function testUntilIsFormattedAsUtc()
+    public function testUntilIsFormattedAsUtc(): void
     {
         $until = new \DateTimeImmutable('2026-12-31 09:00:00', new \DateTimeZone('Europe/Paris'));
 
@@ -57,7 +57,7 @@ final class CalendarRecurrenceTest extends TestCase
     }
 
     #[DataProvider('invalidArgumentsProvider')]
-    public function testRejectsInvalidArguments(callable $build)
+    public function testRejectsInvalidArguments(callable $build): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/src/CalendarLink/tests/CalendarReminderTest.php
+++ b/src/CalendarLink/tests/CalendarReminderTest.php
@@ -31,24 +31,24 @@ final class CalendarReminderTest extends TestCase
     }
 
     #[DataProvider('beforeProvider')]
-    public function testBeforeProducesExpectedMinutes(CalendarReminder $reminder, int $expected)
+    public function testBeforeProducesExpectedMinutes(CalendarReminder $reminder, int $expected): void
     {
         $this->assertSame($expected, $reminder->minutesBefore);
     }
 
-    public function testDescriptionIsKept()
+    public function testDescriptionIsKept(): void
     {
         $this->assertSame('Leave early', CalendarReminder::before(hours: 2, description: 'Leave early')->description);
     }
 
-    public function testRejectsZeroTotal()
+    public function testRejectsZeroTotal(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         CalendarReminder::before();
     }
 
-    public function testRejectsNegativeArgument()
+    public function testRejectsNegativeArgument(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/src/CalendarLink/tests/Ics/IcsBuilderTest.php
+++ b/src/CalendarLink/tests/Ics/IcsBuilderTest.php
@@ -32,7 +32,7 @@ final class IcsBuilderTest extends TestCase
         );
     }
 
-    public function testDtstampUsesTheInjectedClock()
+    public function testDtstampUsesTheInjectedClock(): void
     {
         $event = new CalendarEvent(
             title: 'Demo',
@@ -43,7 +43,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("DTSTAMP:20260514T083000Z\r\n", $this->builder->build($event));
     }
 
-    public function testUidIsStableForTheSameEvent()
+    public function testUidIsStableForTheSameEvent(): void
     {
         $event = new CalendarEvent(
             title: 'Demo',
@@ -57,7 +57,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertSame($first[1], $second[1]);
     }
 
-    public function testDifferentEventsGetDifferentUids()
+    public function testDifferentEventsGetDifferentUids(): void
     {
         $start = new \DateTimeImmutable('2026-05-14 09:00', new \DateTimeZone('UTC'));
         $end = new \DateTimeImmutable('2026-05-14 10:00', new \DateTimeZone('UTC'));
@@ -68,7 +68,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertNotSame($first[1], $second[1]);
     }
 
-    public function testUidIsDerivedThroughTheInjectedUuidFactory()
+    public function testUidIsDerivedThroughTheInjectedUuidFactory(): void
     {
         // MockUuidFactory::nameBased() throws unless the UID matches the v5 it recomputes,
         // which pins both the namespace and the identity string the UID is derived from.
@@ -84,7 +84,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("UID:66da134f-b0c7-54b1-924b-afa4fbe3f952\r\n", $builder->build($event));
     }
 
-    public function testExplicitUidTakesPrecedence()
+    public function testExplicitUidTakesPrecedence(): void
     {
         $event = new CalendarEvent(
             title: 'Demo',
@@ -96,7 +96,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("UID:5fc53010-1267-4f8e-bc28-1d7ae55a7c99\r\n", $this->builder->build($event));
     }
 
-    public function testMinimalTimedEventStructure()
+    public function testMinimalTimedEventStructure(): void
     {
         $event = new CalendarEvent(
             title: 'Demo',
@@ -116,7 +116,7 @@ final class IcsBuilderTest extends TestCase
         );
     }
 
-    public function testAllDayEventUsesValueDateAndIncrementsEnd()
+    public function testAllDayEventUsesValueDateAndIncrementsEnd(): void
     {
         $event = new CalendarEvent(
             title: 'Conf',
@@ -131,7 +131,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("DTEND;VALUE=DATE:20260516\r\n", $ics);
     }
 
-    public function testTimedEventInNamedZoneUsesTzidInsteadOfUtc()
+    public function testTimedEventInNamedZoneUsesTzidInsteadOfUtc(): void
     {
         $event = new CalendarEvent(
             title: 'Standup',
@@ -145,7 +145,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("DTEND;TZID=Europe/Paris:20260701T093000\r\n", $ics);
     }
 
-    public function testNamedZoneEmitsVtimezoneWithDstRules()
+    public function testNamedZoneEmitsVtimezoneWithDstRules(): void
     {
         $event = new CalendarEvent(
             title: 'Standup',
@@ -165,7 +165,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\n", $ics);
     }
 
-    public function testUtcEventDoesNotEmitVtimezone()
+    public function testUtcEventDoesNotEmitVtimezone(): void
     {
         $event = new CalendarEvent(
             title: 'Demo',
@@ -179,7 +179,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("DTSTART:20260514T090000Z\r\n", $ics);
     }
 
-    public function testTextEscaping()
+    public function testTextEscaping(): void
     {
         $event = new CalendarEvent(
             title: 'Symfony, UX; test',
@@ -196,7 +196,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString('LOCATION:A\\\\B', $ics);
     }
 
-    public function testLineFoldingAtSeventyFiveOctets()
+    public function testLineFoldingAtSeventyFiveOctets(): void
     {
         $event = new CalendarEvent(
             title: 'Demo',
@@ -226,7 +226,7 @@ final class IcsBuilderTest extends TestCase
     }
 
     #[DataProvider('triggerFormatProvider')]
-    public function testTriggerFormat(CalendarReminder $reminder, string $expectedTrigger)
+    public function testTriggerFormat(CalendarReminder $reminder, string $expectedTrigger): void
     {
         $event = new CalendarEvent(
             title: 'Demo',
@@ -238,7 +238,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("TRIGGER:$expectedTrigger\r\n", $this->builder->build($event));
     }
 
-    public function testValarmBlockFromReminders()
+    public function testValarmBlockFromReminders(): void
     {
         $event = new CalendarEvent(
             title: 'Demo',
@@ -254,7 +254,7 @@ final class IcsBuilderTest extends TestCase
         $this->assertStringContainsString("END:VALARM\r\n", $ics);
     }
 
-    public function testRrulePassthrough()
+    public function testRrulePassthrough(): void
     {
         $event = new CalendarEvent(
             title: 'Weekly',

--- a/src/CalendarLink/tests/Integration/BundleIntegrationTest.php
+++ b/src/CalendarLink/tests/Integration/BundleIntegrationTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\CalendarLink\Registry\CalendarLinkProviderRegistry;
 
 final class BundleIntegrationTest extends KernelTestCase
 {
-    public function testContainerCompilesAndRegistersAllProviders()
+    public function testContainerCompilesAndRegistersAllProviders(): void
     {
         $container = self::getContainer();
 
@@ -33,7 +33,7 @@ final class BundleIntegrationTest extends KernelTestCase
         }
     }
 
-    public function testDtstampUsesTheContainerClock()
+    public function testDtstampUsesTheContainerClock(): void
     {
         $container = self::getContainer();
         $container->set('clock', new MockClock(new \DateTimeImmutable('2026-05-14 08:30:00', new \DateTimeZone('UTC'))));
@@ -47,7 +47,7 @@ final class BundleIntegrationTest extends KernelTestCase
         $this->assertStringContainsString("DTSTAMP:20260514T083000Z\r\n", $ics);
     }
 
-    public function testTwigRendersCalendarLink()
+    public function testTwigRendersCalendarLink(): void
     {
         $event = new CalendarEvent(
             title: 'Demo',
@@ -63,7 +63,7 @@ final class BundleIntegrationTest extends KernelTestCase
         $this->assertStringContainsString('text=Demo', $rendered);
     }
 
-    public function testTwigRendersAllCalendarLinks()
+    public function testTwigRendersAllCalendarLinks(): void
     {
         $event = new CalendarEvent(
             title: 'Demo',

--- a/src/CalendarLink/tests/Provider/GoogleCalendarLinkProviderTest.php
+++ b/src/CalendarLink/tests/Provider/GoogleCalendarLinkProviderTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\CalendarLink\Provider\GoogleCalendarLinkProvider;
 
 final class GoogleCalendarLinkProviderTest extends TestCase
 {
-    public function testTimedEvent()
+    public function testTimedEvent(): void
     {
         $provider = new GoogleCalendarLinkProvider();
         $event = new CalendarEvent(
@@ -40,7 +40,7 @@ final class GoogleCalendarLinkProviderTest extends TestCase
         $this->assertSame('Paris', $params['location']);
     }
 
-    public function testAllDayEventEndIsExclusive()
+    public function testAllDayEventEndIsExclusive(): void
     {
         $provider = new GoogleCalendarLinkProvider();
         $event = new CalendarEvent(

--- a/src/CalendarLink/tests/Provider/IcsCalendarLinkProviderTest.php
+++ b/src/CalendarLink/tests/Provider/IcsCalendarLinkProviderTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\CalendarLink\Provider\IcsCalendarLinkProvider;
 
 final class IcsCalendarLinkProviderTest extends TestCase
 {
-    public function testReturnsDataUri()
+    public function testReturnsDataUri(): void
     {
         $provider = new IcsCalendarLinkProvider(new IcsBuilder());
         $event = new CalendarEvent(

--- a/src/CalendarLink/tests/Provider/Office365CalendarLinkProviderTest.php
+++ b/src/CalendarLink/tests/Provider/Office365CalendarLinkProviderTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\CalendarLink\Provider\Office365CalendarLinkProvider;
 
 final class Office365CalendarLinkProviderTest extends TestCase
 {
-    public function testOffice365TimedEvent()
+    public function testOffice365TimedEvent(): void
     {
         $provider = new Office365CalendarLinkProvider();
         $event = new CalendarEvent(
@@ -40,7 +40,7 @@ final class Office365CalendarLinkProviderTest extends TestCase
         $this->assertSame('Paris', $params['location']);
     }
 
-    public function testAllDayEvent()
+    public function testAllDayEvent(): void
     {
         $provider = new Office365CalendarLinkProvider();
         $event = new CalendarEvent(

--- a/src/CalendarLink/tests/Provider/OutlookCalendarLinkProviderTest.php
+++ b/src/CalendarLink/tests/Provider/OutlookCalendarLinkProviderTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\CalendarLink\Provider\OutlookCalendarLinkProvider;
 
 final class OutlookCalendarLinkProviderTest extends TestCase
 {
-    public function testOutlookComTimedEvent()
+    public function testOutlookComTimedEvent(): void
     {
         $provider = new OutlookCalendarLinkProvider();
         $event = new CalendarEvent(
@@ -39,7 +39,7 @@ final class OutlookCalendarLinkProviderTest extends TestCase
         $this->assertSame('2026-05-14T18:00:00Z', $params['enddt']);
     }
 
-    public function testAllDayEvent()
+    public function testAllDayEvent(): void
     {
         $provider = new OutlookCalendarLinkProvider();
         $event = new CalendarEvent(

--- a/src/Chartjs/tests/ChartjsBundleTest.php
+++ b/src/Chartjs/tests/ChartjsBundleTest.php
@@ -21,7 +21,7 @@ use Symfony\UX\Chartjs\Tests\Kernel\TwigAppKernel;
  */
 class ChartjsBundleTest extends TestCase
 {
-    public function testBootKernel()
+    public function testBootKernel(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/Chartjs/tests/Twig/ChartExtensionTest.php
+++ b/src/Chartjs/tests/Twig/ChartExtensionTest.php
@@ -23,7 +23,7 @@ use Symfony\UX\Chartjs\Tests\Kernel\TwigAppKernel;
  */
 class ChartExtensionTest extends TestCase
 {
-    public function testRenderChart()
+    public function testRenderChart(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/Cropperjs/tests/CropperjsBundleTest.php
+++ b/src/Cropperjs/tests/CropperjsBundleTest.php
@@ -33,7 +33,7 @@ class CropperjsBundleTest extends TestCase
     }
 
     #[DataProvider('provideKernels')]
-    public function testBootKernel(Kernel $kernel)
+    public function testBootKernel(Kernel $kernel): void
     {
         $kernel->boot();
         $this->assertArrayHasKey('CropperjsBundle', $kernel->getBundles());

--- a/src/Cropperjs/tests/Form/CropperTypeTest.php
+++ b/src/Cropperjs/tests/Form/CropperTypeTest.php
@@ -24,7 +24,7 @@ use Twig\Environment;
  */
 class CropperTypeTest extends TestCase
 {
-    public function testRenderFull()
+    public function testRenderFull(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();
@@ -54,7 +54,7 @@ class CropperTypeTest extends TestCase
         );
     }
 
-    public function testRenderNoOptions()
+    public function testRenderNoOptions(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/Cropperjs/tests/Model/CropTest.php
+++ b/src/Cropperjs/tests/Model/CropTest.php
@@ -51,7 +51,7 @@ class CropTest extends TestCase
         return $crop;
     }
 
-    public function testGetCroppedImageWithRotation()
+    public function testGetCroppedImageWithRotation(): void
     {
         $crop = $this->createCrop(rotate: 90);
 
@@ -62,7 +62,7 @@ class CropTest extends TestCase
         $this->assertSame(200, imagesy($image));
     }
 
-    public function testGetCroppedImageWithoutRotation()
+    public function testGetCroppedImageWithoutRotation(): void
     {
         $crop = $this->createCrop(rotate: 0);
 
@@ -73,7 +73,7 @@ class CropTest extends TestCase
         $this->assertSame(100, imagesy($image));
     }
 
-    public function testGetCroppedThumbnailWithRotation()
+    public function testGetCroppedThumbnailWithRotation(): void
     {
         $crop = $this->createCrop(rotate: 90);
 
@@ -84,7 +84,7 @@ class CropTest extends TestCase
         $this->assertSame(200, imagesy($image));
     }
 
-    public function testGetCroppedThumbnailWithoutRotation()
+    public function testGetCroppedThumbnailWithoutRotation(): void
     {
         $crop = $this->createCrop(rotate: 0);
 

--- a/src/Dropzone/tests/DropzoneBundleTest.php
+++ b/src/Dropzone/tests/DropzoneBundleTest.php
@@ -33,13 +33,13 @@ class DropzoneBundleTest extends TestCase
     }
 
     #[DataProvider('provideKernels')]
-    public function testBootKernel(Kernel $kernel)
+    public function testBootKernel(Kernel $kernel): void
     {
         $kernel->boot();
         $this->assertArrayHasKey('DropzoneBundle', $kernel->getBundles());
     }
 
-    public function testFormThemeMerging()
+    public function testFormThemeMerging(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/Dropzone/tests/Form/DropzoneTypeTest.php
+++ b/src/Dropzone/tests/Form/DropzoneTypeTest.php
@@ -24,7 +24,7 @@ use Twig\Environment;
  */
 class DropzoneTypeTest extends TestCase
 {
-    public function testRenderForm()
+    public function testRenderForm(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/Icons/tests/Integration/Command/ImportIconCommandTest.php
+++ b/src/Icons/tests/Integration/Command/ImportIconCommandTest.php
@@ -38,7 +38,7 @@ final class ImportIconCommandTest extends KernelTestCase
         }
     }
 
-    public function testCanImportIcon()
+    public function testCanImportIcon(): void
     {
         $this->assertFileDoesNotExist($expectedFile = self::ICON_DIR.'/uiw/dashboard.svg');
 
@@ -51,7 +51,7 @@ final class ImportIconCommandTest extends KernelTestCase
         $this->assertFileExists($expectedFile);
     }
 
-    public function testImportInvalidIconName()
+    public function testImportInvalidIconName(): void
     {
         $this->executeConsoleCommand('ux:icons:import something')
             ->assertStatusCode(1)
@@ -59,7 +59,7 @@ final class ImportIconCommandTest extends KernelTestCase
         ;
     }
 
-    public function testImportNonExistentIconSet()
+    public function testImportNonExistentIconSet(): void
     {
         $this->executeConsoleCommand('ux:icons:import something:invalid')
             ->assertStatusCode(1)
@@ -67,7 +67,7 @@ final class ImportIconCommandTest extends KernelTestCase
         ;
     }
 
-    public function testImportNonExistentIcon()
+    public function testImportNonExistentIcon(): void
     {
         $this->executeConsoleCommand('ux:icons:import lucide:not-existing-icon')
             ->assertStatusCode(1)
@@ -78,7 +78,7 @@ final class ImportIconCommandTest extends KernelTestCase
         $this->assertFileDoesNotExist(self::ICON_DIR.'/not-existing-icon.svg');
     }
 
-    public function testImportNonExistentIconWithExistentOne()
+    public function testImportNonExistentIconWithExistentOne(): void
     {
         $this->executeConsoleCommand('ux:icons:import lucide:circle lucide:not-existing-icon')
             ->assertStatusCode(0)

--- a/src/Icons/tests/Integration/Command/LockIconsCommandTest.php
+++ b/src/Icons/tests/Integration/Command/LockIconsCommandTest.php
@@ -42,7 +42,7 @@ final class LockIconsCommandTest extends KernelTestCase
         }
     }
 
-    public function testImportFoundIcons()
+    public function testImportFoundIcons(): void
     {
         foreach (self::ICONS as $icon) {
             $this->assertFileDoesNotExist($icon);
@@ -68,7 +68,7 @@ final class LockIconsCommandTest extends KernelTestCase
         ;
     }
 
-    public function testForceImportFoundIcons()
+    public function testForceImportFoundIcons(): void
     {
         $this->executeConsoleCommand('ux:icons:lock')
             ->assertSuccessful()

--- a/src/Icons/tests/Integration/Command/SearchIconCommandTest.php
+++ b/src/Icons/tests/Integration/Command/SearchIconCommandTest.php
@@ -21,7 +21,7 @@ final class SearchIconCommandTest extends KernelTestCase
 {
     use InteractsWithConsole;
 
-    public function testSearchWithPrefix()
+    public function testSearchWithPrefix(): void
     {
         $this->consoleCommand('ux:icons:search iconoir')
             ->execute()
@@ -39,7 +39,7 @@ final class SearchIconCommandTest extends KernelTestCase
             ->assertStatusCode(0);
     }
 
-    public function testSearchWithPrefixMatchingMultipleSet()
+    public function testSearchWithPrefixMatchingMultipleSet(): void
     {
         $this->consoleCommand('ux:icons:search box')
             ->execute()
@@ -53,7 +53,7 @@ final class SearchIconCommandTest extends KernelTestCase
             ->assertStatusCode(0);
     }
 
-    public function testSearchWithPrefixName()
+    public function testSearchWithPrefixName(): void
     {
         $this->consoleCommand('ux:icons:search lucide arrow')
             ->execute()

--- a/src/Icons/tests/Integration/Command/WarmCacheCommandTest.php
+++ b/src/Icons/tests/Integration/Command/WarmCacheCommandTest.php
@@ -21,7 +21,7 @@ final class WarmCacheCommandTest extends KernelTestCase
 {
     use InteractsWithConsole;
 
-    public function testCanWarmCache()
+    public function testCanWarmCache(): void
     {
         $this->executeConsoleCommand('ux:icons:warm-cache -v')
             ->assertSuccessful()

--- a/src/Icons/tests/Integration/IconRendererTest.php
+++ b/src/Icons/tests/Integration/IconRendererTest.php
@@ -20,18 +20,18 @@ use Symfony\UX\Icons\IconRendererInterface;
  */
 final class IconRendererTest extends KernelTestCase
 {
-    public function testIconRenderService()
+    public function testIconRenderService(): void
     {
         $this->assertTrue(self::getContainer()->has(IconRendererInterface::class));
     }
 
-    public function testIconRendererAlias()
+    public function testIconRendererAlias(): void
     {
         $renderer = self::getContainer()->get(IconRendererInterface::class);
         $this->assertInstanceOf(IconRenderer::class, $renderer);
     }
 
-    public function testIconRendererIsPrivate()
+    public function testIconRendererIsPrivate(): void
     {
         $this->assertFalse(self::getContainer()->has(IconRenderer::class));
     }

--- a/src/Icons/tests/Integration/RenderIconsInTwigTest.php
+++ b/src/Icons/tests/Integration/RenderIconsInTwigTest.php
@@ -21,7 +21,7 @@ use Twig\Error\RuntimeError;
  */
 final class RenderIconsInTwigTest extends KernelTestCase
 {
-    public function testRenderIcons()
+    public function testRenderIcons(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('template1.html.twig');
 
@@ -43,7 +43,7 @@ final class RenderIconsInTwigTest extends KernelTestCase
         );
     }
 
-    public function testRenderAliasIcons()
+    public function testRenderAliasIcons(): void
     {
         $templateIcon = '<twig:ux:icon name="flowbite:close-outline" />';
         $outputIcon = self::getContainer()->get(Environment::class)->createTemplate($templateIcon)->render();
@@ -56,7 +56,7 @@ final class RenderIconsInTwigTest extends KernelTestCase
         $this->assertSame($outputIcon, $outputAlias);
     }
 
-    public function testIconInDirectoryWithUnderscoreIsNotFound()
+    public function testIconInDirectoryWithUnderscoreIsNotFound(): void
     {
         $this->assertFileExists(__DIR__.'/../Fixtures/icons/sub_dir/check.svg');
 

--- a/src/Icons/tests/UXIconsBundleTest.php
+++ b/src/Icons/tests/UXIconsBundleTest.php
@@ -37,7 +37,7 @@ class UXIconsBundleTest extends TestCase
      * @dataProvider provideTestInvalidAliasConfiguration
      */
     #[DataProvider('provideTestInvalidAliasConfiguration')]
-    public function testInvalidAliasConfiguration(mixed $value, string $expectedMessage)
+    public function testInvalidAliasConfiguration(mixed $value, string $expectedMessage): void
     {
         self::expectException(InvalidConfigurationException::class);
         self::expectExceptionMessage($expectedMessage);
@@ -61,7 +61,7 @@ class UXIconsBundleTest extends TestCase
      * @dataProvider provideTestValidAliasConfiguration
      */
     #[DataProvider('provideTestValidAliasConfiguration')]
-    public function testValidAliasConfiguration(array $value)
+    public function testValidAliasConfiguration(array $value): void
     {
         $processor = new Processor();
         $configurableExtension = new UXIconsExtension();
@@ -85,7 +85,7 @@ class UXIconsBundleTest extends TestCase
      * @dataProvider provideTestInvalidIconAttributesConfiguration
      */
     #[DataProvider('provideTestInvalidIconAttributesConfiguration')]
-    public function testInvalidIconAttributeConfiguration(mixed $value, string $expectedMessage)
+    public function testInvalidIconAttributeConfiguration(mixed $value, string $expectedMessage): void
     {
         self::expectException(InvalidConfigurationException::class);
         self::expectExceptionMessage($expectedMessage);
@@ -110,14 +110,14 @@ class UXIconsBundleTest extends TestCase
         return $container;
     }
 
-    public function testAutoLockDefaultsToFalse()
+    public function testAutoLockDefaultsToFalse(): void
     {
         $config = new Processor()->processConfiguration(new UXIconsExtension(), [[]]);
 
         $this->assertFalse($config['iconify']['auto_lock']);
     }
 
-    public function testAutoLockRegistryIsWiredWhenEnabled()
+    public function testAutoLockRegistryIsWiredWhenEnabled(): void
     {
         $container = $this->buildContainer(['iconify' => ['auto_lock' => true]]);
 
@@ -128,7 +128,7 @@ class UXIconsBundleTest extends TestCase
         $this->assertFalse($container->getDefinition('.ux_icons.iconify_on_demand_registry')->hasTag('ux_icons.registry'));
     }
 
-    public function testAutoLockRegistryIsRemovedWhenDisabled()
+    public function testAutoLockRegistryIsRemovedWhenDisabled(): void
     {
         $container = $this->buildContainer(['iconify' => ['auto_lock' => false]]);
 
@@ -136,7 +136,7 @@ class UXIconsBundleTest extends TestCase
         $this->assertTrue($container->getDefinition('.ux_icons.iconify_on_demand_registry')->hasTag('ux_icons.registry'));
     }
 
-    public function testAutoLockRegistryIsRemovedWhenOnDemandDisabled()
+    public function testAutoLockRegistryIsRemovedWhenOnDemandDisabled(): void
     {
         $container = $this->buildContainer(['iconify' => ['on_demand' => false]]);
 
@@ -154,7 +154,7 @@ class UXIconsBundleTest extends TestCase
      * @dataProvider provideTestValidIconAttributesConfiguration
      */
     #[DataProvider('provideTestValidIconAttributesConfiguration')]
-    public function testValidIconAttributeConfiguration(array $value)
+    public function testValidIconAttributeConfiguration(array $value): void
     {
         $processor = new Processor();
         $configurableExtension = new UXIconsExtension();

--- a/src/Icons/tests/Unit/IconFactoryTest.php
+++ b/src/Icons/tests/Unit/IconFactoryTest.php
@@ -22,9 +22,9 @@ final class IconFactoryTest extends TestCase
      * @dataProvider provideSanitizedBodies
      */
     #[DataProvider('provideSanitizedBodies')]
-    public function testFromBodySanitizes(string $body, string $expected)
+    public function testFromBodySanitizes(string $body, string $expected): void
     {
-        $icon = (new IconFactory())->fromBody($body);
+        $icon = new IconFactory()->fromBody($body);
 
         $this->assertInstanceOf(Icon::class, $icon);
         $this->assertSame($expected, $icon->getInnerSvg());
@@ -34,34 +34,34 @@ final class IconFactoryTest extends TestCase
      * @dataProvider provideSafeBodies
      */
     #[DataProvider('provideSafeBodies')]
-    public function testFromBodyKeepsSafeContentVerbatim(string $body)
+    public function testFromBodyKeepsSafeContentVerbatim(string $body): void
     {
         // Safe content must be returned byte-for-byte (no lossy re-serialization).
-        $this->assertSame($body, (new IconFactory())->fromBody($body)->getInnerSvg());
+        $this->assertSame($body, new IconFactory()->fromBody($body)->getInnerSvg());
     }
 
     /**
      * @dataProvider provideInvalidBodies
      */
     #[DataProvider('provideInvalidBodies')]
-    public function testFromBodyThrowsOnInvalidSvg(string $body)
+    public function testFromBodyThrowsOnInvalidSvg(string $body): void
     {
         $this->expectException(\RuntimeException::class);
 
-        (new IconFactory())->fromBody($body);
+        new IconFactory()->fromBody($body);
     }
 
-    public function testFromBodyKeepsGivenAttributes()
+    public function testFromBodyKeepsGivenAttributes(): void
     {
-        $icon = (new IconFactory())->fromBody('<rect onload="alert(1)"/>', ['viewBox' => '0 0 16 16', 'xmlns' => 'http://www.w3.org/2000/svg']);
+        $icon = new IconFactory()->fromBody('<rect onload="alert(1)"/>', ['viewBox' => '0 0 16 16', 'xmlns' => 'http://www.w3.org/2000/svg']);
 
         $this->assertSame('<rect></rect>', $icon->getInnerSvg());
         $this->assertSame(['viewBox' => '0 0 16 16', 'xmlns' => 'http://www.w3.org/2000/svg'], $icon->getAttributes());
     }
 
-    public function testFromFileSanitizesMaliciousIcon()
+    public function testFromFileSanitizesMaliciousIcon(): void
     {
-        $icon = (new IconFactory())->fromFile(__DIR__.'/../Fixtures/svg/malicious.svg');
+        $icon = new IconFactory()->fromFile(__DIR__.'/../Fixtures/svg/malicious.svg');
 
         // <script>, <foreignObject>, <set attributeName="on*"> dropped; on* and javascript: attributes stripped.
         $this->assertSame(
@@ -77,9 +77,9 @@ final class IconFactoryTest extends TestCase
      * @dataProvider provideValidFiles
      */
     #[DataProvider('provideValidFiles')]
-    public function testFromFileReadsValidSvg(string $name, array $expectedAttributes, string $expectedContent)
+    public function testFromFileReadsValidSvg(string $name, array $expectedAttributes, string $expectedContent): void
     {
-        $icon = (new IconFactory())->fromFile(__DIR__.'/../Fixtures/svg/'.$name.'.svg');
+        $icon = new IconFactory()->fromFile(__DIR__.'/../Fixtures/svg/'.$name.'.svg');
 
         $this->assertSame($expectedContent, $icon->getInnerSvg());
         $this->assertSame($expectedAttributes, $icon->getAttributes());
@@ -89,11 +89,11 @@ final class IconFactoryTest extends TestCase
      * @dataProvider provideInvalidFiles
      */
     #[DataProvider('provideInvalidFiles')]
-    public function testFromFileThrowsOnInvalidSvg(string $name)
+    public function testFromFileThrowsOnInvalidSvg(string $name): void
     {
         $this->expectException(\RuntimeException::class);
 
-        (new IconFactory())->fromFile(__DIR__.'/../Fixtures/svg/'.$name.'.svg');
+        new IconFactory()->fromFile(__DIR__.'/../Fixtures/svg/'.$name.'.svg');
     }
 
     /**

--- a/src/Icons/tests/Unit/IconRendererTest.php
+++ b/src/Icons/tests/Unit/IconRendererTest.php
@@ -24,7 +24,7 @@ use Symfony\UX\Icons\Tests\Util\InMemoryIconRegistry;
  */
 class IconRendererTest extends TestCase
 {
-    public function testRenderIcon()
+    public function testRenderIcon(): void
     {
         $registry = $this->createRegistry([
             'user' => '<circle ',
@@ -37,7 +37,7 @@ class IconRendererTest extends TestCase
         $this->assertStringContainsString('<circle', $icon);
     }
 
-    public function testRenderIconThrowsExceptionWhenIconNotFound()
+    public function testRenderIconThrowsExceptionWhenIconNotFound(): void
     {
         $registry = $this->createRegistry([]);
         $iconRenderer = new IconRenderer($registry);
@@ -47,7 +47,7 @@ class IconRendererTest extends TestCase
         $iconRenderer->renderIcon('foo');
     }
 
-    public function testRenderIconThrowsExceptionWhenAttributesAreInvalid()
+    public function testRenderIconThrowsExceptionWhenAttributesAreInvalid(): void
     {
         $registry = $this->createRegistry(['foo' => '<path d="M0 0L12 12"/>']);
         $iconRenderer = new IconRenderer($registry);
@@ -57,7 +57,7 @@ class IconRendererTest extends TestCase
         $iconRenderer->renderIcon('foo', [1, 2, null]);
     }
 
-    public function testRenderIconWithAttributes()
+    public function testRenderIconWithAttributes(): void
     {
         $registry = $this->createRegistry([
             'foo' => '<path d="M0 0L12 12"/>',
@@ -70,7 +70,7 @@ class IconRendererTest extends TestCase
         $this->assertSame('<svg viewBox="0 0 24 24" class="icon" id="FooBar" aria-hidden="true"><path d="M0 0L12 12"/></svg>', $svg);
     }
 
-    public function testRenderIconWithDefaultAttributes()
+    public function testRenderIconWithDefaultAttributes(): void
     {
         $registry = $this->createRegistry([
             'foo' => '<path d="M0 0L12 12"/>',
@@ -279,7 +279,7 @@ class IconRendererTest extends TestCase
      * @param array<string, string|bool>                       $attributes
      */
     #[DataProvider('provideAriaHiddenCases')]
-    public function testRenderIconWithAutoAriaHidden(string|array $icon, array $attributes, string $expectedSvg)
+    public function testRenderIconWithAutoAriaHidden(string|array $icon, array $attributes, string $expectedSvg): void
     {
         $icon = (array) $icon;
         $registry = $this->createRegistry([
@@ -343,7 +343,7 @@ class IconRendererTest extends TestCase
         ];
     }
 
-    public function testRenderIconWithAliases()
+    public function testRenderIconWithAliases(): void
     {
         $registry = $this->createRegistry([
             'foo' => '<path d="M0 FOO"/>',
@@ -366,7 +366,7 @@ class IconRendererTest extends TestCase
      * @param array<string, string> $attributes
      */
     #[DataProvider('provideRenderIconWithIconSetAttributes')]
-    public function testRenderIconWithIconSetAttributes(string $name, array $attributes, string $expectedSvg)
+    public function testRenderIconWithIconSetAttributes(string $name, array $attributes, string $expectedSvg): void
     {
         $registry = $this->createRegistry([
             'a' => '<path d="a"/>',
@@ -408,7 +408,7 @@ class IconRendererTest extends TestCase
      * @dataProvider provideRenderIconWithSuffixCases
      */
     #[DataProvider('provideRenderIconWithSuffixCases')]
-    public function testRenderIconWithSuffixes(string $name, string $expectedSvg)
+    public function testRenderIconWithSuffixes(string $name, string $expectedSvg): void
     {
         $registry = $this->createRegistry([
             'heroicons:arrow-right' => '<path d="outline"/>',
@@ -445,7 +445,7 @@ class IconRendererTest extends TestCase
         ];
     }
 
-    public function testRenderIconWithSuffixAttributeCascade()
+    public function testRenderIconWithSuffixAttributeCascade(): void
     {
         $registry = $this->createRegistry([
             'heroicons:arrow-solid' => ['<path d="solid"/>', ['ico' => 'ICON']],
@@ -465,7 +465,7 @@ class IconRendererTest extends TestCase
         $this->assertSame('<svg ico="ICON" def="DEF" set="SET" suf="SUF" ren="REN">', substr($svg, 0, strpos($svg, '>') + 1));
     }
 
-    public function testRenderIconWithSuffixOverwritesCascade()
+    public function testRenderIconWithSuffixOverwritesCascade(): void
     {
         $registry = $this->createRegistry([
             'heroicons:arrow-solid' => '<path d="solid"/>',
@@ -485,7 +485,7 @@ class IconRendererTest extends TestCase
         $this->assertSame('<svg class="icon-solid"><path d="solid"/></svg>', $svg);
     }
 
-    public function testRenderIconWithSuffixAndRenderTimeOverwrite()
+    public function testRenderIconWithSuffixAndRenderTimeOverwrite(): void
     {
         $registry = $this->createRegistry([
             'heroicons:arrow-solid' => '<path d="solid"/>',
@@ -503,7 +503,7 @@ class IconRendererTest extends TestCase
         $this->assertSame('<svg class="custom"><path d="solid"/></svg>', $svg);
     }
 
-    public function testRenderIconWithoutSuffixesRemainsBackwardsCompatible()
+    public function testRenderIconWithoutSuffixesRemainsBackwardsCompatible(): void
     {
         $registry = $this->createRegistry([
             'heroicons:arrow' => '<path d="arrow"/>',
@@ -516,7 +516,7 @@ class IconRendererTest extends TestCase
         $this->assertSame('<svg class="icon" fill="none"><path d="arrow"/></svg>', $svg);
     }
 
-    public function testRenderIconWithSuffixAndAliases()
+    public function testRenderIconWithSuffixAndAliases(): void
     {
         $registry = $this->createRegistry([
             'heroicons:arrow-solid' => '<path d="solid"/>',
@@ -535,7 +535,7 @@ class IconRendererTest extends TestCase
         $this->assertSame('<svg class="icon-solid"><path d="solid"/></svg>', $svg);
     }
 
-    public function testRenderIconWithNoMatchingSuffix()
+    public function testRenderIconWithNoMatchingSuffix(): void
     {
         $registry = $this->createRegistry([
             'heroicons:arrow-unknown' => '<path d="unknown"/>',
@@ -553,7 +553,7 @@ class IconRendererTest extends TestCase
         $this->assertSame('<svg class="default"><path d="unknown"/></svg>', $svg);
     }
 
-    public function testRenderIconWithSuffixOnIconSetWithoutSuffixes()
+    public function testRenderIconWithSuffixOnIconSetWithoutSuffixes(): void
     {
         $registry = $this->createRegistry([
             'other:icon-solid' => '<path d="solid"/>',

--- a/src/Icons/tests/Unit/IconTest.php
+++ b/src/Icons/tests/Unit/IconTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Icons\Icon;
 
 final class IconTest extends TestCase
 {
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $icon = new Icon('foo', ['foo' => 'bar']);
         $this->assertSame('foo', $icon->getInnerSvg());
@@ -25,13 +25,13 @@ final class IconTest extends TestCase
     }
 
     #[DataProvider('provideIdToName')]
-    public function testIdToName(string $id, string $name)
+    public function testIdToName(string $id, string $name): void
     {
         $this->assertSame($name, Icon::idToName($id));
     }
 
     #[DataProvider('provideInvalidIds')]
-    public function testIdToNameThrowsException(string $id)
+    public function testIdToNameThrowsException(string $id): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The id "'.$id.'" is not a valid id.');
@@ -40,13 +40,13 @@ final class IconTest extends TestCase
     }
 
     #[DataProvider('provideNameToId')]
-    public function testNameToId(string $name, string $id)
+    public function testNameToId(string $name, string $id): void
     {
         $this->assertEquals($id, Icon::nameToId($name));
     }
 
     #[DataProvider('provideInvalidNames')]
-    public function testNameToIdThrowsException(string $name)
+    public function testNameToIdThrowsException(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The name "'.$name.'" is not a valid name.');
@@ -55,31 +55,31 @@ final class IconTest extends TestCase
     }
 
     #[DataProvider('provideValidIds')]
-    public function testIsValidIdWithValidIds(string $id)
+    public function testIsValidIdWithValidIds(string $id): void
     {
         $this->assertTrue(Icon::isValidId($id));
     }
 
     #[DataProvider('provideInvalidIds')]
-    public function testIsValidIdWithInvalidIds(string $id)
+    public function testIsValidIdWithInvalidIds(string $id): void
     {
         $this->assertFalse(Icon::isValidId($id));
     }
 
     #[DataProvider('provideValidNames')]
-    public function testIsValidNameWithValidNames(string $name)
+    public function testIsValidNameWithValidNames(string $name): void
     {
         $this->assertTrue(Icon::isValidName($name));
     }
 
     #[DataProvider('provideInvalidNames')]
-    public function testIsValidNameWithInvalidNames(string $name)
+    public function testIsValidNameWithInvalidNames(string $name): void
     {
         $this->assertFalse(Icon::isValidName($name));
     }
 
     #[DataProvider('provideInvalidIds')]
-    public function testInvalidIdToName(string $id)
+    public function testInvalidIdToName(string $id): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The id "'.$id.'" is not a valid id.');
@@ -89,14 +89,14 @@ final class IconTest extends TestCase
     }
 
     #[DataProvider('provideRenderAttributesTestCases')]
-    public function testRenderAttributes(array $attributes, string $expected)
+    public function testRenderAttributes(array $attributes, string $expected): void
     {
         $icon = new Icon('', $attributes);
         $this->assertStringStartsWith($expected, $icon->toHtml());
     }
 
     #[DataProvider('provideWithAttributesTestCases')]
-    public function testWithAttributes(array $attributes, array $withAttributes, array $expected)
+    public function testWithAttributes(array $attributes, array $withAttributes, array $expected): void
     {
         $icon = new Icon('foo', $attributes);
         $icon = $icon->withAttributes($withAttributes);
@@ -271,7 +271,7 @@ final class IconTest extends TestCase
         ];
     }
 
-    public function testSerialize()
+    public function testSerialize(): void
     {
         $icon = new Icon('foo', ['bar' => 'baz']);
 

--- a/src/Icons/tests/Unit/IconifyTest.php
+++ b/src/Icons/tests/Unit/IconifyTest.php
@@ -26,7 +26,7 @@ use Symfony\UX\Icons\Iconify;
  */
 class IconifyTest extends TestCase
 {
-    public function testFetchIcon()
+    public function testFetchIcon(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -53,7 +53,7 @@ class IconifyTest extends TestCase
         $this->assertEquals($icon->getAttributes(), ['viewBox' => '0 0 24 24', 'xmlns' => 'http://www.w3.org/2000/svg']);
     }
 
-    public function testFetchIconSanitizesBody()
+    public function testFetchIconSanitizesBody(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -68,7 +68,7 @@ class IconifyTest extends TestCase
         $this->assertSame('<rect></rect>', $iconify->fetchIcon('bi', 'heart')->getInnerSvg());
     }
 
-    public function testFetchIconsSanitizesBody()
+    public function testFetchIconsSanitizesBody(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -85,7 +85,7 @@ class IconifyTest extends TestCase
         $this->assertSame('<path d="M0 0"></path>', $icons['heart']->getInnerSvg());
     }
 
-    public function testFetchIconThrowsNotFoundWhenBodyIsInvalid()
+    public function testFetchIconThrowsNotFoundWhenBodyIsInvalid(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -102,7 +102,7 @@ class IconifyTest extends TestCase
         $iconify->fetchIcon('bi', 'heart');
     }
 
-    public function testFetchIconsSkipsIconsWithInvalidBody()
+    public function testFetchIconsSkipsIconsWithInvalidBody(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -123,7 +123,7 @@ class IconifyTest extends TestCase
         $this->assertArrayNotHasKey('bad', $icons);
     }
 
-    public function testFetchIconByAlias()
+    public function testFetchIconByAlias(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -155,7 +155,7 @@ class IconifyTest extends TestCase
         $this->assertEquals($icon->getAttributes(), ['viewBox' => '0 0 24 24', 'xmlns' => 'http://www.w3.org/2000/svg']);
     }
 
-    public function testFetchIconThrowsWhenIconSetDoesNotExists()
+    public function testFetchIconThrowsWhenIconSetDoesNotExists(): void
     {
         $iconify = new Iconify(new NullAdapter(), new IconFactory(), 'https://example.com', new MockHttpClient(new JsonMockResponse([])));
 
@@ -165,7 +165,7 @@ class IconifyTest extends TestCase
         $iconify->fetchIcon('bi', 'heart');
     }
 
-    public function testFetchIconUsesIconsetViewBoxHeight()
+    public function testFetchIconUsesIconsetViewBoxHeight(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -194,7 +194,7 @@ class IconifyTest extends TestCase
         $this->assertEquals('0 0 17 17', $icon->getAttributes()['viewBox']);
     }
 
-    public function testFetchIconSetsDefaultViewBoxTo16()
+    public function testFetchIconSetsDefaultViewBoxTo16(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -221,7 +221,7 @@ class IconifyTest extends TestCase
         $this->assertEquals('0 0 16 16', $icon->getAttributes()['viewBox']);
     }
 
-    public function testFetchIconThrowsWhenStatusCodeNot200()
+    public function testFetchIconThrowsWhenStatusCodeNot200(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -241,7 +241,7 @@ class IconifyTest extends TestCase
         $iconify->fetchIcon('bi', 'heart');
     }
 
-    public function testFetchIcons()
+    public function testFetchIcons(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -273,7 +273,7 @@ class IconifyTest extends TestCase
         $this->assertContainsOnlyInstancesOf(Icon::class, $icons);
     }
 
-    public function testFetchIconsByAliases()
+    public function testFetchIconsByAliases(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -314,7 +314,7 @@ class IconifyTest extends TestCase
         $this->assertContainsOnlyInstancesOf(Icon::class, $icons);
     }
 
-    public function testFetchIconsThrowsWithInvalidIconNames()
+    public function testFetchIconsThrowsWithInvalidIconNames(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -332,7 +332,7 @@ class IconifyTest extends TestCase
         $iconify->fetchIcons('bi', ['à', 'foo']);
     }
 
-    public function testFetchIconsThrowsWithTooManyIcons()
+    public function testFetchIconsThrowsWithTooManyIcons(): void
     {
         $iconify = new Iconify(
             cache: new NullAdapter(),
@@ -350,7 +350,7 @@ class IconifyTest extends TestCase
         $iconify->fetchIcons('bi', array_fill(0, 50, '1234567890'));
     }
 
-    public function testGetMetadata()
+    public function testGetMetadata(): void
     {
         $responseFile = __DIR__.'/../Fixtures/Iconify/collections.json';
         $client = $this->createHttpClient(json_decode(file_get_contents($responseFile)));
@@ -361,7 +361,7 @@ class IconifyTest extends TestCase
     }
 
     #[DataProvider('provideChunkCases')]
-    public function testChunk(int $maxQueryLength, string $prefix, array $names, array $chunks)
+    public function testChunk(int $maxQueryLength, string $prefix, array $names, array $chunks): void
     {
         $iconify = new Iconify(
             new NullAdapter(),
@@ -412,7 +412,7 @@ class IconifyTest extends TestCase
         ];
     }
 
-    public function testChunkThrowWithIconPrefixTooLong()
+    public function testChunkThrowWithIconPrefixTooLong(): void
     {
         $iconify = new Iconify(new NullAdapter(), new IconFactory(), 'https://example.com', new MockHttpClient([]));
 
@@ -425,7 +425,7 @@ class IconifyTest extends TestCase
         $result = iterator_to_array($iconify->chunk($prefix, [$name]));
     }
 
-    public function testChunkThrowWithIconNameTooLong()
+    public function testChunkThrowWithIconNameTooLong(): void
     {
         $iconify = new Iconify(new NullAdapter(), new IconFactory(), 'https://example.com', new MockHttpClient([]));
 

--- a/src/Icons/tests/Unit/Registry/AutoLockIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/AutoLockIconRegistryTest.php
@@ -36,7 +36,7 @@ final class AutoLockIconRegistryTest extends TestCase
         new Filesystem()->remove($this->iconDir);
     }
 
-    public function testReturnsIconFromInnerAndPersistsItToDisk()
+    public function testReturnsIconFromInnerAndPersistsItToDisk(): void
     {
         $icon = new Icon('<path d="M0 0"/>', ['viewBox' => '0 0 24 24']);
         $inner = new InMemoryIconRegistry(['lucide:heart' => $icon]);
@@ -49,7 +49,7 @@ final class AutoLockIconRegistryTest extends TestCase
         $this->assertStringEqualsFile($this->iconDir.'/lucide/heart.svg', $icon->toHtml());
     }
 
-    public function testPropagatesIconNotFoundAndWritesNothing()
+    public function testPropagatesIconNotFoundAndWritesNothing(): void
     {
         $local = new LocalSvgIconRegistry(new IconFactory(), $this->iconDir);
         $registry = new AutoLockIconRegistry(new InMemoryIconRegistry(), $local);
@@ -62,7 +62,7 @@ final class AutoLockIconRegistryTest extends TestCase
         }
     }
 
-    public function testWriteFailureIsNonFatalAndLogged()
+    public function testWriteFailureIsNonFatalAndLogged(): void
     {
         $icon = new Icon('<path d="M0 0"/>');
         $inner = new InMemoryIconRegistry(['lucide:heart' => $icon]);

--- a/src/Icons/tests/Unit/Registry/CacheIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/CacheIconRegistryTest.php
@@ -25,7 +25,7 @@ use Symfony\UX\Icons\Tests\Util\InMemoryIconRegistry;
 final class CacheIconRegistryTest extends TestCase
 {
     #[DataProvider('provideInvalidNames')]
-    public function testInvalidNameIsRejectedEvenIfInnerRegistryHasIt(string $name)
+    public function testInvalidNameIsRejectedEvenIfInnerRegistryHasIt(string $name): void
     {
         $inner = new InMemoryIconRegistry([$name => new Icon('<path d="M0 0h24v24H0z"/>')]);
         $registry = new CacheIconRegistry($inner, new ArrayAdapter());
@@ -36,7 +36,7 @@ final class CacheIconRegistryTest extends TestCase
         $registry->get($name);
     }
 
-    public function testValidNameIsResolvedAndCached()
+    public function testValidNameIsResolvedAndCached(): void
     {
         $icon = new Icon('<path d="M0 0h24v24H0z"/>');
         $cache = new ArrayAdapter();

--- a/src/Icons/tests/Unit/Registry/IconifyOnDemandRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/IconifyOnDemandRegistryTest.php
@@ -25,7 +25,7 @@ use Symfony\UX\Icons\Registry\IconifyOnDemandRegistry;
  */
 final class IconifyOnDemandRegistryTest extends TestCase
 {
-    public function testWithIconSetAlias()
+    public function testWithIconSetAlias(): void
     {
         $client = new MockHttpClient([
             new JsonMockResponse(['lucide' => []]),

--- a/src/Icons/tests/Unit/Registry/InMemoryIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/InMemoryIconRegistryTest.php
@@ -21,7 +21,7 @@ use Symfony\UX\Icons\Tests\Util\InMemoryIconRegistry;
  */
 final class InMemoryIconRegistryTest extends TestCase
 {
-    public function testRegistryConstructor()
+    public function testRegistryConstructor(): void
     {
         $icon = new Icon('foo', ['bar' => 'foobar']);
         $registry = new InMemoryIconRegistry(['foo' => $icon]);
@@ -29,7 +29,7 @@ final class InMemoryIconRegistryTest extends TestCase
         $this->assertSame($icon, $registry->get('foo'));
     }
 
-    public function testRegistryReplaceIcon()
+    public function testRegistryReplaceIcon(): void
     {
         $registry = new InMemoryIconRegistry();
         $foo = new Icon('foo', []);
@@ -45,7 +45,7 @@ final class InMemoryIconRegistryTest extends TestCase
         $this->assertSame($foo, $registry->get('bar'));
     }
 
-    public function testRegistryThrowsExceptionOnUnknownIcon()
+    public function testRegistryThrowsExceptionOnUnknownIcon(): void
     {
         $this->expectException(IconNotFoundException::class);
         $this->expectExceptionMessage('Icon "foo" not found.');

--- a/src/Icons/tests/Unit/Registry/LocalSvgIconRegistryTest.php
+++ b/src/Icons/tests/Unit/Registry/LocalSvgIconRegistryTest.php
@@ -23,7 +23,7 @@ use Symfony\UX\Icons\Registry\LocalSvgIconRegistry;
 final class LocalSvgIconRegistryTest extends TestCase
 {
     #[DataProvider('validSvgProvider')]
-    public function testValidSvgs(string $name, array $expectedAttributes, string $expectedContent)
+    public function testValidSvgs(string $name, array $expectedAttributes, string $expectedContent): void
     {
         $icon = $this->registry()->get($name);
         $this->assertInstanceOf(Icon::class, $icon);
@@ -65,7 +65,7 @@ final class LocalSvgIconRegistryTest extends TestCase
     }
 
     #[DataProvider('invalidSvgProvider')]
-    public function testInvalidSvgs(string $name)
+    public function testInvalidSvgs(string $name): void
     {
         $this->expectException(\RuntimeException::class);
 
@@ -81,7 +81,7 @@ final class LocalSvgIconRegistryTest extends TestCase
     }
 
     #[DataProvider('provideIconSetPathsCases')]
-    public function testIconSetPaths(string $name, array $iconSetPaths, ?string $expectedContent)
+    public function testIconSetPaths(string $name, array $iconSetPaths, ?string $expectedContent): void
     {
         $registry = new LocalSvgIconRegistry(
             iconFactory: new IconFactory(),

--- a/src/Icons/tests/Unit/Twig/UXIconRuntimeTest.php
+++ b/src/Icons/tests/Unit/Twig/UXIconRuntimeTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Icons\Twig\UXIconRuntime;
  */
 class UXIconRuntimeTest extends TestCase
 {
-    public function testRenderIconIgnoreNotFound()
+    public function testRenderIconIgnoreNotFound(): void
     {
         $renderer = $this->createMock(IconRendererInterface::class);
         $renderer->method('renderIcon')

--- a/src/LiveComponent/tests/Functional/Controller/BatchActionControllerTest.php
+++ b/src/LiveComponent/tests/Functional/Controller/BatchActionControllerTest.php
@@ -28,7 +28,7 @@ final class BatchActionControllerTest extends KernelTestCase
     use HasBrowser;
     use LiveComponentTestHelper;
 
-    public function testCanBatchActions()
+    public function testCanBatchActions(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
@@ -83,7 +83,7 @@ final class BatchActionControllerTest extends KernelTestCase
         ;
     }
 
-    public function testCanBatchActionsWithAlternateRoute()
+    public function testCanBatchActionsWithAlternateRoute(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('alternate_route'));
 
@@ -121,7 +121,7 @@ final class BatchActionControllerTest extends KernelTestCase
         ;
     }
 
-    public function testRedirect()
+    public function testRedirect(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
@@ -157,7 +157,7 @@ final class BatchActionControllerTest extends KernelTestCase
         ;
     }
 
-    public function testRedirectWithAcceptHeader()
+    public function testRedirectWithAcceptHeader(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
@@ -197,7 +197,7 @@ final class BatchActionControllerTest extends KernelTestCase
         ;
     }
 
-    public function testDownloadDoesNotShortCircuitBatch()
+    public function testDownloadDoesNotShortCircuitBatch(): void
     {
         // unlike a redirect, a download no longer ends the batch: it rides along with the
         // final render, so the actions queued after it still run
@@ -231,7 +231,7 @@ final class BatchActionControllerTest extends KernelTestCase
         ;
     }
 
-    public function testLastDownloadWinsWithinABatch()
+    public function testLastDownloadWinsWithinABatch(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -257,7 +257,7 @@ final class BatchActionControllerTest extends KernelTestCase
         ;
     }
 
-    public function testException()
+    public function testException(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
@@ -291,7 +291,7 @@ final class BatchActionControllerTest extends KernelTestCase
         ;
     }
 
-    public function testCannotBatchWithNonLiveAction()
+    public function testCannotBatchWithNonLiveAction(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
@@ -325,7 +325,7 @@ final class BatchActionControllerTest extends KernelTestCase
         ;
     }
 
-    public function testAcceptsBatchAtMaxActions()
+    public function testAcceptsBatchAtMaxActions(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 
@@ -363,7 +363,7 @@ final class BatchActionControllerTest extends KernelTestCase
         ;
     }
 
-    public function testRejectsBatchAboveMaxActions()
+    public function testRejectsBatchAboveMaxActions(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_actions'));
 

--- a/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/AddLiveAttributesSubscriberTest.php
@@ -31,7 +31,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
     public const TODO_ITEM_DETERMINISTIC_PREFIX = 'live-1715058793-';
     public const TODO_ITEM_DETERMINISTIC_PREFIX_EMBEDDED = 'live-2285361477-';
 
-    public function testInitLiveComponent()
+    public function testInitLiveComponent(): void
     {
         $div = $this->browser()
             ->visit('/render-template/render_component_with_writable_props')
@@ -52,7 +52,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertArrayHasKey('id', $props['@attributes']);
     }
 
-    public function testCanUseCustomAttributesVariableName()
+    public function testCanUseCustomAttributesVariableName(): void
     {
         $div = $this->browser()
             ->visit('/render-template/render_custom_attributes')
@@ -68,7 +68,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertArrayHasKey('@checksum', $props);
     }
 
-    public function testItAddsIdAndFingerprintToChildComponent()
+    public function testItAddsIdAndFingerprintToChildComponent(): void
     {
         $templateName = 'components/todo_list.html.twig';
         $obscuredName = 'd9bcb8935cbb4282ac5d227fc82ae782';
@@ -100,7 +100,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertSame('XSdvsiDR8VG0GFDQbOnj74XfSmfL6WrzMbSQcdIRhSs=', $lis->eq(1)->attr('data-live-fingerprint-value'));
     }
 
-    public function testItDoesNotOverrideDataLiveIdIfSpecified()
+    public function testItDoesNotOverrideDataLiveIdIfSpecified(): void
     {
         $templateName = 'components/todo_list.html.twig';
         $obscuredName = 'a643d58357b14c9bb077f0c00a742059';
@@ -119,7 +119,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertSame('todo-item-3', $lis->last()->attr('id'));
     }
 
-    public function testQueryStringMappingAttribute()
+    public function testQueryStringMappingAttribute(): void
     {
         $div = $this->browser()
             ->visit('/render-template/render_component_with_url_bound_props')
@@ -151,7 +151,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertEquals($expected, $queryMapping);
     }
 
-    public function testAbsoluteUrl()
+    public function testAbsoluteUrl(): void
     {
         $div = $this->browser()
             ->visit('/render-template/render_with_absolute_url')
@@ -173,7 +173,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertSame($props['count'], 0);
     }
 
-    public function testAbsoluteUrlWithLiveQueryProp()
+    public function testAbsoluteUrlWithLiveQueryProp(): void
     {
         $props = [];
         $div = $this->browser()
@@ -204,7 +204,7 @@ final class AddLiveAttributesSubscriberTest extends KernelTestCase
         $this->assertSame($props['count'], 2);
     }
 
-    public function testFetchCredentials()
+    public function testFetchCredentials(): void
     {
         $div = $this->browser()
             ->visit('/render-template/render_with_fetch_credentials')

--- a/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/DeferLiveComponentSubscriberTest.php
@@ -21,7 +21,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
     use HasBrowser;
     use LiveComponentTestHelper;
 
-    public function testItSetsDeferredTemplateIfLiveIdNotPassed()
+    public function testItSetsDeferredTemplateIfLiveIdNotPassed(): void
     {
         $div = $this->browser()
             ->visit('/render-template/render_deferred_component')
@@ -49,7 +49,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         $this->assertSame('Long awaited data', $div->html());
     }
 
-    public function testItIncludesGivenTemplateWhileLoadingDeferredComponent()
+    public function testItIncludesGivenTemplateWhileLoadingDeferredComponent(): void
     {
         $div = $this->browser()
             ->visit('/render-template/render_deferred_component_with_template')
@@ -76,7 +76,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         $this->assertStringContainsString('Long awaited data', $div->html());
     }
 
-    public function testItIncludesComponentTemplateBlockAsPlaceholder()
+    public function testItIncludesComponentTemplateBlockAsPlaceholder(): void
     {
         $div = $this->browser()
             ->visit('/render-template/render_deferred_component_with_placeholder')
@@ -87,7 +87,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         $this->assertSame('<span class="loading-row"></span><span class="loading-row"></span>', trim($div->html()));
     }
 
-    public function testItDoesNotIncludesPlaceholderWhenRendered()
+    public function testItDoesNotIncludesPlaceholderWhenRendered(): void
     {
         $div = $this->browser()
             ->visit('/render-template/render_component_with_placeholder')
@@ -97,7 +97,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         $this->assertStringNotContainsString('<span class="loading-row">', $div->html());
     }
 
-    public function testItAllowsToSetCustomLoadingHtmlTag()
+    public function testItAllowsToSetCustomLoadingHtmlTag(): void
     {
         $crawler = $this->browser()
             ->visit('/render-template/render_deferred_component_with_li_tag')
@@ -109,7 +109,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         $this->assertSame(1, $crawler->filter('li')->count());
     }
 
-    public function testLazyComponentIsNotRendered()
+    public function testLazyComponentIsNotRendered(): void
     {
         $crawler = $this->browser()
             ->visit('/render-template/render_lazy_component')
@@ -124,7 +124,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
     }
 
     #[DataProvider('provideLoadingValues')]
-    public function testLazyComponentRenderingDependsOnLazyValue(mixed $lazy, bool $isRendered)
+    public function testLazyComponentRenderingDependsOnLazyValue(mixed $lazy, bool $isRendered): void
     {
         $crawler = $this->browser()
             ->visit('/render-template/render_lazy_component_with_value?loading='.$lazy)
@@ -143,7 +143,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         ];
     }
 
-    public function testLazyComponentIsRenderedLaterWithInitialData()
+    public function testLazyComponentIsRenderedLaterWithInitialData(): void
     {
         $crawler = $this->browser()
             ->visit('/render-template/render_lazy_component')
@@ -170,7 +170,7 @@ final class DeferLiveComponentSubscriberTest extends KernelTestCase
         $browser->assertElementAttributeContains('#count', 'value', '7');
     }
 
-    public function testSubscriberDoesNotHandleTwigComponent()
+    public function testSubscriberDoesNotHandleTwigComponent(): void
     {
         $browser = $this->browser()
             ->visit('/render-template/render_lazy_twig_component')

--- a/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/InterceptChildComponentRenderSubscriberTest.php
@@ -14,7 +14,6 @@ namespace Symfony\UX\LiveComponent\Tests\Functional\EventListener;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\BrowserKit\AbstractBrowser;
-use Symfony\UX\LiveComponent\LiveComponentHydrator;
 use Symfony\UX\LiveComponent\Tests\LiveComponentTestHelper;
 use Zenstruck\Browser\Test\HasBrowser;
 
@@ -32,7 +31,7 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
         AddLiveAttributesSubscriberTest::TODO_ITEM_DETERMINISTIC_PREFIX.'1' => '8AooEz36WYQyxj54BCaDm/jKbcdDdPDLaNO4/49bcQk=',
     ];
 
-    public function testItAllowsFullChildRenderOnMissingFingerprints()
+    public function testItAllowsFullChildRenderOnMissingFingerprints(): void
     {
         $this->browser()
             ->visit($this->buildUrlForTodoListComponent([]))
@@ -44,7 +43,7 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testItRendersEmptyElementOnMatchingFingerprintBasic()
+    public function testItRendersEmptyElementOnMatchingFingerprintBasic(): void
     {
         $this->browser()
             ->visit($this->buildUrlForTodoListComponent(self::$actualTodoItemFingerprints))
@@ -56,7 +55,7 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testItRendersEmptyElementOnMatchingFingerprintWithCustomDataLiveId()
+    public function testItRendersEmptyElementOnMatchingFingerprintWithCustomDataLiveId(): void
     {
         $fingerPrintsWithCustomLiveId = [];
         foreach (array_values(self::$actualTodoItemFingerprints) as $key => $fingerprintValue) {
@@ -73,7 +72,7 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testItRendersNewPropWhenFingerprintDoesNotMatch()
+    public function testItRendersNewPropWhenFingerprintDoesNotMatch(): void
     {
         $fingerprints = self::$actualTodoItemFingerprints;
         $fingerprints[AddLiveAttributesSubscriberTest::TODO_ITEM_DETERMINISTIC_PREFIX_EMBEDDED.'0'] = 'wrong fingerprint';
@@ -106,7 +105,7 @@ final class InterceptChildComponentRenderSubscriberTest extends KernelTestCase
             });
     }
 
-    public function testItUsesKeysToRenderChildrenLiveIds()
+    public function testItUsesKeysToRenderChildrenLiveIds(): void
     {
         $fingerprintValues = array_values(self::$actualTodoItemFingerprints);
         $fingerprints = [];

--- a/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/LiveComponentSubscriberTest.php
@@ -44,7 +44,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
      */
     public const DETERMINISTIC_ID_MULTI_2 = 30904230242;
 
-    public function testCanRenderComponentAsHtml()
+    public function testCanRenderComponentAsHtml(): void
     {
         $component = $this->mountComponent('component1', [
             'prop1' => $entity = persist(Entity1::class),
@@ -73,7 +73,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testCanRenderComponentAsHtmlWithAlternateRoute()
+    public function testCanRenderComponentAsHtmlWithAlternateRoute(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('alternate_route'));
 
@@ -93,7 +93,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
     }
 
     #[Group('transient-on-windows')]
-    public function testCanExecuteComponentActionNormalRoute()
+    public function testCanExecuteComponentActionNormalRoute(): void
     {
         $templateName = 'render_embedded_with_blocks.html.twig';
         $obscuredName = '4bd9245af4594aa28cb77583c29e188e';
@@ -131,7 +131,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testCanExecuteComponentActionWithAlternateRoute()
+    public function testCanExecuteComponentActionWithAlternateRoute(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('alternate_route'));
 
@@ -155,7 +155,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testCannotExecuteComponentActionForGetRequest()
+    public function testCannotExecuteComponentActionForGetRequest(): void
     {
         $this->browser()
             ->get('/_components/component2/increase')
@@ -163,7 +163,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testCannotExecuteComponentDefaultActionForGetRequestWhenMethodIsPost()
+    public function testCannotExecuteComponentDefaultActionForGetRequestWhenMethodIsPost(): void
     {
         $this->browser()
             ->get('/_components/with_method_post/__invoke')
@@ -171,7 +171,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testPreReRenderHookOnlyExecutedDuringAjax()
+    public function testPreReRenderHookOnlyExecutedDuringAjax(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('component2'));
 
@@ -192,7 +192,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
     }
 
     #[Group('transient-on-windows')]
-    public function testItAddsEmbeddedTemplateContextToEmbeddedComponents()
+    public function testItAddsEmbeddedTemplateContextToEmbeddedComponents(): void
     {
         $templateName = 'render_embedded_with_blocks.html.twig';
         $obscuredName = '1918f197faab43278ba06c0a672a2b97';
@@ -230,7 +230,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
     }
 
     #[Group('transient-on-windows')]
-    public function testItWorksWithNamespacedTemplateNamesForEmbeddedComponents()
+    public function testItWorksWithNamespacedTemplateNamesForEmbeddedComponents(): void
     {
         $templateName = 'render_embedded_with_blocks.html.twig';
         $obscuredName = 'fb7992f74bbb43c08e47b7cf5c880edb';
@@ -244,7 +244,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
     }
 
     #[Group('transient-on-windows')]
-    public function testItUseBlocksFromEmbeddedContextUsingMultipleComponents()
+    public function testItUseBlocksFromEmbeddedContextUsingMultipleComponents(): void
     {
         $templateName = 'render_multiple_embedded_with_blocks.html.twig';
         $obscuredName = '5c474b02358c46cca3da7340cc79cc2e';
@@ -277,7 +277,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
     }
 
     #[Group('transient-on-windows')]
-    public function testItUseBlocksFromEmbeddedContextUsingMultipleComponentsWithNamespacedTemplate()
+    public function testItUseBlocksFromEmbeddedContextUsingMultipleComponentsWithNamespacedTemplate(): void
     {
         $templateName = 'render_multiple_embedded_with_blocks.html.twig';
         $obscuredName = '5c474b02358c46cca3da7340cc79cc2e';
@@ -309,7 +309,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testCanRedirectFromComponentAction()
+    public function testCanRedirectFromComponentAction(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('component2'));
 
@@ -345,7 +345,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testInjectsLiveArgs()
+    public function testInjectsLiveArgs(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('component6'));
 
@@ -380,7 +380,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testWithNullableEntity()
+    public function testWithNullableEntity(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_nullable_entity'));
 
@@ -398,7 +398,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testCanHaveControllerAttributes()
+    public function testCanHaveControllerAttributes(): void
     {
         if (!class_exists(IsGranted::class)) {
             $this->markTestSkipped('The security attributes are not available.');
@@ -416,7 +416,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testCanInjectSecurityUserIntoAction()
+    public function testCanInjectSecurityUserIntoAction(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('with_security'));
 
@@ -471,7 +471,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ];
     }
 
-    public function testDownloadRidesAlongTheRenderedComponent()
+    public function testDownloadRidesAlongTheRenderedComponent(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -485,7 +485,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame('application/vnd.live-component+html', $result['headers']->get('Content-Type'));
     }
 
-    public function testDownloadKeepsStateChangedByTheAction()
+    public function testDownloadKeepsStateChangedByTheAction(): void
     {
         // the whole point of riding along: the action's LiveProp change survives
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
@@ -495,7 +495,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertStringContainsString('<span id="count">1</span>', $result['html']);
     }
 
-    public function testHtmlLengthIsExactSoTheSplitIsLossless()
+    public function testHtmlLengthIsExactSoTheSplitIsLossless(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -510,7 +510,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         );
     }
 
-    public function testDownloadOfBytesThatAreNotValidUtf8()
+    public function testDownloadOfBytesThatAreNotValidUtf8(): void
     {
         // the split must happen on bytes: decoding first would corrupt this payload
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
@@ -521,7 +521,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame(5, \strlen($result['file']));
     }
 
-    public function testDownloadWithMultibyteHtmlSplitsOnBytesNotCharacters()
+    public function testDownloadWithMultibyteHtmlSplitsOnBytesNotCharacters(): void
     {
         // the rendered HTML carries a multibyte filename, so a character-based
         // offset would land mid-sequence and shift the file
@@ -533,7 +533,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame('résumé.txt', rawurldecode($result['headers']->get('X-Live-Download-Filename')));
     }
 
-    public function testDownloadFilenameIsPercentEncodedForTheHeader()
+    public function testDownloadFilenameIsPercentEncodedForTheHeader(): void
     {
         // headers are ASCII-only: encoding sidesteps the RFC 5987 dance entirely
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
@@ -545,7 +545,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame($raw, preg_replace('/[^\x20-\x7e]/', '', $raw));
     }
 
-    public function testDownloadDefaultsToOctetStream()
+    public function testDownloadDefaultsToOctetStream(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -555,7 +555,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame('plain content', $result['file']);
     }
 
-    public function testDownloadOfEmptyContent()
+    public function testDownloadOfEmptyContent(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -565,7 +565,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame('empty.txt', rawurldecode($result['headers']->get('X-Live-Download-Filename')));
     }
 
-    public function testActionWithoutDownloadCarriesNoDownloadHeaders()
+    public function testActionWithoutDownloadCarriesNoDownloadHeaders(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -581,7 +581,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testStreamedDownloadFromAResource()
+    public function testStreamedDownloadFromAResource(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -593,7 +593,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertStringContainsString('<span id="count">1</span>', $result['html']);
     }
 
-    public function testStreamedDownloadFromAClosure()
+    public function testStreamedDownloadFromAClosure(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -603,7 +603,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame('chunks.txt', rawurldecode($result['headers']->get('X-Live-Download-Filename')));
     }
 
-    public function testStreamedDownloadWithSizeCarriesContentLength()
+    public function testStreamedDownloadWithSizeCarriesContentLength(): void
     {
         // both lengths known: the browser can report progress over the whole body
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
@@ -617,7 +617,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         );
     }
 
-    public function testStreamedDownloadWithoutSizeOmitsContentLength()
+    public function testStreamedDownloadWithoutSizeOmitsContentLength(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -628,7 +628,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame("\x00\x01\x02\xFF\xFE", $result['file']);
     }
 
-    public function testStreamedAndBufferedDownloadsProduceTheSameWireFormat()
+    public function testStreamedAndBufferedDownloadsProduceTheSameWireFormat(): void
     {
         // the client cannot tell the two apart: same headers, same layout
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
@@ -647,7 +647,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         );
     }
 
-    public function testDownloadUrlLeavesTheRenderUntouched()
+    public function testDownloadUrlLeavesTheRenderUntouched(): void
     {
         // the recommended path: the browser fetches the file itself, nothing rides along
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
@@ -665,7 +665,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testDownloadFileFromAnSplFileInfo()
+    public function testDownloadFileFromAnSplFileInfo(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -676,7 +676,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame('foo.json', rawurldecode($result['headers']->get('X-Live-Download-Filename')));
     }
 
-    public function testStreamedDownloadFromAGenerator()
+    public function testStreamedDownloadFromAGenerator(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -685,7 +685,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertSame('part-1part-2', $result['file']);
     }
 
-    public function testDownloadFromALiveListener()
+    public function testDownloadFromALiveListener(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
 
@@ -695,7 +695,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertStringContainsString('<span id="count">1</span>', $result['html']);
     }
 
-    public function testDownloadAlongsideABrowserEvent()
+    public function testDownloadAlongsideABrowserEvent(): void
     {
         // both ride on the same render: the event lands in the attributes, the file after the HTML
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));
@@ -707,7 +707,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         self::assertStringContainsString('export:done', $result['html']);
     }
 
-    public function testDownloadFromTheDefaultActionIsRejected()
+    public function testDownloadFromTheDefaultActionIsRejected(): void
     {
         // the default action runs on every re-render: a polling component would otherwise
         // fire a download every few hundred milliseconds
@@ -724,7 +724,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testAnActionCanStillRedirect()
+    public function testAnActionCanStillRedirect(): void
     {
         // combining a redirect and a download is impossible by construction now: an action
         // returns one or the other
@@ -746,7 +746,7 @@ final class LiveComponentSubscriberTest extends KernelTestCase
         ;
     }
 
-    public function testDownloadIsNotCarriedOverToTheNextResponse()
+    public function testDownloadIsNotCarriedOverToTheNextResponse(): void
     {
         // the responder is a shared service: a consumed download must not leak
         $dehydrated = $this->dehydrateComponent($this->mountComponent('download_file'));

--- a/src/LiveComponent/tests/Functional/EventListener/RequestInitializerSubscriberTest.php
+++ b/src/LiveComponent/tests/Functional/EventListener/RequestInitializerSubscriberTest.php
@@ -18,7 +18,7 @@ class RequestInitializerSubscriberTest extends KernelTestCase
 {
     use HasBrowser;
 
-    public function testQueryStringPropsInitialization()
+    public function testQueryStringPropsInitialization(): void
     {
         $queryString = '?'
             .'stringProp=foo'

--- a/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Functional/Form/ComponentWithFormTest.php
@@ -37,7 +37,7 @@ class ComponentWithFormTest extends KernelTestCase
     use LiveComponentTestHelper;
     use ResetDatabase;
 
-    public function testFormValuesRebuildAfterFormChanges()
+    public function testFormValuesRebuildAfterFormChanges(): void
     {
         $browser = $this->browser();
         $crawler = $browser
@@ -118,7 +118,7 @@ class ComponentWithFormTest extends KernelTestCase
         ;
     }
 
-    public function testFormRemembersValidationFromInitialForm()
+    public function testFormRemembersValidationFromInitialForm(): void
     {
         /** @var FormFactoryInterface $formFactory */
         $formFactory = self::getContainer()->get('form.factory');
@@ -161,7 +161,7 @@ class ComponentWithFormTest extends KernelTestCase
         ;
     }
 
-    public function testHandleCheckboxChanges()
+    public function testHandleCheckboxChanges(): void
     {
         $category = CategoryFixtureEntityFactory::createMany(5);
         $id = $category[0]->getId();
@@ -294,7 +294,7 @@ class ComponentWithFormTest extends KernelTestCase
         ;
     }
 
-    public function testLiveCollectionTypeAddButtonsByDefault()
+    public function testLiveCollectionTypeAddButtonsByDefault(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('form_with_live_collection_type'))->getProps();
 
@@ -311,7 +311,7 @@ class ComponentWithFormTest extends KernelTestCase
         ;
     }
 
-    public function testResetForm()
+    public function testResetForm(): void
     {
         CategoryFixtureEntityFactory::createMany(5);
         $mounted = $this->mountComponent('form_with_many_different_fields_type');
@@ -364,7 +364,7 @@ class ComponentWithFormTest extends KernelTestCase
         ;
     }
 
-    public function testLiveCollectionTypeFieldsAddedAndRemoved()
+    public function testLiveCollectionTypeFieldsAddedAndRemoved(): void
     {
         $dehydratedProps = $this->dehydrateComponent($this->mountComponent('form_with_live_collection_type'))->getProps();
         $updatedProps = [];
@@ -440,7 +440,7 @@ class ComponentWithFormTest extends KernelTestCase
         ;
     }
 
-    public function testDataModelAttributeAutomaticallyAdded()
+    public function testDataModelAttributeAutomaticallyAdded(): void
     {
         $dehydrated = $this->dehydrateComponent($this->mountComponent('form_with_collection_type'))->getProps();
 
@@ -456,7 +456,7 @@ class ComponentWithFormTest extends KernelTestCase
         ;
     }
 
-    public function testFormWithLivePropContainingAnEntityImplementingAnInterface()
+    public function testFormWithLivePropContainingAnEntityImplementingAnInterface(): void
     {
         $user = persist(User::class, ['username' => 'Fabien']);
         self::assertInstanceOf(User::class, $user);
@@ -490,7 +490,7 @@ class ComponentWithFormTest extends KernelTestCase
         self::assertEquals('Nicolas', $user->username);
     }
 
-    public function testSubmitFormExceptionMessageContainsFieldPathsAndMessages()
+    public function testSubmitFormExceptionMessageContainsFieldPathsAndMessages(): void
     {
         $mounted = $this->mountComponent('form_with_collection_type');
         $dehydratedProps = $this->dehydrateComponent($mounted)->getProps();

--- a/src/LiveComponent/tests/Functional/LiveResponderTest.php
+++ b/src/LiveComponent/tests/Functional/LiveResponderTest.php
@@ -23,7 +23,7 @@ final class LiveResponderTest extends KernelTestCase
     use HasBrowser;
     use LiveComponentTestHelper;
 
-    public function testComponentCanEmitEvents()
+    public function testComponentCanEmitEvents(): void
     {
         $component = $this->mountComponent('component_with_emit');
         $dehydrated = $this->dehydrateComponent($component);
@@ -38,7 +38,7 @@ final class LiveResponderTest extends KernelTestCase
             ->assertSee('Data: {"foo":"bar","bar":"foo"}');
     }
 
-    public function testComponentCanDispatchBrowserEvents()
+    public function testComponentCanDispatchBrowserEvents(): void
     {
         $component = $this->mountComponent('component_with_emit');
         $dehydrated = $this->dehydrateComponent($component);

--- a/src/LiveComponent/tests/Functional/LiveResponseRemoveTest.php
+++ b/src/LiveComponent/tests/Functional/LiveResponseRemoveTest.php
@@ -29,7 +29,7 @@ final class LiveResponseRemoveTest extends KernelTestCase
         RemoveComponent::$preReRenderCalls = 0;
     }
 
-    public function testRemoveAnswersWithRenderedHtmlAndTheRemoveHeader()
+    public function testRemoveAnswersWithRenderedHtmlAndTheRemoveHeader(): void
     {
         $response = $this->postAction('dismiss')->client()->getResponse();
 
@@ -39,14 +39,14 @@ final class LiveResponseRemoveTest extends KernelTestCase
         $this->assertStringContainsString('Count: 1', $response->getContent());
     }
 
-    public function testRemoveRendersAndRunsTheHooks()
+    public function testRemoveRendersAndRunsTheHooks(): void
     {
         $this->postAction('dismiss');
 
         $this->assertSame(1, RemoveComponent::$preReRenderCalls);
     }
 
-    public function testRemoveCarriesLiveAndBrowserEventsInTheRenderedHtml()
+    public function testRemoveCarriesLiveAndBrowserEventsInTheRenderedHtml(): void
     {
         $crawler = $this->postAction('dismissWithEvents')->crawler();
         $element = $crawler->filter('[data-controller~="live"]');
@@ -59,7 +59,7 @@ final class LiveResponseRemoveTest extends KernelTestCase
         ], json_decode($element->attr('data-live-events-to-dispatch-value'), true));
     }
 
-    public function testAnOrdinaryActionStillRendersAndRunsTheHooks()
+    public function testAnOrdinaryActionStillRendersAndRunsTheHooks(): void
     {
         $response = $this->postAction('keep')->client()->getResponse();
 

--- a/src/LiveComponent/tests/Functional/Metadata/LiveComponentMetadataFactoryTest.php
+++ b/src/LiveComponent/tests/Functional/Metadata/LiveComponentMetadataFactoryTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Component\ComponentWithUrlBoundProps
 
 class LiveComponentMetadataFactoryTest extends KernelTestCase
 {
-    public function testQueryStringMapping()
+    public function testQueryStringMapping(): void
     {
         /** @var LiveComponentMetadataFactory $metadataFactory */
         $metadataFactory = self::getContainer()->get('ux.live_component.metadata_factory');

--- a/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
+++ b/src/LiveComponent/tests/Functional/Test/InteractsWithLiveComponentsTest.php
@@ -31,7 +31,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
     use InteractsWithLiveComponents;
     use ResetDatabase;
 
-    public function testCanRenderInitialData()
+    public function testCanRenderInitialData(): void
     {
         $testComponent = $this->createLiveComponent('component2');
 
@@ -39,7 +39,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertSame(1, $testComponent->component()->count);
     }
 
-    public function testCanCreateWithClassString()
+    public function testCanCreateWithClassString(): void
     {
         $testComponent = $this->createLiveComponent(Component2::class);
 
@@ -47,7 +47,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertSame(1, $testComponent->component()->count);
     }
 
-    public function testCanCallLiveAction()
+    public function testCanCallLiveAction(): void
     {
         $testComponent = $this->createLiveComponent('component2');
 
@@ -60,7 +60,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertSame(2, $testComponent->component()->count);
     }
 
-    public function testCanCallLiveActionWithArguments()
+    public function testCanCallLiveActionWithArguments(): void
     {
         $testComponent = $this->createLiveComponent('component6');
 
@@ -81,7 +81,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertSame(33.3, $testComponent->component()->arg3);
     }
 
-    public function testCanEmitEvent()
+    public function testCanEmitEvent(): void
     {
         $testComponent = $this->createLiveComponent('component2');
 
@@ -94,7 +94,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertSame(5, $testComponent->component()->count);
     }
 
-    public function testInvalidEventName()
+    public function testInvalidEventName(): void
     {
         $testComponent = $this->createLiveComponent('component2');
 
@@ -103,7 +103,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $testComponent->emit('invalid');
     }
 
-    public function testCanSetLiveProp()
+    public function testCanSetLiveProp(): void
     {
         $testComponent = $this->createLiveComponent('component_with_writable_props');
 
@@ -116,7 +116,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertSame(100, $testComponent->component()->count);
     }
 
-    public function testCanRefreshComponent()
+    public function testCanRefreshComponent(): void
     {
         $testComponent = $this->createLiveComponent('track_renders');
 
@@ -131,7 +131,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertStringContainsString('Re-Render Count: 3', $testComponent->render());
     }
 
-    public function testCanAccessResponse()
+    public function testCanAccessResponse(): void
     {
         $testComponent = $this->createLiveComponent('component2');
 
@@ -141,7 +141,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertSame('1', $response->headers->get('X-Custom-Header'));
     }
 
-    public function testCannotUpdateComponentIfNoLongerInContext()
+    public function testCannotUpdateComponentIfNoLongerInContext(): void
     {
         $testComponent = $this->createLiveComponent('component2')->call('redirect');
 
@@ -150,7 +150,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $testComponent->call('increase');
     }
 
-    public function testRenderingIsLazy()
+    public function testRenderingIsLazy(): void
     {
         if (!class_exists(IsGranted::class)) {
             $this->markTestSkipped('The security attributes are not available.');
@@ -163,7 +163,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $testComponent->render();
     }
 
-    public function testActingAs()
+    public function testActingAs(): void
     {
         $testComponent = $this->createLiveComponent('with_security')
             ->actingAs(new InMemoryUser('kevin', 'pass', ['ROLE_USER']))
@@ -176,7 +176,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertStringContainsString('Username: kevin', $testComponent->render());
     }
 
-    public function testCanSubmitForm()
+    public function testCanSubmitForm(): void
     {
         CategoryFixtureEntityFactory::createMany(5);
         $testComponent = $this->createLiveComponent('form_with_many_different_fields_type');
@@ -187,7 +187,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertStringContainsString('foobar', $testComponent->render());
     }
 
-    public function testAccessAllLivePropsInsideOnUpdatedHook()
+    public function testAccessAllLivePropsInsideOnUpdatedHook(): void
     {
         $testComponent = $this->createLiveComponent('with_on_updated', [
             'number1' => 1,
@@ -202,7 +202,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertStringContainsString('Total: 9', $testComponent->render());
     }
 
-    public function testSetLocaleRenderLocalizedComponent()
+    public function testSetLocaleRenderLocalizedComponent(): void
     {
         $testComponent = $this->createLiveComponent('localized_route');
         $testComponent->setRouteLocale('fr');
@@ -219,7 +219,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertStringContainsString('Locale: de', $testComponent->render());
     }
 
-    public function testAssertComponentEmitEvent()
+    public function testAssertComponentEmitEvent(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -232,7 +232,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
             ]);
     }
 
-    public function testAssertComponentEmitEventFails()
+    public function testAssertComponentEmitEventFails(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -245,7 +245,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         ]);
     }
 
-    public function testComponentEmitsExpectedPartialEventData()
+    public function testComponentEmitsExpectedPartialEventData(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -257,7 +257,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         ;
     }
 
-    public function testComponentDoesNotEmitUnexpectedEvent()
+    public function testComponentDoesNotEmitUnexpectedEvent(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -266,7 +266,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertComponentNotEmitEvent($testComponent, 'event2');
     }
 
-    public function testComponentDoesNotEmitUnexpectedEventFails()
+    public function testComponentDoesNotEmitUnexpectedEventFails(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -277,7 +277,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertComponentNotEmitEvent($testComponent, 'event1');
     }
 
-    public function testComponentEmitsEventWithIncorrectDataFails()
+    public function testComponentEmitsEventWithIncorrectDataFails(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -291,7 +291,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         ]);
     }
 
-    public function testAssertComponentDispatchBrowserEvent()
+    public function testAssertComponentDispatchBrowserEvent(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -304,7 +304,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
             ]);
     }
 
-    public function testAssertComponentDispatchBrowserEventFails()
+    public function testAssertComponentDispatchBrowserEventFails(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -317,7 +317,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         ]);
     }
 
-    public function testComponentDispatchesExpectedPartialBrowserEventData()
+    public function testComponentDispatchesExpectedPartialBrowserEventData(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -329,7 +329,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         ;
     }
 
-    public function testComponentDoesNotDispatchUnexpectedBrowserEvent()
+    public function testComponentDoesNotDispatchUnexpectedBrowserEvent(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -338,7 +338,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertComponentNotDispatchBrowserEvent($testComponent, 'browser-event2');
     }
 
-    public function testComponentDoesNotDispatchUnexpectedBrowserEventFails()
+    public function testComponentDoesNotDispatchUnexpectedBrowserEventFails(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 
@@ -349,7 +349,7 @@ final class InteractsWithLiveComponentsTest extends KernelTestCase
         $this->assertComponentNotDispatchBrowserEvent($testComponent, 'browser-event');
     }
 
-    public function testComponentDispatchesBrowserEventWithIncorrectDataFails()
+    public function testComponentDispatchesBrowserEventWithIncorrectDataFails(): void
     {
         $testComponent = $this->createLiveComponent('component_with_emit');
 

--- a/src/LiveComponent/tests/Functional/Util/RequestPropsExtractorTest.php
+++ b/src/LiveComponent/tests/Functional/Util/RequestPropsExtractorTest.php
@@ -24,7 +24,7 @@ class RequestPropsExtractorTest extends KernelTestCase
     use LiveComponentTestHelper;
 
     #[DataProvider('getQueryStringTests')]
-    public function testExtractFromQueryString(string $queryString, array $expected, array $attributes = [])
+    public function testExtractFromQueryString(string $queryString, array $expected, array $attributes = []): void
     {
         $extractor = new RequestPropsExtractor($this->hydrator());
 

--- a/src/LiveComponent/tests/Functional/ValidatableComponentTraitTest.php
+++ b/src/LiveComponent/tests/Functional/ValidatableComponentTraitTest.php
@@ -24,7 +24,7 @@ class ValidatableComponentTraitTest extends KernelTestCase
     use LiveComponentTestHelper;
     use ResetDatabase;
 
-    public function testFormValuesRebuildAfterFormChanges()
+    public function testFormValuesRebuildAfterFormChanges(): void
     {
         $dehydratedProps = $this->dehydrateComponent($this->mountComponent('validating_component'))->getProps();
 

--- a/src/LiveComponent/tests/Integration/Command/LiveComponentDebugCommandTest.php
+++ b/src/LiveComponent/tests/Integration/Command/LiveComponentDebugCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class LiveComponentDebugCommandTest extends KernelTestCase
 {
-    public function testList()
+    public function testList(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute([]);
@@ -31,7 +31,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('component2', $display);
     }
 
-    public function testListListeningToEvent()
+    public function testListListeningToEvent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['--listening' => 'the_event_name']);
@@ -45,7 +45,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('component5', $display);
     }
 
-    public function testEmptyListListeningToEvent()
+    public function testEmptyListListeningToEvent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['--listening' => 'event_not_defined']);
@@ -59,7 +59,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringNotContainsString('component5', $display);
     }
 
-    public function testWithNoMatchComponent()
+    public function testWithNoMatchComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $result = $commandTester->execute(['name' => 'NoMatchComponent']);
@@ -68,7 +68,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Unknown component "NoMatchComponent".', $commandTester->getDisplay());
     }
 
-    public function testNotLiveComponentsIsNotListed()
+    public function testNotLiveComponentsIsNotListed(): void
     {
         $commandTester = $this->createCommandTester();
         $result = $commandTester->execute(['name' => 'SimpleTwigComponent']);
@@ -77,7 +77,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Unknown component "SimpleTwigComponent".', $commandTester->getDisplay());
     }
 
-    public function testWithOnePartialMatchComponent()
+    public function testWithOnePartialMatchComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->setInputs([]);
@@ -91,7 +91,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Component\\TodoListWithKeysComponent', $commandTester->getDisplay());
     }
 
-    public function testWithMultiplePartialMatchComponent()
+    public function testWithMultiplePartialMatchComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->setInputs(['todo_list']);
@@ -109,7 +109,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringNotContainsString('Component\\TodoListWithKeysComponent', $commandTester->getDisplay());
     }
 
-    public function testComponent()
+    public function testComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'component1']);
@@ -123,7 +123,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Component\\Component1', $display);
     }
 
-    public function testLivePropsWithFieldName()
+    public function testLivePropsWithFieldName(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'component3']);
@@ -139,7 +139,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('$prop2 (fieldName: "getProp2Name()"', $display);
     }
 
-    public function testLivePropsWithUrlMapping()
+    public function testLivePropsWithUrlMapping(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'component_with_url_bound_props']);
@@ -154,7 +154,7 @@ class LiveComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('$pathPropWithAlias (writable: true, url: {"as":"pathAlias","mapPath":true})', $display);
     }
 
-    public function testWithLiveListeners()
+    public function testWithLiveListeners(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'component2']);

--- a/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
+++ b/src/LiveComponent/tests/Integration/EventListener/DataModelPropsSubscriberTest.php
@@ -19,7 +19,7 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
 {
     use LiveComponentTestHelper;
 
-    public function testDataModelPropsAreSharedToChild()
+    public function testDataModelPropsAreSharedToChild(): void
     {
         /** @var ComponentRenderer $renderer */
         $renderer = self::getContainer()->get('ux.twig_component.component_renderer');
@@ -38,7 +38,7 @@ final class DataModelPropsSubscriberTest extends KernelTestCase
         $this->assertStringContainsString('<textarea data-model="content2:value">Value for second child</textarea>', $html);
     }
 
-    public function testDataModelPropsAreAvailableInEmbeddedComponents()
+    public function testDataModelPropsAreAvailableInEmbeddedComponents(): void
     {
         $templateName = 'components/parent_component_data_model.html.twig';
         $obscuredName = '684c45bf85d3461dbe587407892e59d8';

--- a/src/LiveComponent/tests/Integration/Hydration/DoctrineEntityHydrationExtensionTest.php
+++ b/src/LiveComponent/tests/Integration/Hydration/DoctrineEntityHydrationExtensionTest.php
@@ -25,7 +25,7 @@ class DoctrineEntityHydrationExtensionTest extends KernelTestCase
     use Factories;
     use ResetDatabase;
 
-    public function testCompositeId()
+    public function testCompositeId(): void
     {
         $compositeIdEntity = CompositeIdEntityFactory::createOne();
 
@@ -38,7 +38,7 @@ class DoctrineEntityHydrationExtensionTest extends KernelTestCase
         );
     }
 
-    public function testForeignKeyId()
+    public function testForeignKeyId(): void
     {
         $foreignKeyIdEntity = ForeignKeyIdEntityFactory::createOne();
 

--- a/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Integration/LiveComponentHydratorTest.php
@@ -160,7 +160,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
 
     #[Group('transient-on-windows')]
     #[DataProvider('provideDehydrationHydrationTests')]
-    public function testCanDehydrateAndHydrateComponentWithTestCases(callable $testFactory, ?int $minPhpVersion = null)
+    public function testCanDehydrateAndHydrateComponentWithTestCases(callable $testFactory, ?int $minPhpVersion = null): void
     {
         $this->executeHydrationTestCase($testFactory, $minPhpVersion);
     }
@@ -182,7 +182,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 #[LiveProp(writable: true, onUpdated: 'onFirstNameUpdated')]
                 public string $firstName;
 
-                public function onFirstNameUpdated($oldValue)
+                public function onFirstNameUpdated($oldValue): void
                 {
                     if ('Victor' === $this->firstName) {
                         $this->firstName = 'Revert to '.$oldValue;
@@ -205,7 +205,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 #[LiveProp(writable: ['name'], onUpdated: ['name' => 'onNameUpdated'])]
                 public ProductFixtureEntity $product;
 
-                public function onNameUpdated($oldValue)
+                public function onNameUpdated($oldValue): void
                 {
                     if ('Rabbit' === $this->product->name) {
                         $this->product->name = 'Revert to '.$oldValue;
@@ -229,7 +229,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 #[LiveProp(writable: [LiveProp::IDENTITY], onUpdated: [LiveProp::IDENTITY => 'onEntireEntityUpdated'])]
                 public Entity1 $entity1;
 
-                public function onEntireEntityUpdated($oldValue)
+                public function onEntireEntityUpdated($oldValue): void
                 {
                     // Sanity check
                     if ($this->entity1 === $oldValue) {
@@ -927,7 +927,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 #[LiveProp(writable: true)]
                 public ?Address $address = null;
 
-                public function mount()
+                public function mount(): void
                 {
                     $this->address = new Address();
                     $this->address->address = '1 rue du Bac';
@@ -954,7 +954,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 #[LiveProp(writable: true)]
                 public ?Address $address = null;
 
-                public function mount()
+                public function mount(): void
                 {
                     $this->address = new Address();
                     $this->address->address = '1 rue du Bac';
@@ -977,7 +977,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 #[LiveProp(writable: true)]
                 public ?CustomerDetails $customerDetails = null;
 
-                public function mount()
+                public function mount(): void
                 {
                     $this->customerDetails = new CustomerDetails();
                     $this->customerDetails->lastName = 'Matheo';
@@ -1013,7 +1013,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 #[LiveProp(writable: true)]
                 public array $customerDetailsCollection = [];
 
-                public function mount()
+                public function mount(): void
                 {
                     $customerDetails = new CustomerDetails();
                     $customerDetails->lastName = 'Matheo';
@@ -1259,7 +1259,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
                 #[LiveProp(writable: true)]
                 public ?ParentDTO $parent = null;
 
-                public function mount()
+                public function mount(): void
                 {
                     $this->parent = new ParentDTO();
                     $this->parent->name = 'Mozart';
@@ -1731,7 +1731,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         }];
     }
 
-    public function testHydrationWithInvalidDate()
+    public function testHydrationWithInvalidDate(): void
     {
         $this->expectException(BadRequestHttpException::class);
         $this->expectExceptionMessage('The model path "createdAt" was sent invalid date data "0" or in an invalid format. Make sure it\'s a valid date and it matches the expected format "Y. m. d.".');
@@ -1759,7 +1759,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         });
     }
 
-    public function testPassingArrayToWritablePropForHydrationIsNotAllowed()
+    public function testPassingArrayToWritablePropForHydrationIsNotAllowed(): void
     {
         $component = new class {
             #[LiveProp(writable: true)]
@@ -1790,7 +1790,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         );
     }
 
-    public function testInterfaceTypedLivePropCannotBeHydrated()
+    public function testInterfaceTypedLivePropCannotBeHydrated(): void
     {
         $componentClass = new class {
             #[LiveProp(writable: true)]
@@ -1809,7 +1809,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         );
     }
 
-    public function testInterfaceTypedLivePropCannotBeDehydrated()
+    public function testInterfaceTypedLivePropCannotBeDehydrated(): void
     {
         $componentClass = new class {
             #[LiveProp(writable: true)]
@@ -1826,7 +1826,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
     }
 
     #[DataProvider('provideInvalidHydrationTests')]
-    public function testInvalidTypeHydration(callable $testFactory, ?int $minPhpVersion = null)
+    public function testInvalidTypeHydration(callable $testFactory, ?int $minPhpVersion = null): void
     {
         $this->executeHydrationTestCase($testFactory, $minPhpVersion);
     }
@@ -1923,7 +1923,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         }];
     }
 
-    public function testHydrationFailsIfChecksumMissing()
+    public function testHydrationFailsIfChecksumMissing(): void
     {
         $component = $this->getComponent('component1');
 
@@ -1932,7 +1932,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         $this->hydrateComponent($component, 'component1', []);
     }
 
-    public function testHydrationFailsOnChecksumMismatch()
+    public function testHydrationFailsOnChecksumMismatch(): void
     {
         $component = $this->getComponent('component1');
 
@@ -1941,7 +1941,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         $this->hydrateComponent($component, 'component1', ['@checksum' => 'invalid']);
     }
 
-    public function testHydrationTakeUpdatedParentPropsIntoAccount()
+    public function testHydrationTakeUpdatedParentPropsIntoAccount(): void
     {
         $component = new class {
             #[LiveProp(writable: true)]
@@ -1975,7 +1975,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         $this->assertTrue($freshComponent->shouldUppercase);
     }
 
-    public function testHydrationWithUpdatesParentPropsAndBadChecksumFails()
+    public function testHydrationWithUpdatesParentPropsAndBadChecksumFails(): void
     {
         $component = new class {
             #[LiveProp(updateFromParent: true)]
@@ -2005,7 +2005,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         );
     }
 
-    public function testCrossComponentChecksumReplayIsRejected()
+    public function testCrossComponentChecksumReplayIsRejected(): void
     {
         // Two components sharing a prop name. The MAC must be bound to the
         // component identity so a blob minted for "componentA" cannot be
@@ -2038,7 +2038,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         );
     }
 
-    public function testCrossSlotChecksumReplayIsRejected()
+    public function testCrossSlotChecksumReplayIsRejected(): void
     {
         // A blob signed for the regular `props` slot must not be accepted
         // when replayed in the `propsFromParent` slot.
@@ -2072,7 +2072,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         );
     }
 
-    public function testPreDehydrateAndPostHydrateHooksCalled()
+    public function testPreDehydrateAndPostHydrateHooksCalled(): void
     {
         $mounted = $this->mountComponent('component2');
 
@@ -2099,7 +2099,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         $this->assertTrue($component->postHydrateCalled);
     }
 
-    public function testCorrectlyUsesCustomFrontendNameInDehydrateAndHydrate()
+    public function testCorrectlyUsesCustomFrontendNameInDehydrateAndHydrate(): void
     {
         $mounted = $this->mountComponent('component3', ['prop1' => 'value1', 'prop2' => 'value2']);
         $dehydratedProps = $this->dehydrateComponent($mounted)->getProps();
@@ -2120,7 +2120,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         $this->assertSame('value2', $component->prop2);
     }
 
-    public function testCanDehydrateAndHydrateComponentsWithAttributes()
+    public function testCanDehydrateAndHydrateComponentsWithAttributes(): void
     {
         $mounted = $this->mountComponent('with_attributes', $attributes = ['class' => 'foo', 'value' => null], false);
 
@@ -2136,7 +2136,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
         $this->assertSame($attributes, $actualAttributes->all());
     }
 
-    public function testCanDehydrateAndHydrateComponentsWithEmptyAttributes()
+    public function testCanDehydrateAndHydrateComponentsWithEmptyAttributes(): void
     {
         $mounted = $this->mountComponent('with_attributes', [], false);
 
@@ -2152,7 +2152,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
     }
 
     #[DataProvider('truthyValueProvider')]
-    public function testCoerceTruthyValuesForScalarTypes($prop, $value, $expected)
+    public function testCoerceTruthyValuesForScalarTypes($prop, $value, $expected): void
     {
         $dehydratedProps = $this->dehydrateComponent($this->mountComponent('scalar_types'))->getProps();
 
@@ -2164,7 +2164,7 @@ final class LiveComponentHydratorTest extends KernelTestCase
     }
 
     #[DataProvider('falseyValueProvider')]
-    public function testCoerceFalseyValuesForScalarTypes($prop, $value, $expected)
+    public function testCoerceFalseyValuesForScalarTypes($prop, $value, $expected): void
     {
         $dehydratedProps = $this->dehydrateComponent($this->mountComponent('scalar_types'))->getProps();
 

--- a/src/LiveComponent/tests/Integration/LivePropInheritanceTest.php
+++ b/src/LiveComponent/tests/Integration/LivePropInheritanceTest.php
@@ -33,7 +33,7 @@ final class LivePropInheritanceTest extends KernelTestCase
      * Sanity check: the parent component itself must have the LiveProp with
      * the correct fieldName callable.
      */
-    public function testParentComponentHasLivePropWithFieldName()
+    public function testParentComponentHasLivePropWithFieldName(): void
     {
         self::bootKernel();
 
@@ -57,7 +57,7 @@ final class LivePropInheritanceTest extends KernelTestCase
      * Before the fix the LiveProp was either not registered at all for the child,
      * or registered without the fieldName, causing the frontend key mismatch.
      */
-    public function testChildComponentInheritsLivePropWithFieldName()
+    public function testChildComponentInheritsLivePropWithFieldName(): void
     {
         self::bootKernel();
 
@@ -80,7 +80,7 @@ final class LivePropInheritanceTest extends KernelTestCase
     /**
      * Sanity check: the save() action must be allowed on the parent component.
      */
-    public function testParentComponentHasSaveAction()
+    public function testParentComponentHasSaveAction(): void
     {
         self::bootKernel();
 
@@ -94,7 +94,7 @@ final class LivePropInheritanceTest extends KernelTestCase
      * Regression test for Bug #3: the save() action declared with #[LiveAction]
      * on the parent class must also be allowed on the child component.
      */
-    public function testChildComponentInheritsLiveAction()
+    public function testChildComponentInheritsLiveAction(): void
     {
         self::bootKernel();
 
@@ -110,7 +110,7 @@ final class LivePropInheritanceTest extends KernelTestCase
      * #[LiveListener("save")] on the parent class must appear in the child's
      * live listeners.
      */
-    public function testChildComponentInheritsLiveListener()
+    public function testChildComponentInheritsLiveListener(): void
     {
         self::bootKernel();
 

--- a/src/LiveComponent/tests/Integration/Twig/DeterministicTwigIdCalculatorTest.php
+++ b/src/LiveComponent/tests/Integration/Twig/DeterministicTwigIdCalculatorTest.php
@@ -17,7 +17,7 @@ use Twig\Environment;
 
 final class DeterministicTwigIdCalculatorTest extends KernelTestCase
 {
-    public function testReturnsDeterministicId()
+    public function testReturnsDeterministicId(): void
     {
         /** @var Environment $twig */
         $twig = self::getContainer()->get('twig');

--- a/src/LiveComponent/tests/Integration/Twig/LiveComponentExtensionTest.php
+++ b/src/LiveComponent/tests/Integration/Twig/LiveComponentExtensionTest.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  */
 final class LiveComponentExtensionTest extends KernelTestCase
 {
-    public function testGetComponentUrl()
+    public function testGetComponentUrl(): void
     {
         $rendered = self::getContainer()->get('twig')->render('component_url.html.twig', [
             'date' => new \DateTime('2022-10-06-0'),

--- a/src/LiveComponent/tests/Integration/Twig/LiveComponentRuntimeTest.php
+++ b/src/LiveComponent/tests/Integration/Twig/LiveComponentRuntimeTest.php
@@ -22,7 +22,7 @@ final class LiveComponentRuntimeTest extends KernelTestCase
 {
     use HasBrowser;
 
-    public function testGetComponentUrl()
+    public function testGetComponentUrl(): void
     {
         $runtime = self::getContainer()->get('ux.live_component.twig.component_runtime');
         \assert($runtime instanceof LiveComponentRuntime);

--- a/src/LiveComponent/tests/Integration/Util/FingerprintCalculatorTest.php
+++ b/src/LiveComponent/tests/Integration/Util/FingerprintCalculatorTest.php
@@ -25,7 +25,7 @@ final class FingerprintCalculatorTest extends KernelTestCase
     use Factories;
     use ResetDatabase;
 
-    public function testFingerprintEqual()
+    public function testFingerprintEqual(): void
     {
         $fingerprintCalculator = $this->getFingerprintCalculator();
         $entityOne = persist(Entity1::class);
@@ -57,7 +57,7 @@ final class FingerprintCalculatorTest extends KernelTestCase
         );
     }
 
-    public function testFingerprintNotEqual()
+    public function testFingerprintNotEqual(): void
     {
         $fingerprintCalculator = $this->getFingerprintCalculator();
 
@@ -85,7 +85,7 @@ final class FingerprintCalculatorTest extends KernelTestCase
         );
     }
 
-    public function testFingerprintOnlyUsesPropsThatAcceptUpdates()
+    public function testFingerprintOnlyUsesPropsThatAcceptUpdates(): void
     {
         $fingerprintCalculator = $this->getFingerprintCalculator();
 

--- a/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/AsLiveComponentTest.php
@@ -26,22 +26,22 @@ use Symfony\UX\LiveComponent\Tests\Fixtures\Component\ComponentWithRepeatedLiveL
  */
 final class AsLiveComponentTest extends TestCase
 {
-    public function testPreDehydrateMethodsAreOrderedByPriority()
+    public function testPreDehydrateMethodsAreOrderedByPriority(): void
     {
         $hooks = AsLiveComponent::preDehydrateMethods(
             new class {
                 #[PreDehydrate(priority: -10)]
-                public function hook1()
+                public function hook1(): void
                 {
                 }
 
                 #[PreDehydrate(priority: 10)]
-                public function hook2()
+                public function hook2(): void
                 {
                 }
 
                 #[PreDehydrate]
-                public function hook3()
+                public function hook3(): void
                 {
                 }
             }
@@ -53,22 +53,22 @@ final class AsLiveComponentTest extends TestCase
         $this->assertSame('hook1', $hooks[2]->name);
     }
 
-    public function testPostHydrateMethodsAreOrderedByPriority()
+    public function testPostHydrateMethodsAreOrderedByPriority(): void
     {
         $hooks = AsLiveComponent::postHydrateMethods(
             new class {
                 #[PostHydrate(priority: -10)]
-                public function hook1()
+                public function hook1(): void
                 {
                 }
 
                 #[PostHydrate(priority: 10)]
-                public function hook2()
+                public function hook2(): void
                 {
                 }
 
                 #[PostHydrate]
-                public function hook3()
+                public function hook3(): void
                 {
                 }
             }
@@ -80,22 +80,22 @@ final class AsLiveComponentTest extends TestCase
         $this->assertSame('hook1', $hooks[2]->name);
     }
 
-    public function testPreMountHooksAreOrderedByPriority()
+    public function testPreMountHooksAreOrderedByPriority(): void
     {
         $hooks = AsLiveComponent::preReRenderMethods(
             new class {
                 #[PreReRender(priority: -10)]
-                public function hook1()
+                public function hook1(): void
                 {
                 }
 
                 #[PreReRender(priority: 10)]
-                public function hook2()
+                public function hook2(): void
                 {
                 }
 
                 #[PreReRender]
-                public function hook3()
+                public function hook3(): void
                 {
                 }
             }
@@ -107,7 +107,7 @@ final class AsLiveComponentTest extends TestCase
         $this->assertSame('hook1', $hooks[2]->name);
     }
 
-    public function testCanGetPostHydrateMethodsFromClassString()
+    public function testCanGetPostHydrateMethodsFromClassString(): void
     {
         $methods = AsLiveComponent::postHydrateMethods(DummyLiveComponent::class);
 
@@ -116,7 +116,7 @@ final class AsLiveComponentTest extends TestCase
         $this->assertSame(DummyLiveComponent::class, $methods[0]->getDeclaringClass()?->getName());
     }
 
-    public function testCanGetLiveListeners()
+    public function testCanGetLiveListeners(): void
     {
         $liveListeners = AsLiveComponent::liveListeners(new Component5());
 
@@ -127,7 +127,7 @@ final class AsLiveComponentTest extends TestCase
         ], $liveListeners[0]);
     }
 
-    public function testCanGetLiveListenersFromClassString()
+    public function testCanGetLiveListenersFromClassString(): void
     {
         $liveListeners = AsLiveComponent::liveListeners(DummyLiveComponent::class);
 
@@ -138,7 +138,7 @@ final class AsLiveComponentTest extends TestCase
         ], $liveListeners[0]);
     }
 
-    public function testCanGetRepeatedLiveListeners()
+    public function testCanGetRepeatedLiveListeners(): void
     {
         $liveListeners = AsLiveComponent::liveListeners(new ComponentWithRepeatedLiveListener());
 
@@ -163,14 +163,14 @@ final class AsLiveComponentTest extends TestCase
         ], $liveListeners);
     }
 
-    public function testCanGetRepeatedLiveListenersFromClassString()
+    public function testCanGetRepeatedLiveListenersFromClassString(): void
     {
         $liveListeners = AsLiveComponent::liveListeners(ComponentWithRepeatedLiveListener::class);
 
         $this->assertCount(4, $liveListeners);
     }
 
-    public function testCanCheckIfMethodIsAllowed()
+    public function testCanCheckIfMethodIsAllowed(): void
     {
         $component = new Component5();
 

--- a/src/LiveComponent/tests/Unit/Attribute/LivePropTest.php
+++ b/src/LiveComponent/tests/Unit/Attribute/LivePropTest.php
@@ -19,26 +19,26 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
  */
 final class LivePropTest extends TestCase
 {
-    public function testHydrateWithMethod()
+    public function testHydrateWithMethod(): void
     {
         $this->assertSame('someMethod', new LiveProp(false, 'someMethod')->hydrateMethod());
         $this->assertSame('someMethod', new LiveProp(false, 'someMethod()')->hydrateMethod());
     }
 
-    public function testDehydrateWithMethod()
+    public function testDehydrateWithMethod(): void
     {
         $this->assertSame('someMethod', new LiveProp(false, null, 'someMethod')->dehydrateMethod());
         $this->assertSame('someMethod', new LiveProp(false, null, 'someMethod()')->dehydrateMethod());
     }
 
-    public function testCanCallCalculateFieldNameAsString()
+    public function testCanCallCalculateFieldNameAsString(): void
     {
         $component = new class {};
 
         $this->assertSame('field', new LiveProp(false, null, null, false, [], 'field')->calculateFieldName($component, 'fallback'));
     }
 
-    public function testCanCallCalculateFieldNameAsMethod()
+    public function testCanCallCalculateFieldNameAsMethod(): void
     {
         $component = new class {
             public function fieldName(): string
@@ -50,14 +50,14 @@ final class LivePropTest extends TestCase
         $this->assertSame('foo', new LiveProp(false, null, null, false, [], 'fieldName()')->calculateFieldName($component, 'fallback'));
     }
 
-    public function testCanCallCalculateFieldNameWhenNotSet()
+    public function testCanCallCalculateFieldNameWhenNotSet(): void
     {
         $component = new class {};
 
         $this->assertSame('fallback', new LiveProp()->calculateFieldName($component, 'fallback'));
     }
 
-    public function testIsIdentityWritableAndWritablePaths()
+    public function testIsIdentityWritableAndWritablePaths(): void
     {
         $liveProp = new LiveProp(true);
         $this->assertTrue($liveProp->isIdentityWritable());
@@ -73,7 +73,7 @@ final class LivePropTest extends TestCase
     }
 
     // test updateFromParent property being set and accessed with acceptUpdatesFromParent()
-    public function testUpdateFromParent()
+    public function testUpdateFromParent(): void
     {
         $liveProp = new LiveProp();
         $this->assertFalse($liveProp->acceptUpdatesFromParent());

--- a/src/LiveComponent/tests/Unit/DependencyInjection/LiveComponentConfigurationTest.php
+++ b/src/LiveComponent/tests/Unit/DependencyInjection/LiveComponentConfigurationTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\LiveComponent\DependencyInjection\LiveComponentExtension;
 
 class LiveComponentConfigurationTest extends TestCase
 {
-    public function testDefaultSecret()
+    public function testDefaultSecret(): void
     {
         $processor = new Processor();
         $config = $processor->processConfiguration(new LiveComponentExtension(), []);
@@ -26,7 +26,7 @@ class LiveComponentConfigurationTest extends TestCase
         $this->assertEquals('%kernel.secret%', $config['secret']);
     }
 
-    public function testEmptySecretThrows()
+    public function testEmptySecretThrows(): void
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('The path "live_component.secret" cannot contain an empty value, but got null.');
@@ -39,7 +39,7 @@ class LiveComponentConfigurationTest extends TestCase
         ]);
     }
 
-    public function testCustomSecret()
+    public function testCustomSecret(): void
     {
         $processor = new Processor();
         $config = $processor->processConfiguration(new LiveComponentExtension(), [

--- a/src/LiveComponent/tests/Unit/DependencyInjection/LiveComponentExtensionTest.php
+++ b/src/LiveComponent/tests/Unit/DependencyInjection/LiveComponentExtensionTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\LiveComponent\DependencyInjection\LiveComponentExtension;
 
 class LiveComponentExtensionTest extends TestCase
 {
-    public function testKernelSecretIsUsedByDefault()
+    public function testKernelSecretIsUsedByDefault(): void
     {
         $container = $this->createContainer();
         $container->registerExtension(new LiveComponentExtension());
@@ -29,7 +29,7 @@ class LiveComponentExtensionTest extends TestCase
         $this->assertSame('%kernel.secret%', $container->getDefinition('ux.live_component.fingerprint_calculator')->getArgument(0));
     }
 
-    public function testCustomSecretIsUsedInDefinition()
+    public function testCustomSecretIsUsedInDefinition(): void
     {
         $container = $this->createContainer();
         $container->registerExtension(new LiveComponentExtension());

--- a/src/LiveComponent/tests/Unit/EventListener/DeferLiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Unit/EventListener/DeferLiveComponentSubscriberTest.php
@@ -26,7 +26,7 @@ use Twig\Runtime\EscaperRuntime;
  */
 class DeferLiveComponentSubscriberTest extends TestCase
 {
-    public function testLoadingAttributeIsExtracted()
+    public function testLoadingAttributeIsExtracted(): void
     {
         $subscriber = new DeferLiveComponentSubscriber();
         $event = $this->createPostMountEvent(['loading' => 'lazy']);
@@ -38,7 +38,7 @@ class DeferLiveComponentSubscriberTest extends TestCase
         $this->assertArrayNotHasKey('loading', $event->getData());
     }
 
-    public function testLoadingAttributeIsNotExtractedWhenComponentIsNotLive()
+    public function testLoadingAttributeIsNotExtractedWhenComponentIsNotLive(): void
     {
         $data = ['loading' => 'lazy'];
         $event = new PostMountEvent(new \stdClass(), $data, new ComponentMetadata([]));
@@ -51,7 +51,7 @@ class DeferLiveComponentSubscriberTest extends TestCase
         $this->assertArrayHasKey('loading', $event->getData());
     }
 
-    public function testLoadingAttributesAreRemoved()
+    public function testLoadingAttributesAreRemoved(): void
     {
         $subscriber = new DeferLiveComponentSubscriber();
         $event = $this->createPostMountEvent([
@@ -68,7 +68,7 @@ class DeferLiveComponentSubscriberTest extends TestCase
     }
 
     #[DataProvider('provideInvalidLoadingValues')]
-    public function testInvalidLoadingValuesThrows(mixed $value)
+    public function testInvalidLoadingValuesThrows(mixed $value): void
     {
         $subscriber = new DeferLiveComponentSubscriber();
         $event = $this->createPostMountEvent([
@@ -90,7 +90,7 @@ class DeferLiveComponentSubscriberTest extends TestCase
         ];
     }
 
-    public function testOnPreRenderUsesEventTemplateInsteadOfMetadataTemplate()
+    public function testOnPreRenderUsesEventTemplateInsteadOfMetadataTemplate(): void
     {
         $subscriber = new DeferLiveComponentSubscriber();
 
@@ -123,7 +123,7 @@ class DeferLiveComponentSubscriberTest extends TestCase
         $this->assertSame('value', $variables['existing_var']);
     }
 
-    public function testOnPreRenderDoesNothingWhenNoLoadingMetadata()
+    public function testOnPreRenderDoesNothingWhenNoLoadingMetadata(): void
     {
         $subscriber = new DeferLiveComponentSubscriber();
 

--- a/src/LiveComponent/tests/Unit/EventListener/LiveComponentSubscriberTest.php
+++ b/src/LiveComponent/tests/Unit/EventListener/LiveComponentSubscriberTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\LiveComponent\EventListener\LiveComponentSubscriber;
 
 class LiveComponentSubscriberTest extends TestCase
 {
-    public function testDefaultConstructedSubscriberRejectsRequestWithoutAcceptHeader()
+    public function testDefaultConstructedSubscriberRejectsRequestWithoutAcceptHeader(): void
     {
         $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class));
 
@@ -32,7 +32,7 @@ class LiveComponentSubscriberTest extends TestCase
         );
     }
 
-    public function testDefaultConstructedSubscriberAcceptsRequestWithProperAcceptHeader()
+    public function testDefaultConstructedSubscriberAcceptsRequestWithProperAcceptHeader(): void
     {
         $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class));
 
@@ -44,7 +44,7 @@ class LiveComponentSubscriberTest extends TestCase
         $this->assertTrue($this->callIsLiveComponentRequest($subscriber, $request));
     }
 
-    public function testTestModeBypassesAcceptHeaderCheck()
+    public function testTestModeBypassesAcceptHeaderCheck(): void
     {
         $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class), true);
 
@@ -65,7 +65,7 @@ class LiveComponentSubscriberTest extends TestCase
     }
 
     #[DataProvider('provideProductionGateScenarios')]
-    public function testProductionGateRequiresNonSafelistedHeader(array $headers, bool $expected)
+    public function testProductionGateRequiresNonSafelistedHeader(array $headers, bool $expected): void
     {
         $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class), testMode: false);
 
@@ -75,7 +75,7 @@ class LiveComponentSubscriberTest extends TestCase
             $request->headers->set($name, $value);
         }
 
-        $isLiveRequest = (new \ReflectionMethod($subscriber, 'isLiveComponentRequest'))->invoke($subscriber, $request);
+        $isLiveRequest = new \ReflectionMethod($subscriber, 'isLiveComponentRequest')->invoke($subscriber, $request);
 
         $this->assertSame($expected, $isLiveRequest);
     }
@@ -109,7 +109,7 @@ class LiveComponentSubscriberTest extends TestCase
         ];
     }
 
-    public function testRequestWithoutLiveComponentAttributeIsRejected()
+    public function testRequestWithoutLiveComponentAttributeIsRejected(): void
     {
         $subscriber = new LiveComponentSubscriber($this->createStub(ContainerInterface::class), testMode: false);
 
@@ -117,7 +117,7 @@ class LiveComponentSubscriberTest extends TestCase
         $request->headers->set('Accept', 'application/vnd.live-component+html');
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $isLiveRequest = (new \ReflectionMethod($subscriber, 'isLiveComponentRequest'))->invoke($subscriber, $request);
+        $isLiveRequest = new \ReflectionMethod($subscriber, 'isLiveComponentRequest')->invoke($subscriber, $request);
 
         $this->assertFalse($isLiveRequest);
     }

--- a/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
+++ b/src/LiveComponent/tests/Unit/Form/ComponentWithFormTest.php
@@ -25,7 +25,7 @@ class ComponentWithFormTest extends KernelTestCase
     use Factories;
     use ResetDatabase;
 
-    public function testFormValues()
+    public function testFormValues(): void
     {
         $category = CategoryFixtureEntityFactory::createMany(5);
         $id = $category[0]->getId();

--- a/src/LiveComponent/tests/Unit/Form/Type/LiveCollectionTypeTest.php
+++ b/src/LiveComponent/tests/Unit/Form/Type/LiveCollectionTypeTest.php
@@ -20,7 +20,7 @@ use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
  */
 final class LiveCollectionTypeTest extends TypeTestCase
 {
-    public function testAddButtonPrototypeDefaultBlockPrefixes()
+    public function testAddButtonPrototypeDefaultBlockPrefixes(): void
     {
         $collectionView = $this->factory->createNamed('fields', LiveCollectionType::class, [], [
             'allow_add' => true,
@@ -38,7 +38,7 @@ final class LiveCollectionTypeTest extends TypeTestCase
         $this->assertSame($expectedBlockPrefixes, $collectionView->vars['button_add']->vars['block_prefixes']);
     }
 
-    public function testAddButtonPrototypeBlockPrefixesWithCustomBlockPrefix()
+    public function testAddButtonPrototypeBlockPrefixesWithCustomBlockPrefix(): void
     {
         $collectionView = $this->factory->createNamed('fields', LiveCollectionType::class, [], [
             'allow_add' => true,
@@ -58,7 +58,7 @@ final class LiveCollectionTypeTest extends TypeTestCase
         $this->assertSame($expectedBlockPrefixes, $collectionView->vars['button_add']->vars['block_prefixes']);
     }
 
-    public function testDeleteButtonPrototypeDefaultBlockPrefixes()
+    public function testDeleteButtonPrototypeDefaultBlockPrefixes(): void
     {
         $collectionView = $this->factory->createNamed('tags', LiveCollectionType::class, [
             'tags' => ['tag01'],
@@ -79,7 +79,7 @@ final class LiveCollectionTypeTest extends TypeTestCase
         $this->assertSame($expectedBlockPrefixes, $collectionView['tags']->vars['button_delete']->vars['block_prefixes']);
     }
 
-    public function testDeleteButtonPrototypeBlockPrefixesWithCustomBlockPrefix()
+    public function testDeleteButtonPrototypeBlockPrefixesWithCustomBlockPrefix(): void
     {
         $collectionView = $this->factory->createNamed('tags', LiveCollectionType::class, [
             'tags' => ['tag01'],

--- a/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
+++ b/src/LiveComponent/tests/Unit/LiveCollectionTraitTest.php
@@ -23,7 +23,7 @@ use Symfony\UX\LiveComponent\LiveCollectionTrait;
 final class LiveCollectionTraitTest extends TestCase
 {
     #[DataProvider('provideAddedItems')]
-    public function testAddCollectionItem(array $postedFormData, string $collectionFieldName, array $expectedFormData)
+    public function testAddCollectionItem(array $postedFormData, string $collectionFieldName, array $expectedFormData): void
     {
         $component = $this->createComponent($postedFormData);
 
@@ -33,7 +33,7 @@ final class LiveCollectionTraitTest extends TestCase
     }
 
     #[DataProvider('provideRemovedItems')]
-    public function testRemoveCollectionItem(array $postedFormData, string $collectionFieldName, int $index, array $expectedFormData)
+    public function testRemoveCollectionItem(array $postedFormData, string $collectionFieldName, int $index, array $expectedFormData): void
     {
         $component = $this->createComponent($postedFormData);
 

--- a/src/LiveComponent/tests/Unit/LiveComponentHydratorTest.php
+++ b/src/LiveComponent/tests/Unit/LiveComponentHydratorTest.php
@@ -26,7 +26,7 @@ use Twig\Environment;
 
 final class LiveComponentHydratorTest extends TestCase
 {
-    public function testConstructWithEmptySecret()
+    public function testConstructWithEmptySecret(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('A non-empty secret is required.');
@@ -41,7 +41,7 @@ final class LiveComponentHydratorTest extends TestCase
         );
     }
 
-    public function testItCanHydrateWithNullValues()
+    public function testItCanHydrateWithNullValues(): void
     {
         // BC layer when "symfony/type-info" is not available
         if (!class_exists(Type::class)) {

--- a/src/LiveComponent/tests/Unit/LiveResponderTest.php
+++ b/src/LiveComponent/tests/Unit/LiveResponderTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\LiveComponent\LiveResponder;
 
 class LiveResponderTest extends TestCase
 {
-    public function testEmit()
+    public function testEmit(): void
     {
         $responder = new LiveResponder();
         $responder->emit('event_name1', ['data_key' => 'data_value']);
@@ -38,7 +38,7 @@ class LiveResponderTest extends TestCase
         ], $responder->getEventsToEmit());
     }
 
-    public function testEmitUp()
+    public function testEmitUp(): void
     {
         $responder = new LiveResponder();
         $responder->emitUp('event_name1', ['data_key' => 'data_value']);
@@ -60,7 +60,7 @@ class LiveResponderTest extends TestCase
         ], $responder->getEventsToEmit());
     }
 
-    public function testEmitSelf()
+    public function testEmitSelf(): void
     {
         $responder = new LiveResponder();
         $responder->emitSelf('event_name1', ['data_key' => 'data_value']);
@@ -82,7 +82,7 @@ class LiveResponderTest extends TestCase
         ], $responder->getEventsToEmit());
     }
 
-    public function testDispatchBrowserEvent()
+    public function testDispatchBrowserEvent(): void
     {
         $responder = new LiveResponder();
         $responder->dispatchBrowserEvent('event_name1', ['data_key' => 'data_value']);

--- a/src/LiveComponent/tests/Unit/LiveResponseTest.php
+++ b/src/LiveComponent/tests/Unit/LiveResponseTest.php
@@ -18,7 +18,7 @@ final class LiveResponseTest extends TestCase
 {
     private const FILE = __DIR__.'/../Fixtures/files/test.txt';
 
-    public function testDownloadFileWithContent()
+    public function testDownloadFileWithContent(): void
     {
         $response = LiveResponse::downloadFile('a,b,c', 'report.csv', 'text/csv');
 
@@ -29,12 +29,12 @@ final class LiveResponseTest extends TestCase
         $this->assertFalse($response->isDownloadUrl());
     }
 
-    public function testDownloadFileDefaultsToOctetStream()
+    public function testDownloadFileDefaultsToOctetStream(): void
     {
         $this->assertSame('application/octet-stream', LiveResponse::downloadFile('x', 'f.bin')->contentType);
     }
 
-    public function testDownloadFileWithSplFileInfoDeducesNameAndSize()
+    public function testDownloadFileWithSplFileInfoDeducesNameAndSize(): void
     {
         $response = LiveResponse::downloadFile(new \SplFileInfo(self::FILE));
 
@@ -42,7 +42,7 @@ final class LiveResponseTest extends TestCase
         $this->assertSame(filesize(self::FILE), $response->size);
     }
 
-    public function testDownloadFileWithSplFileObjectUsesThePathBasename()
+    public function testDownloadFileWithSplFileObjectUsesThePathBasename(): void
     {
         // SplFileObject::__toString() returns the current line, so the name must come from the path
         $response = LiveResponse::downloadFile(new \SplFileObject(self::FILE));
@@ -50,7 +50,7 @@ final class LiveResponseTest extends TestCase
         $this->assertSame('test.txt', $response->filename);
     }
 
-    public function testDownloadFileWithAStreamBackedSplFileObjectHasNoSize()
+    public function testDownloadFileWithAStreamBackedSplFileObjectHasNoSize(): void
     {
         // getSize() throws on php://temp, so nothing can be deduced
         $temp = new \SplTempFileObject();
@@ -59,7 +59,7 @@ final class LiveResponseTest extends TestCase
         $this->assertNull(LiveResponse::downloadFile($temp, 'temp.txt')->size);
     }
 
-    public function testDownloadFileWithAResource()
+    public function testDownloadFileWithAResource(): void
     {
         $resource = fopen('php://memory', 'r+');
 
@@ -70,12 +70,12 @@ final class LiveResponseTest extends TestCase
         fclose($resource);
     }
 
-    public function testDownloadFileWithAClosureHasNoSizeUnlessGiven()
+    public function testDownloadFileWithAClosureHasNoSizeUnlessGiven(): void
     {
         $this->assertNull(LiveResponse::downloadFile(static fn () => null, 'f.txt')->size);
     }
 
-    public function testDownloadFileKeepsBytesThatAreNotValidUtf8()
+    public function testDownloadFileKeepsBytesThatAreNotValidUtf8(): void
     {
         $response = LiveResponse::downloadFile("\x00\xFF\xFE", 'blob.bin');
 
@@ -83,7 +83,7 @@ final class LiveResponseTest extends TestCase
         $this->assertSame(3, $response->size);
     }
 
-    public function testDownloadFileRejectsAnUnsupportedContent()
+    public function testDownloadFileRejectsAnUnsupportedContent(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The content must be a string, an \SplFileInfo, a resource or a closure, "int" given.');
@@ -91,7 +91,7 @@ final class LiveResponseTest extends TestCase
         LiveResponse::downloadFile(42, 'f.txt');
     }
 
-    public function testDownloadFileRequiresAFilenameForAString()
+    public function testDownloadFileRequiresAFilenameForAString(): void
     {
         // only an SplFileInfo carries a name of its own
         $this->expectException(\InvalidArgumentException::class);
@@ -100,14 +100,14 @@ final class LiveResponseTest extends TestCase
         LiveResponse::downloadFile('content');
     }
 
-    public function testDownloadFileRejectsABlankFilename()
+    public function testDownloadFileRejectsABlankFilename(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         LiveResponse::downloadFile('content', '   ');
     }
 
-    public function testDownloadFileRejectsASizeThatContradictsTheContent()
+    public function testDownloadFileRejectsASizeThatContradictsTheContent(): void
     {
         // an inexact Content-Length truncates the response or leaves the client waiting
         $this->expectException(\InvalidArgumentException::class);
@@ -116,12 +116,12 @@ final class LiveResponseTest extends TestCase
         LiveResponse::downloadFile('a,b,c', 'report.csv', null, 99);
     }
 
-    public function testDownloadFileAcceptsASizeThatMatches()
+    public function testDownloadFileAcceptsASizeThatMatches(): void
     {
         $this->assertSame(5, LiveResponse::downloadFile('a,b,c', 'report.csv', null, 5)->size);
     }
 
-    public function testDownloadFileRejectsAContentTypeWithALineBreak()
+    public function testDownloadFileRejectsAContentTypeWithALineBreak(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('cannot contain a line break');
@@ -129,7 +129,7 @@ final class LiveResponseTest extends TestCase
         LiveResponse::downloadFile('x', 'f.txt', "text/csv\r\nX-Injected: 1");
     }
 
-    public function testDownloadUrl()
+    public function testDownloadUrl(): void
     {
         $response = LiveResponse::downloadUrl('/exports/report.csv');
 
@@ -138,14 +138,14 @@ final class LiveResponseTest extends TestCase
         $this->assertNull($response->content);
     }
 
-    public function testDownloadUrlRejectsAnEmptyUrl()
+    public function testDownloadUrlRejectsAnEmptyUrl(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         LiveResponse::downloadUrl('  ');
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $response = LiveResponse::remove();
 
@@ -154,13 +154,13 @@ final class LiveResponseTest extends TestCase
         $this->assertNull($response->url);
     }
 
-    public function testDownloadsAreNotRemovals()
+    public function testDownloadsAreNotRemovals(): void
     {
         $this->assertFalse(LiveResponse::downloadFile('x', 'f.bin')->isRemove());
         $this->assertFalse(LiveResponse::downloadUrl('/f.bin')->isRemove());
     }
 
-    public function testARemovalIsNotADownloadUrl()
+    public function testARemovalIsNotADownloadUrl(): void
     {
         $this->assertFalse(LiveResponse::remove()->isDownloadUrl());
     }

--- a/src/LiveComponent/tests/Unit/Metadata/LiveComponentMetadataTest.php
+++ b/src/LiveComponent/tests/Unit/Metadata/LiveComponentMetadataTest.php
@@ -20,7 +20,7 @@ use Symfony\UX\TwigComponent\ComponentMetadata;
 
 class LiveComponentMetadataTest extends TestCase
 {
-    public function testGetOnlyPropsThatAcceptUpdatesFromParent()
+    public function testGetOnlyPropsThatAcceptUpdatesFromParent(): void
     {
         $propMetadatas = [
             new LivePropMetadata('noUpdateFromParent1', new LiveProp(updateFromParent: false), null, false, false, null),
@@ -39,7 +39,7 @@ class LiveComponentMetadataTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetAllUrlMappings()
+    public function testGetAllUrlMappings(): void
     {
         $aliasUrlMapping = new UrlMapping('alias');
         $propMetadas = [

--- a/src/LiveComponent/tests/Unit/Metadata/LivePropMetadataTest.php
+++ b/src/LiveComponent/tests/Unit/Metadata/LivePropMetadataTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\LiveComponent\Metadata\LivePropMetadata;
 
 class LivePropMetadataTest extends TestCase
 {
-    public function testWithModifier()
+    public function testWithModifier(): void
     {
         $liveProp = new LiveProp(modifier: 'modifyProp');
         $livePropMetadata = new LivePropMetadata('propWithModifier', $liveProp, null, false, false, null);
@@ -34,7 +34,7 @@ class LivePropMetadataTest extends TestCase
         $this->assertEquals('customField', $livePropMetadata->calculateFieldName($component, 'propWithModifier'));
     }
 
-    public function testWithModifierThrowsErrorIfNoMethodExistsInComponent()
+    public function testWithModifierThrowsErrorIfNoMethodExistsInComponent(): void
     {
         $liveProp = new LiveProp(modifier: 'modifyProp');
         $livePropMetadata = new LivePropMetadata('propWithModifier', $liveProp, null, false, false, null);
@@ -45,7 +45,7 @@ class LivePropMetadataTest extends TestCase
         $livePropMetadata->withModifier(new \stdClass());
     }
 
-    public function testWithModifierThrowsAnErrorIfModifierMethodDoesNotReturnLiveProp()
+    public function testWithModifierThrowsAnErrorIfModifierMethodDoesNotReturnLiveProp(): void
     {
         $liveProp = new LiveProp(modifier: 'modifyProp');
         $livePropMetadata = new LivePropMetadata('propWithModifier', $liveProp, null, false, false, null);

--- a/src/LiveComponent/tests/Unit/Twig/LiveComponentRuntimeTest.php
+++ b/src/LiveComponent/tests/Unit/Twig/LiveComponentRuntimeTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\LiveComponent\Twig\LiveComponentRuntime;
 
 final class LiveComponentRuntimeTest extends KernelTestCase
 {
-    public function testGetLiveAction()
+    public function testGetLiveAction(): void
     {
         $runtime = self::getContainer()->get('ux.live_component.twig.component_runtime');
         \assert($runtime instanceof LiveComponentRuntime);

--- a/src/LiveComponent/tests/Unit/Twig/TemplateCacheWarmerTest.php
+++ b/src/LiveComponent/tests/Unit/Twig/TemplateCacheWarmerTest.php
@@ -39,7 +39,7 @@ final class TemplateCacheWarmerTest extends TestCase
         );
     }
 
-    public function testWarmUpCreatesCacheFile()
+    public function testWarmUpCreatesCacheFile(): void
     {
         $this->assertFileDoesNotExist($this->cacheFile);
 
@@ -48,7 +48,7 @@ final class TemplateCacheWarmerTest extends TestCase
         $this->assertFileExists($this->cacheFile);
     }
 
-    public function testWarmUpCreatesCorrectCacheContent()
+    public function testWarmUpCreatesCorrectCacheContent(): void
     {
         $this->templateCacheWarmer->warmUp($this->cacheDir);
         $adapter = new PhpArrayAdapter($this->cacheFile, new NullAdapter());
@@ -63,7 +63,7 @@ final class TemplateCacheWarmerTest extends TestCase
         );
     }
 
-    public function testWarmUpCreatesReproductibleTemplateMap()
+    public function testWarmUpCreatesReproductibleTemplateMap(): void
     {
         $this->templateCacheWarmer->warmUp($this->cacheDir);
         $adapter = new PhpArrayAdapter($this->cacheFile, new NullAdapter());

--- a/src/LiveComponent/tests/Unit/Util/DehydratedPropsTest.php
+++ b/src/LiveComponent/tests/Unit/Util/DehydratedPropsTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\LiveComponent\Util\DehydratedProps;
 
 class DehydratedPropsTest extends TestCase
 {
-    public function testDataIsBuiltCorrectly()
+    public function testDataIsBuiltCorrectly(): void
     {
         $dehydratedProps = new DehydratedProps();
         $dehydratedProps->addPropValue('firstName', 'Ryan');
@@ -43,7 +43,7 @@ class DehydratedPropsTest extends TestCase
         $this->assertEquals($dehydratedProps->getProps(), $propsFromArray->getProps());
     }
 
-    public function testRemovePropValue()
+    public function testRemovePropValue(): void
     {
         $props = new DehydratedProps();
         $props->addPropValue('firstName', 'Ryan');
@@ -52,7 +52,7 @@ class DehydratedPropsTest extends TestCase
         $this->assertSame(['lastName' => 'Weaver'], $props->getProps());
     }
 
-    public function testGetAndHasPropValue()
+    public function testGetAndHasPropValue(): void
     {
         $props = new DehydratedProps();
         $props->addPropValue('firstName', 'Ryan');
@@ -63,7 +63,7 @@ class DehydratedPropsTest extends TestCase
         $this->assertNull($props->getPropValue('middleName'));
     }
 
-    public function testGetAndHasNestedPathValue()
+    public function testGetAndHasNestedPathValue(): void
     {
         $props = new DehydratedProps();
         $props->addPropValue('student', '11');
@@ -80,7 +80,7 @@ class DehydratedPropsTest extends TestCase
         $this->assertSame('Campfire Food', $props->getNestedPathValue('product', 'category.name'));
     }
 
-    public function testCreateFromUpdatedArray()
+    public function testCreateFromUpdatedArray(): void
     {
         $actual = DehydratedProps::createFromUpdatedArray([
             'isPublic' => true,
@@ -102,7 +102,7 @@ class DehydratedPropsTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetNestedPathsForProperty()
+    public function testGetNestedPathsForProperty(): void
     {
         $props = DehydratedProps::createFromUpdatedArray([
             'invoice.number' => '123',
@@ -118,7 +118,7 @@ class DehydratedPropsTest extends TestCase
         );
     }
 
-    public function testCalculateUnexpectedWritablePaths()
+    public function testCalculateUnexpectedWritablePaths(): void
     {
         $props = DehydratedProps::createFromUpdatedArray([
             'product.tags' => ['pretzels', 'nonsense'],

--- a/src/LiveComponent/tests/Unit/Util/FingerprintCalculatorTest.php
+++ b/src/LiveComponent/tests/Unit/Util/FingerprintCalculatorTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\LiveComponent\Util\FingerprintCalculator;
 
 final class FingerprintCalculatorTest extends TestCase
 {
-    public function testConstructWithEmptySecret()
+    public function testConstructWithEmptySecret(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('A non-empty secret is required.');

--- a/src/LiveComponent/tests/Unit/Util/LiveAttributesCollectionTest.php
+++ b/src/LiveComponent/tests/Unit/Util/LiveAttributesCollectionTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\LiveComponent\Util\LiveAttributesCollection;
 
 class LiveAttributesCollectionTest extends KernelTestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         self::bootKernel();
         $collection = new LiveAttributesCollection(self::getContainer()->get('twig'));

--- a/src/LiveComponent/tests/Unit/Util/LiveFormUtilityTest.php
+++ b/src/LiveComponent/tests/Unit/Util/LiveFormUtilityTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\LiveComponent\Util\LiveFormUtility;
 final class LiveFormUtilityTest extends TestCase
 {
     #[DataProvider('getPathsTests')]
-    public function testRemovePathsNotInData(array $inputPaths, array $inputData, array $expectedPaths)
+    public function testRemovePathsNotInData(array $inputPaths, array $inputData, array $expectedPaths): void
     {
         $this->assertEquals($expectedPaths, LiveFormUtility::removePathsNotInData($inputPaths, $inputData));
     }
@@ -63,7 +63,7 @@ final class LiveFormUtilityTest extends TestCase
     }
 
     #[DataProvider('provideFormContainsAnyErrorsTests')]
-    public function testDoesFormContainAnyErrors(FormView $formView, bool $expected)
+    public function testDoesFormContainAnyErrors(FormView $formView, bool $expected): void
     {
         $this->assertSame($expected, LiveFormUtility::doesFormContainAnyErrors($formView));
     }

--- a/src/LiveComponent/tests/Unit/Util/ModelBindingParserTest.php
+++ b/src/LiveComponent/tests/Unit/Util/ModelBindingParserTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\LiveComponent\Util\ModelBindingParser;
 final class ModelBindingParserTest extends TestCase
 {
     #[DataProvider('getModelStringTests')]
-    public function testParseAllValidStrings(string $input, array $expectedBindings)
+    public function testParseAllValidStrings(string $input, array $expectedBindings): void
     {
         $parser = new ModelBindingParser();
         $this->assertEquals($expectedBindings, $parser->parse($input));
@@ -42,7 +42,7 @@ final class ModelBindingParserTest extends TestCase
         ]];
     }
 
-    public function testParseThrowsExceptionWithMultipleColons()
+    public function testParseThrowsExceptionWithMultipleColons(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value "foo:bar:baz" given for "data-model"');

--- a/src/Map/src/Bridge/Google/tests/GoogleOptionsTest.php
+++ b/src/Map/src/Bridge/Google/tests/GoogleOptionsTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Map\Bridge\Google\Option\MapTypeControlStyle;
 
 class GoogleOptionsTest extends TestCase
 {
-    public function testWithMinimalConfiguration()
+    public function testWithMinimalConfiguration(): void
     {
         $options = new GoogleOptions();
 
@@ -47,7 +47,7 @@ class GoogleOptionsTest extends TestCase
         self::assertEquals($options, GoogleOptions::fromArray($options->toArray()));
     }
 
-    public function testWithMinimalConfigurationAndWithoutControls()
+    public function testWithMinimalConfigurationAndWithoutControls(): void
     {
         $options = new GoogleOptions(
             mapId: 'abcdefgh12345678',

--- a/src/Map/src/Bridge/Google/tests/Option/ControlPositionTest.php
+++ b/src/Map/src/Bridge/Google/tests/Option/ControlPositionTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Map\Bridge\Google\Option\ControlPosition;
 
 class ControlPositionTest extends TestCase
 {
-    public function testEnumValues()
+    public function testEnumValues(): void
     {
         self::assertSame(24, ControlPosition::BLOCK_END_INLINE_CENTER->value);
         self::assertSame(25, ControlPosition::BLOCK_END_INLINE_END->value);

--- a/src/Map/src/Bridge/Google/tests/Option/FullscreenControlOptionsTest.php
+++ b/src/Map/src/Bridge/Google/tests/Option/FullscreenControlOptionsTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Map\Bridge\Google\Option\FullscreenControlOptions;
 
 class FullscreenControlOptionsTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $options = new FullscreenControlOptions(
             position: ControlPosition::BLOCK_END_INLINE_CENTER

--- a/src/Map/src/Bridge/Google/tests/Option/GestureHandlingTest.php
+++ b/src/Map/src/Bridge/Google/tests/Option/GestureHandlingTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Map\Bridge\Google\Option\GestureHandling;
 
 class GestureHandlingTest extends TestCase
 {
-    public function testEnumValues()
+    public function testEnumValues(): void
     {
         self::assertSame('cooperative', GestureHandling::COOPERATIVE->value);
         self::assertSame('greedy', GestureHandling::GREEDY->value);

--- a/src/Map/src/Bridge/Google/tests/Option/MapTypeControlOptionsTest.php
+++ b/src/Map/src/Bridge/Google/tests/Option/MapTypeControlOptionsTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\Map\Bridge\Google\Option\MapTypeControlStyle;
 
 class MapTypeControlOptionsTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $options = new MapTypeControlOptions(
             mapTypeIds: ['satellite', 'hybrid'],

--- a/src/Map/src/Bridge/Google/tests/Option/MapTypeControlStyleTest.php
+++ b/src/Map/src/Bridge/Google/tests/Option/MapTypeControlStyleTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Map\Bridge\Google\Option\MapTypeControlStyle;
 
 class MapTypeControlStyleTest extends TestCase
 {
-    public function testEnumValues()
+    public function testEnumValues(): void
     {
         self::assertSame(0, MapTypeControlStyle::DEFAULT->value);
         self::assertSame(2, MapTypeControlStyle::DROPDOWN_MENU->value);

--- a/src/Map/src/Bridge/Google/tests/Option/StreetViewControlOptionsTest.php
+++ b/src/Map/src/Bridge/Google/tests/Option/StreetViewControlOptionsTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Map\Bridge\Google\Option\StreetViewControlOptions;
 
 class StreetViewControlOptionsTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $options = new StreetViewControlOptions(
             position: ControlPosition::INLINE_END_BLOCK_CENTER

--- a/src/Map/src/Bridge/Google/tests/Option/ZoomControlOptionsTest.php
+++ b/src/Map/src/Bridge/Google/tests/Option/ZoomControlOptionsTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Map\Bridge\Google\Option\ZoomControlOptions;
 
 class ZoomControlOptionsTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $options = new ZoomControlOptions(
             position: ControlPosition::BLOCK_START_INLINE_END,

--- a/src/Map/src/Bridge/Leaflet/tests/LeafletOptionsTest.php
+++ b/src/Map/src/Bridge/Leaflet/tests/LeafletOptionsTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Map\Bridge\Leaflet\Option\TileLayer;
 
 class LeafletOptionsTest extends TestCase
 {
-    public function testWithMinimalConfiguration()
+    public function testWithMinimalConfiguration(): void
     {
         $leafletOptions = new LeafletOptions();
 
@@ -43,7 +43,7 @@ class LeafletOptionsTest extends TestCase
         self::assertEquals($leafletOptions, LeafletOptions::fromArray($leafletOptions->toArray()));
     }
 
-    public function testWithMaximumConfiguration()
+    public function testWithMaximumConfiguration(): void
     {
         $leafletOptions = new LeafletOptions(
             tileLayer: new TileLayer(
@@ -85,7 +85,7 @@ class LeafletOptionsTest extends TestCase
         self::assertEquals($leafletOptions, LeafletOptions::fromArray($leafletOptions->toArray()));
     }
 
-    public function testWithTileLayerFalse()
+    public function testWithTileLayerFalse(): void
     {
         $leafletOptions = new LeafletOptions(tileLayer: false);
 
@@ -107,7 +107,7 @@ class LeafletOptionsTest extends TestCase
         self::assertEquals($leafletOptions, LeafletOptions::fromArray($leafletOptions->toArray()));
     }
 
-    public function testWithoutControls()
+    public function testWithoutControls(): void
     {
         $leafletOptions = new LeafletOptions(
             attributionControl: false,

--- a/src/Map/src/Bridge/Leaflet/tests/Option/AttributionControlOptionsTest.php
+++ b/src/Map/src/Bridge/Leaflet/tests/Option/AttributionControlOptionsTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Map\Bridge\Leaflet\Option\ControlPosition;
 
 class AttributionControlOptionsTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $options = new AttributionControlOptions();
 
@@ -27,7 +27,7 @@ class AttributionControlOptionsTest extends TestCase
         ], $options->toArray());
     }
 
-    public function testToArrayWithDifferentConfiguration()
+    public function testToArrayWithDifferentConfiguration(): void
     {
         $options = new AttributionControlOptions(
             position: ControlPosition::BOTTOM_LEFT,

--- a/src/Map/src/Bridge/Leaflet/tests/Option/TileLayerTest.php
+++ b/src/Map/src/Bridge/Leaflet/tests/Option/TileLayerTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Map\Bridge\Leaflet\Option\TileLayer;
 
 class TileLayerTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $tileLayer = new TileLayer(
             url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/src/Map/src/Bridge/Leaflet/tests/Option/ZoomControlOptionsTest.php
+++ b/src/Map/src/Bridge/Leaflet/tests/Option/ZoomControlOptionsTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Map\Bridge\Leaflet\Option\ZoomControlOptions;
 
 class ZoomControlOptionsTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $options = new ZoomControlOptions(
             position: ControlPosition::TOP_LEFT,

--- a/src/Map/tests/CircleTest.php
+++ b/src/Map/tests/CircleTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Map\Point;
 
 class CircleTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $center = new Point(1.1, 2.2);
         $infoWindow = new InfoWindow('info content');
@@ -49,7 +49,7 @@ class CircleTest extends TestCase
         ], $array);
     }
 
-    public function testFromArray()
+    public function testFromArray(): void
     {
         $data = [
             'center' => ['lat' => 1.1, 'lng' => 2.2],
@@ -80,19 +80,19 @@ class CircleTest extends TestCase
         ], $array);
     }
 
-    public function testFromArrayThrowsExceptionIfCenterMissing()
+    public function testFromArrayThrowsExceptionIfCenterMissing(): void
     {
         $this->expectException(InvalidArgumentException::class);
         Circle::fromArray(['radius' => 500, 'invalid' => 'No center']);
     }
 
-    public function testFromArrayThrowsExceptionIfRadiusMissing()
+    public function testFromArrayThrowsExceptionIfRadiusMissing(): void
     {
         $this->expectException(InvalidArgumentException::class);
         Circle::fromArray(['center' => ['lat' => 1.1, 'lng' => 2.2], 'invalid' => 'No radius']);
     }
 
-    public function testConstructorThrowsExceptionIfRadiusNotPositive()
+    public function testConstructorThrowsExceptionIfRadiusNotPositive(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new Circle(new Point(1.1, 2.2), 0);

--- a/src/Map/tests/Cluster/ClusteringPerformanceTest.php
+++ b/src/Map/tests/Cluster/ClusteringPerformanceTest.php
@@ -55,7 +55,7 @@ class ClusteringPerformanceTest extends TestCase
      * Scenario 1: Large number of points (50,000), concentrated area (Paris region).
      */
     #[DataProvider('algorithmProvider')]
-    public function testScenarioRegion50000(ClusteringAlgorithmInterface $algorithm, float $zoom)
+    public function testScenarioRegion50000(ClusteringAlgorithmInterface $algorithm, float $zoom): void
     {
         $points = $this->generatePoints(50000, 48.8, 49, 2.2, 2.5);
 
@@ -66,7 +66,7 @@ class ClusteringPerformanceTest extends TestCase
      * Scenario 2: Moderate number of points (5,000), broad area (France and surroundings).
      */
     #[DataProvider('algorithmProvider')]
-    public function testScenarioCountry5000(ClusteringAlgorithmInterface $algorithm, float $zoom)
+    public function testScenarioCountry5000(ClusteringAlgorithmInterface $algorithm, float $zoom): void
     {
         $points = $this->generatePoints(5000, 30, 60, -10, 35);
 
@@ -77,7 +77,7 @@ class ClusteringPerformanceTest extends TestCase
      * Scenario 3: Very large number of points (100,000), global distribution.
      */
     #[DataProvider('algorithmProvider')]
-    public function testScenarioWorld100000(ClusteringAlgorithmInterface $algorithm, float $zoom)
+    public function testScenarioWorld100000(ClusteringAlgorithmInterface $algorithm, float $zoom): void
     {
         $points = $this->generatePoints(100000, -90, 90, -180, 180);
 

--- a/src/Map/tests/Distance/DistanceCalculatorTest.php
+++ b/src/Map/tests/Distance/DistanceCalculatorTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Map\Point;
 
 class DistanceCalculatorTest extends TestCase
 {
-    public function testCalculateDistanceUseCalculator()
+    public function testCalculateDistanceUseCalculator(): void
     {
         $calculator = new class implements DistanceCalculatorInterface {
             public function calculateDistance(Point $point1, Point $point2): float
@@ -41,7 +41,7 @@ class DistanceCalculatorTest extends TestCase
      * produce results close to the reference (Vincenty) within an acceptable margin.
      */
     #[DataProvider('distanceAccuracyProvider')]
-    public function testAccuracyAgainstVincenty(Point $point1, Point $point2, float $tolerance)
+    public function testAccuracyAgainstVincenty(Point $point1, Point $point2, float $tolerance): void
     {
         $vincenty = new VincentyDistanceCalculator();
         $referenceDistance = $vincenty->calculateDistance($point1, $point2);

--- a/src/Map/tests/Distance/DistanceUnitTest.php
+++ b/src/Map/tests/Distance/DistanceUnitTest.php
@@ -17,14 +17,14 @@ use Symfony\UX\Map\Distance\DistanceUnit;
 
 class DistanceUnitTest extends TestCase
 {
-    public function testConversionFactorIsPositive()
+    public function testConversionFactorIsPositive(): void
     {
         foreach (DistanceUnit::cases() as $unit) {
             $this->assertGreaterThan(0, $unit->getConversionFactor());
         }
     }
 
-    public function testConversionFactorToMeterIsSameAsConversionFactor()
+    public function testConversionFactorToMeterIsSameAsConversionFactor(): void
     {
         foreach (DistanceUnit::cases() as $unit) {
             $this->assertEquals($unit->getConversionFactor(), $unit->getConversionFactorTo(DistanceUnit::Meter));
@@ -32,7 +32,7 @@ class DistanceUnitTest extends TestCase
     }
 
     #[DataProvider('provideConvertedUnits')]
-    public function testConversionFactorFrom(DistanceUnit $unit, DistanceUnit $otherUnit, float $expected)
+    public function testConversionFactorFrom(DistanceUnit $unit, DistanceUnit $otherUnit, float $expected): void
     {
         $this->assertEqualsWithDelta($expected, $unit->getConversionFactorFrom($otherUnit), 0.001);
     }

--- a/src/Map/tests/IconTest.php
+++ b/src/Map/tests/IconTest.php
@@ -43,19 +43,19 @@ class IconTest extends TestCase
      * @param class-string<Icon> $expectedInstance
      */
     #[DataProvider('provideIcons')]
-    public function testIconConstruction(Icon $icon, string $expectedInstance, array $expectedToArray)
+    public function testIconConstruction(Icon $icon, string $expectedInstance, array $expectedToArray): void
     {
         self::assertInstanceOf($expectedInstance, $icon);
     }
 
     #[DataProvider('provideIcons')]
-    public function testToArray(Icon $icon, string $expectedInstance, array $expectedToArray)
+    public function testToArray(Icon $icon, string $expectedInstance, array $expectedToArray): void
     {
         self::assertSame($expectedToArray, $icon->toArray());
     }
 
     #[DataProvider('provideIcons')]
-    public function testFromArray(Icon $icon, string $expectedInstance, array $expectedToArray)
+    public function testFromArray(Icon $icon, string $expectedInstance, array $expectedToArray): void
     {
         self::assertEquals($icon, Icon::fromArray($expectedToArray));
     }
@@ -81,7 +81,7 @@ class IconTest extends TestCase
     }
 
     #[DataProvider('dataProviderForTestSvgIconCustomizationMethodsCanNotBeCalled')]
-    public function testSvgIconCustomizationMethodsCanNotBeCalled(string $method, mixed ...$args)
+    public function testSvgIconCustomizationMethodsCanNotBeCalled(string $method, mixed ...$args): void
     {
         $this->expectException(\LogicException::class);
         if (\in_array($method, ['width', 'height'], true)) {

--- a/src/Map/tests/InfoWindowTest.php
+++ b/src/Map/tests/InfoWindowTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Map\Point;
 
 class InfoWindowTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $infoWindow = new InfoWindow(
             headerContent: 'Paris',

--- a/src/Map/tests/MapFactoryTest.php
+++ b/src/Map/tests/MapFactoryTest.php
@@ -30,7 +30,7 @@ class MapFactoryTest extends TestCase
         DummyOptions::unregisterFromNormalizer();
     }
 
-    public function testFromArray()
+    public function testFromArray(): void
     {
         $array = self::createMapArray();
         $map = Map::fromArray($array);
@@ -60,7 +60,7 @@ class MapFactoryTest extends TestCase
         $this->assertSame($array['polylines'][0]['infoWindow']['content'], $polylines[0]['infoWindow']['content']);
     }
 
-    public function testToArrayFromArray()
+    public function testToArrayFromArray(): void
     {
         $map = new Map()
             ->center(new Point(48.8566, 2.3522))
@@ -92,7 +92,7 @@ class MapFactoryTest extends TestCase
         $this->assertEquals($map->toArray(), $newMap->toArray());
     }
 
-    public function testFromArrayWithInvalidCenter()
+    public function testFromArrayWithInvalidCenter(): void
     {
         $array = self::createMapArray();
         $array['center'] = 'invalid';
@@ -101,7 +101,7 @@ class MapFactoryTest extends TestCase
         Map::fromArray($array);
     }
 
-    public function testFromArrayWithInvalidZoom()
+    public function testFromArrayWithInvalidZoom(): void
     {
         $array = self::createMapArray();
         $array['zoom'] = 'invalid';
@@ -110,7 +110,7 @@ class MapFactoryTest extends TestCase
         Map::fromArray($array);
     }
 
-    public function testFromArrayWithInvalidMarkers()
+    public function testFromArrayWithInvalidMarkers(): void
     {
         $array = self::createMapArray();
         $array['markers'] = 'invalid';
@@ -120,7 +120,7 @@ class MapFactoryTest extends TestCase
         Map::fromArray($array);
     }
 
-    public function testFromArrayWithInvalidMarker()
+    public function testFromArrayWithInvalidMarker(): void
     {
         $array = self::createMapArray();
         $array['markers'] = [
@@ -134,7 +134,7 @@ class MapFactoryTest extends TestCase
         Map::fromArray($array);
     }
 
-    public function testFromArrayWithInvalidPolygons()
+    public function testFromArrayWithInvalidPolygons(): void
     {
         $array = self::createMapArray();
         $array['polygons'] = 'invalid';
@@ -144,7 +144,7 @@ class MapFactoryTest extends TestCase
         Map::fromArray($array);
     }
 
-    public function testFromArrayWithInvalidPolygon()
+    public function testFromArrayWithInvalidPolygon(): void
     {
         $array = self::createMapArray();
         $array['polygons'] = [
@@ -158,7 +158,7 @@ class MapFactoryTest extends TestCase
         Map::fromArray($array);
     }
 
-    public function testFromArrayWithInvalidPolylines()
+    public function testFromArrayWithInvalidPolylines(): void
     {
         $array = self::createMapArray();
         $array['polylines'] = 'invalid';
@@ -168,7 +168,7 @@ class MapFactoryTest extends TestCase
         Map::fromArray($array);
     }
 
-    public function testFromArrayWithInvalidPolyline()
+    public function testFromArrayWithInvalidPolyline(): void
     {
         $array = self::createMapArray();
         $array['polylines'] = [

--- a/src/Map/tests/MapOptionsNormalizerTest.php
+++ b/src/Map/tests/MapOptionsNormalizerTest.php
@@ -22,7 +22,7 @@ final class MapOptionsNormalizerTest extends TestCase
         DummyOptions::unregisterFromNormalizer();
     }
 
-    public function testDenormalizingWhenProviderKeyIsMissing()
+    public function testDenormalizingWhenProviderKeyIsMissing(): void
     {
         $this->expectException(UnableToDenormalizeOptionsException::class);
         $this->expectExceptionMessage(' the provider key "@provider" is missing in the normalized options.');
@@ -30,7 +30,7 @@ final class MapOptionsNormalizerTest extends TestCase
         MapOptionsNormalizer::denormalize([]);
     }
 
-    public function testDenormalizingWhenProviderIsNotSupported()
+    public function testDenormalizingWhenProviderIsNotSupported(): void
     {
         $this->expectException(UnableToDenormalizeOptionsException::class);
         $this->expectExceptionMessage(' the provider "foo" is not supported. Supported providers are "google", "leaflet".');
@@ -38,7 +38,7 @@ final class MapOptionsNormalizerTest extends TestCase
         MapOptionsNormalizer::denormalize(['@provider' => 'foo']);
     }
 
-    public function testDenormalizingAndNormalizing()
+    public function testDenormalizingAndNormalizing(): void
     {
         DummyOptions::registerToNormalizer();
 

--- a/src/Map/tests/MapTest.php
+++ b/src/Map/tests/MapTest.php
@@ -35,7 +35,7 @@ class MapTest extends TestCase
         DummyOptions::unregisterFromNormalizer();
     }
 
-    public function testCenterValidation()
+    public function testCenterValidation(): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('The map "center" must be explicitly set when not enabling "fitBoundsToMarkers" feature.');
@@ -44,7 +44,7 @@ class MapTest extends TestCase
         $map->toArray();
     }
 
-    public function testZoomValidation()
+    public function testZoomValidation(): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('The map "zoom" must be explicitly set when not enabling "fitBoundsToMarkers" feature.');
@@ -55,7 +55,7 @@ class MapTest extends TestCase
         $map->toArray();
     }
 
-    public function testZoomAndCenterCanBeOmittedIfFitBoundsToMarkers()
+    public function testZoomAndCenterCanBeOmittedIfFitBoundsToMarkers(): void
     {
         $map = new Map(
             fitBoundsToMarkers: true
@@ -79,7 +79,7 @@ class MapTest extends TestCase
         ], $array);
     }
 
-    public function testWithMinimumConfiguration()
+    public function testWithMinimumConfiguration(): void
     {
         $map = new Map();
         $map
@@ -104,7 +104,7 @@ class MapTest extends TestCase
         ], $array);
     }
 
-    public function testWithMaximumConfiguration()
+    public function testWithMaximumConfiguration(): void
     {
         $map = new Map();
         $map
@@ -415,7 +415,7 @@ class MapTest extends TestCase
     #[TestWith([5.0, 2.0, null, 'The "zoom" must be greater than or equal to "minZoom".'])]
     #[TestWith([null, 5.0, 2.0, 'The "zoom" must be less than or equal to "maxZoom".'])]
     #[TestWith([2.1, null, 2.0, 'The "minZoom" must be less than or equal to "maxZoom".'])]
-    public function testZoomsValidation(?float $minZoom, ?float $zoom, ?float $maxZoom, string $expectedExceptionMessage)
+    public function testZoomsValidation(?float $minZoom, ?float $zoom, ?float $maxZoom, string $expectedExceptionMessage): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage($expectedExceptionMessage);

--- a/src/Map/tests/MarkerTest.php
+++ b/src/Map/tests/MarkerTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Map\Point;
 
 class MarkerTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $marker = new Marker(
             position: new Point(48.8566, 2.3522),

--- a/src/Map/tests/PointTest.php
+++ b/src/Map/tests/PointTest.php
@@ -27,7 +27,7 @@ class PointTest extends TestCase
     }
 
     #[DataProvider('provideInvalidPoint')]
-    public function testInvalidPoint(float $latitude, float $longitude, string $expectedExceptionMessage)
+    public function testInvalidPoint(float $latitude, float $longitude, string $expectedExceptionMessage): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage($expectedExceptionMessage);
@@ -35,21 +35,21 @@ class PointTest extends TestCase
         new Point($latitude, $longitude);
     }
 
-    public function testGetLatitude()
+    public function testGetLatitude(): void
     {
         $point = new Point(48.8566, 2.3533);
 
         self::assertSame(48.8566, $point->getLatitude());
     }
 
-    public function testGetLongitude()
+    public function testGetLongitude(): void
     {
         $point = new Point(48.8566, 2.3533);
 
         self::assertSame(2.3533, $point->getLongitude());
     }
 
-    public function testToArray()
+    public function testToArray(): void
     {
         $point = new Point(48.8566, 2.3533);
 

--- a/src/Map/tests/PolygonTest.php
+++ b/src/Map/tests/PolygonTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Map\Polygon;
 
 class PolygonTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $point1 = new Point(1.1, 2.2);
         $point2 = new Point(3.3, 4.4);
@@ -49,7 +49,7 @@ class PolygonTest extends TestCase
         ], $array);
     }
 
-    public function testToArrayMultidimensional()
+    public function testToArrayMultidimensional(): void
     {
         $point1 = new Point(1.1, 2.2);
         $point2 = new Point(3.3, 4.4);
@@ -71,7 +71,7 @@ class PolygonTest extends TestCase
         ], $array);
     }
 
-    public function testFromArray()
+    public function testFromArray(): void
     {
         $data = [
             'points' => [
@@ -102,7 +102,7 @@ class PolygonTest extends TestCase
         ], $array);
     }
 
-    public function testFromArrayMultidimensional()
+    public function testFromArrayMultidimensional(): void
     {
         $data = [
             'points' => [
@@ -137,7 +137,7 @@ class PolygonTest extends TestCase
         ], $array);
     }
 
-    public function testFromArrayThrowsExceptionIfPointsMissing()
+    public function testFromArrayThrowsExceptionIfPointsMissing(): void
     {
         $this->expectException(InvalidArgumentException::class);
         Polygon::fromArray(['invalid' => 'No points']);

--- a/src/Map/tests/RectangleTest.php
+++ b/src/Map/tests/RectangleTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Map\Rectangle;
 
 class RectangleTest extends TestCase
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $infoWindow = new InfoWindow('Hello');
 
@@ -38,7 +38,7 @@ class RectangleTest extends TestCase
         ], $array);
     }
 
-    public function testFromArray()
+    public function testFromArray(): void
     {
         $data = [
             'southWest' => ['lat' => 1.0, 'lng' => 2.0],
@@ -67,7 +67,7 @@ class RectangleTest extends TestCase
         ], $array);
     }
 
-    public function testFromArrayThrowsExceptionIfSouthWestMissing()
+    public function testFromArrayThrowsExceptionIfSouthWestMissing(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -76,7 +76,7 @@ class RectangleTest extends TestCase
         ]);
     }
 
-    public function testFromArrayThrowsExceptionIfNorthEastMissing()
+    public function testFromArrayThrowsExceptionIfNorthEastMissing(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/src/Map/tests/Renderer/DsnTest.php
+++ b/src/Map/tests/Renderer/DsnTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Map\Renderer\Dsn;
 final class DsnTest extends TestCase
 {
     #[DataProvider('constructDsn')]
-    public function testConstruct(string $dsnString, string $scheme, string $host, ?string $user = null, array $options = [], ?string $path = null)
+    public function testConstruct(string $dsnString, string $scheme, string $host, ?string $user = null, array $options = [], ?string $path = null): void
     {
         $dsn = new Dsn($dsnString);
         self::assertSame($dsnString, $dsn->getOriginalDsn());
@@ -77,7 +77,7 @@ final class DsnTest extends TestCase
     }
 
     #[DataProvider('invalidDsn')]
-    public function testInvalidDsn(string $dsnString, string $exceptionMessage)
+    public function testInvalidDsn(string $dsnString, string $exceptionMessage): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage($exceptionMessage);

--- a/src/Map/tests/Renderer/NullRendererTest.php
+++ b/src/Map/tests/Renderer/NullRendererTest.php
@@ -41,7 +41,7 @@ final class NullRendererTest extends TestCase
     }
 
     #[DataProvider('provideTestRenderMap')]
-    public function testRenderMap(string $expectedExceptionMessage, RendererInterface $renderer)
+    public function testRenderMap(string $expectedExceptionMessage, RendererInterface $renderer): void
     {
         self::expectException(LogicException::class);
         self::expectExceptionMessage($expectedExceptionMessage);

--- a/src/Map/tests/Renderer/RendererTest.php
+++ b/src/Map/tests/Renderer/RendererTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Map\Renderer\RendererInterface;
 
 final class RendererTest extends TestCase
 {
-    public function testUnsupportedSchemeException()
+    public function testUnsupportedSchemeException(): void
     {
         self::expectException(UnsupportedSchemeException::class);
         self::expectExceptionMessage('The renderer "scheme" is not supported.');
@@ -28,7 +28,7 @@ final class RendererTest extends TestCase
         $renderer->fromString('scheme://default');
     }
 
-    public function testSupportedFactory()
+    public function testSupportedFactory(): void
     {
         $renderer = new Renderer([
             'one' => $oneFactory = self::createMock(RendererFactoryInterface::class),

--- a/src/Map/tests/Renderer/RenderersTest.php
+++ b/src/Map/tests/Renderer/RenderersTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Map\Renderer\Renderers;
 
 class RenderersTest extends TestCase
 {
-    public function testConstructWithoutRenderers()
+    public function testConstructWithoutRenderers(): void
     {
         self::expectException(LogicException::class);
         self::expectExceptionMessage('"Symfony\UX\Map\Renderer\Renderers" must have at least one renderer configured.');
@@ -27,7 +27,7 @@ class RenderersTest extends TestCase
         new Renderers([]);
     }
 
-    public function testRenderMapWithDefaultRenderer()
+    public function testRenderMapWithDefaultRenderer(): void
     {
         $defaultRenderer = $this->createMock(RendererInterface::class);
         $defaultRenderer->expects(self::once())->method('renderMap')->willReturn('<div data-controller="@symfony/ux-default-map"></div>');
@@ -37,7 +37,7 @@ class RenderersTest extends TestCase
         self::assertSame('<div data-controller="@symfony/ux-default-map"></div>', $renderers->renderMap(new Map()));
     }
 
-    public function testRenderMapWithCustomRenderer()
+    public function testRenderMapWithCustomRenderer(): void
     {
         $defaultRenderer = $this->createMock(RendererInterface::class);
         $defaultRenderer->expects(self::never())->method('renderMap');
@@ -52,7 +52,7 @@ class RenderersTest extends TestCase
         self::assertSame('<div data-controller="@symfony/ux-custom-map"></div>', $renderers->renderMap($map));
     }
 
-    public function testRenderMapWithUnknownRenderer()
+    public function testRenderMapWithUnknownRenderer(): void
     {
         self::expectException(LogicException::class);
         self::expectExceptionMessage('The "unknown" renderer does not exist (available renderers: "default").');

--- a/src/Map/tests/Twig/MapComponentTest.php
+++ b/src/Map/tests/Twig/MapComponentTest.php
@@ -24,7 +24,7 @@ class MapComponentTest extends KernelTestCase
         return TwigComponentKernel::class;
     }
 
-    public function testRenderMapComponent()
+    public function testRenderMapComponent(): void
     {
         $map = new Map()
             ->center(new Point(latitude: 5, longitude: 10))

--- a/src/Map/tests/Twig/MapExtensionTest.php
+++ b/src/Map/tests/Twig/MapExtensionTest.php
@@ -27,7 +27,7 @@ class MapExtensionTest extends KernelTestCase
         return TwigAppKernel::class;
     }
 
-    public function testExtensionIsRegistered()
+    public function testExtensionIsRegistered(): void
     {
         /** @var Environment $twig */
         $twig = self::getContainer()->get('twig');
@@ -36,7 +36,7 @@ class MapExtensionTest extends KernelTestCase
         $this->assertInstanceOf(MapExtension::class, $twig->getExtension(MapExtension::class));
     }
 
-    public function testRuntimeIsRegistered()
+    public function testRuntimeIsRegistered(): void
     {
         /** @var Environment $twig */
         $twig = self::getContainer()->get('twig');
@@ -44,7 +44,7 @@ class MapExtensionTest extends KernelTestCase
         $this->assertInstanceOf(MapRuntime::class, $twig->getRuntime(MapRuntime::class));
     }
 
-    public function testMapFunctionWithArray()
+    public function testMapFunctionWithArray(): void
     {
         $map = new Map()
             ->center(new Point(latitude: 5, longitude: 10))

--- a/src/Map/tests/TwigTest.php
+++ b/src/Map/tests/TwigTest.php
@@ -25,7 +25,7 @@ final class TwigTest extends KernelTestCase
         return TwigAppKernel::class;
     }
 
-    public function testRenderMap()
+    public function testRenderMap(): void
     {
         $map = new Map();
         $attributes = ['data-foo' => 'bar'];

--- a/src/Map/tests/UXMapBundleTest.php
+++ b/src/Map/tests/UXMapBundleTest.php
@@ -35,7 +35,7 @@ class UXMapBundleTest extends TestCase
      * @param class-string<Kernel> $kernelClass
      */
     #[DataProvider('provideKernelClasses')]
-    public function testBootKernel(string $kernelClass)
+    public function testBootKernel(string $kernelClass): void
     {
         $kernel = new $kernelClass('test', true);
         $kernel->boot();
@@ -47,7 +47,7 @@ class UXMapBundleTest extends TestCase
      * @param class-string<Kernel> $kernelClass
      */
     #[DataProvider('provideKernelClasses')]
-    public function testNullRendererAsDefault(string $kernelClass)
+    public function testNullRendererAsDefault(string $kernelClass): void
     {
         $expectedRenderer = new NullRenderer(['symfony/ux-google-map', 'symfony/ux-leaflet-map']);
 

--- a/src/Map/tests/Utils/CoordinateUtilsTest.php
+++ b/src/Map/tests/Utils/CoordinateUtilsTest.php
@@ -15,31 +15,31 @@ use PHPUnit\Framework\TestCase;
 
 class CoordinateUtilsTest extends TestCase
 {
-    public function testDecimalToDMSConvertsCorrectly()
+    public function testDecimalToDMSConvertsCorrectly(): void
     {
         $result = CoordinateUtils::decimalToDMS(48.8588443);
         $this->assertSame([48, 51, 31.83948], $result);
     }
 
-    public function testDecimalToDMSHandlesNegativeValues()
+    public function testDecimalToDMSHandlesNegativeValues(): void
     {
         $result = CoordinateUtils::decimalToDMS(-48.8588443);
         $this->assertSame([-48, 51, 31.83948], $result);
     }
 
-    public function testDMSToDecimalConvertsCorrectly()
+    public function testDMSToDecimalConvertsCorrectly(): void
     {
         $result = CoordinateUtils::DMSToDecimal(48, 51, 31.8388);
         $this->assertSame(48.858844, $result);
     }
 
-    public function testDMSToDecimalHandlesNegativeValues()
+    public function testDMSToDecimalHandlesNegativeValues(): void
     {
         $result = CoordinateUtils::DMSToDecimal(-48, 51, 31.8388);
         $this->assertSame(-48.858844, $result);
     }
 
-    public function testDMSToDecimalHandlesZeroValues()
+    public function testDMSToDecimalHandlesZeroValues(): void
     {
         $result = CoordinateUtils::DMSToDecimal(0, 0, 0.0);
         $this->assertSame(0.0, $result);

--- a/src/Native/tests/Command/BuildConfigurationsCommandTest.php
+++ b/src/Native/tests/Command/BuildConfigurationsCommandTest.php
@@ -33,7 +33,7 @@ final class BuildConfigurationsCommandTest extends TestCase
         new Filesystem()->remove($this->outputDir);
     }
 
-    public function testExecuteCallsBuildAndReturnsSuccess()
+    public function testExecuteCallsBuildAndReturnsSuccess(): void
     {
         $builder = new ConfigurationBuilder($this->outputDir);
         $builder->add('/config/test.json', new Configuration(
@@ -51,7 +51,7 @@ final class BuildConfigurationsCommandTest extends TestCase
         self::assertStringContainsString('built successfully', $commandTester->getDisplay());
     }
 
-    public function testExecuteWithNoConfigurations()
+    public function testExecuteWithNoConfigurations(): void
     {
         $builder = new ConfigurationBuilder($this->outputDir);
 

--- a/src/Native/tests/Configuration/ConfigurationTest.php
+++ b/src/Native/tests/Configuration/ConfigurationTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Native\Configuration\Rule;
 
 final class ConfigurationTest extends TestCase
 {
-    public function testToArrayWithAllValues()
+    public function testToArrayWithAllValues(): void
     {
         $configuration = new Configuration(
             settings: ['use_local_db' => true, 'cable' => ['script_url' => 'https://example.com/cable.js']],
@@ -37,7 +37,7 @@ final class ConfigurationTest extends TestCase
         ], $configuration->toArray());
     }
 
-    public function testToArrayWithSettingsOnly()
+    public function testToArrayWithSettingsOnly(): void
     {
         $configuration = new Configuration(
             settings: ['use_local_db' => false],
@@ -48,7 +48,7 @@ final class ConfigurationTest extends TestCase
         ], $configuration->toArray());
     }
 
-    public function testToArrayWithRulesOnly()
+    public function testToArrayWithRulesOnly(): void
     {
         $configuration = new Configuration(
             rules: [
@@ -66,14 +66,14 @@ final class ConfigurationTest extends TestCase
         ], $configuration->toArray());
     }
 
-    public function testToArrayWithNoValues()
+    public function testToArrayWithNoValues(): void
     {
         $configuration = new Configuration();
 
         self::assertSame([], $configuration->toArray());
     }
 
-    public function testToArrayWithMultipleRules()
+    public function testToArrayWithMultipleRules(): void
     {
         $configuration = new Configuration(
             rules: [

--- a/src/Native/tests/Configuration/RuleTest.php
+++ b/src/Native/tests/Configuration/RuleTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Native\Configuration\Rule;
 
 final class RuleTest extends TestCase
 {
-    public function testToArrayWithAllValues()
+    public function testToArrayWithAllValues(): void
     {
         $rule = new Rule(
             patterns: ['/articles/.*', '/pages/.*'],
@@ -29,7 +29,7 @@ final class RuleTest extends TestCase
         ], $rule->toArray());
     }
 
-    public function testToArrayWithPatternsOnly()
+    public function testToArrayWithPatternsOnly(): void
     {
         $rule = new Rule(
             patterns: ['.*'],
@@ -40,7 +40,7 @@ final class RuleTest extends TestCase
         ], $rule->toArray());
     }
 
-    public function testToArrayWithPropertiesOnly()
+    public function testToArrayWithPropertiesOnly(): void
     {
         $rule = new Rule(
             properties: ['context' => 'modal'],
@@ -51,7 +51,7 @@ final class RuleTest extends TestCase
         ], $rule->toArray());
     }
 
-    public function testToArrayWithNoValues()
+    public function testToArrayWithNoValues(): void
     {
         $rule = new Rule();
 

--- a/src/Native/tests/ConfigurationBuilderTest.php
+++ b/src/Native/tests/ConfigurationBuilderTest.php
@@ -32,7 +32,7 @@ final class ConfigurationBuilderTest extends TestCase
         new Filesystem()->remove($this->outputDir);
     }
 
-    public function testAddAndHas()
+    public function testAddAndHas(): void
     {
         $builder = new ConfigurationBuilder($this->outputDir);
         $configuration = new Configuration(settings: ['use_local_db' => true]);
@@ -44,14 +44,14 @@ final class ConfigurationBuilderTest extends TestCase
         self::assertTrue($builder->has('/config/ios_v1.json'));
     }
 
-    public function testHasReturnsFalseForUnknownPath()
+    public function testHasReturnsFalseForUnknownPath(): void
     {
         $builder = new ConfigurationBuilder($this->outputDir);
 
         self::assertFalse($builder->has('/config/unknown.json'));
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $builder = new ConfigurationBuilder($this->outputDir);
         $configuration = new Configuration(settings: ['use_local_db' => true]);
@@ -62,7 +62,7 @@ final class ConfigurationBuilderTest extends TestCase
         self::assertSame($configuration, $result);
     }
 
-    public function testGetThrowsExceptionForUnknownPath()
+    public function testGetThrowsExceptionForUnknownPath(): void
     {
         $builder = new ConfigurationBuilder($this->outputDir);
 
@@ -72,7 +72,7 @@ final class ConfigurationBuilderTest extends TestCase
         $builder->get('/config/unknown.json');
     }
 
-    public function testBuild()
+    public function testBuild(): void
     {
         $builder = new ConfigurationBuilder($this->outputDir);
         $builder->add('/config/ios_v1.json', new Configuration(
@@ -89,7 +89,7 @@ final class ConfigurationBuilderTest extends TestCase
         self::assertFileExists($this->outputDir.'/config/android_v1.json');
     }
 
-    public function testBuildEncodesJsonCorrectly()
+    public function testBuildEncodesJsonCorrectly(): void
     {
         $builder = new ConfigurationBuilder($this->outputDir);
         $builder->add('/config/ios_v1.json', new Configuration(

--- a/src/Native/tests/ConfigurationCompilerPassTest.php
+++ b/src/Native/tests/ConfigurationCompilerPassTest.php
@@ -21,7 +21,7 @@ use Symfony\UX\Native\Tests\Fixtures\StaticMethodConfigurationProvider;
 
 final class ConfigurationCompilerPassTest extends TestCase
 {
-    public function testEarlyReturnWhenNoConfigurationBuilder()
+    public function testEarlyReturnWhenNoConfigurationBuilder(): void
     {
         $container = new ContainerBuilder();
         $pass = new ConfigurationCompilerPass();
@@ -32,7 +32,7 @@ final class ConfigurationCompilerPassTest extends TestCase
         self::assertFalse($container->hasDefinition('.ux_native.configuration_builder'));
     }
 
-    public function testThrowsExceptionWhenPathIsMissing()
+    public function testThrowsExceptionWhenPathIsMissing(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('.ux_native.configuration_builder', new Definition(ConfigurationBuilder::class, ['/tmp']));
@@ -49,7 +49,7 @@ final class ConfigurationCompilerPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionForStaticMethod()
+    public function testThrowsExceptionForStaticMethod(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('.ux_native.configuration_builder', new Definition(ConfigurationBuilder::class, ['/tmp']));
@@ -66,7 +66,7 @@ final class ConfigurationCompilerPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionForWrongReturnType()
+    public function testThrowsExceptionForWrongReturnType(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('.ux_native.configuration_builder', new Definition(ConfigurationBuilder::class, ['/tmp']));
@@ -83,7 +83,7 @@ final class ConfigurationCompilerPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testRegistersAttributeConfigurations()
+    public function testRegistersAttributeConfigurations(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('.ux_native.configuration_builder', new Definition(ConfigurationBuilder::class, ['/tmp']));
@@ -112,7 +112,7 @@ final class ConfigurationCompilerPassTest extends TestCase
         self::assertSame('add', $methodCalls[0][0]);
     }
 
-    public function testRegistersManualTaggedConfigurations()
+    public function testRegistersManualTaggedConfigurations(): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition('.ux_native.configuration_builder', new Definition(ConfigurationBuilder::class, ['/tmp']));

--- a/src/Native/tests/EventListener/DevServerEventListenerTest.php
+++ b/src/Native/tests/EventListener/DevServerEventListenerTest.php
@@ -23,7 +23,7 @@ use Symfony\UX\Native\EventListener\DevServerEventListener;
 
 final class DevServerEventListenerTest extends TestCase
 {
-    public function testServesConfigurationForMatchingPath()
+    public function testServesConfigurationForMatchingPath(): void
     {
         $builder = new ConfigurationBuilder(sys_get_temp_dir());
         $builder->add('/config/ios_v1.json', new Configuration(
@@ -45,7 +45,7 @@ final class DevServerEventListenerTest extends TestCase
         self::assertTrue($event->isPropagationStopped());
     }
 
-    public function testDoesNothingForNonMatchingPath()
+    public function testDoesNothingForNonMatchingPath(): void
     {
         $builder = new ConfigurationBuilder(sys_get_temp_dir());
         $builder->add('/config/ios_v1.json', new Configuration(settings: ['use_local_db' => true]));
@@ -60,7 +60,7 @@ final class DevServerEventListenerTest extends TestCase
         self::assertFalse($event->isPropagationStopped());
     }
 
-    public function testIgnoresSubRequests()
+    public function testIgnoresSubRequests(): void
     {
         $builder = new ConfigurationBuilder(sys_get_temp_dir());
         $builder->add('/config/ios_v1.json', new Configuration(settings: ['use_local_db' => true]));

--- a/src/Native/tests/EventListener/NativeListenerTest.php
+++ b/src/Native/tests/EventListener/NativeListenerTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Native\EventListener\NativeListener;
 
 final class NativeListenerTest extends TestCase
 {
-    public function testSetsNativeAttributeToTrueWithHotwireNativeUserAgent()
+    public function testSetsNativeAttributeToTrueWithHotwireNativeUserAgent(): void
     {
         $listener = new NativeListener();
         $request = Request::create('/', server: ['HTTP_USER_AGENT' => 'Hotwire Native']);
@@ -30,7 +30,7 @@ final class NativeListenerTest extends TestCase
         self::assertTrue($request->attributes->get(NativeListener::NATIVE_ATTRIBUTE));
     }
 
-    public function testSetsNativeAttributeToTrueWithHotwireNativeInLongerUserAgent()
+    public function testSetsNativeAttributeToTrueWithHotwireNativeInLongerUserAgent(): void
     {
         $listener = new NativeListener();
         $request = Request::create('/', server: ['HTTP_USER_AGENT' => 'Turbo Native iOS; Hotwire Native Android']);
@@ -41,7 +41,7 @@ final class NativeListenerTest extends TestCase
         self::assertTrue($request->attributes->get(NativeListener::NATIVE_ATTRIBUTE));
     }
 
-    public function testSetsNativeAttributeToFalseWithStandardUserAgent()
+    public function testSetsNativeAttributeToFalseWithStandardUserAgent(): void
     {
         $listener = new NativeListener();
         $request = Request::create('/', server: ['HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)']);
@@ -52,7 +52,7 @@ final class NativeListenerTest extends TestCase
         self::assertFalse($request->attributes->get(NativeListener::NATIVE_ATTRIBUTE));
     }
 
-    public function testSetsNativeAttributeToFalseWithEmptyUserAgent()
+    public function testSetsNativeAttributeToFalseWithEmptyUserAgent(): void
     {
         $listener = new NativeListener();
         $request = Request::create('/');

--- a/src/Native/tests/Twig/NativeExtensionTest.php
+++ b/src/Native/tests/Twig/NativeExtensionTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Native\Twig\NativeExtension;
 
 final class NativeExtensionTest extends TestCase
 {
-    public function testIsNativeReturnsTrueWhenAttributeIsTrue()
+    public function testIsNativeReturnsTrueWhenAttributeIsTrue(): void
     {
         $request = Request::create('/');
         $request->attributes->set(NativeListener::NATIVE_ATTRIBUTE, true);
@@ -29,7 +29,7 @@ final class NativeExtensionTest extends TestCase
         self::assertTrue($extension->isNative());
     }
 
-    public function testIsNativeReturnsFalseWhenAttributeIsFalse()
+    public function testIsNativeReturnsFalseWhenAttributeIsFalse(): void
     {
         $request = Request::create('/');
         $request->attributes->set(NativeListener::NATIVE_ATTRIBUTE, false);
@@ -39,14 +39,14 @@ final class NativeExtensionTest extends TestCase
         self::assertFalse($extension->isNative());
     }
 
-    public function testIsNativeReturnsFalseWhenNoRequest()
+    public function testIsNativeReturnsFalseWhenNoRequest(): void
     {
         $extension = $this->createExtension(null);
 
         self::assertFalse($extension->isNative());
     }
 
-    public function testIsNativeReturnsFalseWhenAttributeNotSet()
+    public function testIsNativeReturnsFalseWhenAttributeNotSet(): void
     {
         $request = Request::create('/');
 
@@ -55,7 +55,7 @@ final class NativeExtensionTest extends TestCase
         self::assertFalse($extension->isNative());
     }
 
-    public function testGetFunctionsRegistersUxIsNative()
+    public function testGetFunctionsRegistersUxIsNative(): void
     {
         $extension = $this->createExtension(null);
 

--- a/src/Notify/tests/NotifyBundleTest.php
+++ b/src/Notify/tests/NotifyBundleTest.php
@@ -21,7 +21,7 @@ use Symfony\UX\Notify\Tests\Kernel\TwigAppKernel;
  */
 class NotifyBundleTest extends TestCase
 {
-    public function testBootKernel()
+    public function testBootKernel(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/Notify/tests/Twig/NotifyRuntimeTest.php
+++ b/src/Notify/tests/Twig/NotifyRuntimeTest.php
@@ -24,7 +24,7 @@ use Symfony\UX\Notify\Twig\NotifyRuntime;
 class NotifyRuntimeTest extends TestCase
 {
     #[DataProvider('streamNotificationsDataProvider')]
-    public function testStreamNotifications(array $params, string $expected)
+    public function testStreamNotifications(array $params, string $expected): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/Pagination/tests/Adapter/ArrayCursorInvariantTest.php
+++ b/src/Pagination/tests/Adapter/ArrayCursorInvariantTest.php
@@ -37,7 +37,7 @@ final class ArrayCursorInvariantTest extends TestCase
         $this->ascendingIdOrder = CursorOrder::byFields(['id'], 'ASC');
     }
 
-    public function testForwardWalkPartitionsDatasetAsc()
+    public function testForwardWalkPartitionsDatasetAsc(): void
     {
         $source = $this->makeSource(23);
 
@@ -46,7 +46,7 @@ final class ArrayCursorInvariantTest extends TestCase
         self::assertSame(range(1, 23), $ids);
     }
 
-    public function testForwardWalkPartitionsDatasetDesc()
+    public function testForwardWalkPartitionsDatasetDesc(): void
     {
         $source = $this->makeSource(23);
 
@@ -55,7 +55,7 @@ final class ArrayCursorInvariantTest extends TestCase
         self::assertSame(range(23, 1), $ids);
     }
 
-    public function testForwardWalkPartitionsDatasetWithCompositeCursor()
+    public function testForwardWalkPartitionsDatasetWithCompositeCursor(): void
     {
         // Non-unique first field: 23 items sharing only 3 distinct prices
         $source = [];
@@ -75,7 +75,7 @@ final class ArrayCursorInvariantTest extends TestCase
         self::assertSame(array_column($expected, 'id'), $ids);
     }
 
-    public function testBackwardWalkIsExactInverseOfForwardWalk()
+    public function testBackwardWalkIsExactInverseOfForwardWalk(): void
     {
         $source = $this->makeSource(23);
 
@@ -105,7 +105,7 @@ final class ArrayCursorInvariantTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function testDeletionBetweenPagesNeverSkipsSurvivors()
+    public function testDeletionBetweenPagesNeverSkipsSurvivors(): void
     {
         $source = $this->makeSource(15);
 
@@ -121,7 +121,7 @@ final class ArrayCursorInvariantTest extends TestCase
         self::assertSame([6, 8, 9, 10, 11], array_column($page2->items, 'id'));
     }
 
-    public function testInsertionBetweenPagesNeverDuplicates()
+    public function testInsertionBetweenPagesNeverDuplicates(): void
     {
         $source = $this->makeSource(15);
 

--- a/src/Pagination/tests/Adapter/ArrayPaginationAdapterTest.php
+++ b/src/Pagination/tests/Adapter/ArrayPaginationAdapterTest.php
@@ -28,7 +28,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         $this->defaultOrder = CursorOrder::byFields(['id'], 'ASC');
     }
 
-    public function testSupportsArrays()
+    public function testSupportsArrays(): void
     {
         self::assertTrue($this->adapter->supports([1, 2, 3]));
         self::assertTrue($this->adapter->supports([]));
@@ -37,50 +37,50 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertFalse($this->adapter->supports(new \stdClass()));
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         self::assertSame(0, $this->adapter->count([]));
         self::assertSame(3, $this->adapter->count([1, 2, 3]));
         self::assertSame(100, $this->adapter->count(range(1, 100)));
     }
 
-    public function testCursorContextUsesTheExplicitApplicationContext()
+    public function testCursorContextUsesTheExplicitApplicationContext(): void
     {
         self::assertSame('tenant-a:products', $this->adapter->getCursorContext([], 'tenant-a:products'));
     }
 
-    public function testCursorContextRequiresAnArraySource()
+    public function testCursorContextRequiresAnArraySource(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->adapter->getCursorContext(new \stdClass(), 'products');
     }
 
-    public function testCursorContextRequiresAnExplicitContext()
+    public function testCursorContextRequiresAnExplicitContext(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('requires an explicit context()');
         $this->adapter->getCursorContext([], null);
     }
 
-    public function testCursorFieldsRequireAnArraySource()
+    public function testCursorFieldsRequireAnArraySource(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->adapter->resolveCursorFields(new \stdClass(), 'id');
     }
 
-    public function testCursorFieldsRejectAnEmptyOrder()
+    public function testCursorFieldsRejectAnEmptyOrder(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('At least one non-empty cursor field');
         $this->adapter->resolveCursorFields([], []);
     }
 
-    public function testCursorFieldsAreNormalizedToAList()
+    public function testCursorFieldsAreNormalizedToAList(): void
     {
         self::assertSame(['id'], $this->adapter->resolveCursorFields([], 'id'));
     }
 
-    public function testCursorOrderMustBeExplicit()
+    public function testCursorOrderMustBeExplicit(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('requires an explicit orderBy()');
@@ -88,7 +88,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         $this->adapter->resolveCursorOrder([], null, null);
     }
 
-    public function testCursorOrderIsResolvedFromFieldsAndDirection()
+    public function testCursorOrderIsResolvedFromFieldsAndDirection(): void
     {
         $order = $this->adapter->resolveCursorOrder([], ['id'], 'desc');
 
@@ -96,7 +96,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertSame('DESC', $order->getDirection());
     }
 
-    public function testSlice()
+    public function testSlice(): void
     {
         $items = range(1, 50);
 
@@ -105,7 +105,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertSame([46, 47, 48, 49, 50], $this->adapter->slice($items, 45, 5));
     }
 
-    public function testSliceBeyondEnd()
+    public function testSliceBeyondEnd(): void
     {
         $items = [1, 2, 3];
 
@@ -113,7 +113,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertSame([], $this->adapter->slice($items, 10, 5));
     }
 
-    public function testSliceWithLookahead()
+    public function testSliceWithLookahead(): void
     {
         $items = range(1, 50);
 
@@ -133,25 +133,25 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertFalse($hasMore);
     }
 
-    public function testCountThrowsForNonArray()
+    public function testCountThrowsForNonArray(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->adapter->count('not an array');
     }
 
-    public function testSliceThrowsForNonArray()
+    public function testSliceThrowsForNonArray(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->adapter->slice('not an array', 0, 10);
     }
 
-    public function testSliceWithLookaheadThrowsForNonArray()
+    public function testSliceWithLookaheadThrowsForNonArray(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->adapter->sliceWithLookahead('not an array', 0, 10);
     }
 
-    public function testSliceWithCursorFirstPage()
+    public function testSliceWithCursorFirstPage(): void
     {
         $source = [];
         for ($i = 1; $i <= 30; ++$i) {
@@ -167,14 +167,14 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertNull($result->previous);
     }
 
-    public function testSliceWithCursorRejectsInvalidDirection()
+    public function testSliceWithCursorRejectsInvalidDirection(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('direction must be "ASC" or "DESC"');
         CursorOrder::byFields(['id'], 'sideways');
     }
 
-    public function testSliceWithCursorSecondPage()
+    public function testSliceWithCursorSecondPage(): void
     {
         $source = [];
         for ($i = 1; $i <= 30; ++$i) {
@@ -196,7 +196,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertNotSame($cursor, $page2->previous);
     }
 
-    public function testSliceWithCursorBackwardReturnsPreviousPage()
+    public function testSliceWithCursorBackwardReturnsPreviousPage(): void
     {
         $source = [];
         for ($i = 1; $i <= 30; ++$i) {
@@ -221,7 +221,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertSame(11, $forwardAgain->items[0]['id']);
     }
 
-    public function testSliceWithCursorBackwardFromMiddleKeepsPreviousCursor()
+    public function testSliceWithCursorBackwardFromMiddleKeepsPreviousCursor(): void
     {
         $source = [];
         for ($i = 1; $i <= 30; ++$i) {
@@ -241,7 +241,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertNotNull($back->previous);
     }
 
-    public function testSliceWithCursorDateTimeField()
+    public function testSliceWithCursorDateTimeField(): void
     {
         $source = [
             ['id' => 1, 'createdAt' => new \DateTimeImmutable('2024-01-01 10:00:00')],
@@ -262,7 +262,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertSame(3, $page2->items[0]['id']);
     }
 
-    public function testCursorDateTimesAreOrderedByInstantAcrossTimezones()
+    public function testCursorDateTimesAreOrderedByInstantAcrossTimezones(): void
     {
         $source = [
             // 22:30 UTC: lexicographically later before UTC normalization.
@@ -280,7 +280,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertSame([2], array_column($second->items, 'id'));
     }
 
-    public function testSliceWithCursorLastPage()
+    public function testSliceWithCursorLastPage(): void
     {
         $source = [];
         for ($i = 1; $i <= 15; ++$i) {
@@ -295,7 +295,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertNull($page2->next);
     }
 
-    public function testSliceWithCursorDescDirection()
+    public function testSliceWithCursorDescDirection(): void
     {
         $source = [];
         for ($i = 1; $i <= 20; ++$i) {
@@ -310,7 +310,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertTrue($result->hasNext);
     }
 
-    public function testSliceWithCursorMultipleFields()
+    public function testSliceWithCursorMultipleFields(): void
     {
         $source = [
             ['id' => 1, 'price' => 10.0],
@@ -326,7 +326,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         self::assertTrue($result->hasNext);
     }
 
-    public function testSliceWithCursorMismatchedFieldsThrows()
+    public function testSliceWithCursorMismatchedFieldsThrows(): void
     {
         $source = [['id' => 1, 'price' => 10.0]];
 
@@ -338,13 +338,13 @@ final class ArrayPaginationAdapterTest extends TestCase
         $this->adapter->sliceWithCursor($source, $cursor, 10, CursorOrder::byFields(['price', 'id'], 'ASC'));
     }
 
-    public function testSliceWithCursorThrowsForNonArray()
+    public function testSliceWithCursorThrowsForNonArray(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->adapter->sliceWithCursor('not an array', null, 10, $this->defaultOrder);
     }
 
-    public function testSliceWithCursorRejectsAnOpaqueOrder()
+    public function testSliceWithCursorRejectsAnOpaqueOrder(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('requires a field-based cursor order');
@@ -352,7 +352,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         $this->adapter->sliceWithCursor([], null, 10, CursorOrder::byIdentity('remote-order'));
     }
 
-    public function testCursorRejectsDuplicateTuplesWithoutUniqueTieBreaker()
+    public function testCursorRejectsDuplicateTuplesWithoutUniqueTieBreaker(): void
     {
         $source = [
             ['id' => 1, 'category' => 'same'],
@@ -364,7 +364,7 @@ final class ArrayPaginationAdapterTest extends TestCase
         $this->adapter->sliceWithCursor($source, null, 10, CursorOrder::byFields(['category'], 'ASC'));
     }
 
-    public function testSliceWithCursorEmptySource()
+    public function testSliceWithCursorEmptySource(): void
     {
         $result = $this->adapter->sliceWithCursor([], null, 10, $this->defaultOrder);
 

--- a/src/Pagination/tests/Adapter/CallablePaginationAdapterTest.php
+++ b/src/Pagination/tests/Adapter/CallablePaginationAdapterTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\Pagination\Adapter\CallablePaginationAdapter;
 #[CoversClass(CallablePaginationAdapter::class)]
 final class CallablePaginationAdapterTest extends TestCase
 {
-    public function testSupportsReturnsFalse()
+    public function testSupportsReturnsFalse(): void
     {
         $adapter = new CallablePaginationAdapter(
             static fn (int $offset, int $limit): array => [],
@@ -29,7 +29,7 @@ final class CallablePaginationAdapterTest extends TestCase
         self::assertFalse($adapter->supports('anything'));
     }
 
-    public function testSliceAndCount()
+    public function testSliceAndCount(): void
     {
         $data = range(1, 50);
 
@@ -43,7 +43,7 @@ final class CallablePaginationAdapterTest extends TestCase
         self::assertSame([11, 12, 13, 14, 15], $adapter->slice(null, 10, 5));
     }
 
-    public function testSliceWithLookahead()
+    public function testSliceWithLookahead(): void
     {
         $data = range(1, 25);
 
@@ -61,7 +61,7 @@ final class CallablePaginationAdapterTest extends TestCase
         self::assertFalse($hasMore);
     }
 
-    public function testSliceThrowsForNonArray()
+    public function testSliceThrowsForNonArray(): void
     {
         $adapter = new CallablePaginationAdapter(
             static fn (int $offset, int $limit): string => 'not an array', // @phpstan-ignore return.type
@@ -72,7 +72,7 @@ final class CallablePaginationAdapterTest extends TestCase
         $adapter->slice(null, 0, 10);
     }
 
-    public function testSliceWithLookaheadThrowsForNonArray()
+    public function testSliceWithLookaheadThrowsForNonArray(): void
     {
         $adapter = new CallablePaginationAdapter(
             static fn (int $offset, int $limit): string => 'not an array', // @phpstan-ignore return.type
@@ -84,7 +84,7 @@ final class CallablePaginationAdapterTest extends TestCase
         $adapter->sliceWithLookahead(null, 0, 10);
     }
 
-    public function testCountRejectsANonIntegerResult()
+    public function testCountRejectsANonIntegerResult(): void
     {
         $adapter = new CallablePaginationAdapter(
             static fn (int $offset, int $limit): array => [],
@@ -96,7 +96,7 @@ final class CallablePaginationAdapterTest extends TestCase
         $adapter->count(null);
     }
 
-    public function testCountRejectsANegativeResult()
+    public function testCountRejectsANegativeResult(): void
     {
         $adapter = new CallablePaginationAdapter(
             static fn (int $offset, int $limit): array => [],

--- a/src/Pagination/tests/Adapter/CursorValuesTraitTest.php
+++ b/src/Pagination/tests/Adapter/CursorValuesTraitTest.php
@@ -31,7 +31,7 @@ final class CursorValuesTraitTest extends TestCase
         };
     }
 
-    public function testExtractFromObjectGetter()
+    public function testExtractFromObjectGetter(): void
     {
         $item = new class {
             public function getId(): int
@@ -43,7 +43,7 @@ final class CursorValuesTraitTest extends TestCase
         self::assertSame([42], $this->encoder->extractCursorValues($item, ['id']));
     }
 
-    public function testExtractFromObjectIsGetter()
+    public function testExtractFromObjectIsGetter(): void
     {
         $item = new class {
             public function isActive(): bool
@@ -55,7 +55,7 @@ final class CursorValuesTraitTest extends TestCase
         self::assertSame([1], $this->encoder->extractCursorValues($item, ['active']));
     }
 
-    public function testExtractFromPublicProperty()
+    public function testExtractFromPublicProperty(): void
     {
         $item = new class {
             public string $name = 'Alice';
@@ -64,7 +64,7 @@ final class CursorValuesTraitTest extends TestCase
         self::assertSame(['Alice'], $this->encoder->extractCursorValues($item, ['name']));
     }
 
-    public function testPrivatePropertyWithoutGetterIsReportedAsInaccessible()
+    public function testPrivatePropertyWithoutGetterIsReportedAsInaccessible(): void
     {
         $item = new class {
             private string $name = 'Alice';
@@ -76,24 +76,24 @@ final class CursorValuesTraitTest extends TestCase
         $this->encoder->extractCursorValues($item, ['name']);
     }
 
-    public function testExtractFromArrayKey()
+    public function testExtractFromArrayKey(): void
     {
         self::assertSame([7, 'b'], $this->encoder->extractCursorValues(['id' => 7, 'code' => 'b'], ['id', 'code']));
     }
 
-    public function testExtractFromScalarWithIdField()
+    public function testExtractFromScalarWithIdField(): void
     {
         self::assertSame([5], $this->encoder->extractCursorValues(5, ['id']));
     }
 
-    public function testExtractNormalizesDateTime()
+    public function testExtractNormalizesDateTime(): void
     {
         $item = ['createdAt' => new \DateTimeImmutable('2024-06-15 10:30:00')];
 
         self::assertSame(['2024-06-15T10:30:00.000000Z'], $this->encoder->extractCursorValues($item, ['createdAt']));
     }
 
-    public function testExtractNormalizesDateTimeFromGetter()
+    public function testExtractNormalizesDateTimeFromGetter(): void
     {
         $item = new class {
             public function getCreatedAt(): \DateTimeImmutable
@@ -105,7 +105,7 @@ final class CursorValuesTraitTest extends TestCase
         self::assertSame(['2023-01-02T03:04:05.000000Z'], $this->encoder->extractCursorValues($item, ['createdAt']));
     }
 
-    public function testExtractRejectsNull()
+    public function testExtractRejectsNull(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('must be non-null');
@@ -113,12 +113,12 @@ final class CursorValuesTraitTest extends TestCase
         $this->encoder->extractCursorValues(['field' => null], ['field']);
     }
 
-    public function testExtractNormalizesBool()
+    public function testExtractNormalizesBool(): void
     {
         self::assertSame([1, 0], $this->encoder->extractCursorValues(['a' => true, 'b' => false], ['a', 'b']));
     }
 
-    public function testExtractThrowsForMissingField()
+    public function testExtractThrowsForMissingField(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot extract cursor field "missing"');
@@ -126,7 +126,7 @@ final class CursorValuesTraitTest extends TestCase
         $this->encoder->extractCursorValues(['id' => 1], ['missing']);
     }
 
-    public function testExtractThrowsForUnsupportedValueType()
+    public function testExtractThrowsForUnsupportedValueType(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('must be scalar or \DateTimeInterface');
@@ -134,24 +134,24 @@ final class CursorValuesTraitTest extends TestCase
         $this->encoder->extractCursorValues(['field' => new \stdClass()], ['field']);
     }
 
-    public function testCompareTuplesEqual()
+    public function testCompareTuplesEqual(): void
     {
         self::assertSame(0, $this->encoder->compareTuples([1, 'a'], [1, 'a']));
     }
 
-    public function testCompareTuplesFirstFieldWins()
+    public function testCompareTuplesFirstFieldWins(): void
     {
         self::assertGreaterThan(0, $this->encoder->compareTuples([2, 'a'], [1, 'z']));
         self::assertLessThan(0, $this->encoder->compareTuples([1, 'z'], [2, 'a']));
     }
 
-    public function testCompareTuplesFallsBackToNextField()
+    public function testCompareTuplesFallsBackToNextField(): void
     {
         self::assertGreaterThan(0, $this->encoder->compareTuples([1, 'b'], [1, 'a']));
         self::assertLessThan(0, $this->encoder->compareTuples([1, 'a'], [1, 'b']));
     }
 
-    public function testCompareTuplesWithDateStrings()
+    public function testCompareTuplesWithDateStrings(): void
     {
         self::assertLessThan(0, $this->encoder->compareTuples(['2024-01-01 00:00:00'], ['2024-06-15 10:30:00']));
     }

--- a/src/Pagination/tests/Adapter/DoctrineCursorInvariantTest.php
+++ b/src/Pagination/tests/Adapter/DoctrineCursorInvariantTest.php
@@ -60,7 +60,7 @@ final class DoctrineCursorInvariantTest extends TestCase
         }
     }
 
-    public function testForwardWalkPartitionsDataset()
+    public function testForwardWalkPartitionsDataset(): void
     {
         $this->createAuthors(23);
 
@@ -76,7 +76,7 @@ final class DoctrineCursorInvariantTest extends TestCase
         self::assertSame(range(1, 23), $ids);
     }
 
-    public function testBackwardWalkIsExactInverseOfForwardWalk()
+    public function testBackwardWalkIsExactInverseOfForwardWalk(): void
     {
         $this->createAuthors(23);
 
@@ -104,7 +104,7 @@ final class DoctrineCursorInvariantTest extends TestCase
         self::assertSame(\array_slice($forwardPages, 0, -1), array_reverse($backwardPages));
     }
 
-    public function testDeletionBetweenPagesNeverSkipsSurvivors()
+    public function testDeletionBetweenPagesNeverSkipsSurvivors(): void
     {
         $this->createAuthors(15);
 
@@ -125,7 +125,7 @@ final class DoctrineCursorInvariantTest extends TestCase
         self::assertSame([6, 8, 9, 10, 11], $this->idsOf($page2->items));
     }
 
-    public function testInsertionBetweenPagesNeverDuplicates()
+    public function testInsertionBetweenPagesNeverDuplicates(): void
     {
         $this->createAuthors(15);
 
@@ -150,7 +150,7 @@ final class DoctrineCursorInvariantTest extends TestCase
         self::assertSame(range(1, 16), $seen, 'Every row, including the inserted one, is seen exactly once');
     }
 
-    public function testDatetimeCursorBoundariesAreStableInNonUtcDefaultTimezone()
+    public function testDatetimeCursorBoundariesAreStableInNonUtcDefaultTimezone(): void
     {
         $previousTimezone = date_default_timezone_get();
         date_default_timezone_set('Europe/Paris');
@@ -188,7 +188,7 @@ final class DoctrineCursorInvariantTest extends TestCase
         }
     }
 
-    public function testExistingOrderIsRejectedEvenWhenCompatible()
+    public function testExistingOrderIsRejectedEvenWhenCompatible(): void
     {
         $this->createAuthors(8);
         $query = $this->queryBuilder()->orderBy('a.id', 'ASC');
@@ -198,7 +198,7 @@ final class DoctrineCursorInvariantTest extends TestCase
         $this->adapter->sliceWithCursor($query, null, 5, $this->ascendingIdOrder);
     }
 
-    public function testIncompatibleExistingOrderIsRejected()
+    public function testIncompatibleExistingOrderIsRejected(): void
     {
         $this->createAuthors(8);
         $query = $this->queryBuilder()->orderBy('a.name', 'ASC');
@@ -208,7 +208,7 @@ final class DoctrineCursorInvariantTest extends TestCase
         $this->adapter->sliceWithCursor($query, null, 5, $this->ascendingIdOrder);
     }
 
-    public function testAutomaticContextBindsDoctrineDqlAndParameters()
+    public function testAutomaticContextBindsDoctrineDqlAndParameters(): void
     {
         $this->createAuthors(12);
         $paginator = new Paginator([$this->adapter], cursorCodec: new CursorCodec('test-secret'));
@@ -234,7 +234,7 @@ final class DoctrineCursorInvariantTest extends TestCase
         $builder->paginate();
     }
 
-    public function testSignedOrderIncludesAutomaticallyAppendedIdentifierFields()
+    public function testSignedOrderIncludesAutomaticallyAppendedIdentifierFields(): void
     {
         $this->createAuthors(6);
         $codec = new CursorCodec('test-secret');

--- a/src/Pagination/tests/Adapter/DoctrineDbalAdapterTest.php
+++ b/src/Pagination/tests/Adapter/DoctrineDbalAdapterTest.php
@@ -58,13 +58,13 @@ final class DoctrineDbalAdapterTest extends TestCase
         $this->connection->close();
     }
 
-    public function testSupportsDbalQueryBuilder()
+    public function testSupportsDbalQueryBuilder(): void
     {
         self::assertTrue($this->adapter->supports($this->query()));
         self::assertFalse($this->adapter->supports([]));
     }
 
-    public function testSlicesWithoutMutatingTheSource()
+    public function testSlicesWithoutMutatingTheSource(): void
     {
         $source = $this->query()->orderBy('id', 'ASC');
 
@@ -74,7 +74,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         self::assertCount(25, $source->executeQuery()->fetchAllAssociative());
     }
 
-    public function testCountsAFilteredQueryAndIgnoresOrderingAndLimits()
+    public function testCountsAFilteredQueryAndIgnoresOrderingAndLimits(): void
     {
         $source = $this->query()
             ->where('category = :category')
@@ -86,7 +86,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         self::assertSame(12, $this->adapter->count($source));
     }
 
-    public function testCursorContextFingerprintsSqlParametersTypesAndApplicationContext()
+    public function testCursorContextFingerprintsSqlParametersTypesAndApplicationContext(): void
     {
         $source = $this->query()
             ->where('category = :category')
@@ -117,13 +117,13 @@ final class DoctrineDbalAdapterTest extends TestCase
         );
     }
 
-    public function testCursorContextRejectsUnsupportedSources()
+    public function testCursorContextRejectsUnsupportedSources(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->adapter->getCursorContext([], null);
     }
 
-    public function testCursorContextRejectsUnstableParameterValues()
+    public function testCursorContextRejectsUnstableParameterValues(): void
     {
         $source = $this->query()->setParameter('invalid', new \stdClass());
 
@@ -132,7 +132,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         $this->adapter->getCursorContext($source, null);
     }
 
-    public function testSlicesWithLookahead()
+    public function testSlicesWithLookahead(): void
     {
         [$items, $hasMore] = $this->adapter->sliceWithLookahead($this->query()->orderBy('id', 'ASC'), 10, 10);
 
@@ -140,7 +140,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         self::assertTrue($hasMore);
     }
 
-    public function testCursorPaginatesForwardAndBackward()
+    public function testCursorPaginatesForwardAndBackward(): void
     {
         $source = $this->query();
         $order = CursorOrder::byFields(['id'], 'ASC');
@@ -161,7 +161,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         self::assertNotNull($back->next);
     }
 
-    public function testCursorDoesNotOverwriteApplicationParameters()
+    public function testCursorDoesNotOverwriteApplicationParameters(): void
     {
         $source = $this->query()
             ->where('id > :ux_pagination_cursor_0')
@@ -177,7 +177,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         self::assertSame([9, 10], array_column($result->items, 'id'));
     }
 
-    public function testCursorBackwardFromThirdPageKeepsBothDirections()
+    public function testCursorBackwardFromThirdPageKeepsBothDirections(): void
     {
         $source = $this->query();
         $order = CursorOrder::byFields(['id'], 'ASC');
@@ -191,7 +191,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         self::assertNotNull($back->next);
     }
 
-    public function testCursorBackwardBeforeFirstItemReturnsAnEmptySlice()
+    public function testCursorBackwardBeforeFirstItemReturnsAnEmptySlice(): void
     {
         $result = $this->adapter->sliceWithCursor(
             $this->query(),
@@ -206,7 +206,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         self::assertFalse($result->hasNext);
     }
 
-    public function testCursorSupportsCompositeQualifiedFields()
+    public function testCursorSupportsCompositeQualifiedFields(): void
     {
         $source = $this->connection->createQueryBuilder()
             ->select('i.id', 'i.category', 'i.name')
@@ -222,7 +222,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         self::assertNotSame(array_column($first->items, 'id'), array_column($second->items, 'id'));
     }
 
-    public function testCursorRejectsUnsafeFieldNamesAndExistingOrder()
+    public function testCursorRejectsUnsafeFieldNamesAndExistingOrder(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid DBAL cursor field');
@@ -230,21 +230,21 @@ final class DoctrineDbalAdapterTest extends TestCase
         $this->adapter->resolveCursorOrder($this->query(), ['id DESC; DELETE'], 'ASC');
     }
 
-    public function testCursorRejectsInvalidDirection()
+    public function testCursorRejectsInvalidDirection(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('direction must be "ASC" or "DESC"');
         $this->adapter->resolveCursorOrder($this->query(), ['id'], 'sideways');
     }
 
-    public function testCursorRejectsAnEmptyFieldList()
+    public function testCursorRejectsAnEmptyFieldList(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('At least one cursor field');
         $this->adapter->resolveCursorOrder($this->query(), [], 'ASC');
     }
 
-    public function testCursorRejectsANonStringField()
+    public function testCursorRejectsANonStringField(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('must be non-empty strings');
@@ -252,7 +252,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         $this->adapter->resolveCursorFields($this->query(), [42]); // @phpstan-ignore argument.type
     }
 
-    public function testCursorOrderMustBeExplicit()
+    public function testCursorOrderMustBeExplicit(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('requires an explicit orderBy()');
@@ -260,14 +260,14 @@ final class DoctrineDbalAdapterTest extends TestCase
         $this->adapter->resolveCursorOrder($this->query(), null, null);
     }
 
-    public function testCursorRejectsAnExistingOrder()
+    public function testCursorRejectsAnExistingOrder(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('owns ORDER BY');
         $this->adapter->sliceWithCursor($this->query()->orderBy('id'), null, 10, CursorOrder::byFields(['id'], 'ASC'));
     }
 
-    public function testCursorRejectsMismatchedBoundary()
+    public function testCursorRejectsMismatchedBoundary(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cursor values count does not match');
@@ -275,7 +275,7 @@ final class DoctrineDbalAdapterTest extends TestCase
         $this->adapter->sliceWithCursor($this->query(), new CursorBoundary([1]), 10, CursorOrder::byFields(['category', 'id'], 'ASC'));
     }
 
-    public function testCursorRejectsAnOpaqueOrder()
+    public function testCursorRejectsAnOpaqueOrder(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('requires a field-based cursor order');

--- a/src/Pagination/tests/Adapter/DoctrineDbalCursorInvariantTest.php
+++ b/src/Pagination/tests/Adapter/DoctrineDbalCursorInvariantTest.php
@@ -55,7 +55,7 @@ final class DoctrineDbalCursorInvariantTest extends TestCase
         $this->connection->close();
     }
 
-    public function testForwardWalkPartitionsDataset()
+    public function testForwardWalkPartitionsDataset(): void
     {
         $seen = [];
         $cursor = null;
@@ -68,7 +68,7 @@ final class DoctrineDbalCursorInvariantTest extends TestCase
         self::assertSame(range(1, 15), $seen);
     }
 
-    public function testBackwardWalkIsExactInverseOfForwardWalk()
+    public function testBackwardWalkIsExactInverseOfForwardWalk(): void
     {
         $forwardPages = [];
         $cursor = null;
@@ -94,7 +94,7 @@ final class DoctrineDbalCursorInvariantTest extends TestCase
         self::assertSame(\array_slice($forwardPages, 0, -1), array_reverse($backwardPages));
     }
 
-    public function testDeletionBetweenPagesDoesNotSkipSurvivingRows()
+    public function testDeletionBetweenPagesDoesNotSkipSurvivingRows(): void
     {
         $first = $this->adapter->sliceWithCursor($this->query(), null, 5, $this->ascendingIdOrder);
         self::assertSame(range(1, 5), array_column($first->items, 'id'));
@@ -107,7 +107,7 @@ final class DoctrineDbalCursorInvariantTest extends TestCase
         self::assertSame([6, 8, 9, 10, 11], array_column($second->items, 'id'));
     }
 
-    public function testInsertionBetweenPagesDoesNotDuplicateRows()
+    public function testInsertionBetweenPagesDoesNotDuplicateRows(): void
     {
         $first = $this->adapter->sliceWithCursor($this->query(), null, 5, $this->ascendingIdOrder);
         $this->connection->insert('items', ['name' => 'Inserted']);
@@ -124,7 +124,7 @@ final class DoctrineDbalCursorInvariantTest extends TestCase
         self::assertSame(range(1, 16), $seen);
     }
 
-    public function testNonTotalOrderIsRejected()
+    public function testNonTotalOrderIsRejected(): void
     {
         $this->connection->executeStatement('UPDATE items SET name = ?', ['duplicate']);
 

--- a/src/Pagination/tests/Adapter/DoctrineOrmAdapterTest.php
+++ b/src/Pagination/tests/Adapter/DoctrineOrmAdapterTest.php
@@ -64,7 +64,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         }
     }
 
-    public function testCountUsesDistinctForArbitraryClassJoins()
+    public function testCountUsesDistinctForArbitraryClassJoins(): void
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -74,7 +74,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertSame(0, $this->adapter->count($qb));
     }
 
-    public function testCountFallsBackToDistinctForNonAssociationJoins()
+    public function testCountFallsBackToDistinctForNonAssociationJoins(): void
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -87,7 +87,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->count($qb);
     }
 
-    public function testCountFallsBackToDistinctForUnresolvableJoinAliases()
+    public function testCountFallsBackToDistinctForUnresolvableJoinAliases(): void
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -98,7 +98,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->count($qb);
     }
 
-    public function testSupportsQueryBuilder()
+    public function testSupportsQueryBuilder(): void
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -110,7 +110,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertFalse($this->adapter->supports(new \stdClass()));
     }
 
-    public function testCursorContextFingerprintsDqlParametersAndApplicationContext()
+    public function testCursorContextFingerprintsDqlParametersAndApplicationContext(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -143,7 +143,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         );
     }
 
-    public function testCursorContextNormalizesMappedEntityIdentifiers()
+    public function testCursorContextNormalizesMappedEntityIdentifiers(): void
     {
         $author = new Author();
         $author->setName('Alice');
@@ -163,7 +163,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         );
     }
 
-    public function testCursorContextRejectsAnUnsavedMappedEntity()
+    public function testCursorContextRejectsAnUnsavedMappedEntity(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -175,7 +175,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->getCursorContext($queryBuilder, null);
     }
 
-    public function testCursorContextRejectsATransientObject()
+    public function testCursorContextRejectsATransientObject(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -187,7 +187,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->getCursorContext($queryBuilder, null);
     }
 
-    public function testCursorContextRejectsAnUnsupportedParameterType()
+    public function testCursorContextRejectsAnUnsupportedParameterType(): void
     {
         $resource = fopen('php://memory', 'r');
         \assert(false !== $resource);
@@ -206,7 +206,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         }
     }
 
-    public function testCursorContextRejectsUnsupportedSourcesAndMultipleRoots()
+    public function testCursorContextRejectsUnsupportedSourcesAndMultipleRoots(): void
     {
         try {
             $this->adapter->getCursorContext([], null);
@@ -224,7 +224,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->getCursorContext($queryBuilder, null);
     }
 
-    public function testBasicCountWithoutJoin()
+    public function testBasicCountWithoutJoin(): void
     {
         // Create test data
         for ($i = 1; $i <= 5; ++$i) {
@@ -241,7 +241,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertSame(5, $this->adapter->count($qb));
     }
 
-    public function testCountRejectsGroupByWithActionableAlternative()
+    public function testCountRejectsGroupByWithActionableAlternative(): void
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->select('a.name')
@@ -253,7 +253,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->count($qb);
     }
 
-    public function testCountRejectsHavingWithActionableAlternative()
+    public function testCountRejectsHavingWithActionableAlternative(): void
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->select('a.name')
@@ -265,7 +265,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->count($qb);
     }
 
-    public function testBasicSlice()
+    public function testBasicSlice(): void
     {
         // Create test data
         for ($i = 1; $i <= 20; ++$i) {
@@ -290,7 +290,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertCount(5, $results); // Only 5 left
     }
 
-    public function testSliceWithToOneJoinExecutesOneQuery()
+    public function testSliceWithToOneJoinExecutesOneQuery(): void
     {
         $author = new Author();
         $author->setName('Author');
@@ -317,7 +317,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertCount(1, $this->queryCollector->queries());
     }
 
-    public function testCountWithToOneJoinDoesNotUseDistinct()
+    public function testCountWithToOneJoinDoesNotUseDistinct(): void
     {
         $author = new Author();
         $author->setName('Author');
@@ -351,7 +351,7 @@ final class DoctrineOrmAdapterTest extends TestCase
      * - Without DISTINCT, COUNT would return 15 (5 authors × 3 books each)
      * - With DISTINCT, COUNT correctly returns 5 (unique authors)
      */
-    public function testCountWithOneToManyJoin()
+    public function testCountWithOneToManyJoin(): void
     {
         // Create 5 authors, each with 3 books
         for ($i = 1; $i <= 5; ++$i) {
@@ -390,7 +390,7 @@ final class DoctrineOrmAdapterTest extends TestCase
      * This tests the scenario where books have multiple categories and
      * categories have multiple books.
      */
-    public function testCountWithManyToManyJoin()
+    public function testCountWithManyToManyJoin(): void
     {
         // Create categories
         $fiction = new Category();
@@ -438,7 +438,7 @@ final class DoctrineOrmAdapterTest extends TestCase
      * - Pagination works correctly
      * - The same entity doesn't appear multiple times due to JOIN
      */
-    public function testSliceWithJoin()
+    public function testSliceWithJoin(): void
     {
         // Create authors with books
         for ($i = 1; $i <= 10; ++$i) {
@@ -471,7 +471,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertIsArray($results);
     }
 
-    public function testSliceWithFetchJoinCollectionReturnsCompleteRootEntities()
+    public function testSliceWithFetchJoinCollectionReturnsCompleteRootEntities(): void
     {
         for ($i = 1; $i <= 8; ++$i) {
             $author = new Author();
@@ -505,7 +505,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test lookahead pagination with JOINs.
      */
-    public function testLookaheadWithJoin()
+    public function testLookaheadWithJoin(): void
     {
         // Create test data
         for ($i = 1; $i <= 25; ++$i) {
@@ -537,7 +537,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test cursor-based pagination.
      */
-    public function testCursorPagination()
+    public function testCursorPagination(): void
     {
         // Create test data
         for ($i = 1; $i <= 20; ++$i) {
@@ -564,7 +564,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertNotNull($result->next);
     }
 
-    public function testCursorDoesNotOverwriteApplicationParameters()
+    public function testCursorDoesNotOverwriteApplicationParameters(): void
     {
         for ($i = 1; $i <= 12; ++$i) {
             $author = new Author();
@@ -605,7 +605,7 @@ final class DoctrineOrmAdapterTest extends TestCase
      * For precise pagination with JOINs, consider using DISTINCT in your query
      * or using lookahead pagination.
      */
-    public function testCursorPaginationWithJoin()
+    public function testCursorPaginationWithJoin(): void
     {
         // Create authors with books
         for ($i = 1; $i <= 15; ++$i) {
@@ -636,14 +636,14 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertCount(5, $result->items);
     }
 
-    public function testCountThrowsForNonQueryBuilder()
+    public function testCountThrowsForNonQueryBuilder(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Source must be a Doctrine ORM QueryBuilder.');
         $this->adapter->count('not a query builder');
     }
 
-    public function testCountRejectsMultipleRootEntities()
+    public function testCountRejectsMultipleRootEntities(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('a', 'c')
@@ -655,28 +655,28 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->count($queryBuilder);
     }
 
-    public function testSliceThrowsForNonQueryBuilder()
+    public function testSliceThrowsForNonQueryBuilder(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Source must be a Doctrine ORM QueryBuilder.');
         $this->adapter->slice('not a query builder', 0, 10);
     }
 
-    public function testLookaheadThrowsForNonQueryBuilder()
+    public function testLookaheadThrowsForNonQueryBuilder(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Source must be a Doctrine ORM QueryBuilder.');
         $this->adapter->sliceWithLookahead('not a query builder', 0, 10);
     }
 
-    public function testCursorThrowsForNonQueryBuilder()
+    public function testCursorThrowsForNonQueryBuilder(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Source must be a Doctrine ORM QueryBuilder.');
         $this->adapter->sliceWithCursor('not a query builder', null, 10, CursorOrder::byFields(['id'], 'ASC'));
     }
 
-    public function testCursorFieldResolutionRejectsNonQueryBuilders()
+    public function testCursorFieldResolutionRejectsNonQueryBuilders(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Source must be a Doctrine ORM QueryBuilder.');
@@ -684,7 +684,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->resolveCursorFields([], 'id');
     }
 
-    public function testCursorFieldsMustBeNonEmptyStrings()
+    public function testCursorFieldsMustBeNonEmptyStrings(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -696,7 +696,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->resolveCursorFields($queryBuilder, []);
     }
 
-    public function testCursorOrderMustBeExplicit()
+    public function testCursorOrderMustBeExplicit(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -708,7 +708,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->resolveCursorOrder($queryBuilder, null, null);
     }
 
-    public function testCursorRejectsAnOpaqueOrder()
+    public function testCursorRejectsAnOpaqueOrder(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -720,7 +720,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->sliceWithCursor($queryBuilder, null, 10, CursorOrder::byIdentity('remote-order'));
     }
 
-    public function testCursorRejectsInvalidDirection()
+    public function testCursorRejectsInvalidDirection(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -731,7 +731,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->resolveCursorOrder($queryBuilder, ['id'], 'sideways');
     }
 
-    public function testCursorRejectsMissingFromClause()
+    public function testCursorRejectsMissingFromClause(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()->select('1');
 
@@ -740,7 +740,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->resolveCursorOrder($queryBuilder, ['id'], 'ASC');
     }
 
-    public function testCursorRejectsUnknownField()
+    public function testCursorRejectsUnknownField(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('a')
@@ -754,7 +754,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test that COUNT works with WHERE clauses.
      */
-    public function testCountWithWhereClause()
+    public function testCountWithWhereClause(): void
     {
         // Create test data
         for ($i = 1; $i <= 10; ++$i) {
@@ -777,7 +777,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test COUNT with complex WHERE and JOIN.
      */
-    public function testCountWithWhereAndJoin()
+    public function testCountWithWhereAndJoin(): void
     {
         // Create authors, some active and some not
         for ($i = 1; $i <= 10; ++$i) {
@@ -811,7 +811,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test single-field cursor pagination (backward compatibility).
      */
-    public function testSingleFieldCursorPagination()
+    public function testSingleFieldCursorPagination(): void
     {
         // Create test data with sequential IDs
         for ($i = 1; $i <= 20; ++$i) {
@@ -851,7 +851,7 @@ final class DoctrineOrmAdapterTest extends TestCase
      * Test backward navigation: the previousCursor of page 2 must
      * return the items of page 1, in display order.
      */
-    public function testCursorBackwardNavigationReturnsPreviousPage()
+    public function testCursorBackwardNavigationReturnsPreviousPage(): void
     {
         for ($i = 1; $i <= 20; ++$i) {
             $author = new Author();
@@ -888,7 +888,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test backward navigation from a middle page keeps a previousCursor.
      */
-    public function testCursorBackwardNavigationFromMiddlePage()
+    public function testCursorBackwardNavigationFromMiddlePage(): void
     {
         for ($i = 1; $i <= 20; ++$i) {
             $author = new Author();
@@ -920,7 +920,7 @@ final class DoctrineOrmAdapterTest extends TestCase
      * (price) could cause duplicates or skips. Using a composite cursor
      * with ID as tie-breaker ensures deterministic ordering.
      */
-    public function testCompositeCursorWithTwoFields()
+    public function testCompositeCursorWithTwoFields(): void
     {
         // Create books with duplicate prices
         $prices = [10.0, 10.0, 10.0, 20.0, 20.0, 30.0, 30.0, 30.0, 40.0, 50.0];
@@ -981,7 +981,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertCount(9, array_unique($allIds));
     }
 
-    public function testSingleNonUniqueCursorFieldAutomaticallyUsesIdentifierTieBreaker()
+    public function testSingleNonUniqueCursorFieldAutomaticallyUsesIdentifierTieBreaker(): void
     {
         $names = ['Alice', 'Alice', 'Alice', 'Bob', 'Bob', 'Charlie', 'Charlie', 'Charlie'];
 
@@ -1014,7 +1014,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test composite cursor with DESC direction.
      */
-    public function testCompositeCursorWithDescDirection()
+    public function testCompositeCursorWithDescDirection(): void
     {
         // Create books with prices in ascending order
         for ($i = 1; $i <= 10; ++$i) {
@@ -1060,7 +1060,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test composite cursor with 3 fields.
      */
-    public function testCompositeCursorWithThreeFields()
+    public function testCompositeCursorWithThreeFields(): void
     {
         // Create authors with duplicate names for testing
         $names = ['Alice', 'Alice', 'Alice', 'Bob', 'Bob', 'Charlie'];
@@ -1099,7 +1099,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test encoding and decoding of composite cursors.
      */
-    public function testCompositeCursorBoundaryRoundTrip()
+    public function testCompositeCursorBoundaryRoundTrip(): void
     {
         // Create test data
         for ($i = 1; $i <= 5; ++$i) {
@@ -1133,7 +1133,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertNotEmpty($result2->items);
     }
 
-    public function testCursorRejectsNullableScalarField()
+    public function testCursorRejectsNullableScalarField(): void
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->select('b')
@@ -1144,7 +1144,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->resolveCursorOrder($qb, ['rating'], 'ASC');
     }
 
-    public function testCursorRejectsUnsupportedDoctrineFieldTypes()
+    public function testCursorRejectsUnsupportedDoctrineFieldTypes(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('b')
@@ -1157,7 +1157,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         $this->adapter->sliceWithCursor($queryBuilder, new CursorBoundary(['{}', 1]), 10, $order);
     }
 
-    public function testCursorNormalizesValidDateValues()
+    public function testCursorNormalizesValidDateValues(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('b')
@@ -1174,7 +1174,7 @@ final class DoctrineOrmAdapterTest extends TestCase
         self::assertSame([], $result->items);
     }
 
-    public function testCursorRejectsInvalidDateValues()
+    public function testCursorRejectsInvalidDateValues(): void
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('b')
@@ -1190,7 +1190,7 @@ final class DoctrineOrmAdapterTest extends TestCase
     /**
      * Test error handling: cursor values count mismatch.
      */
-    public function testCompositeCursorMismatchThrowsException()
+    public function testCompositeCursorMismatchThrowsException(): void
     {
         $author = new Author();
         $author->setName('Author 1');

--- a/src/Pagination/tests/CursorCodecTest.php
+++ b/src/Pagination/tests/CursorCodecTest.php
@@ -19,21 +19,21 @@ use Symfony\UX\Pagination\Exception\RuntimeException;
 #[CoversClass(CursorCodec::class)]
 final class CursorCodecTest extends TestCase
 {
-    public function testConstructorMarksTheSecretAsSensitive()
+    public function testConstructorMarksTheSecretAsSensitive(): void
     {
         $parameter = new \ReflectionMethod(CursorCodec::class, '__construct')->getParameters()[0];
 
         self::assertNotEmpty($parameter->getAttributes(\SensitiveParameter::class));
     }
 
-    public function testEmptySecretIsRejected()
+    public function testEmptySecretIsRejected(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('non-empty "ux_pagination.cursor.secret" or "kernel.secret"');
         new CursorCodec('');
     }
 
-    public function testSignedVersionedRoundTrip()
+    public function testSignedVersionedRoundTrip(): void
     {
         $codec = new CursorCodec('application-secret');
         $token = $codec->encode([12, '2026-07-25'], true, 'order-a', 'products');
@@ -44,7 +44,7 @@ final class CursorCodecTest extends TestCase
         ], $codec->decode($token, 'order-a', 'products'));
     }
 
-    public function testTamperedTokenIsRejected()
+    public function testTamperedTokenIsRejected(): void
     {
         $codec = new CursorCodec('application-secret');
         $token = $codec->encode([12], true, 'order-a', 'products');
@@ -54,7 +54,7 @@ final class CursorCodecTest extends TestCase
         $codec->decode($token, 'order-a', 'products');
     }
 
-    public function testTokenCannotBeReusedForAnotherOrder()
+    public function testTokenCannotBeReusedForAnotherOrder(): void
     {
         $codec = new CursorCodec('application-secret');
         $token = $codec->encode([12], true, 'order-a', 'products');
@@ -64,7 +64,7 @@ final class CursorCodecTest extends TestCase
         $codec->decode($token, 'order-b', 'products');
     }
 
-    public function testTokenCannotBeVerifiedWithAnotherSecret()
+    public function testTokenCannotBeVerifiedWithAnotherSecret(): void
     {
         $token = new CursorCodec('first-secret')->encode([12], true, 'order-a', 'products');
 
@@ -73,7 +73,7 @@ final class CursorCodecTest extends TestCase
         new CursorCodec('second-secret')->decode($token, 'order-a', 'products');
     }
 
-    public function testTokenCannotBeReusedForAnotherContext()
+    public function testTokenCannotBeReusedForAnotherContext(): void
     {
         $codec = new CursorCodec('application-secret');
         $token = $codec->encode([12], true, 'order-a', 'products');
@@ -82,7 +82,7 @@ final class CursorCodecTest extends TestCase
         $codec->decode($token, 'order-a', 'orders');
     }
 
-    public function testUnsignedLegacyTokenIsRejected()
+    public function testUnsignedLegacyTokenIsRejected(): void
     {
         $token = base64_encode(json_encode(['v' => [12]], \JSON_THROW_ON_ERROR));
 
@@ -90,13 +90,13 @@ final class CursorCodecTest extends TestCase
         new CursorCodec('application-secret')->decode($token, 'order-a', 'products');
     }
 
-    public function testOversizedTokenIsRejectedBeforeDecoding()
+    public function testOversizedTokenIsRejectedBeforeDecoding(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         new CursorCodec('secret')->decode(str_repeat('a', 4097), 'order-a', 'products');
     }
 
-    public function testTooManyOrderedValuesAreRejectedBeforeEncoding()
+    public function testTooManyOrderedValuesAreRejectedBeforeEncoding(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('at most 16 ordered values');
@@ -104,14 +104,14 @@ final class CursorCodecTest extends TestCase
         new CursorCodec('secret')->encode(range(1, 17), true, 'order-a', 'products');
     }
 
-    public function testNonScalarOrderedValueIsRejectedBeforeEncoding()
+    public function testNonScalarOrderedValueIsRejectedBeforeEncoding(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid cursor value');
         new CursorCodec('secret')->encode([new \stdClass()], true, 'order-a', 'products');
     }
 
-    public function testNonFiniteFloatIsRejectedBeforeEncoding()
+    public function testNonFiniteFloatIsRejectedBeforeEncoding(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('must be finite');
@@ -119,14 +119,14 @@ final class CursorCodecTest extends TestCase
         new CursorCodec('secret')->encode([\NAN], true, 'order-a', 'products');
     }
 
-    public function testInvalidBase64IsRejectedBeforeDecoding()
+    public function testInvalidBase64IsRejectedBeforeDecoding(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid cursor value');
         new CursorCodec('secret')->decode('*', 'order-a', 'products');
     }
 
-    public function testOversizedPayloadIsRejectedBeforeEncoding()
+    public function testOversizedPayloadIsRejectedBeforeEncoding(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('too large to encode safely');

--- a/src/Pagination/tests/CursorPaginationBuilderTest.php
+++ b/src/Pagination/tests/CursorPaginationBuilderTest.php
@@ -36,13 +36,13 @@ use Symfony\UX\Pagination\Paginator;
 #[CoversClass(CursorPaginationBuilder::class)]
 final class CursorPaginationBuilderTest extends TestCase
 {
-    public function testArraySourceRequiresExplicitContext()
+    public function testArraySourceRequiresExplicitContext(): void
     {
         $this->expectException(RuntimeException::class);
         $this->paginator()->cursor($this->source())->paginate();
     }
 
-    public function testBuildsSignedBidirectionalPagination()
+    public function testBuildsSignedBidirectionalPagination(): void
     {
         $page1 = $this->paginator()->cursor($this->source())
             ->orderBy('id', 'ASC')
@@ -65,7 +65,7 @@ final class CursorPaginationBuilderTest extends TestCase
     }
 
     #[DataProvider('invalidOrderByArguments')]
-    public function testRejectsInvalidOrderByArguments(string|array $fields, string $direction)
+    public function testRejectsInvalidOrderByArguments(string|array $fields, string $direction): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -79,7 +79,7 @@ final class CursorPaginationBuilderTest extends TestCase
         yield 'invalid direction' => ['id', 'sideways'];
     }
 
-    public function testRejectsInvalidPageSize()
+    public function testRejectsInvalidPageSize(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('perPage must be >= 1');
@@ -87,7 +87,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $this->paginator()->cursor($this->source())->perPage(0);
     }
 
-    public function testRejectsPageSizeThatWouldOverflowLookahead()
+    public function testRejectsPageSizeThatWouldOverflowLookahead(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('less than PHP_INT_MAX');
@@ -95,7 +95,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $this->paginator()->cursor($this->source())->perPage(\PHP_INT_MAX);
     }
 
-    public function testRejectsEmptyCursorParameter()
+    public function testRejectsEmptyCursorParameter(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cursor parameter name must not be empty');
@@ -103,7 +103,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $this->paginator()->cursor($this->source())->cursorParameter('');
     }
 
-    public function testConstructorRejectsPerPageOverflow()
+    public function testConstructorRejectsPerPageOverflow(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('less than PHP_INT_MAX');
@@ -116,7 +116,7 @@ final class CursorPaginationBuilderTest extends TestCase
         );
     }
 
-    public function testRejectsEmptyContext()
+    public function testRejectsEmptyContext(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cursor context must not be empty');
@@ -124,7 +124,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $this->paginator()->cursor($this->source())->context('');
     }
 
-    public function testTokenIsBoundToBusinessContext()
+    public function testTokenIsBoundToBusinessContext(): void
     {
         $token = $this->paginator()->cursor($this->source())
             ->orderBy('id', 'ASC')
@@ -143,7 +143,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $builder->paginate();
     }
 
-    public function testUrlCompositionPreservesFiltersAndCustomCursorParameter()
+    public function testUrlCompositionPreservesFiltersAndCustomCursorParameter(): void
     {
         $stack = new RequestStack();
         $stack->push(Request::create('/catalog', 'GET', ['q' => 'phone', 'sort' => 'price']));
@@ -167,7 +167,7 @@ final class CursorPaginationBuilderTest extends TestCase
         self::assertStringNotContainsString('cursor=', $url);
     }
 
-    public function testRouteAndQueryStringPoliciesAreImmutable()
+    public function testRouteAndQueryStringPoliciesAreImmutable(): void
     {
         $routes = new RouteCollection();
         $routes->add('catalog', new Route('/{section}'));
@@ -203,7 +203,7 @@ final class CursorPaginationBuilderTest extends TestCase
         self::assertStringNotContainsString('debug=', $preservedUrl);
     }
 
-    public function testReadsAValidCursorFromTheRequest()
+    public function testReadsAValidCursorFromTheRequest(): void
     {
         $firstPage = $this->paginator()->cursor($this->source())
             ->orderBy('id', 'ASC')
@@ -226,7 +226,7 @@ final class CursorPaginationBuilderTest extends TestCase
     }
 
     #[DataProvider('invalidRequestCursors')]
-    public function testRejectsInvalidRequestCursor(mixed $value)
+    public function testRejectsInvalidRequestCursor(mixed $value): void
     {
         $stack = new RequestStack();
         $stack->push(new Request(['cursor' => $value]));
@@ -244,7 +244,7 @@ final class CursorPaginationBuilderTest extends TestCase
         yield 'oversized' => [str_repeat('a', 4097)];
     }
 
-    public function testTamperedRequestCursorFailsAtPaginateTime()
+    public function testTamperedRequestCursorFailsAtPaginateTime(): void
     {
         $token = $this->paginator()->cursor($this->source())
             ->orderBy('id', 'ASC')
@@ -265,7 +265,7 @@ final class CursorPaginationBuilderTest extends TestCase
             ->paginate();
     }
 
-    public function testMalformedSignedTokenUsesDomainException()
+    public function testMalformedSignedTokenUsesDomainException(): void
     {
         $builder = $this->paginator()->cursor($this->source())
             ->orderBy('id')
@@ -276,7 +276,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $builder->paginate();
     }
 
-    public function testDoctrineDbalSourceDerivesContextFromSqlAndParameters()
+    public function testDoctrineDbalSourceDerivesContextFromSqlAndParameters(): void
     {
         if (!class_exists(\Doctrine\DBAL\DriverManager::class)) {
             self::markTestSkipped('Doctrine DBAL is not installed.');
@@ -316,7 +316,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $changedQuery->paginate();
     }
 
-    public function testExcludedQueryParameterNameCannotBeEmpty()
+    public function testExcludedQueryParameterNameCannotBeEmpty(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('must not be empty');
@@ -324,7 +324,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $this->paginator()->cursor($this->source())->excludeQueryParameters('');
     }
 
-    public function testRejectsAnAdapterWithoutCursorSupport()
+    public function testRejectsAnAdapterWithoutCursorSupport(): void
     {
         $adapter = $this->createStub(PaginationAdapterInterface::class);
         $adapter->method('supports')->willReturn(true);
@@ -339,7 +339,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $paginator->cursor($this->source())->context('products')->paginate();
     }
 
-    public function testRejectsAnUnsupportedSource()
+    public function testRejectsAnUnsupportedSource(): void
     {
         $paginator = new Paginator(
             [new ArrayPaginationAdapter()],
@@ -352,7 +352,7 @@ final class CursorPaginationBuilderTest extends TestCase
         $paginator->cursor(new \stdClass())->context('products')->paginate();
     }
 
-    public function testAdapterOwnedOrderDoesNotRequireOrderBy()
+    public function testAdapterOwnedOrderDoesNotRequireOrderBy(): void
     {
         $source = new \stdClass();
         $adapter = new class implements CursorAdapterInterface {
@@ -390,7 +390,7 @@ final class CursorPaginationBuilderTest extends TestCase
         self::assertSame([['number' => 1]], $pagination->getItems());
     }
 
-    public function testCursorResolutionSkipsAMatchingAdapterWithoutCursorCapability()
+    public function testCursorResolutionSkipsAMatchingAdapterWithoutCursorCapability(): void
     {
         $source = new \stdClass();
         $genericAdapter = $this->createStub(PaginationAdapterInterface::class);

--- a/src/Pagination/tests/CursorPaginationTest.php
+++ b/src/Pagination/tests/CursorPaginationTest.php
@@ -26,7 +26,7 @@ use Symfony\UX\Pagination\Navigation\PaginationUrlGenerator;
 #[CoversClass(CursorPagination::class)]
 final class CursorPaginationTest extends TestCase
 {
-    public function testItemsFirstPage()
+    public function testItemsFirstPage(): void
     {
         $source = $this->createSource(50);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -37,7 +37,7 @@ final class CursorPaginationTest extends TestCase
         self::assertSame(10, $items[9]['id']);
     }
 
-    public function testIterateReturnsItems()
+    public function testIterateReturnsItems(): void
     {
         $source = $this->createSource(5);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -50,7 +50,7 @@ final class CursorPaginationTest extends TestCase
         self::assertCount(5, $items);
     }
 
-    public function testCountReturnsItemsOnThisPage()
+    public function testCountReturnsItemsOnThisPage(): void
     {
         $source = $this->createSource(25);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -59,7 +59,7 @@ final class CursorPaginationTest extends TestCase
         self::assertCount(10, $pagination);
     }
 
-    public function testThroughTransformsItems()
+    public function testThroughTransformsItems(): void
     {
         $source = $this->createSource(3);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -69,7 +69,7 @@ final class CursorPaginationTest extends TestCase
         self::assertArrayNotHasKey('doubled', $pagination->getItems()[0]);
     }
 
-    public function testMapTransformsItemsToAnotherTypeAndFetchesOnlyTheClone()
+    public function testMapTransformsItemsToAnotherTypeAndFetchesOnlyTheClone(): void
     {
         $adapter = new class implements CursorAdapterInterface {
             public int $calls = 0;
@@ -111,7 +111,7 @@ final class CursorPaginationTest extends TestCase
         self::assertSame(1, $adapter->calls);
     }
 
-    public function testFailedFetchIsNotCachedAsAnEmptyPage()
+    public function testFailedFetchIsNotCachedAsAnEmptyPage(): void
     {
         $pagination = $this->createCursorPagination($this->createSource(5), 'invalid', 10);
         $failures = 0;
@@ -128,14 +128,14 @@ final class CursorPaginationTest extends TestCase
         self::assertSame(2, $failures);
     }
 
-    public function testPerPage()
+    public function testPerPage(): void
     {
         $pagination = $this->createCursorPagination($this->createSource(50), null, 25);
 
         self::assertSame(25, $pagination->getItemsPerPage());
     }
 
-    public function testPerPageMustBePositive()
+    public function testPerPageMustBePositive(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('perPage must be >= 1.');
@@ -143,7 +143,7 @@ final class CursorPaginationTest extends TestCase
         $this->createCursorPagination([], null, 0);
     }
 
-    public function testPerPageMustNotOverflowLookahead()
+    public function testPerPageMustNotOverflowLookahead(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('less than PHP_INT_MAX');
@@ -151,21 +151,21 @@ final class CursorPaginationTest extends TestCase
         $this->createCursorPagination([], null, \PHP_INT_MAX);
     }
 
-    public function testCursorIsNullForFirstPage()
+    public function testCursorIsNullForFirstPage(): void
     {
         $pagination = $this->createCursorPagination($this->createSource(50), null, 10);
 
         self::assertNull($pagination->getCursor());
     }
 
-    public function testIsEmpty()
+    public function testIsEmpty(): void
     {
         $pagination = $this->createCursorPagination([], null, 10);
 
         self::assertTrue($pagination->isEmpty());
     }
 
-    public function testHasNextWhenMoreItemsExist()
+    public function testHasNextWhenMoreItemsExist(): void
     {
         $source = $this->createSource(50);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -173,7 +173,7 @@ final class CursorPaginationTest extends TestCase
         self::assertTrue($pagination->hasNext());
     }
 
-    public function testHasNextIsFalseOnLastPage()
+    public function testHasNextIsFalseOnLastPage(): void
     {
         $source = $this->createSource(5);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -181,7 +181,7 @@ final class CursorPaginationTest extends TestCase
         self::assertFalse($pagination->hasNext());
     }
 
-    public function testHasPreviousOnFirstPage()
+    public function testHasPreviousOnFirstPage(): void
     {
         $pagination = $this->createCursorPagination($this->createSource(50), null, 10);
 
@@ -189,7 +189,7 @@ final class CursorPaginationTest extends TestCase
         self::assertNull($pagination->getPreviousUrl());
     }
 
-    public function testHasPreviousOnSecondPage()
+    public function testHasPreviousOnSecondPage(): void
     {
         $source = $this->createSource(50);
 
@@ -203,7 +203,7 @@ final class CursorPaginationTest extends TestCase
         self::assertTrue($page2->hasPrevious());
     }
 
-    public function testNextCursorProvided()
+    public function testNextCursorProvided(): void
     {
         $source = $this->createSource(50);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -211,7 +211,7 @@ final class CursorPaginationTest extends TestCase
         self::assertNotNull($pagination->getNextCursor());
     }
 
-    public function testNextCursorNullOnLastPage()
+    public function testNextCursorNullOnLastPage(): void
     {
         $source = $this->createSource(5);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -219,7 +219,7 @@ final class CursorPaginationTest extends TestCase
         self::assertNull($pagination->getNextCursor());
     }
 
-    public function testCursorPaginationFlow()
+    public function testCursorPaginationFlow(): void
     {
         $source = $this->createSource(25);
 
@@ -243,7 +243,7 @@ final class CursorPaginationTest extends TestCase
         self::assertNull($page3->getNextCursor());
     }
 
-    public function testNextUrlProvided()
+    public function testNextUrlProvided(): void
     {
         $source = $this->createSource(50);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -253,7 +253,7 @@ final class CursorPaginationTest extends TestCase
         self::assertStringContainsString('cursor=', $nextUrl);
     }
 
-    public function testNextUrlNullOnLastPage()
+    public function testNextUrlNullOnLastPage(): void
     {
         $source = $this->createSource(5);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -261,7 +261,7 @@ final class CursorPaginationTest extends TestCase
         self::assertNull($pagination->getNextUrl());
     }
 
-    public function testPreviousUrlOnSecondPage()
+    public function testPreviousUrlOnSecondPage(): void
     {
         $source = $this->createSource(50);
         $page1 = $this->createCursorPagination($source, null, 10);
@@ -271,7 +271,7 @@ final class CursorPaginationTest extends TestCase
         self::assertStringContainsString('cursor=', $page2->getPreviousUrl());
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $source = $this->createSource(50);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -290,7 +290,7 @@ final class CursorPaginationTest extends TestCase
         self::assertNotNull($json['links']['next']);
     }
 
-    public function testInfo()
+    public function testInfo(): void
     {
         $source = $this->createSource(50);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -298,7 +298,7 @@ final class CursorPaginationTest extends TestCase
         self::assertSame('Showing 10 items', $pagination->getInfo());
     }
 
-    public function testInfoLastPage()
+    public function testInfoLastPage(): void
     {
         $source = $this->createSource(5);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -306,14 +306,14 @@ final class CursorPaginationTest extends TestCase
         self::assertSame('Showing 5 items (last page)', $pagination->getInfo());
     }
 
-    public function testInfoEmpty()
+    public function testInfoEmpty(): void
     {
         $pagination = $this->createCursorPagination([], null, 10);
 
         self::assertSame('No items', $pagination->getInfo());
     }
 
-    public function testItemsAreLazyLoaded()
+    public function testItemsAreLazyLoaded(): void
     {
         $source = $this->createSource(50);
         $pagination = $this->createCursorPagination($source, null, 10);
@@ -323,7 +323,7 @@ final class CursorPaginationTest extends TestCase
         self::assertSame(10, $pagination->count());
     }
 
-    public function testCursorUrl()
+    public function testCursorUrl(): void
     {
         $source = $this->createSource(50);
         $pagination = $this->createCursorPagination($source, null, 10);

--- a/src/Pagination/tests/CursorValueObjectTest.php
+++ b/src/Pagination/tests/CursorValueObjectTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Pagination\Cursor\CursorSlice;
 #[CoversClass(CursorSlice::class)]
 final class CursorValueObjectTest extends TestCase
 {
-    public function testBoundaryExposesItsValuesAndDirection()
+    public function testBoundaryExposesItsValuesAndDirection(): void
     {
         $boundary = new CursorBoundary([42, 'release'], false);
 
@@ -30,7 +30,7 @@ final class CursorValueObjectTest extends TestCase
         self::assertFalse($boundary->pointsForward());
     }
 
-    public function testSliceExposesItemsAndBoundaries()
+    public function testSliceExposesItemsAndBoundaries(): void
     {
         $next = new CursorBoundary([3]);
         $previous = new CursorBoundary([1], false);
@@ -42,7 +42,7 @@ final class CursorValueObjectTest extends TestCase
         self::assertTrue($slice->hasNext());
     }
 
-    public function testFieldOrderExposesNormalizedFieldsAndStableFingerprint()
+    public function testFieldOrderExposesNormalizedFieldsAndStableFingerprint(): void
     {
         $order = CursorOrder::byFields(['createdAt', 'id'], 'desc');
 
@@ -58,7 +58,7 @@ final class CursorValueObjectTest extends TestCase
         );
     }
 
-    public function testOpaqueOrderIdentityIsStableAndNotFieldBased()
+    public function testOpaqueOrderIdentityIsStableAndNotFieldBased(): void
     {
         $order = CursorOrder::byIdentity('github:pull-requests:created-desc');
 
@@ -74,19 +74,19 @@ final class CursorValueObjectTest extends TestCase
         );
     }
 
-    public function testOrderRejectsInvalidDefinitions()
+    public function testOrderRejectsInvalidDefinitions(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         CursorOrder::byFields([], 'ASC');
     }
 
-    public function testOrderRejectsInvalidDirection()
+    public function testOrderRejectsInvalidDirection(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         CursorOrder::byFields(['id'], 'sideways');
     }
 
-    public function testOpaqueOrderRejectsEmptyIdentity()
+    public function testOpaqueOrderRejectsEmptyIdentity(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         CursorOrder::byIdentity('');

--- a/src/Pagination/tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Pagination/tests/DependencyInjection/ConfigurationTest.php
@@ -23,7 +23,7 @@ use Symfony\UX\Pagination\UXPaginationBundle;
 #[CoversClass(UXPaginationBundle::class)]
 final class ConfigurationTest extends TestCase
 {
-    public function testDefaultConfiguration()
+    public function testDefaultConfiguration(): void
     {
         $config = $this->processConfiguration([]);
 
@@ -40,7 +40,7 @@ final class ConfigurationTest extends TestCase
         self::assertSame([], $config['paginators']);
     }
 
-    public function testCustomConfiguration()
+    public function testCustomConfiguration(): void
     {
         $config = $this->processConfiguration([
             'items_per_page' => 50,
@@ -79,21 +79,21 @@ final class ConfigurationTest extends TestCase
         ], $config['paginators']);
     }
 
-    public function testItemsPerPageMinimum()
+    public function testItemsPerPageMinimum(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
         $this->processConfiguration(['items_per_page' => 0]);
     }
 
-    public function testItemsPerPageMustBePositive()
+    public function testItemsPerPageMustBePositive(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
         $this->processConfiguration(['items_per_page' => -5]);
     }
 
-    public function testMaximumOffsetCannotBeNegative()
+    public function testMaximumOffsetCannotBeNegative(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
@@ -101,14 +101,14 @@ final class ConfigurationTest extends TestCase
     }
 
     #[DataProvider('emptyStringOptions')]
-    public function testStringOptionsCannotBeEmpty(array $config)
+    public function testStringOptionsCannotBeEmpty(array $config): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
         $this->processConfiguration($config);
     }
 
-    public function testThemeMustBeASingleValue()
+    public function testThemeMustBeASingleValue(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
@@ -120,7 +120,7 @@ final class ConfigurationTest extends TestCase
         ]);
     }
 
-    public function testTemplateIsNotAConfigurationOption()
+    public function testTemplateIsNotAConfigurationOption(): void
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Unrecognized option "template"');
@@ -130,7 +130,7 @@ final class ConfigurationTest extends TestCase
         ]);
     }
 
-    public function testThemeIsNotNestedUnderTwig()
+    public function testThemeIsNotNestedUnderTwig(): void
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Unrecognized option "twig"');
@@ -155,7 +155,7 @@ final class ConfigurationTest extends TestCase
     }
 
     #[DataProvider('nonStringOptions')]
-    public function testStringOptionsRejectNonStringScalars(array $config)
+    public function testStringOptionsRejectNonStringScalars(array $config): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
@@ -171,14 +171,14 @@ final class ConfigurationTest extends TestCase
         yield 'named cursor parameter' => [['paginators' => ['blog' => ['cursor_parameter' => false]]]];
     }
 
-    public function testItemsPerPageRejectsLookaheadOverflow()
+    public function testItemsPerPageRejectsLookaheadOverflow(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
         $this->processConfiguration(['items_per_page' => \PHP_INT_MAX]);
     }
 
-    public function testNamedItemsPerPageRejectsLookaheadOverflow()
+    public function testNamedItemsPerPageRejectsLookaheadOverflow(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
@@ -189,21 +189,21 @@ final class ConfigurationTest extends TestCase
         ]);
     }
 
-    public function testNavigationModeMustBeSupported()
+    public function testNavigationModeMustBeSupported(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
         $this->processConfiguration(['navigation' => ['mode' => 'unknown']]);
     }
 
-    public function testNamedPaginatorValuesAreValidated()
+    public function testNamedPaginatorValuesAreValidated(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
         $this->processConfiguration(['paginators' => ['blog' => ['navigation' => ['size' => 0]]]]);
     }
 
-    public function testPaginatorNameMustBeAValidAutowiringTarget()
+    public function testPaginatorNameMustBeAValidAutowiringTarget(): void
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Invalid paginator name "1blog"');
@@ -211,7 +211,7 @@ final class ConfigurationTest extends TestCase
         $this->processConfiguration(['paginators' => ['1blog' => []]]);
     }
 
-    public function testPaginatorNamesMustNotResolveToTheSameAutowiringTarget()
+    public function testPaginatorNamesMustNotResolveToTheSameAutowiringTarget(): void
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Paginator names "blog-posts" and "blog_posts" resolve to the same autowiring target "blogPosts".');
@@ -224,7 +224,7 @@ final class ConfigurationTest extends TestCase
         ]);
     }
 
-    public function testTreeBuilderName()
+    public function testTreeBuilderName(): void
     {
         $bundle = new UXPaginationBundle();
         $extension = $bundle->getContainerExtension();

--- a/src/Pagination/tests/DependencyInjection/CursorSecretLifecycleTest.php
+++ b/src/Pagination/tests/DependencyInjection/CursorSecretLifecycleTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Pagination\UXPaginationBundle;
 #[CoversNothing]
 final class CursorSecretLifecycleTest extends TestCase
 {
-    public function testCursorCodecUsesAnInterfaceBasedLazyProxy()
+    public function testCursorCodecUsesAnInterfaceBasedLazyProxy(): void
     {
         $container = $this->loadContainer(kernelSecret: null);
         $definition = $container->getDefinition('ux_pagination.cursor_codec');
@@ -34,7 +34,7 @@ final class CursorSecretLifecycleTest extends TestCase
         );
     }
 
-    public function testOffsetPaginationWorksWithoutAnySigningSecret()
+    public function testOffsetPaginationWorksWithoutAnySigningSecret(): void
     {
         $container = $this->loadContainer(kernelSecret: null);
         $container->compile();
@@ -46,7 +46,7 @@ final class CursorSecretLifecycleTest extends TestCase
         self::assertSame([3, 4], $pagination->getItems());
     }
 
-    public function testMissingSecretFailsOnlyWhenCursorSigningIsNeeded()
+    public function testMissingSecretFailsOnlyWhenCursorSigningIsNeeded(): void
     {
         $container = $this->loadContainer(kernelSecret: null);
         $container->compile();
@@ -66,7 +66,7 @@ final class CursorSecretLifecycleTest extends TestCase
         $pagination->getItems();
     }
 
-    public function testMissingSecretIsNotReportedAsAnInvalidClientCursor()
+    public function testMissingSecretIsNotReportedAsAnInvalidClientCursor(): void
     {
         $container = $this->loadContainer(kernelSecret: null);
         $container->compile();
@@ -86,7 +86,7 @@ final class CursorSecretLifecycleTest extends TestCase
         $builder->paginate();
     }
 
-    public function testKernelSecretIsUsedAsTheDefaultCursorSecret()
+    public function testKernelSecretIsUsedAsTheDefaultCursorSecret(): void
     {
         $firstContainer = $this->loadContainer(kernelSecret: 'shared-kernel-secret');
         $firstContainer->compile();
@@ -119,7 +119,7 @@ final class CursorSecretLifecycleTest extends TestCase
         self::assertSame([3, 4], array_column($secondPage->getItems(), 'id'));
     }
 
-    public function testDedicatedCursorSecretOverridesKernelSecret()
+    public function testDedicatedCursorSecretOverridesKernelSecret(): void
     {
         $firstContainer = $this->loadContainer(
             kernelSecret: 'first-kernel-secret',

--- a/src/Pagination/tests/DependencyInjection/UXPaginationExtensionTest.php
+++ b/src/Pagination/tests/DependencyInjection/UXPaginationExtensionTest.php
@@ -26,7 +26,7 @@ use Symfony\UX\Pagination\UXPaginationBundle;
 #[CoversClass(UXPaginationBundle::class)]
 final class UXPaginationExtensionTest extends TestCase
 {
-    public function testLoadInjectsDefaultConfigurationWithoutExposingParameters()
+    public function testLoadInjectsDefaultConfigurationWithoutExposingParameters(): void
     {
         $container = $this->createContainer();
         $extension = $this->getExtension();
@@ -48,7 +48,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertSame('%kernel.secret%', $cursorSecret);
     }
 
-    public function testLoadInjectsCustomConfiguration()
+    public function testLoadInjectsCustomConfiguration(): void
     {
         $container = $this->createContainer();
         $container->setParameter('kernel.bundles', ['TwigBundle' => TwigBundle::class]);
@@ -82,7 +82,7 @@ final class UXPaginationExtensionTest extends TestCase
         );
     }
 
-    public function testLoadWithCustomThemeName()
+    public function testLoadWithCustomThemeName(): void
     {
         $container = $this->createContainer();
         $container->setParameter('kernel.bundles', ['TwigBundle' => TwigBundle::class]);
@@ -100,7 +100,7 @@ final class UXPaginationExtensionTest extends TestCase
         );
     }
 
-    public function testLoadWithApplicationThemePath()
+    public function testLoadWithApplicationThemePath(): void
     {
         $container = $this->createContainer();
         $container->setParameter(
@@ -120,7 +120,7 @@ final class UXPaginationExtensionTest extends TestCase
         );
     }
 
-    public function testNamedPaginatorsInheritRootConfigurationAndOverrideSelectedValues()
+    public function testNamedPaginatorsInheritRootConfigurationAndOverrideSelectedValues(): void
     {
         $container = $this->createContainer();
 
@@ -150,7 +150,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertSame(PaginatorInterface::class.' $blogPaginator', (string) $container->getAlias('.'.PaginatorInterface::class.' $blog'));
     }
 
-    public function testNamedPaginatorInjectionSupportsEveryPublicEntryPoint()
+    public function testNamedPaginatorInjectionSupportsEveryPublicEntryPoint(): void
     {
         $container = $this->createContainer();
         $bundle = new UXPaginationBundle();
@@ -194,7 +194,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertSame([1, 2], array_column($cursor->getItems(), 'id'));
     }
 
-    public function testAdapterIteratorUsesTheSymfonyDefaultPriorityConvention()
+    public function testAdapterIteratorUsesTheSymfonyDefaultPriorityConvention(): void
     {
         $container = $this->createContainer();
 
@@ -205,7 +205,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertSame('getDefaultPriority', $adapters->getDefaultPriorityMethod());
     }
 
-    public function testAdapterDefaultPriorityMethodControlsResolutionOrder()
+    public function testAdapterDefaultPriorityMethodControlsResolutionOrder(): void
     {
         $container = $this->createContainerWithAdapters([
             'app.adapter.explicit' => [TaggedTestPaginationAdapter::class, ['explicit'], 10],
@@ -218,7 +218,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertSame(['static'], $paginator->paginate(new PriorityTestSource())->getItems());
     }
 
-    public function testExplicitAdapterTagPriorityTakesPrecedence()
+    public function testExplicitAdapterTagPriorityTakesPrecedence(): void
     {
         $container = $this->createContainerWithAdapters([
             'app.adapter.static' => [DefaultPriorityTestPaginationAdapter::class, [], null],
@@ -231,7 +231,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertSame(['explicit'], $paginator->paginate(new PriorityTestSource())->getItems());
     }
 
-    public function testEqualAdapterPrioritiesKeepRegistrationOrder()
+    public function testEqualAdapterPrioritiesKeepRegistrationOrder(): void
     {
         $container = $this->createContainerWithAdapters([
             'app.adapter.first' => [TaggedTestPaginationAdapter::class, ['first'], 10],
@@ -244,14 +244,14 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertSame(['first'], $paginator->paginate(new PriorityTestSource())->getItems());
     }
 
-    public function testGetAlias()
+    public function testGetAlias(): void
     {
         $extension = $this->getExtension();
 
         self::assertSame('ux_pagination', $extension->getAlias());
     }
 
-    public function testLoadRegistersDoctrineOrmAdapter()
+    public function testLoadRegistersDoctrineOrmAdapter(): void
     {
         if (!class_exists(\Doctrine\ORM\QueryBuilder::class)) {
             self::markTestSkipped('Doctrine ORM is not installed.');
@@ -265,7 +265,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertTrue($container->hasDefinition('ux_pagination.adapter.doctrine_orm'));
     }
 
-    public function testLoadRegistersDoctrineDbalAdapter()
+    public function testLoadRegistersDoctrineDbalAdapter(): void
     {
         if (!class_exists(\Doctrine\DBAL\Query\QueryBuilder::class)) {
             self::markTestSkipped('Doctrine DBAL is not installed.');
@@ -278,7 +278,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertTrue($container->hasDefinition('ux_pagination.adapter.doctrine_dbal'));
     }
 
-    public function testTwigServicesAreNotRegisteredWhenTwigBundleIsInstalledButInactive()
+    public function testTwigServicesAreNotRegisteredWhenTwigBundleIsInstalledButInactive(): void
     {
         self::assertTrue(class_exists(TwigBundle::class));
 
@@ -291,7 +291,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertFalse($container->hasDefinition('ux_pagination.renderer'));
     }
 
-    public function testTwigServicesAreRegisteredWhenTwigBundleIsActive()
+    public function testTwigServicesAreRegisteredWhenTwigBundleIsActive(): void
     {
         $container = $this->createContainer();
         $container->setParameter('kernel.bundles', ['TwigBundle' => TwigBundle::class]);
@@ -303,7 +303,7 @@ final class UXPaginationExtensionTest extends TestCase
         self::assertTrue($container->hasDefinition('ux_pagination.renderer'));
     }
 
-    public function testCustomAdaptersAreAutoconfigured()
+    public function testCustomAdaptersAreAutoconfigured(): void
     {
         $container = $this->createContainer();
         new UXPaginationBundle()->build($container);
@@ -322,7 +322,7 @@ final class UXPaginationExtensionTest extends TestCase
         return $bundle->getContainerExtension();
     }
 
-    public function testMissingKernelSecretFallsBackToAnEmptyCursorSecret()
+    public function testMissingKernelSecretFallsBackToAnEmptyCursorSecret(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.project_dir', sys_get_temp_dir());

--- a/src/Pagination/tests/Exception/ExceptionInterfaceTest.php
+++ b/src/Pagination/tests/Exception/ExceptionInterfaceTest.php
@@ -29,12 +29,12 @@ use Symfony\UX\Pagination\Navigation\PaginationUrlGenerator;
 final class ExceptionInterfaceTest extends TestCase
 {
     #[DataProvider('providePublicExceptions')]
-    public function testPublicExceptionImplementsPackageMarker(string $exception)
+    public function testPublicExceptionImplementsPackageMarker(string $exception): void
     {
         self::assertTrue(is_subclass_of($exception, ExceptionInterface::class));
     }
 
-    public function testPackageErrorsCanBeCaughtByTheMarker()
+    public function testPackageErrorsCanBeCaughtByTheMarker(): void
     {
         try {
             new Navigation(1, 10, new PaginationUrlGenerator(), modeParameter: -1);

--- a/src/Pagination/tests/Exception/ExceptionValueTest.php
+++ b/src/Pagination/tests/Exception/ExceptionValueTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Pagination\Exception\OffsetLimitExceededException;
 #[CoversClass(OffsetLimitExceededException::class)]
 final class ExceptionValueTest extends TestCase
 {
-    public function testInvalidCursorPreservesMessageAndPreviousException()
+    public function testInvalidCursorPreservesMessageAndPreviousException(): void
     {
         $previous = new \RuntimeException('decoder failed');
         $exception = new InvalidCursorException('Bad cursor.', $previous);
@@ -32,7 +32,7 @@ final class ExceptionValueTest extends TestCase
         self::assertSame(400, $exception->getStatusCode());
     }
 
-    public function testOffsetLimitPreservesContext()
+    public function testOffsetLimitPreservesContext(): void
     {
         $exception = new OffsetLimitExceededException(51, 20, 1000);
 
@@ -43,7 +43,7 @@ final class ExceptionValueTest extends TestCase
         self::assertSame(400, $exception->getStatusCode());
     }
 
-    public function testNavigationTooLargeExplainsTheLimit()
+    public function testNavigationTooLargeExplainsTheLimit(): void
     {
         $exception = new NavigationTooLargeException(500, 100);
 

--- a/src/Pagination/tests/Exception/OutOfRangePageExceptionTest.php
+++ b/src/Pagination/tests/Exception/OutOfRangePageExceptionTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Pagination\Exception\OutOfRangePageException;
 #[CoversClass(OutOfRangePageException::class)]
 final class OutOfRangePageExceptionTest extends TestCase
 {
-    public function testPagesAreExposed()
+    public function testPagesAreExposed(): void
     {
         $exception = new OutOfRangePageException(12, 5);
 
@@ -27,7 +27,7 @@ final class OutOfRangePageExceptionTest extends TestCase
         self::assertSame(5, $exception->lastPage);
     }
 
-    public function testMessageContainsPages()
+    public function testMessageContainsPages(): void
     {
         $exception = new OutOfRangePageException(12, 5);
 
@@ -35,7 +35,7 @@ final class OutOfRangePageExceptionTest extends TestCase
         self::assertStringContainsString('5', $exception->getMessage());
     }
 
-    public function testIsANotFoundHttpException()
+    public function testIsANotFoundHttpException(): void
     {
         $exception = new OutOfRangePageException(2, 1);
 

--- a/src/Pagination/tests/Integration/UXPaginationIntegrationTest.php
+++ b/src/Pagination/tests/Integration/UXPaginationIntegrationTest.php
@@ -54,7 +54,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         return UXPaginationTestKernel::class;
     }
 
-    public function testPaginatorServiceIsAutowirable()
+    public function testPaginatorServiceIsAutowirable(): void
     {
         self::bootKernel();
 
@@ -63,7 +63,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertInstanceOf(PaginatorInterface::class, $paginator);
     }
 
-    public function testNamedPaginatorSupportsSymfonyAutowiringConventions()
+    public function testNamedPaginatorSupportsSymfonyAutowiringConventions(): void
     {
         self::bootKernel();
 
@@ -78,7 +78,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertCount(8, $pagination->getPages());
     }
 
-    public function testPaginatorIsInjectedIntoAControllerAction()
+    public function testPaginatorIsInjectedIntoAControllerAction(): void
     {
         $kernel = self::bootKernel(['environment' => 'controller_injection']);
         $request = Request::create('/_ux-pagination/controller');
@@ -90,7 +90,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         $kernel->terminate($request, $response);
     }
 
-    public function testRendererServiceIsConfigured()
+    public function testRendererServiceIsConfigured(): void
     {
         self::bootKernel();
 
@@ -100,7 +100,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         );
     }
 
-    public function testTwigRegistersThePaginationFunctions()
+    public function testTwigRegistersThePaginationFunctions(): void
     {
         self::bootKernel();
 
@@ -111,7 +111,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertNull($twig->getFunction('pagination_head'));
     }
 
-    public function testArrayAdapterIsWired()
+    public function testArrayAdapterIsWired(): void
     {
         self::bootKernel();
 
@@ -126,7 +126,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertSame(5, $pagination->getTotalPages());
     }
 
-    public function testDoctrineOrmAdapterIsTagged()
+    public function testDoctrineOrmAdapterIsTagged(): void
     {
         if (!class_exists(\Doctrine\ORM\QueryBuilder::class)) {
             self::markTestSkipped('Doctrine ORM is not installed.');
@@ -139,7 +139,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertTrue($container->has('ux_pagination.adapter.doctrine_orm'));
     }
 
-    public function testDoctrineDbalAdapterIsTagged()
+    public function testDoctrineDbalAdapterIsTagged(): void
     {
         if (!class_exists(\Doctrine\DBAL\Query\QueryBuilder::class)) {
             self::markTestSkipped('Doctrine DBAL is not installed.');
@@ -150,7 +150,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertTrue(self::getContainer()->has('ux_pagination.adapter.doctrine_dbal'));
     }
 
-    public function testTwigFunctionRendersNavigationWithTranslations()
+    public function testTwigFunctionRendersNavigationWithTranslations(): void
     {
         self::bootKernel();
 
@@ -176,7 +176,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertStringContainsString('100', $html);
     }
 
-    public function testBootstrapThemeRenders()
+    public function testBootstrapThemeRenders(): void
     {
         self::bootKernel();
 
@@ -199,7 +199,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertStringContainsString('ux-pagination-bootstrap', $html);
     }
 
-    public function testConfiguredThemeIsUsedByDefault()
+    public function testConfiguredThemeIsUsedByDefault(): void
     {
         self::bootKernel(['environment' => 'bootstrap_theme']);
 
@@ -221,7 +221,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertStringNotContainsString('ux-pagination-tailwind', $html);
     }
 
-    public function testExplicitThemeOverridesConfiguredTheme()
+    public function testExplicitThemeOverridesConfiguredTheme(): void
     {
         self::bootKernel(['environment' => 'bootstrap_theme']);
 
@@ -246,7 +246,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertStringNotContainsString('ux-pagination-bootstrap', $html);
     }
 
-    public function testDocumentedTwigComponentRenders()
+    public function testDocumentedTwigComponentRenders(): void
     {
         self::bootKernel();
 
@@ -279,7 +279,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertStringNotContainsString('theme=', $html);
     }
 
-    public function testTwigComponentUsesTheConfiguredTheme()
+    public function testTwigComponentUsesTheConfiguredTheme(): void
     {
         self::bootKernel(['environment' => 'bootstrap_theme']);
 
@@ -301,7 +301,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertStringNotContainsString('ux-pagination-tailwind', $html);
     }
 
-    public function testTwigComponentThemeOverridesTheConfiguredTheme()
+    public function testTwigComponentThemeOverridesTheConfiguredTheme(): void
     {
         self::bootKernel(['environment' => 'bootstrap_theme']);
 
@@ -327,7 +327,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertStringNotContainsString('ux-pagination-bootstrap', $html);
     }
 
-    public function testInfoFallsBackToEnglishWithoutTranslator()
+    public function testInfoFallsBackToEnglishWithoutTranslator(): void
     {
         self::bootKernel(['environment' => 'no_translator']);
 
@@ -339,7 +339,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertSame('Showing 21-30 of 100', $pagination->getInfo());
     }
 
-    public function testPaginatesRealQueryBuilderThroughContainerService()
+    public function testPaginatesRealQueryBuilderThroughContainerService(): void
     {
         if (!class_exists(\Doctrine\ORM\EntityManager::class)) {
             self::markTestSkipped('Doctrine ORM is not installed.');
@@ -370,7 +370,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertSame([6, 7, 8, 9, 10], array_map(static fn (Author $a) => $a->getId(), $pagination->getItems()));
     }
 
-    public function testDefaultTemplateRendersCursorPagination()
+    public function testDefaultTemplateRendersCursorPagination(): void
     {
         self::bootKernel();
 
@@ -394,7 +394,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertStringContainsString('Next', $html);
     }
 
-    public function testComponentWithPaginationTraitHandlesARealLiveComponentAction()
+    public function testComponentWithPaginationTraitHandlesARealLiveComponentAction(): void
     {
         self::bootKernel();
 
@@ -416,7 +416,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertSame(2, $component->component()->page);
     }
 
-    public function testBundleTemplateOverrideAppliesToTheDefaultTheme()
+    public function testBundleTemplateOverrideAppliesToTheDefaultTheme(): void
     {
         self::bootKernel();
 
@@ -436,7 +436,7 @@ final class UXPaginationIntegrationTest extends KernelTestCase
         self::assertStringContainsString('Previous', $html);
     }
 
-    public function testCapturedRouteKeepsLinkUrlsStableAcrossLiveRerenders()
+    public function testCapturedRouteKeepsLinkUrlsStableAcrossLiveRerenders(): void
     {
         self::bootKernel();
 

--- a/src/Pagination/tests/LiveComponent/ComponentWithPaginationTraitTest.php
+++ b/src/Pagination/tests/LiveComponent/ComponentWithPaginationTraitTest.php
@@ -33,12 +33,12 @@ use Symfony\UX\Pagination\Paginator;
 #[CoversTrait(ComponentWithPaginationTrait::class)]
 final class ComponentWithPaginationTraitTest extends TestCase
 {
-    public function testDefaultState()
+    public function testDefaultState(): void
     {
         self::assertSame(1, $this->createComponent([1, 2, 3])->page);
     }
 
-    public function testPageIsWritableAndSynchronizedWithTheUrl()
+    public function testPageIsWritableAndSynchronizedWithTheUrl(): void
     {
         $property = new \ReflectionProperty(ComponentWithPaginationTrait::class, 'page');
         $attributes = $property->getAttributes(LiveProp::class);
@@ -52,7 +52,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
     }
 
     #[DataProvider('liveActions')]
-    public function testNavigationMethodsAreLiveActions(string $method)
+    public function testNavigationMethodsAreLiveActions(string $method): void
     {
         $attributes = new \ReflectionMethod(ComponentWithPaginationTrait::class, $method)
             ->getAttributes(LiveAction::class);
@@ -70,7 +70,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         yield 'previous page' => ['previousPage'];
     }
 
-    public function testBuilderOwnsTheSourceAndPageSize()
+    public function testBuilderOwnsTheSourceAndPageSize(): void
     {
         $component = $this->createComponent(range(1, 50));
         $component->page = 2;
@@ -82,7 +82,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         self::assertSame(10, $pagination->getItemsPerPage());
     }
 
-    public function testGetPaginationCachesResultForTheCurrentPage()
+    public function testGetPaginationCachesResultForTheCurrentPage(): void
     {
         $callCount = 0;
         $component = $this->createComponent(range(1, 50), $callCount);
@@ -91,7 +91,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         self::assertSame(1, $callCount);
     }
 
-    public function testChangingThePublicPageInvalidatesTheCachedResult()
+    public function testChangingThePublicPageInvalidatesTheCachedResult(): void
     {
         $callCount = 0;
         $component = $this->createComponent(range(1, 100), $callCount);
@@ -103,7 +103,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         self::assertSame(2, $callCount);
     }
 
-    public function testGoToPageChangesStateAndClearsCache()
+    public function testGoToPageChangesStateAndClearsCache(): void
     {
         $callCount = 0;
         $component = $this->createComponent(range(1, 100), $callCount);
@@ -116,7 +116,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         self::assertSame(2, $callCount);
     }
 
-    public function testGoToPageRejectsInvalidState()
+    public function testGoToPageRejectsInvalidState(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Page must be greater than or equal to 1.');
@@ -124,7 +124,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         $this->createComponent(range(1, 100))->goToPage(0);
     }
 
-    public function testNextAndPreviousPageRespectAvailableNavigation()
+    public function testNextAndPreviousPageRespectAvailableNavigation(): void
     {
         $component = $this->createComponent(range(1, 25));
 
@@ -142,7 +142,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         self::assertSame(3, $component->page);
     }
 
-    public function testResetPageIsAvailableForFilterChanges()
+    public function testResetPageIsAvailableForFilterChanges(): void
     {
         $component = $this->createComponent(range(1, 100));
         $component->page = 4;
@@ -152,7 +152,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         self::assertSame(1, $component->page);
     }
 
-    public function testPaginationLinkAttributesBridgeLinksToTheLiveAction()
+    public function testPaginationLinkAttributesBridgeLinksToTheLiveAction(): void
     {
         $attributes = $this->createComponent(range(1, 50))
             ->getPaginationLinkAttributes()([
@@ -169,7 +169,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         ], $attributes);
     }
 
-    public function testPagePropUrlParameterFollowsTheConfiguredPageParameter()
+    public function testPagePropUrlParameterFollowsTheConfiguredPageParameter(): void
     {
         $paginator = new Paginator([new ArrayPaginationAdapter()]);
         $component = new class($paginator) {
@@ -193,7 +193,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         self::assertFalse($url->mapPath);
     }
 
-    public function testCapturesThePageRouteAndKeepsItDuringLiveRequests()
+    public function testCapturesThePageRouteAndKeepsItDuringLiveRequests(): void
     {
         $routes = new RouteCollection();
         $routes->add('demo_page', new Route('/demo'));
@@ -222,7 +222,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         self::assertSame('/demo?page=3', $component->getPagination()->getNextUrl());
     }
 
-    public function testAnAlreadyCapturedRouteIsNeverOverwritten()
+    public function testAnAlreadyCapturedRouteIsNeverOverwritten(): void
     {
         $stack = new RequestStack();
         $otherPageRequest = Request::create('/other');
@@ -238,7 +238,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         self::assertSame('captured_page', $component->paginationRoute);
     }
 
-    public function testNeverCapturesTheInternalLiveComponentRoute()
+    public function testNeverCapturesTheInternalLiveComponentRoute(): void
     {
         $stack = new RequestStack();
         $liveRequest = Request::create('/_components/foo');
@@ -276,7 +276,7 @@ final class ComponentWithPaginationTraitTest extends TestCase
         };
     }
 
-    public function testGoToPageArgumentIsExplicitlyMapped()
+    public function testGoToPageArgumentIsExplicitlyMapped(): void
     {
         $parameter = new \ReflectionMethod(ComponentWithPaginationTrait::class, 'goToPage')->getParameters()[0];
         $attributes = $parameter->getAttributes(LiveArg::class);

--- a/src/Pagination/tests/NavigationTest.php
+++ b/src/Pagination/tests/NavigationTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Pagination\Navigation\PaginationUrlGenerator;
 #[CoversClass(Navigation::class)]
 final class NavigationTest extends TestCase
 {
-    public function testSlidingDefault()
+    public function testSlidingDefault(): void
     {
         $nav = $this->navigation(5, 20);
         $links = $this->toArray($nav);
@@ -36,7 +36,7 @@ final class NavigationTest extends TestCase
         self::assertContains('...', $pages);
     }
 
-    public function testSlidingFirstPage()
+    public function testSlidingFirstPage(): void
     {
         $nav = $this->navigation(1, 20);
         $links = $this->toArray($nav);
@@ -48,7 +48,7 @@ final class NavigationTest extends TestCase
         self::assertFalse($first->isGap);
     }
 
-    public function testSlidingLastPage()
+    public function testSlidingLastPage(): void
     {
         $nav = $this->navigation(20, 20);
         $links = $this->toArray($nav);
@@ -59,7 +59,7 @@ final class NavigationTest extends TestCase
         self::assertTrue($last->isCurrent);
     }
 
-    public function testSlidingSize()
+    public function testSlidingSize(): void
     {
         $nav = $this->navigation(10, 20, NavigationMode::Sliding, 7);
         $links = $this->toArray($nav);
@@ -70,13 +70,13 @@ final class NavigationTest extends TestCase
         );
     }
 
-    public function testSlidingRejectsEmptySize()
+    public function testSlidingRejectsEmptySize(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->navigation(10, 20, NavigationMode::Sliding, 0);
     }
 
-    public function testFixedMode()
+    public function testFixedMode(): void
     {
         $nav = $this->navigation(3, 20, NavigationMode::Fixed, 5);
         $links = $this->toArray($nav);
@@ -91,13 +91,13 @@ final class NavigationTest extends TestCase
         }
     }
 
-    public function testFixedRejectsSizeBelowOne()
+    public function testFixedRejectsSizeBelowOne(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->navigation(3, 20, NavigationMode::Fixed, 0);
     }
 
-    public function testFullMode()
+    public function testFullMode(): void
     {
         $nav = $this->navigation(3, 10, NavigationMode::Full, 500);
         $links = $this->toArray($nav);
@@ -115,7 +115,7 @@ final class NavigationTest extends TestCase
         self::assertFalse($links[0]->isCurrent);
     }
 
-    public function testFullModeRefusesAnUnboundedNumberOfLinks()
+    public function testFullModeRefusesAnUnboundedNumberOfLinks(): void
     {
         $nav = $this->navigation(3, 501, NavigationMode::Full, 500);
 
@@ -124,14 +124,14 @@ final class NavigationTest extends TestCase
         iterator_to_array($nav);
     }
 
-    public function testFullModeAcceptsAnExplicitHigherLimit()
+    public function testFullModeAcceptsAnExplicitHigherLimit(): void
     {
         $nav = $this->navigation(3, 501, NavigationMode::Full, 501);
 
         self::assertCount(501, $nav);
     }
 
-    public function testNullTotalPagesYieldsNothing()
+    public function testNullTotalPagesYieldsNothing(): void
     {
         $paginationUrlGenerator = new PaginationUrlGenerator(basePath: '/items');
         $nav = new Navigation(1, null, $paginationUrlGenerator);
@@ -139,7 +139,7 @@ final class NavigationTest extends TestCase
         self::assertCount(0, $nav);
     }
 
-    public function testZeroTotalPagesYieldsNothing()
+    public function testZeroTotalPagesYieldsNothing(): void
     {
         $paginationUrlGenerator = new PaginationUrlGenerator(basePath: '/items');
         $nav = new Navigation(1, 0, $paginationUrlGenerator);
@@ -148,7 +148,7 @@ final class NavigationTest extends TestCase
         self::assertSame([], $this->toArray($nav));
     }
 
-    public function testCountSlidingMode()
+    public function testCountSlidingMode(): void
     {
         $nav = $this->navigation(5, 20);
 
@@ -157,21 +157,21 @@ final class NavigationTest extends TestCase
         self::assertSame(\count($links), $nav->count());
     }
 
-    public function testCountSlidingModeFirstPage()
+    public function testCountSlidingModeFirstPage(): void
     {
         $nav = $this->navigation(1, 20);
         $links = $this->toArray($nav);
         self::assertSame(\count($links), $nav->count());
     }
 
-    public function testCountSlidingModeLastPage()
+    public function testCountSlidingModeLastPage(): void
     {
         $nav = $this->navigation(20, 20);
         $links = $this->toArray($nav);
         self::assertSame(\count($links), $nav->count());
     }
 
-    public function testCountSlidingModeSmallRange()
+    public function testCountSlidingModeSmallRange(): void
     {
         // totalPages fits within the range, no gaps
         $nav = $this->navigation(2, 3);
@@ -179,48 +179,48 @@ final class NavigationTest extends TestCase
         self::assertSame(\count($links), $nav->count());
     }
 
-    public function testCountFixedMode()
+    public function testCountFixedMode(): void
     {
         $nav = $this->navigation(7, 20, NavigationMode::Fixed, 5);
         $links = $this->toArray($nav);
         self::assertSame(\count($links), $nav->count());
     }
 
-    public function testCountFixedModeFirstBlock()
+    public function testCountFixedModeFirstBlock(): void
     {
         $nav = $this->navigation(1, 20, NavigationMode::Fixed, 5);
         $links = $this->toArray($nav);
         self::assertSame(\count($links), $nav->count());
     }
 
-    public function testCountFixedModeLastBlock()
+    public function testCountFixedModeLastBlock(): void
     {
         $nav = $this->navigation(20, 20, NavigationMode::Fixed, 5);
         $links = $this->toArray($nav);
         self::assertSame(\count($links), $nav->count());
     }
 
-    public function testCountFullMode()
+    public function testCountFullMode(): void
     {
         $nav = $this->navigation(5, 15, NavigationMode::Full, 500);
         self::assertSame(15, $nav->count());
     }
 
-    public function testCountNullTotalPages()
+    public function testCountNullTotalPages(): void
     {
         $paginationUrlGenerator = new PaginationUrlGenerator(basePath: '/items');
         $nav = new Navigation(1, null, $paginationUrlGenerator);
         self::assertSame(0, $nav->count());
     }
 
-    public function testCountZeroTotalPages()
+    public function testCountZeroTotalPages(): void
     {
         $paginationUrlGenerator = new PaginationUrlGenerator(basePath: '/items');
         $nav = new Navigation(1, 0, $paginationUrlGenerator);
         self::assertSame(0, $nav->count());
     }
 
-    public function testFixedModeMiddleBlock()
+    public function testFixedModeMiddleBlock(): void
     {
         // Page 12 of 30 with block size 5: current block is [11-15]
         $nav = $this->navigation(12, 30, NavigationMode::Fixed, 5);
@@ -236,7 +236,7 @@ final class NavigationTest extends TestCase
         self::assertContains('...', $pages);
     }
 
-    public function testFixedModeAdjacentBlocks()
+    public function testFixedModeAdjacentBlocks(): void
     {
         // Page 6 of 20 with block size 5: current block is [6-10], adjacent to first block [1-5]
         $nav = $this->navigation(6, 20, NavigationMode::Fixed, 5);
@@ -248,7 +248,7 @@ final class NavigationTest extends TestCase
         self::assertContains('6', $pages);
     }
 
-    public function testFixedModeLastBlock()
+    public function testFixedModeLastBlock(): void
     {
         // Page 19 of 20 with block size 5: current block is [16-20] which IS the last block
         $nav = $this->navigation(19, 20, NavigationMode::Fixed, 5);
@@ -260,7 +260,7 @@ final class NavigationTest extends TestCase
         self::assertSame(20, $last->page);
     }
 
-    public function testSlidingNearStartNoGapBefore()
+    public function testSlidingNearStartNoGapBefore(): void
     {
         // Page 2 of 20 with default proximity: range starts at 1, no gap before
         $nav = $this->navigation(2, 20);
@@ -271,7 +271,7 @@ final class NavigationTest extends TestCase
         self::assertFalse($first->isGap);
     }
 
-    public function testSlidingNearEndNoGapAfter()
+    public function testSlidingNearEndNoGapAfter(): void
     {
         // Page 19 of 20: range ends at 20, no gap after
         $nav = $this->navigation(19, 20);
@@ -283,7 +283,7 @@ final class NavigationTest extends TestCase
         self::assertFalse($last->isGap);
     }
 
-    public function testSlidingGapOnBothSides()
+    public function testSlidingGapOnBothSides(): void
     {
         $nav = $this->navigation(10, 20);
         $links = $this->toArray($nav);
@@ -293,7 +293,7 @@ final class NavigationTest extends TestCase
         self::assertCount(2, $gaps);
     }
 
-    public function testSlidingNoGapWhenRangeAdjacentToFirst()
+    public function testSlidingNoGapWhenRangeAdjacentToFirst(): void
     {
         // Page 3 of 20 with size 5: range [1..5], no gap before
         $nav = $this->navigation(3, 20, NavigationMode::Sliding, 5);
@@ -304,7 +304,7 @@ final class NavigationTest extends TestCase
         self::assertSame(1, $links[0]->page);
     }
 
-    public function testSlidingNoGapWhenRangeAdjacentToLast()
+    public function testSlidingNoGapWhenRangeAdjacentToLast(): void
     {
         // Page 18 of 20 with size 5: range [16..20], no gap after
         $nav = $this->navigation(18, 20, NavigationMode::Sliding, 5);

--- a/src/Pagination/tests/PageLinkTest.php
+++ b/src/Pagination/tests/PageLinkTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\Pagination\Navigation\PageLink;
 #[CoversClass(PageLink::class)]
 final class PageLinkTest extends TestCase
 {
-    public function testConstructorSetsProperties()
+    public function testConstructorSetsProperties(): void
     {
         $link = new PageLink(
             page: 5,
@@ -37,7 +37,7 @@ final class PageLinkTest extends TestCase
         self::assertFalse($link->isGap());
     }
 
-    public function testGapLink()
+    public function testGapLink(): void
     {
         $link = new PageLink(
             page: 0,
@@ -50,7 +50,7 @@ final class PageLinkTest extends TestCase
         self::assertFalse($link->isCurrent);
     }
 
-    public function testRegularLink()
+    public function testRegularLink(): void
     {
         $link = new PageLink(
             page: 3,

--- a/src/Pagination/tests/PaginationBuilderTest.php
+++ b/src/Pagination/tests/PaginationBuilderTest.php
@@ -28,7 +28,7 @@ use Symfony\UX\Pagination\PaginationBuilder;
 #[CoversClass(PaginationBuilder::class)]
 final class PaginationBuilderTest extends TestCase
 {
-    public function testBasicBuild()
+    public function testBasicBuild(): void
     {
         $builder = $this->builder(range(1, 100));
         $result = $builder->paginate(page: 1);
@@ -39,7 +39,7 @@ final class PaginationBuilderTest extends TestCase
     }
 
     #[DataProvider('invalidRequestPages')]
-    public function testInvalidRequestPageIsRejected(mixed $value)
+    public function testInvalidRequestPageIsRejected(mixed $value): void
     {
         $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
         $requestStack->push(new \Symfony\Component\HttpFoundation\Request(['page' => $value]));
@@ -65,7 +65,7 @@ final class PaginationBuilderTest extends TestCase
         yield 'integer overflow' => [str_repeat('9', 100)];
     }
 
-    public function testRoutePageHasPriorityOverQueryPage()
+    public function testRoutePageHasPriorityOverQueryPage(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request(['page' => '9']);
         $request->attributes->set('page', '3');
@@ -82,7 +82,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(3, $result->getCurrentPage());
     }
 
-    public function testPerPage()
+    public function testPerPage(): void
     {
         $result = $this->builder(range(1, 100))->perPage(5)->paginate(page: 2);
 
@@ -91,13 +91,13 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame([6, 7, 8, 9, 10], $result->getItems());
     }
 
-    public function testPerPageThrowsForInvalid()
+    public function testPerPageThrowsForInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->builder([])->perPage(0);
     }
 
-    public function testPerPageRejectsIntegerOverflow()
+    public function testPerPageRejectsIntegerOverflow(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('less than PHP_INT_MAX');
@@ -105,7 +105,7 @@ final class PaginationBuilderTest extends TestCase
         $this->builder([])->perPage(\PHP_INT_MAX);
     }
 
-    public function testDeveloperPerPageIsNotSilentlyCapped()
+    public function testDeveloperPerPageIsNotSilentlyCapped(): void
     {
         $result = $this->builder(range(1, 2000))->perPage(1500)->paginate();
 
@@ -113,21 +113,21 @@ final class PaginationBuilderTest extends TestCase
         self::assertCount(1500, $result);
     }
 
-    public function testSlidingRejectsEmptyWindow()
+    public function testSlidingRejectsEmptyWindow(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('size must be >= 1.');
         $this->builder([])->sliding(0);
     }
 
-    public function testFixedRejectsEmptyWindow()
+    public function testFixedRejectsEmptyWindow(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('size must be >= 1.');
         $this->builder([])->fixed(0);
     }
 
-    public function testSlidingMode()
+    public function testSlidingMode(): void
     {
         $result = $this->builder(range(1, 200))->sliding(7)->paginate(page: 10);
 
@@ -135,7 +135,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertNotEmpty($links);
     }
 
-    public function testFixedMode()
+    public function testFixedMode(): void
     {
         $result = $this->builder(range(1, 200))->fixed(5)->paginate(page: 3);
 
@@ -143,7 +143,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertNotEmpty($links);
     }
 
-    public function testFullMode()
+    public function testFullMode(): void
     {
         $result = $this->builder(range(1, 50))->perPage(10)->full()->paginate(page: 3);
 
@@ -153,14 +153,14 @@ final class PaginationBuilderTest extends TestCase
         self::assertCount(5, $nonGaps);
     }
 
-    public function testFullRejectsInvalidMaximum()
+    public function testFullRejectsInvalidMaximum(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('maxPages must be >= 1.');
         $this->builder([])->full(0);
     }
 
-    public function testLookahead()
+    public function testLookahead(): void
     {
         $result = $this->builder(range(1, 50))->lookahead()->paginate(page: 1);
 
@@ -170,7 +170,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertCount(20, $result);
     }
 
-    public function testLookaheadCannotBeCombinedWithAnExactTotal()
+    public function testLookaheadCannotBeCombinedWithAnExactTotal(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('lookahead() cannot be combined with total()');
@@ -181,7 +181,7 @@ final class PaginationBuilderTest extends TestCase
             ->paginate();
     }
 
-    public function testLookaheadCannotThrowOnAnUnknownLastPage()
+    public function testLookaheadCannotThrowOnAnUnknownLastPage(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('lookahead() cannot be combined with throwOnOutOfRange()');
@@ -192,7 +192,7 @@ final class PaginationBuilderTest extends TestCase
             ->paginate();
     }
 
-    public function testLookaheadRejectsAnAdapterWithoutLookaheadSupport()
+    public function testLookaheadRejectsAnAdapterWithoutLookaheadSupport(): void
     {
         $source = new \stdClass();
         $adapter = new class implements OffsetAdapterInterface {
@@ -218,7 +218,7 @@ final class PaginationBuilderTest extends TestCase
         new PaginationBuilder($source, [$adapter])->lookahead()->paginate();
     }
 
-    public function testExplicitAdapterMustSupportTheSelectedMode()
+    public function testExplicitAdapterMustSupportTheSelectedMode(): void
     {
         $adapter = new class implements OffsetAdapterInterface {
             public function supports(mixed $source): bool
@@ -243,7 +243,7 @@ final class PaginationBuilderTest extends TestCase
         new PaginationBuilder(new \stdClass(), [], adapter: $adapter)->lookahead()->paginate();
     }
 
-    public function testOffsetResolutionSkipsACursorOnlyAdapterForTheSameSource()
+    public function testOffsetResolutionSkipsACursorOnlyAdapterForTheSameSource(): void
     {
         $source = new \stdClass();
         $cursorAdapter = new class implements CursorAdapterInterface {
@@ -289,7 +289,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(['offset'], $pagination->getItems());
     }
 
-    public function testAppends()
+    public function testAppends(): void
     {
         $result = $this->builder(range(1, 100))
             ->queryParameters(['q' => 'test', 'sort' => 'name'])
@@ -300,7 +300,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertStringContainsString('sort=name', $url);
     }
 
-    public function testFragment()
+    public function testFragment(): void
     {
         $result = $this->builder(range(1, 100))
             ->fragment('results')
@@ -310,7 +310,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertStringContainsString('#results', $url);
     }
 
-    public function testWithPath()
+    public function testWithPath(): void
     {
         $result = $this->builder(range(1, 100))
             ->path('/admin/posts')
@@ -320,7 +320,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertStringStartsWith('/admin/posts', $url);
     }
 
-    public function testQueryParam()
+    public function testQueryParam(): void
     {
         $result = $this->builder(range(1, 100))
             ->pageParameter('p')
@@ -331,7 +331,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertStringNotContainsString('page=', $url);
     }
 
-    public function testQueryParameterNameCannotBeEmpty()
+    public function testQueryParameterNameCannotBeEmpty(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('must not be empty');
@@ -339,7 +339,7 @@ final class PaginationBuilderTest extends TestCase
         $this->builder([])->pageParameter('');
     }
 
-    public function testImmutability()
+    public function testImmutability(): void
     {
         $builder = $this->builder(range(1, 100));
         $modified = $builder->perPage(5);
@@ -354,13 +354,13 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(5, $result2->getItemsPerPage());
     }
 
-    public function testPaginateThrowsForInvalidPage()
+    public function testPaginateThrowsForInvalidPage(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->builder([])->paginate(page: 0);
     }
 
-    public function testDefaultMaximumOffsetAllowsItsBoundary()
+    public function testDefaultMaximumOffsetAllowsItsBoundary(): void
     {
         $pagination = $this->builder([])
             ->perPage(20)
@@ -369,7 +369,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(5001, $pagination->getCurrentPage());
     }
 
-    public function testDefaultMaximumOffsetRejectsLargerPagesWithCursorGuidance()
+    public function testDefaultMaximumOffsetRejectsLargerPagesWithCursorGuidance(): void
     {
         $this->expectException(OffsetLimitExceededException::class);
         $this->expectExceptionMessage('maximum offset of 100000');
@@ -380,7 +380,7 @@ final class PaginationBuilderTest extends TestCase
             ->paginate(page: 5002);
     }
 
-    public function testMaximumOffsetCanBeRaisedExplicitly()
+    public function testMaximumOffsetCanBeRaisedExplicitly(): void
     {
         $pagination = $this->builder([])
             ->perPage(20)
@@ -390,7 +390,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(5002, $pagination->getCurrentPage());
     }
 
-    public function testMaximumOffsetRejectsIntegerOverflow()
+    public function testMaximumOffsetRejectsIntegerOverflow(): void
     {
         $this->expectException(OffsetLimitExceededException::class);
 
@@ -400,7 +400,7 @@ final class PaginationBuilderTest extends TestCase
             ->paginate(page: \PHP_INT_MAX);
     }
 
-    public function testMaximumOffsetMustBePositiveOrZero()
+    public function testMaximumOffsetMustBePositiveOrZero(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('maxOffset must be >= 0.');
@@ -408,7 +408,7 @@ final class PaginationBuilderTest extends TestCase
         $this->builder([])->maxOffset(-1);
     }
 
-    public function testThrowsForUnsupportedSource()
+    public function testThrowsForUnsupportedSource(): void
     {
         $builder = new PaginationBuilder(
             source: new \stdClass(),
@@ -419,7 +419,7 @@ final class PaginationBuilderTest extends TestCase
         $builder->paginate();
     }
 
-    public function testWithTotalInt()
+    public function testWithTotalInt(): void
     {
         $result = $this->builder(range(1, 100))
             ->total(50)
@@ -430,7 +430,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertCount(20, $result); // Still returns 20 items on the page
     }
 
-    public function testWithTotalCallable()
+    public function testWithTotalCallable(): void
     {
         $result = $this->builder(range(1, 100))
             ->total(static fn () => 42)
@@ -440,7 +440,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(3, $result->getTotalPages()); // 42 items / 20 per page = ceil(2.1) = 3 pages
     }
 
-    public function testWithTotalCallableThrowsForInvalidReturn()
+    public function testWithTotalCallableThrowsForInvalidReturn(): void
     {
         $result = $this->builder(range(1, 100))
             ->total(static fn () => 'invalid')
@@ -451,7 +451,7 @@ final class PaginationBuilderTest extends TestCase
         $result->getTotalItems();
     }
 
-    public function testWithTotalRejectsNegativeInteger()
+    public function testWithTotalRejectsNegativeInteger(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('greater than or equal to 0');
@@ -459,7 +459,7 @@ final class PaginationBuilderTest extends TestCase
         $this->builder([])->total(-1);
     }
 
-    public function testWithTotalAcceptsInvokableService()
+    public function testWithTotalAcceptsInvokableService(): void
     {
         $counter = new class {
             public function __invoke(): int
@@ -473,7 +473,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(73, $result->getTotalItems());
     }
 
-    public function testWithTotalMaintainsImmutability()
+    public function testWithTotalMaintainsImmutability(): void
     {
         $builder = $this->builder(range(1, 100));
         $modified = $builder->total(50);
@@ -487,7 +487,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(50, $result2->getTotalItems());
     }
 
-    public function testWithTotalCaching()
+    public function testWithTotalCaching(): void
     {
         $callCount = 0;
         $callable = static function () use (&$callCount) {
@@ -509,7 +509,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(1, $callCount);
     }
 
-    public function testConstructorRejectsPerPageOverflow()
+    public function testConstructorRejectsPerPageOverflow(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('less than PHP_INT_MAX');
@@ -517,7 +517,7 @@ final class PaginationBuilderTest extends TestCase
         new PaginationBuilder(range(1, 3), [new ArrayPaginationAdapter()], defaultPerPage: \PHP_INT_MAX);
     }
 
-    public function testExposesTheConfiguredPageParameterName()
+    public function testExposesTheConfiguredPageParameterName(): void
     {
         $builder = new PaginationBuilder(range(1, 3), [new ArrayPaginationAdapter()]);
 
@@ -525,7 +525,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame('p', $builder->pageParameter('p')->getPageParameterName());
     }
 
-    public function testExposesWhetherAnExplicitRouteWasConfigured()
+    public function testExposesWhetherAnExplicitRouteWasConfigured(): void
     {
         $builder = new PaginationBuilder(range(1, 3), [new ArrayPaginationAdapter()]);
 
@@ -533,7 +533,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertTrue($builder->route('items_list')->hasRoute());
     }
 
-    public function testWithQueryStringPreservesRequestParams()
+    public function testWithQueryStringPreservesRequestParams(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request(query: ['q' => 'search', 'sort' => 'name']);
         $request->attributes->set('_route', 'item_list');
@@ -553,7 +553,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertStringContainsString('sort=name', $url);
     }
 
-    public function testWithoutQueryStringDiscardsRequestParams()
+    public function testWithoutQueryStringDiscardsRequestParams(): void
     {
         $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
         $requestStack->push(new \Symfony\Component\HttpFoundation\Request(query: ['q' => 'search']));
@@ -565,7 +565,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame('/?page=2', $result->getUrl(2));
     }
 
-    public function testWithoutQueryParametersExcludesAndDeduplicatesNames()
+    public function testWithoutQueryParametersExcludesAndDeduplicatesNames(): void
     {
         $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
         $requestStack->push(new \Symfony\Component\HttpFoundation\Request(query: [
@@ -583,14 +583,14 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame('/?sort=name&page=2', $result->getUrl(2));
     }
 
-    public function testWithoutQueryParametersRejectsEmptyName()
+    public function testWithoutQueryParametersRejectsEmptyName(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('must not be empty');
         $this->builder([])->excludeQueryParameters('');
     }
 
-    public function testRouteWithUrlGenerator()
+    public function testRouteWithUrlGenerator(): void
     {
         $urlGenerator = $this->createStub(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class);
         $urlGenerator->method('generate')
@@ -611,7 +611,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertStringContainsString('category=books', $url);
     }
 
-    public function testPaginateResolvesPageFromRequest()
+    public function testPaginateResolvesPageFromRequest(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request(query: ['page' => '3']);
         $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
@@ -628,7 +628,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(3, $result->getCurrentPage());
     }
 
-    public function testEmptyRequestDefaultsToFirstPage()
+    public function testEmptyRequestDefaultsToFirstPage(): void
     {
         $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
         $requestStack->push(new \Symfony\Component\HttpFoundation\Request());
@@ -638,7 +638,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(1, $result->getCurrentPage());
     }
 
-    public function testExplicitPageDoesNotReadTheRequestStack()
+    public function testExplicitPageDoesNotReadTheRequestStack(): void
     {
         $requestStack = $this->createMock(\Symfony\Component\HttpFoundation\RequestStack::class);
         $requestStack->expects(self::never())->method('getCurrentRequest');
@@ -649,7 +649,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(3, $result->getCurrentPage());
     }
 
-    public function testExplicitAdapterIsUsedWithoutDiscovery()
+    public function testExplicitAdapterIsUsedWithoutDiscovery(): void
     {
         $adapter = new ArrayPaginationAdapter();
         $result = new PaginationBuilder(
@@ -661,7 +661,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(range(1, 10), $result->getItems());
     }
 
-    public function testPaginateResolvesPageFromCustomParam()
+    public function testPaginateResolvesPageFromCustomParam(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request(query: ['p' => '5']);
         $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
@@ -678,7 +678,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(5, $result->getCurrentPage());
     }
 
-    public function testPaginateResolvesPageFromPathParameter()
+    public function testPaginateResolvesPageFromPathParameter(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request();
         $request->attributes->set('_route', 'blog_list');
@@ -699,7 +699,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(4, $result->getCurrentPage());
     }
 
-    public function testPaginatePathParameterPriorityOverQuery()
+    public function testPaginatePathParameterPriorityOverQuery(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request(query: ['page' => '2']);
         $request->attributes->set('_route', 'blog_list');
@@ -720,7 +720,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(8, $result->getCurrentPage());
     }
 
-    public function testPaginatePathParameterWithCustomQueryParam()
+    public function testPaginatePathParameterWithCustomQueryParam(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request();
         $request->attributes->set('_route', 'blog_list');
@@ -741,7 +741,7 @@ final class PaginationBuilderTest extends TestCase
         self::assertSame(6, $result->getCurrentPage());
     }
 
-    public function testThrowOnOutOfRangeThrowsFromBuilder()
+    public function testThrowOnOutOfRangeThrowsFromBuilder(): void
     {
         $this->expectException(OutOfRangePageException::class);
 
@@ -750,7 +750,7 @@ final class PaginationBuilderTest extends TestCase
             ->paginate(page: 5);
     }
 
-    public function testThrowOnOutOfRangeDoesNotThrowWhenInRange()
+    public function testThrowOnOutOfRangeDoesNotThrowWhenInRange(): void
     {
         $result = $this->builder(range(1, 100))
             ->throwOnOutOfRange()

--- a/src/Pagination/tests/PaginationInfoFormatterTest.php
+++ b/src/Pagination/tests/PaginationInfoFormatterTest.php
@@ -25,7 +25,7 @@ use Symfony\UX\Pagination\PaginationInfoFormatter;
 #[CoversClass(PaginationInfoFormatter::class)]
 final class PaginationInfoFormatterTest extends TestCase
 {
-    public function testEnglishFallbackForEmptyNumberedPaginationWithTotal()
+    public function testEnglishFallbackForEmptyNumberedPaginationWithTotal(): void
     {
         $formatter = new PaginationInfoFormatter();
         $pagination = $this->createPagination([], 1, 10);
@@ -33,21 +33,21 @@ final class PaginationInfoFormatterTest extends TestCase
         self::assertSame('No items', $formatter->format($pagination));
     }
 
-    public function testEnglishFallbackForEmptyCursorPagination()
+    public function testEnglishFallbackForEmptyCursorPagination(): void
     {
         $formatter = new PaginationInfoFormatter();
 
         self::assertSame('No items', $formatter->formatCursor($this->createCursorPagination([], false)));
     }
 
-    public function testEnglishFallbackForNumberedPaginationWithTotal()
+    public function testEnglishFallbackForNumberedPaginationWithTotal(): void
     {
         $formatter = new PaginationInfoFormatter();
 
         self::assertSame('Showing 11-20 of 30', $formatter->format($this->createPagination(range(1, 30), 2, 10)));
     }
 
-    public function testEnglishFallbackForNumberedPaginationWithoutTotal()
+    public function testEnglishFallbackForNumberedPaginationWithoutTotal(): void
     {
         $formatter = new PaginationInfoFormatter();
         $pagination = new Pagination(
@@ -62,7 +62,7 @@ final class PaginationInfoFormatterTest extends TestCase
         self::assertSame('Showing 11-20', $formatter->format($pagination));
     }
 
-    public function testEnglishFallbackForCursorPaginationWithMore()
+    public function testEnglishFallbackForCursorPaginationWithMore(): void
     {
         $formatter = new PaginationInfoFormatter();
 
@@ -72,7 +72,7 @@ final class PaginationInfoFormatterTest extends TestCase
         );
     }
 
-    public function testEnglishFallbackPluralizesASingleItem()
+    public function testEnglishFallbackPluralizesASingleItem(): void
     {
         $formatter = new PaginationInfoFormatter();
 
@@ -86,7 +86,7 @@ final class PaginationInfoFormatterTest extends TestCase
         );
     }
 
-    public function testEnglishFallbackForLastCursorPage()
+    public function testEnglishFallbackForLastCursorPage(): void
     {
         $formatter = new PaginationInfoFormatter();
 
@@ -96,7 +96,7 @@ final class PaginationInfoFormatterTest extends TestCase
         );
     }
 
-    public function testFormatWithTotal()
+    public function testFormatWithTotal(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects(self::once())
@@ -116,7 +116,7 @@ final class PaginationInfoFormatterTest extends TestCase
         self::assertSame('Showing 11-20 of 100', $result);
     }
 
-    public function testFormatWithoutTotal()
+    public function testFormatWithoutTotal(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects(self::once())
@@ -143,7 +143,7 @@ final class PaginationInfoFormatterTest extends TestCase
         self::assertSame('Showing 11-20', $result);
     }
 
-    public function testFormatFirstPage()
+    public function testFormatFirstPage(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects(self::once())
@@ -163,7 +163,7 @@ final class PaginationInfoFormatterTest extends TestCase
         self::assertSame('Showing 1-10 of 50', $result);
     }
 
-    public function testFormatLastPage()
+    public function testFormatLastPage(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects(self::once())
@@ -183,7 +183,7 @@ final class PaginationInfoFormatterTest extends TestCase
         self::assertSame('Showing 21-25 of 25', $result);
     }
 
-    public function testFormatCursorNoItems()
+    public function testFormatCursorNoItems(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects(self::once())
@@ -203,7 +203,7 @@ final class PaginationInfoFormatterTest extends TestCase
         self::assertSame('No items', $result);
     }
 
-    public function testFormatCursorWithMore()
+    public function testFormatCursorWithMore(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects(self::once())
@@ -223,7 +223,7 @@ final class PaginationInfoFormatterTest extends TestCase
         self::assertSame('Showing 10 items', $result);
     }
 
-    public function testFormatNoItems()
+    public function testFormatNoItems(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects(self::once())
@@ -244,7 +244,7 @@ final class PaginationInfoFormatterTest extends TestCase
         self::assertSame('No results', $result);
     }
 
-    public function testFormatCursorLastPage()
+    public function testFormatCursorLastPage(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->expects(self::once())

--- a/src/Pagination/tests/PaginationTest.php
+++ b/src/Pagination/tests/PaginationTest.php
@@ -25,7 +25,7 @@ use Symfony\UX\Pagination\Pagination;
 #[CoversClass(Pagination::class)]
 final class PaginationTest extends TestCase
 {
-    public function testConstructorRejectsInvalidArguments()
+    public function testConstructorRejectsInvalidArguments(): void
     {
         $arguments = [
             [0, 10, 100_000, 'currentPage'],
@@ -51,7 +51,7 @@ final class PaginationTest extends TestCase
         }
     }
 
-    public function testConstructorRejectsOffsetIntegerOverflow()
+    public function testConstructorRejectsOffsetIntegerOverflow(): void
     {
         $this->expectException(\Symfony\UX\Pagination\Exception\OffsetLimitExceededException::class);
         new Pagination(
@@ -64,7 +64,7 @@ final class PaginationTest extends TestCase
         );
     }
 
-    public function testConstructorRejectsOffsetAboveConfiguredLimit()
+    public function testConstructorRejectsOffsetAboveConfiguredLimit(): void
     {
         $this->expectException(\Symfony\UX\Pagination\Exception\OffsetLimitExceededException::class);
         new Pagination(
@@ -77,7 +77,7 @@ final class PaginationTest extends TestCase
         );
     }
 
-    public function testConstructorRequiresTheCapabilityMatchingTheSelectedMode()
+    public function testConstructorRequiresTheCapabilityMatchingTheSelectedMode(): void
     {
         $adapter = new class implements PaginationAdapterInterface {
             public function supports(mixed $source): bool
@@ -103,7 +103,7 @@ final class PaginationTest extends TestCase
         }
     }
 
-    public function testIterateReturnsItems()
+    public function testIterateReturnsItems(): void
     {
         $pagination = $this->paginate(range(1, 100), 1, 10);
 
@@ -115,14 +115,14 @@ final class PaginationTest extends TestCase
         self::assertSame([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], $items);
     }
 
-    public function testItemsReturnsArray()
+    public function testItemsReturnsArray(): void
     {
         $pagination = $this->paginate(range(1, 50), 2, 10);
 
         self::assertSame([11, 12, 13, 14, 15, 16, 17, 18, 19, 20], $pagination->getItems());
     }
 
-    public function testCountReturnsItemsOnThisPage()
+    public function testCountReturnsItemsOnThisPage(): void
     {
         $pagination = $this->paginate(range(1, 25), 3, 10);
 
@@ -130,7 +130,7 @@ final class PaginationTest extends TestCase
         self::assertCount(5, $pagination);
     }
 
-    public function testMapTransformsItemsToAnotherType()
+    public function testMapTransformsItemsToAnotherType(): void
     {
         $pagination = $this->paginate([1, 2, 3], 1, 10);
         $labels = $pagination->map(static fn (int $item): string => 'item-'.$item);
@@ -140,7 +140,7 @@ final class PaginationTest extends TestCase
         self::assertSame([1, 2, 3], $pagination->getItems());
     }
 
-    public function testMetadata()
+    public function testMetadata(): void
     {
         $pagination = $this->paginate(range(1, 100), 3, 10);
 
@@ -153,7 +153,7 @@ final class PaginationTest extends TestCase
         self::assertFalse($pagination->isEmpty());
     }
 
-    public function testEmptyResult()
+    public function testEmptyResult(): void
     {
         $pagination = $this->paginate([], 1, 10);
 
@@ -165,7 +165,7 @@ final class PaginationTest extends TestCase
         self::assertNull($pagination->getLastItemNumber());
     }
 
-    public function testItemNumbersUseTheActualLastPageSize()
+    public function testItemNumbersUseTheActualLastPageSize(): void
     {
         $pagination = $this->paginate(range(1, 25), 3, 10);
 
@@ -173,7 +173,7 @@ final class PaginationTest extends TestCase
         self::assertSame(25, $pagination->getLastItemNumber());
     }
 
-    public function testNavigationStateFirstPage()
+    public function testNavigationStateFirstPage(): void
     {
         $pagination = $this->paginate(range(1, 100), 1, 10);
 
@@ -183,7 +183,7 @@ final class PaginationTest extends TestCase
         self::assertFalse($pagination->isLast());
     }
 
-    public function testNavigationStateMiddlePage()
+    public function testNavigationStateMiddlePage(): void
     {
         $pagination = $this->paginate(range(1, 100), 5, 10);
 
@@ -193,7 +193,7 @@ final class PaginationTest extends TestCase
         self::assertFalse($pagination->isLast());
     }
 
-    public function testNavigationStateLastPage()
+    public function testNavigationStateLastPage(): void
     {
         $pagination = $this->paginate(range(1, 100), 10, 10);
 
@@ -203,7 +203,7 @@ final class PaginationTest extends TestCase
         self::assertTrue($pagination->isLast());
     }
 
-    public function testSinglePage()
+    public function testSinglePage(): void
     {
         $pagination = $this->paginate([1, 2, 3], 1, 10);
 
@@ -213,7 +213,7 @@ final class PaginationTest extends TestCase
         self::assertTrue($pagination->isLast());
     }
 
-    public function testUrls()
+    public function testUrls(): void
     {
         $pagination = $this->paginate(range(1, 100), 5, 10);
 
@@ -226,7 +226,7 @@ final class PaginationTest extends TestCase
         $pagination->getAbsoluteUrl(5);
     }
 
-    public function testUrlsOnFirstPage()
+    public function testUrlsOnFirstPage(): void
     {
         $pagination = $this->paginate(range(1, 100), 1, 10);
 
@@ -234,7 +234,7 @@ final class PaginationTest extends TestCase
         self::assertNotNull($pagination->getNextUrl());
     }
 
-    public function testUrlsOnLastPage()
+    public function testUrlsOnLastPage(): void
     {
         $pagination = $this->paginate(range(1, 100), 10, 10);
 
@@ -242,7 +242,7 @@ final class PaginationTest extends TestCase
         self::assertNotNull($pagination->getPreviousUrl());
     }
 
-    public function testPagesReturnNavigation()
+    public function testPagesReturnNavigation(): void
     {
         $pagination = $this->paginate(range(1, 100), 5, 10);
         $pages = $pagination->getPages();
@@ -257,7 +257,7 @@ final class PaginationTest extends TestCase
         }
     }
 
-    public function testSlidingNavigation()
+    public function testSlidingNavigation(): void
     {
         $pagination = $this->paginate(range(1, 200), 10, 10);
         $links = iterator_to_array($pagination->getPages());
@@ -280,7 +280,7 @@ final class PaginationTest extends TestCase
         self::assertSame(10, $currentLink->page);
     }
 
-    public function testLookaheadMode()
+    public function testLookaheadMode(): void
     {
         $source = range(1, 50);
         $adapter = new ArrayPaginationAdapter();
@@ -305,7 +305,7 @@ final class PaginationTest extends TestCase
         self::assertCount(10, $pagination->getItems());
     }
 
-    public function testLookaheadLastPage()
+    public function testLookaheadLastPage(): void
     {
         $source = range(1, 25);
         $adapter = new ArrayPaginationAdapter();
@@ -324,7 +324,7 @@ final class PaginationTest extends TestCase
         self::assertCount(5, $pagination->getItems());
     }
 
-    public function testItemsAreLazyLoaded()
+    public function testItemsAreLazyLoaded(): void
     {
         $sliceCallCount = 0;
         $innerAdapter = new ArrayPaginationAdapter();
@@ -383,7 +383,7 @@ final class PaginationTest extends TestCase
         self::assertSame(1, $sliceCallCount);
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $pagination = $this->paginate(range(1, 30), 2, 10);
         $json = $pagination->jsonSerialize();
@@ -397,28 +397,28 @@ final class PaginationTest extends TestCase
         self::assertSame(3, $json['total_pages']);
     }
 
-    public function testInfo()
+    public function testInfo(): void
     {
         $pagination = $this->paginate(range(1, 100), 2, 10);
 
         self::assertSame('Showing 11-20 of 100', $pagination->getInfo());
     }
 
-    public function testInfoLastPage()
+    public function testInfoLastPage(): void
     {
         $pagination = $this->paginate(range(1, 25), 3, 10);
 
         self::assertSame('Showing 21-25 of 25', $pagination->getInfo());
     }
 
-    public function testQueryParamReturnsDefault()
+    public function testQueryParamReturnsDefault(): void
     {
         $pagination = $this->paginate(range(1, 10), 1, 10);
 
         self::assertSame('page', $pagination->getPageParameterName());
     }
 
-    public function testQueryParamReturnsCustomValue()
+    public function testQueryParamReturnsCustomValue(): void
     {
         $paginationUrlGenerator = new PaginationUrlGenerator(queryParam: 'p', basePath: '/items');
         $pagination = new Pagination(
@@ -432,21 +432,21 @@ final class PaginationTest extends TestCase
         self::assertSame('p', $pagination->getPageParameterName());
     }
 
-    public function testIsOutOfRangeTrue()
+    public function testIsOutOfRangeTrue(): void
     {
         $pagination = $this->paginate(range(1, 30), 5, 10);
 
         self::assertTrue($pagination->isOutOfRange());
     }
 
-    public function testIsOutOfRangeFalse()
+    public function testIsOutOfRangeFalse(): void
     {
         $pagination = $this->paginate(range(1, 100), 5, 10);
 
         self::assertFalse($pagination->isOutOfRange());
     }
 
-    public function testIsOutOfRangeFalseInLookaheadMode()
+    public function testIsOutOfRangeFalseInLookaheadMode(): void
     {
         $pagination = new Pagination(
             source: range(1, 10),
@@ -460,7 +460,7 @@ final class PaginationTest extends TestCase
         self::assertFalse($pagination->isOutOfRange());
     }
 
-    public function testThrowOnOutOfRangeThrows()
+    public function testThrowOnOutOfRangeThrows(): void
     {
         $pagination = $this->paginate(range(1, 30), 5, 10);
 
@@ -470,7 +470,7 @@ final class PaginationTest extends TestCase
         $pagination->throwOnOutOfRange();
     }
 
-    public function testThrowOnOutOfRangeReturnsSelfWhenInRange()
+    public function testThrowOnOutOfRangeReturnsSelfWhenInRange(): void
     {
         $pagination = $this->paginate(range(1, 100), 5, 10);
 
@@ -479,7 +479,7 @@ final class PaginationTest extends TestCase
         self::assertSame($pagination, $result);
     }
 
-    public function testMeta()
+    public function testMeta(): void
     {
         $pagination = $this->paginate(range(1, 50), 2, 10);
         $meta = $pagination->getMetadata();
@@ -492,7 +492,7 @@ final class PaginationTest extends TestCase
         self::assertSame(5, $meta['total_pages']);
     }
 
-    public function testMetaInLookaheadMode()
+    public function testMetaInLookaheadMode(): void
     {
         $pagination = new Pagination(
             source: range(1, 50),
@@ -510,7 +510,7 @@ final class PaginationTest extends TestCase
         self::assertTrue($meta['has_next']);
     }
 
-    public function testLinks()
+    public function testLinks(): void
     {
         $pagination = $this->paginate(range(1, 50), 2, 10);
         $links = $pagination->getLinks();
@@ -526,7 +526,7 @@ final class PaginationTest extends TestCase
         self::assertNotNull($links['next']);
     }
 
-    public function testLinksFirstPage()
+    public function testLinksFirstPage(): void
     {
         $pagination = $this->paginate(range(1, 50), 1, 10);
         $links = $pagination->getLinks();
@@ -535,7 +535,7 @@ final class PaginationTest extends TestCase
         self::assertNotNull($links['next']);
     }
 
-    public function testLinksLastPage()
+    public function testLinksLastPage(): void
     {
         $pagination = $this->paginate(range(1, 50), 5, 10);
         $links = $pagination->getLinks();
@@ -544,7 +544,7 @@ final class PaginationTest extends TestCase
         self::assertNull($links['next']);
     }
 
-    public function testLastUrl()
+    public function testLastUrl(): void
     {
         $pagination = $this->paginate(range(1, 50), 1, 10);
 
@@ -554,7 +554,7 @@ final class PaginationTest extends TestCase
         self::assertStringContainsString('page=5', $lastUrl);
     }
 
-    public function testLastUrlIsUnknownWithLookahead()
+    public function testLastUrlIsUnknownWithLookahead(): void
     {
         $pagination = new Pagination(
             source: range(1, 20),
@@ -568,7 +568,7 @@ final class PaginationTest extends TestCase
         self::assertNull($pagination->getLastUrl());
     }
 
-    public function testFirstUrlOmitsPageParam()
+    public function testFirstUrlOmitsPageParam(): void
     {
         $pagination = $this->paginate(range(1, 100), 5, 10);
 
@@ -577,7 +577,7 @@ final class PaginationTest extends TestCase
         self::assertStringNotContainsString('page=', $firstUrl);
     }
 
-    public function testTotalInt()
+    public function testTotalInt(): void
     {
         $pagination = new Pagination(
             source: range(1, 100),
@@ -592,7 +592,7 @@ final class PaginationTest extends TestCase
         self::assertSame(5, $pagination->getTotalPages());
     }
 
-    public function testTotalPagesKeepsIntegerPrecisionForLargeCounts()
+    public function testTotalPagesKeepsIntegerPrecisionForLargeCounts(): void
     {
         $pagination = new Pagination(
             source: [],
@@ -606,7 +606,7 @@ final class PaginationTest extends TestCase
         self::assertSame(intdiv(\PHP_INT_MAX, 2) + 1, $pagination->getTotalPages());
     }
 
-    public function testNegativeCountIsRejected()
+    public function testNegativeCountIsRejected(): void
     {
         $adapter = $this->createStub(OffsetAdapterInterface::class);
         $adapter->method('count')->willReturn(-1);
@@ -624,7 +624,7 @@ final class PaginationTest extends TestCase
         $pagination->getTotalItems();
     }
 
-    public function testTotalCallable()
+    public function testTotalCallable(): void
     {
         $callCount = 0;
         $pagination = new Pagination(
@@ -645,7 +645,7 @@ final class PaginationTest extends TestCase
         self::assertSame(1, $callCount);
     }
 
-    public function testInfoEmptyWithTotal()
+    public function testInfoEmptyWithTotal(): void
     {
         // Page beyond the last page: count is 0, total is known
         $pagination = $this->paginate(range(1, 10), 5, 10);
@@ -653,7 +653,7 @@ final class PaginationTest extends TestCase
         self::assertSame('No items', $pagination->getInfo());
     }
 
-    public function testInfoEmptyWithoutTotal()
+    public function testInfoEmptyWithoutTotal(): void
     {
         $pagination = new Pagination(
             source: [],
@@ -667,7 +667,7 @@ final class PaginationTest extends TestCase
         self::assertSame('No items', $pagination->getInfo());
     }
 
-    public function testInfoWithFormatter()
+    public function testInfoWithFormatter(): void
     {
         $translator = $this->createStub(\Symfony\Contracts\Translation\TranslatorInterface::class);
         $translator->method('trans')->willReturn('Page 2 sur 5');
@@ -685,7 +685,7 @@ final class PaginationTest extends TestCase
         self::assertSame('Page 2 sur 5', $pagination->getInfo());
     }
 
-    public function testInfoWithoutTotal()
+    public function testInfoWithoutTotal(): void
     {
         $pagination = new Pagination(
             source: range(1, 100),
@@ -699,7 +699,7 @@ final class PaginationTest extends TestCase
         self::assertSame('Showing 11-20', $pagination->getInfo());
     }
 
-    public function testTotalCallableReturningNonIntThrows()
+    public function testTotalCallableReturningNonIntThrows(): void
     {
         $pagination = new Pagination(
             source: range(1, 100),
@@ -716,7 +716,7 @@ final class PaginationTest extends TestCase
         $pagination->getTotalItems();
     }
 
-    public function testPerPageOfOnePaginatesItemByItem()
+    public function testPerPageOfOnePaginatesItemByItem(): void
     {
         $middle = $this->paginate(range(1, 3), 2, 1);
 

--- a/src/Pagination/tests/PaginationUrlGeneratorTest.php
+++ b/src/Pagination/tests/PaginationUrlGeneratorTest.php
@@ -21,7 +21,7 @@ use Symfony\UX\Pagination\Navigation\PaginationUrlGenerator;
 #[CoversClass(PaginationUrlGenerator::class)]
 final class PaginationUrlGeneratorTest extends TestCase
 {
-    public function testParameterNamesCanBeConfiguredImmutably()
+    public function testParameterNamesCanBeConfiguredImmutably(): void
     {
         $generator = new PaginationUrlGenerator(basePath: '/items');
         $configured = $generator
@@ -36,7 +36,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items?after=opaque', $configured->getCursorUrl('opaque'));
     }
 
-    public function testEmptyParameterAndRouteNamesAreRejected()
+    public function testEmptyParameterAndRouteNamesAreRejected(): void
     {
         $generator = new PaginationUrlGenerator();
 
@@ -54,7 +54,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         }
     }
 
-    public function testEmptyExcludedQueryParameterIsRejected()
+    public function testEmptyExcludedQueryParameterIsRejected(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('must not be empty');
@@ -62,7 +62,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         new PaginationUrlGenerator()->withoutQueryParameters('');
     }
 
-    public function testWithRouteReplacesPathConfiguration()
+    public function testWithRouteReplacesPathConfiguration(): void
     {
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects(self::once())
@@ -77,7 +77,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/catalog/books?page=2', $url);
     }
 
-    public function testUrlWithBasePath()
+    public function testUrlWithBasePath(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
 
@@ -86,7 +86,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items?page=10', $recipe->getUrl(10));
     }
 
-    public function testPageUrlsRejectNonPositivePages()
+    public function testPageUrlsRejectNonPositivePages(): void
     {
         $generator = new PaginationUrlGenerator(basePath: '/items');
 
@@ -103,7 +103,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         }
     }
 
-    public function testUrlOmitsPageParamForFirstPage()
+    public function testUrlOmitsPageParamForFirstPage(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
 
@@ -112,7 +112,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringNotContainsString('page=', $url);
     }
 
-    public function testWithQueryParameters()
+    public function testWithQueryParameters(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
         $withQueryParameters = $recipe->withQueryParameters(['sort' => 'name', 'filter' => 'active']);
@@ -124,7 +124,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('page=2', $url);
     }
 
-    public function testWithQueryParametersImmutability()
+    public function testWithQueryParametersImmutability(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
         $withQueryParameters = $recipe->withQueryParameters(['sort' => 'name']);
@@ -133,7 +133,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('sort=name', $withQueryParameters->getUrl(2));
     }
 
-    public function testWithFragment()
+    public function testWithFragment(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
         $withFragment = $recipe->withFragment('results');
@@ -143,7 +143,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('#results', $url);
     }
 
-    public function testWithFragmentImmutability()
+    public function testWithFragmentImmutability(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
         $withFragment = $recipe->withFragment('results');
@@ -152,7 +152,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('#results', $withFragment->getUrl(2));
     }
 
-    public function testWithPath()
+    public function testWithPath(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/old-path');
         $withPath = $recipe->withPath('/new-path');
@@ -160,7 +160,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('/new-path', $withPath->getUrl(2));
     }
 
-    public function testWithQueryString()
+    public function testWithQueryString(): void
     {
         $request = new Request(['existing' => 'param']);
         $requestStack = new RequestStack();
@@ -178,7 +178,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('page=2', $url);
     }
 
-    public function testPreservesQueryStringByDefault()
+    public function testPreservesQueryStringByDefault(): void
     {
         $request = new Request([
             'q' => 'phone',
@@ -200,7 +200,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         ], $query);
     }
 
-    public function testOffsetUrlDropsAnExistingCursorParameter()
+    public function testOffsetUrlDropsAnExistingCursorParameter(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['cursor' => 'old', 'q' => 'phone']));
@@ -210,7 +210,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items?q=phone&page=2', $url);
     }
 
-    public function testWithoutQueryStringDiscardsRequestParameters()
+    public function testWithoutQueryStringDiscardsRequestParameters(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['q' => 'phone']));
@@ -223,7 +223,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items?sort=name&page=2', $url);
     }
 
-    public function testWithoutQueryParametersRemovesSelectedParametersBeforeExplicitParameters()
+    public function testWithoutQueryParametersRemovesSelectedParametersBeforeExplicitParameters(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request(['debug' => '1', 'token' => 'secret', 'sort' => 'price']));
@@ -236,7 +236,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items?sort=name&page=2', $url);
     }
 
-    public function testWithQueryStringExcludesPageParam()
+    public function testWithQueryStringExcludesPageParam(): void
     {
         $request = new Request(['page' => '5', 'sort' => 'name']);
         $requestStack = new RequestStack();
@@ -255,7 +255,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringNotContainsString('page=5', $url);
     }
 
-    public function testCursorUrl()
+    public function testCursorUrl(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
 
@@ -265,7 +265,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringNotContainsString('page=', $url);
     }
 
-    public function testCursorUrlRejectsAnEmptyCursor()
+    public function testCursorUrlRejectsAnEmptyCursor(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cursor value must not be empty');
@@ -273,7 +273,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         new PaginationUrlGenerator(basePath: '/items')->getCursorUrl('');
     }
 
-    public function testCursorUrlWithFragment()
+    public function testCursorUrlWithFragment(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
         $withFragment = $recipe->withFragment('results');
@@ -284,7 +284,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('#results', $url);
     }
 
-    public function testCustomQueryParam()
+    public function testCustomQueryParam(): void
     {
         $recipe = new PaginationUrlGenerator(
             queryParam: 'p',
@@ -295,7 +295,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringNotContainsString('page=', $recipe->getUrl(2));
     }
 
-    public function testUrlWithRouteAndGenerator()
+    public function testUrlWithRouteAndGenerator(): void
     {
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects(self::once())
@@ -314,7 +314,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items/books?page=2', $url);
     }
 
-    public function testUrlWithRouteOmitsPageOneFromParams()
+    public function testUrlWithRouteOmitsPageOneFromParams(): void
     {
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects(self::once())
@@ -333,7 +333,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items/books', $url);
     }
 
-    public function testChainedModifiers()
+    public function testChainedModifiers(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
 
@@ -348,7 +348,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('#list', $url);
     }
 
-    public function testUrlWithNoRequestStackReturnsEmptyPath()
+    public function testUrlWithNoRequestStackReturnsEmptyPath(): void
     {
         $recipe = new PaginationUrlGenerator();
 
@@ -357,14 +357,14 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('?page=2', $url);
     }
 
-    public function testUrlGeneratorWithoutRequestFallsBackToQueryString()
+    public function testUrlGeneratorWithoutRequestFallsBackToQueryString(): void
     {
         $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
 
         self::assertSame('?page=2', new PaginationUrlGenerator(urlGenerator: $urlGenerator)->getUrl(2));
     }
 
-    public function testRequestWithoutRouteNameFallsBackToPath()
+    public function testRequestWithoutRouteNameFallsBackToPath(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(Request::create('/items'));
@@ -376,7 +376,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         )->getUrl(2));
     }
 
-    public function testExposesTheConfiguredRouteName()
+    public function testExposesTheConfiguredRouteName(): void
     {
         $recipe = new PaginationUrlGenerator();
 
@@ -384,7 +384,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('items_list', $recipe->withRoute('items_list')->getRouteName());
     }
 
-    public function testAutoDetectedRouteReceivesMergedParams()
+    public function testAutoDetectedRouteReceivesMergedParams(): void
     {
         $request = new Request();
         $request->attributes->set('_route', 'app_items');
@@ -409,7 +409,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items/books?page=2', $url);
     }
 
-    public function testPreservedQueryParametersCannotOverrideRouteParameters()
+    public function testPreservedQueryParametersCannotOverrideRouteParameters(): void
     {
         $request = Request::create('/articles/php?slug=spoofed&filter=recent');
         $request->attributes->set('_route', 'article_show');
@@ -432,7 +432,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/articles/php?filter=recent&page=2', $recipe->getUrl(2));
     }
 
-    public function testGetCurrentPathFallsBackToPathInfo()
+    public function testGetCurrentPathFallsBackToPathInfo(): void
     {
         $request = Request::create('/my-path');
         $requestStack = new RequestStack();
@@ -448,7 +448,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('page=2', $url);
     }
 
-    public function testCursorUrlWithRoute()
+    public function testCursorUrlWithRoute(): void
     {
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects(self::once())
@@ -466,7 +466,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items?cursor=abc123', $url);
     }
 
-    public function testCursorUrlWithRouteAndFragment()
+    public function testCursorUrlWithRouteAndFragment(): void
     {
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects(self::once())
@@ -485,7 +485,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items?cursor=abc123#results', $url);
     }
 
-    public function testCursorUrlWithQueryString()
+    public function testCursorUrlWithQueryString(): void
     {
         $request = new Request(['sort' => 'name']);
         $requestStack = new RequestStack();
@@ -503,7 +503,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertStringContainsString('cursor=abc123', $url);
     }
 
-    public function testWithQueryStringNoRequest()
+    public function testWithQueryStringNoRequest(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
         $withQs = $recipe->withQueryString();
@@ -513,7 +513,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items?page=2', $url);
     }
 
-    public function testCursorUrlWithNoPath()
+    public function testCursorUrlWithNoPath(): void
     {
         $recipe = new PaginationUrlGenerator();
 
@@ -522,7 +522,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('?cursor=abc123', $url);
     }
 
-    public function testUrlWithRouteAndFragment()
+    public function testUrlWithRouteAndFragment(): void
     {
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects(self::once())
@@ -543,7 +543,7 @@ final class PaginationUrlGeneratorTest extends TestCase
 
     // ── Path-based page parameter tests ──────────────────────
 
-    public function testAutoDetectedRouteWithPageInPath()
+    public function testAutoDetectedRouteWithPageInPath(): void
     {
         $request = new Request();
         $request->attributes->set('_route', 'blog_list');
@@ -568,7 +568,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/blog/3', $url);
     }
 
-    public function testAutoDetectedRoutePageOneOmitsPageParam()
+    public function testAutoDetectedRoutePageOneOmitsPageParam(): void
     {
         $request = new Request();
         $request->attributes->set('_route', 'blog_list');
@@ -594,7 +594,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/blog', $url);
     }
 
-    public function testAutoDetectedRoutePreservesOtherRouteParams()
+    public function testAutoDetectedRoutePreservesOtherRouteParams(): void
     {
         $request = new Request();
         $request->attributes->set('_route', 'category_list');
@@ -619,7 +619,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/blog/php/5', $url);
     }
 
-    public function testCursorUrlWithAutoDetectedRoute()
+    public function testCursorUrlWithAutoDetectedRoute(): void
     {
         $request = new Request();
         $request->attributes->set('_route', 'item_list');
@@ -644,7 +644,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/items/books?cursor=abc123', $url);
     }
 
-    public function testAbsoluteUrlUsesRequestSchemeAndHost()
+    public function testAbsoluteUrlUsesRequestSchemeAndHost(): void
     {
         $request = Request::create('https://example.com/items?page=2');
         $requestStack = new RequestStack();
@@ -655,7 +655,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('https://example.com/items?page=3', $recipe->getAbsoluteUrl(3));
     }
 
-    public function testAbsoluteUrlRequiresRequestOrRouterRoute()
+    public function testAbsoluteUrlRequiresRequestOrRouterRoute(): void
     {
         $recipe = new PaginationUrlGenerator(basePath: '/items');
 
@@ -665,7 +665,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         $recipe->getAbsoluteUrl(3);
     }
 
-    public function testPageOneFallsBackToExplicitParamWhenRouteRequiresIt()
+    public function testPageOneFallsBackToExplicitParamWhenRouteRequiresIt(): void
     {
         $generator = $this->createMock(UrlGeneratorInterface::class);
         $generator->expects(self::exactly(2))
@@ -683,7 +683,7 @@ final class PaginationUrlGeneratorTest extends TestCase
         self::assertSame('/blog/1', $recipe->getUrl(1));
     }
 
-    public function testMissingParamOtherThanPageStillThrows()
+    public function testMissingParamOtherThanPageStillThrows(): void
     {
         $generator = $this->createStub(UrlGeneratorInterface::class);
         $generator->method('generate')

--- a/src/Pagination/tests/PaginatorInterfaceTest.php
+++ b/src/Pagination/tests/PaginatorInterfaceTest.php
@@ -25,7 +25,7 @@ use Symfony\UX\Pagination\PaginatorInterface;
 #[CoversNothing]
 final class PaginatorInterfaceTest extends TestCase
 {
-    public function testPublicMethodsExposeTheSimpleAndBuilderContracts()
+    public function testPublicMethodsExposeTheSimpleAndBuilderContracts(): void
     {
         self::assertSame(
             NumberedPaginationInterface::class,
@@ -45,7 +45,7 @@ final class PaginatorInterfaceTest extends TestCase
         self::assertNotContains('cursorPaginate', get_class_methods(PaginatorInterface::class));
     }
 
-    public function testCommonResultContractDoesNotExposeConfigurationOrTransformation()
+    public function testCommonResultContractDoesNotExposeConfigurationOrTransformation(): void
     {
         $methods = get_class_methods(PaginationInterface::class);
 
@@ -67,7 +67,7 @@ final class PaginatorInterfaceTest extends TestCase
         }
     }
 
-    public function testNumberedResultContractDoesNotExposeFlowPolicies()
+    public function testNumberedResultContractDoesNotExposeFlowPolicies(): void
     {
         $methods = get_class_methods(NumberedPaginationInterface::class);
 
@@ -77,7 +77,7 @@ final class PaginatorInterfaceTest extends TestCase
         self::assertNotContains('throwOnCanonicalPage', get_class_methods(Pagination::class));
     }
 
-    public function testSerializationShapesStayOutOfTheResultInterfaces()
+    public function testSerializationShapesStayOutOfTheResultInterfaces(): void
     {
         $numbered = get_class_methods(NumberedPaginationInterface::class);
         foreach (['getMetadata', 'getLinks', 'getAbsoluteUrl'] as $method) {

--- a/src/Pagination/tests/PaginatorTest.php
+++ b/src/Pagination/tests/PaginatorTest.php
@@ -32,12 +32,12 @@ final class PaginatorTest extends TestCase
         $this->paginator = new Paginator([new ArrayPaginationAdapter()], cursorCodec: new \Symfony\UX\Pagination\Cursor\CursorCodec('test-secret'));
     }
 
-    public function testImplementsInterface()
+    public function testImplementsInterface(): void
     {
         self::assertInstanceOf(PaginatorInterface::class, $this->paginator);
     }
 
-    public function testPaginateArray()
+    public function testPaginateArray(): void
     {
         $result = $this->paginator->paginate(range(1, 100), 1, 10);
 
@@ -49,7 +49,7 @@ final class PaginatorTest extends TestCase
         self::assertCount(10, $result);
     }
 
-    public function testPaginateSecondPage()
+    public function testPaginateSecondPage(): void
     {
         $result = $this->paginator->paginate(range(1, 100), 3, 20);
 
@@ -58,7 +58,7 @@ final class PaginatorTest extends TestCase
         self::assertSame([41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60], $result->getItems());
     }
 
-    public function testPaginateUsesConfiguredDefaultPerPage()
+    public function testPaginateUsesConfiguredDefaultPerPage(): void
     {
         $paginator = new Paginator(
             [new ArrayPaginationAdapter()],
@@ -72,7 +72,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(4, $result->getTotalPages());
     }
 
-    public function testPaginateUsesConfiguredMaximumOffset()
+    public function testPaginateUsesConfiguredMaximumOffset(): void
     {
         $paginator = new Paginator(
             [new ArrayPaginationAdapter()],
@@ -84,7 +84,7 @@ final class PaginatorTest extends TestCase
         $paginator->paginate(range(1, 100), page: 3, perPage: 20);
     }
 
-    public function testFromCallbacksUsesConfiguredDefaultPerPage()
+    public function testFromCallbacksUsesConfiguredDefaultPerPage(): void
     {
         $paginator = new Paginator(
             [new ArrayPaginationAdapter()],
@@ -103,7 +103,7 @@ final class PaginatorTest extends TestCase
         self::assertCount(15, $result);
     }
 
-    public function testFromCallbacksExposesTheCompleteNumberedBuilder()
+    public function testFromCallbacksExposesTheCompleteNumberedBuilder(): void
     {
         $items = range(1, 5);
         $countCalls = 0;
@@ -126,7 +126,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(0, $countCalls);
     }
 
-    public function testFromCallbacksAcceptsInvokableServices()
+    public function testFromCallbacksAcceptsInvokableServices(): void
     {
         $items = range(1, 10);
         $slicer = new class($items) {
@@ -162,7 +162,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(10, $result->getTotalItems());
     }
 
-    public function testCursorBuilderUsesConfiguredDefaultPerPage()
+    public function testCursorBuilderUsesConfiguredDefaultPerPage(): void
     {
         $paginator = new Paginator(
             [new ArrayPaginationAdapter()],
@@ -185,7 +185,7 @@ final class PaginatorTest extends TestCase
         self::assertCount(5, $result);
     }
 
-    public function testPaginateExplicitPerPageOverridesDefault()
+    public function testPaginateExplicitPerPageOverridesDefault(): void
     {
         $paginator = new Paginator(
             [new ArrayPaginationAdapter()],
@@ -198,33 +198,33 @@ final class PaginatorTest extends TestCase
         self::assertCount(10, $result);
     }
 
-    public function testPaginateThrowsForInvalidPage()
+    public function testPaginateThrowsForInvalidPage(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->paginator->paginate(range(1, 10), 0);
     }
 
-    public function testPaginateThrowsForInvalidPerPage()
+    public function testPaginateThrowsForInvalidPerPage(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->paginator->paginate(range(1, 10), 1, 0);
     }
 
-    public function testPaginateThrowsForUnsupportedSource()
+    public function testPaginateThrowsForUnsupportedSource(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/No "offset" pagination adapter/');
         $this->paginator->paginate(new \stdClass());
     }
 
-    public function testQueryReturnsBuilder()
+    public function testQueryReturnsBuilder(): void
     {
         $builder = $this->paginator->query(range(1, 50));
 
         self::assertInstanceOf(PaginationBuilder::class, $builder);
     }
 
-    public function testCursorRequiresConfiguredCodec()
+    public function testCursorRequiresConfiguredCodec(): void
     {
         $paginator = new Paginator([new ArrayPaginationAdapter()]);
 
@@ -233,7 +233,7 @@ final class PaginatorTest extends TestCase
         $paginator->cursor([]);
     }
 
-    public function testCursorBuilderPaginatesAnArray()
+    public function testCursorBuilderPaginatesAnArray(): void
     {
         $source = [];
         for ($i = 1; $i <= 50; ++$i) {
@@ -253,7 +253,7 @@ final class PaginatorTest extends TestCase
         self::assertNotNull($result->getNextCursor());
     }
 
-    public function testCursorBuilderRequiresAStableApplicationContextForArrays()
+    public function testCursorBuilderRequiresAStableApplicationContextForArrays(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('requires an explicit context()');
@@ -264,7 +264,7 @@ final class PaginatorTest extends TestCase
             ->paginate();
     }
 
-    public function testCursorBuilderContextRemainsValidWhenTheSourceMutates()
+    public function testCursorBuilderContextRemainsValidWhenTheSourceMutates(): void
     {
         $source = array_map(static fn (int $id): array => ['id' => $id], range(1, 15));
 
@@ -290,7 +290,7 @@ final class PaginatorTest extends TestCase
         self::assertSame([6, 8, 9, 10, 11], array_column($second->getItems(), 'id'));
     }
 
-    public function testCursorBuilderSupportsACustomField()
+    public function testCursorBuilderSupportsACustomField(): void
     {
         $source = [];
         for ($i = 1; $i <= 30; ++$i) {
@@ -323,7 +323,7 @@ final class PaginatorTest extends TestCase
         self::assertTrue($page2->hasNext());
     }
 
-    public function testCursorBuilderSupportsADirection()
+    public function testCursorBuilderSupportsADirection(): void
     {
         $source = [];
         for ($i = 1; $i <= 25; ++$i) {
@@ -341,7 +341,7 @@ final class PaginatorTest extends TestCase
         self::assertTrue($result->hasNext());
     }
 
-    public function testCursorBuilderAllowsAnAdapterOwnedOrder()
+    public function testCursorBuilderAllowsAnAdapterOwnedOrder(): void
     {
         $source = new \stdClass();
         $adapter = new class implements \Symfony\UX\Pagination\Adapter\CursorAdapterInterface {
@@ -383,26 +383,26 @@ final class PaginatorTest extends TestCase
         self::assertSame([42], $pagination->getItems());
     }
 
-    public function testCursorBuilderThrowsForInvalidDirection()
+    public function testCursorBuilderThrowsForInvalidDirection(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('direction must be "ASC" or "DESC"');
         $this->paginator->cursor([['id' => 1]])->orderBy('id', 'INVALID');
     }
 
-    public function testCursorBuilderThrowsForInvalidPerPage()
+    public function testCursorBuilderThrowsForInvalidPerPage(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->paginator->cursor([['id' => 1]])->perPage(0);
     }
 
-    public function testCursorBuilderThrowsForUnsupportedSource()
+    public function testCursorBuilderThrowsForUnsupportedSource(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->paginator->cursor(new \stdClass())->paginate();
     }
 
-    public function testFromCallbacksThrowsForInvalidPage()
+    public function testFromCallbacksThrowsForInvalidPage(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Page must be >= 1');
@@ -415,7 +415,7 @@ final class PaginatorTest extends TestCase
             ->paginate(0);
     }
 
-    public function testFromCallbacksThrowsForInvalidPerPage()
+    public function testFromCallbacksThrowsForInvalidPerPage(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('perPage must be >= 1');
@@ -428,7 +428,7 @@ final class PaginatorTest extends TestCase
             ->perPage(0);
     }
 
-    public function testCursorBuilderThrowsForNonCursorAdapter()
+    public function testCursorBuilderThrowsForNonCursorAdapter(): void
     {
         $adapter = $this->createStub(\Symfony\UX\Pagination\Adapter\PaginationAdapterInterface::class);
         $adapter->method('supports')->willReturn(true);
@@ -441,14 +441,14 @@ final class PaginatorTest extends TestCase
         $paginator->cursor('some source')->paginate();
     }
 
-    public function testPaginateDefaultsToPage1WithoutRequest()
+    public function testPaginateDefaultsToPage1WithoutRequest(): void
     {
         $result = $this->paginator->paginate(range(1, 50));
 
         self::assertSame(1, $result->getCurrentPage());
     }
 
-    public function testPaginateDefaultsToPage1WhenRequestHasNoPageParam()
+    public function testPaginateDefaultsToPage1WhenRequestHasNoPageParam(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request(query: ['sort' => 'name']);
         $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
@@ -464,7 +464,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(1, $result->getCurrentPage());
     }
 
-    public function testPaginateResolvesPageFromRequest()
+    public function testPaginateResolvesPageFromRequest(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request(query: ['page' => '3']);
         $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
@@ -480,7 +480,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(3, $result->getCurrentPage());
     }
 
-    public function testPaginateResolvesPageFromPathParameter()
+    public function testPaginateResolvesPageFromPathParameter(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request();
         $request->attributes->set('_route', 'blog_list');
@@ -500,7 +500,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(5, $result->getCurrentPage());
     }
 
-    public function testPaginatePathParameterTakesPriorityOverQueryParameter()
+    public function testPaginatePathParameterTakesPriorityOverQueryParameter(): void
     {
         $request = new \Symfony\Component\HttpFoundation\Request(query: ['page' => '2']);
         $request->attributes->set('_route', 'blog_list');
@@ -520,7 +520,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(7, $result->getCurrentPage());
     }
 
-    public function testPaginateExplicitPageOverridesPathParameter()
+    public function testPaginateExplicitPageOverridesPathParameter(): void
     {
         $requestStack = $this->createMock(\Symfony\Component\HttpFoundation\RequestStack::class);
         $requestStack->expects(self::never())->method('getCurrentRequest');
@@ -535,7 +535,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(3, $result->getCurrentPage());
     }
 
-    public function testCursorBuilderReadsCursorFromRequest()
+    public function testCursorBuilderReadsCursorFromRequest(): void
     {
         $source = [];
         for ($i = 1; $i <= 30; ++$i) {
@@ -564,7 +564,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(11, $result->getItems()[0]['id']);
     }
 
-    public function testCursorBuilderExplicitCursorWinsOverRequest()
+    public function testCursorBuilderExplicitCursorWinsOverRequest(): void
     {
         $source = [];
         for ($i = 1; $i <= 30; ++$i) {
@@ -594,7 +594,7 @@ final class PaginatorTest extends TestCase
         self::assertSame(21, $result->getItems()[0]['id']);
     }
 
-    public function testCursorBuilderUsesConfiguredCursorParameter()
+    public function testCursorBuilderUsesConfiguredCursorParameter(): void
     {
         $source = [];
         for ($i = 1; $i <= 30; ++$i) {
@@ -625,7 +625,7 @@ final class PaginatorTest extends TestCase
         self::assertStringContainsString('after=', (string) $result->getNextUrl());
     }
 
-    public function testPaginateAllowsExplicitPerPageAboveBuilderGuard()
+    public function testPaginateAllowsExplicitPerPageAboveBuilderGuard(): void
     {
         $paginator = new Paginator([new ArrayPaginationAdapter()]);
 

--- a/src/Pagination/tests/Test/PaginatorFactoryTest.php
+++ b/src/Pagination/tests/Test/PaginatorFactoryTest.php
@@ -26,7 +26,7 @@ use Symfony\UX\Pagination\Test\PaginatorFactory;
 #[CoversClass(PaginatorFactory::class)]
 final class PaginatorFactoryTest extends TestCase
 {
-    public function testCursorSecretIsMarkedAsSensitive()
+    public function testCursorSecretIsMarkedAsSensitive(): void
     {
         $parameters = new \ReflectionMethod(PaginatorFactory::class, 'create')->getParameters();
         $cursorSecret = array_find($parameters, static fn (\ReflectionParameter $parameter): bool => 'cursorSecret' === $parameter->getName());
@@ -35,7 +35,7 @@ final class PaginatorFactoryTest extends TestCase
         self::assertNotEmpty($cursorSecret->getAttributes(\SensitiveParameter::class));
     }
 
-    public function testCreatesDeterministicOffsetPagination()
+    public function testCreatesDeterministicOffsetPagination(): void
     {
         $paginator = PaginatorFactory::create(defaultPerPage: 2);
 
@@ -49,7 +49,7 @@ final class PaginatorFactoryTest extends TestCase
         self::assertSame('/', $pagination->getPreviousUrl());
     }
 
-    public function testUsesARequestForPageResolutionAndRealisticUrls()
+    public function testUsesARequestForPageResolutionAndRealisticUrls(): void
     {
         $request = Request::create('https://example.test/products?category=books&page=2');
         $paginator = PaginatorFactory::create(request: $request, defaultPerPage: 2);
@@ -62,7 +62,7 @@ final class PaginatorFactoryTest extends TestCase
         self::assertSame('https://example.test/products?category=books&page=3', $pagination->getAbsoluteUrl(3));
     }
 
-    public function testUsesAProvidedRequestStackAndCustomParameterNames()
+    public function testUsesAProvidedRequestStackAndCustomParameterNames(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(Request::create('/catalog?filter=active&offset=2'));
@@ -80,7 +80,7 @@ final class PaginatorFactoryTest extends TestCase
         self::assertSame('/catalog?filter=active&offset=3', $pagination->getNextUrl());
     }
 
-    public function testExplicitRequestBecomesCurrentOnAProvidedStack()
+    public function testExplicitRequestBecomesCurrentOnAProvidedStack(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(Request::create('/old?page=3'));
@@ -98,7 +98,7 @@ final class PaginatorFactoryTest extends TestCase
         self::assertSame('/new?page=2', $requestStack->getCurrentRequest()?->getRequestUri());
     }
 
-    public function testUsesARealUrlGeneratorForRoutes()
+    public function testUsesARealUrlGeneratorForRoutes(): void
     {
         $routes = new RouteCollection();
         $routes->add('product_list', new Route('/catalog/{section}'));
@@ -119,7 +119,7 @@ final class PaginatorFactoryTest extends TestCase
         self::assertSame('/catalog/books?filter=active&page=2', $pagination->getNextUrl());
     }
 
-    public function testForwardsTheMaximumOffsetGuard()
+    public function testForwardsTheMaximumOffsetGuard(): void
     {
         $paginator = PaginatorFactory::create(
             defaultPerPage: 2,
@@ -131,7 +131,7 @@ final class PaginatorFactoryTest extends TestCase
         $paginator->paginate(range(1, 6), page: 2);
     }
 
-    public function testSignedCursorUrlsRoundTripForwardAndBackward()
+    public function testSignedCursorUrlsRoundTripForwardAndBackward(): void
     {
         $source = $this->cursorSource();
         $first = PaginatorFactory::create(request: Request::create('/events?type=release'))
@@ -177,7 +177,7 @@ final class PaginatorFactoryTest extends TestCase
         self::assertSame([1, 2], array_column($again->getItems(), 'id'));
     }
 
-    public function testUsesACustomCursorParameterInRequestsAndUrls()
+    public function testUsesACustomCursorParameterInRequestsAndUrls(): void
     {
         $source = $this->cursorSource();
         $first = PaginatorFactory::create(
@@ -208,7 +208,7 @@ final class PaginatorFactoryTest extends TestCase
         self::assertSame([3, 4], array_column($second->getItems(), 'id'));
     }
 
-    public function testCursorSecretCanBeOverridden()
+    public function testCursorSecretCanBeOverridden(): void
     {
         $source = $this->cursorSource();
         $first = PaginatorFactory::create(cursorSecret: 'first-test-secret')

--- a/src/Pagination/tests/Twig/PaginationExtensionTest.php
+++ b/src/Pagination/tests/Twig/PaginationExtensionTest.php
@@ -25,7 +25,7 @@ use Twig\Loader\ArrayLoader;
 #[CoversClass(PaginationExtension::class)]
 final class PaginationExtensionTest extends TestCase
 {
-    public function testRenderPaginationUsesDefaultTheme()
+    public function testRenderPaginationUsesDefaultTheme(): void
     {
         $pagination = $this->createPagination();
 
@@ -36,7 +36,7 @@ final class PaginationExtensionTest extends TestCase
         self::assertSame('default-theme:'.$pagination->getInfo(), $extension->renderPagination($pagination));
     }
 
-    public function testRenderPaginationPassesExplicitArgumentsToTheme()
+    public function testRenderPaginationPassesExplicitArgumentsToTheme(): void
     {
         $pagination = $this->createPagination();
 
@@ -55,7 +55,7 @@ final class PaginationExtensionTest extends TestCase
         self::assertSame('bootstrap-theme:info-off:my-nav', $result);
     }
 
-    public function testRenderDispatchesToRenderPagination()
+    public function testRenderDispatchesToRenderPagination(): void
     {
         $pagination = $this->createPagination();
 
@@ -72,7 +72,7 @@ final class PaginationExtensionTest extends TestCase
         self::assertSame('tailwind-theme:no-theme', $result);
     }
 
-    public function testRenderRequiresPaginationArgument()
+    public function testRenderRequiresPaginationArgument(): void
     {
         $extension = new PaginationExtension(new PaginationRenderer($this->createTwig()));
 
@@ -82,7 +82,7 @@ final class PaginationExtensionTest extends TestCase
         $extension->render();
     }
 
-    public function testRenderRejectsInvalidTheme()
+    public function testRenderRejectsInvalidTheme(): void
     {
         $extension = new PaginationExtension(new PaginationRenderer($this->createTwig()));
 
@@ -92,7 +92,7 @@ final class PaginationExtensionTest extends TestCase
         $extension->render(['pagination' => $this->createPagination(), 'theme' => false]);
     }
 
-    public function testRenderRejectsEmptyTheme()
+    public function testRenderRejectsEmptyTheme(): void
     {
         $extension = new PaginationExtension(
             new PaginationRenderer($this->createTwig()),
@@ -109,7 +109,7 @@ final class PaginationExtensionTest extends TestCase
         ]);
     }
 
-    public function testRenderRejectsInvalidShowInfo()
+    public function testRenderRejectsInvalidShowInfo(): void
     {
         $extension = new PaginationExtension(new PaginationRenderer($this->createTwig()));
 
@@ -119,7 +119,7 @@ final class PaginationExtensionTest extends TestCase
         $extension->render(['pagination' => $this->createPagination(), 'showInfo' => 'yes']);
     }
 
-    public function testRenderAcceptsAttributeGroups()
+    public function testRenderAcceptsAttributeGroups(): void
     {
         $pagination = $this->createPagination();
         $linkAttributes = static fn (array $link): array => ['data-page' => $link['page']];
@@ -139,7 +139,7 @@ final class PaginationExtensionTest extends TestCase
         self::assertSame('product-pages:product-pagination:controls:2', $result);
     }
 
-    public function testRenderRejectsInvalidLinkAttributes()
+    public function testRenderRejectsInvalidLinkAttributes(): void
     {
         $extension = new PaginationExtension(new PaginationRenderer($this->createTwig()));
 
@@ -149,7 +149,7 @@ final class PaginationExtensionTest extends TestCase
         $extension->render(['pagination' => $this->createPagination(), 'linkAttributes' => 'unsafe']);
     }
 
-    public function testRenderRejectsInvalidRootAttributes()
+    public function testRenderRejectsInvalidRootAttributes(): void
     {
         $extension = new PaginationExtension(new PaginationRenderer($this->createTwig()));
 
@@ -159,7 +159,7 @@ final class PaginationExtensionTest extends TestCase
         $extension->render(['pagination' => $this->createPagination(), 'attributes' => 'invalid']);
     }
 
-    public function testRenderRejectsInvalidNavigationAttributes()
+    public function testRenderRejectsInvalidNavigationAttributes(): void
     {
         $extension = new PaginationExtension(new PaginationRenderer($this->createTwig()));
 

--- a/src/Pagination/tests/Twig/PaginationRendererTest.php
+++ b/src/Pagination/tests/Twig/PaginationRendererTest.php
@@ -28,7 +28,7 @@ use Twig\Loader\ArrayLoader;
 #[CoversClass(PaginationRenderer::class)]
 final class PaginationRendererTest extends TestCase
 {
-    public function testRenderUsesDefaultTheme()
+    public function testRenderUsesDefaultTheme(): void
     {
         $pagination = $this->createPagination();
 
@@ -41,7 +41,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('default-theme:'.$pagination->getInfo(), $result);
     }
 
-    public function testRenderWithBootstrapTheme()
+    public function testRenderWithBootstrapTheme(): void
     {
         $pagination = $this->createPagination();
 
@@ -58,7 +58,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('bootstrap-theme:'.$pagination->getInfo(), $result);
     }
 
-    public function testRenderWithTailwindTheme()
+    public function testRenderWithTailwindTheme(): void
     {
         $pagination = $this->createPagination();
 
@@ -75,7 +75,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('tailwind-theme:'.$pagination->getInfo(), $result);
     }
 
-    public function testRenderWithCustomTheme()
+    public function testRenderWithCustomTheme(): void
     {
         $pagination = $this->createPagination();
 
@@ -89,7 +89,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('custom-theme:'.$pagination->getInfo(), $result);
     }
 
-    public function testRootLevelTwigPathIsPreserved()
+    public function testRootLevelTwigPathIsPreserved(): void
     {
         $pagination = $this->createPagination();
 
@@ -106,7 +106,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('root-theme:'.$pagination->getInfo(), $result);
     }
 
-    public function testExplicitThemeMustNotBeEmpty()
+    public function testExplicitThemeMustNotBeEmpty(): void
     {
         $renderer = new PaginationRenderer($this->createTwig());
 
@@ -118,7 +118,7 @@ final class PaginationRendererTest extends TestCase
         $renderer->renderPagination($this->createPagination(), theme: '  ');
     }
 
-    public function testConfiguredDefaultThemeMustNotBeEmpty()
+    public function testConfiguredDefaultThemeMustNotBeEmpty(): void
     {
         $renderer = new PaginationRenderer(
             $this->createTwig(),
@@ -133,7 +133,7 @@ final class PaginationRendererTest extends TestCase
         $renderer->renderPagination($this->createPagination());
     }
 
-    public function testRenderPassesOptionsAsThemeVariables()
+    public function testRenderPassesOptionsAsThemeVariables(): void
     {
         $pagination = $this->createPagination();
 
@@ -146,7 +146,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('info-off:my-nav:snake-case', $result);
     }
 
-    public function testEmptyLinkAttributesDoNotTraverseNumberedLinks()
+    public function testEmptyLinkAttributesDoNotTraverseNumberedLinks(): void
     {
         $pagination = $this->createMock(NumberedPaginationInterface::class);
         $pagination->expects(self::never())->method('getPages');
@@ -158,7 +158,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('0:0:0', $renderer->renderPagination($pagination));
     }
 
-    public function testRenderWithConfiguredDefaultTheme()
+    public function testRenderWithConfiguredDefaultTheme(): void
     {
         $pagination = $this->createPagination();
 
@@ -175,7 +175,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('bootstrap-theme', $result);
     }
 
-    public function testExplicitThemeOverridesConfiguredDefault()
+    public function testExplicitThemeOverridesConfiguredDefault(): void
     {
         $pagination = $this->createPagination();
 
@@ -195,7 +195,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('tailwind-theme', $result);
     }
 
-    public function testRenderCursorPaginationUsesDefaultTheme()
+    public function testRenderCursorPaginationUsesDefaultTheme(): void
     {
         $pagination = $this->createCursorPagination();
 
@@ -208,7 +208,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('default-theme:plain', $result);
     }
 
-    public function testBootstrapThemeSupportsCursorPagination()
+    public function testBootstrapThemeSupportsCursorPagination(): void
     {
         $pagination = $this->createCursorPagination();
 
@@ -226,7 +226,7 @@ final class PaginationRendererTest extends TestCase
         );
     }
 
-    public function testBuiltInThemeSupportsThirdPartyPaginationContract()
+    public function testBuiltInThemeSupportsThirdPartyPaginationContract(): void
     {
         $pagination = $this->createStub(PaginationInterface::class);
 
@@ -244,7 +244,7 @@ final class PaginationRendererTest extends TestCase
         );
     }
 
-    public function testCursorPaginationUsesConfiguredCustomTemplate()
+    public function testCursorPaginationUsesConfiguredCustomTemplate(): void
     {
         $pagination = $this->createCursorPagination();
 
@@ -259,7 +259,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('custom-cursor-theme', $renderer->renderPagination($pagination));
     }
 
-    public function testThemeRendersLikeAnOrdinaryTwigTemplate()
+    public function testThemeRendersLikeAnOrdinaryTwigTemplate(): void
     {
         $renderer = new PaginationRenderer($this->createTwig([
             'block.html.twig' => '{% block pagination %}probe-block{% endblock %}{% block leak %}LEAK{% endblock %}',
@@ -271,7 +271,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('standalone-body', $renderer->renderPagination($pagination, theme: 'standalone.html.twig'));
     }
 
-    public function testRenderResolvesLinkAttributeClosureWithNavigationContext()
+    public function testRenderResolvesLinkAttributeClosureWithNavigationContext(): void
     {
         $pagination = new Pagination(
             source: range(1, 50),
@@ -292,7 +292,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('1:3:3', $html);
     }
 
-    public function testRenderRejectsInvalidAttributeName()
+    public function testRenderRejectsInvalidAttributeName(): void
     {
         $renderer = new PaginationRenderer($this->createTwig());
 
@@ -302,7 +302,7 @@ final class PaginationRendererTest extends TestCase
         $renderer->renderPagination($this->createPagination(), ['onload x' => 'alert(1)']);
     }
 
-    public function testRenderRejectsNonScalarAttributeValue()
+    public function testRenderRejectsNonScalarAttributeValue(): void
     {
         $renderer = new PaginationRenderer($this->createTwig());
 
@@ -312,7 +312,7 @@ final class PaginationRendererTest extends TestCase
         $renderer->renderPagination($this->createPagination(), ['data-context' => []]);
     }
 
-    public function testRenderRejectsNonStringClass()
+    public function testRenderRejectsNonStringClass(): void
     {
         $renderer = new PaginationRenderer($this->createTwig());
 
@@ -322,7 +322,7 @@ final class PaginationRendererTest extends TestCase
         $renderer->renderPagination($this->createPagination(), ['CLASS' => true]);
     }
 
-    public function testRenderRejectsHrefOverrideFromLinkAttributes()
+    public function testRenderRejectsHrefOverrideFromLinkAttributes(): void
     {
         $renderer = new PaginationRenderer($this->createTwig());
 
@@ -332,7 +332,7 @@ final class PaginationRendererTest extends TestCase
         $renderer->renderPagination($this->createPagination(), linkAttributes: ['href' => 'javascript:alert(1)']);
     }
 
-    public function testCursorLinkContextContainsTheOpaqueCursor()
+    public function testCursorLinkContextContainsTheOpaqueCursor(): void
     {
         $renderer = new PaginationRenderer($this->createTwig([
             '@UXPagination/theme/default.html.twig' => "{{ link_attributes.next['data-cursor'] is null ? 'missing-cursor' : 'opaque-cursor' }}",
@@ -345,7 +345,7 @@ final class PaginationRendererTest extends TestCase
         self::assertSame('opaque-cursor', $html);
     }
 
-    public function testLinkContextRejectsAnInconsistentPaginationResult()
+    public function testLinkContextRejectsAnInconsistentPaginationResult(): void
     {
         $pagination = $this->createStub(PaginationInterface::class);
         $pagination->method('hasNext')->willReturn(true);
@@ -358,7 +358,7 @@ final class PaginationRendererTest extends TestCase
         $renderer->renderPagination($pagination, linkAttributes: static fn (array $link): array => []);
     }
 
-    public function testRenderRejectsInvalidClosureReturnValue()
+    public function testRenderRejectsInvalidClosureReturnValue(): void
     {
         $renderer = new PaginationRenderer($this->createTwig());
 

--- a/src/Pagination/tests/Twig/TemplateIntegrationTest.php
+++ b/src/Pagination/tests/Twig/TemplateIntegrationTest.php
@@ -55,7 +55,7 @@ final class TemplateIntegrationTest extends TestCase
         });
     }
 
-    public function testDefaultTemplateRendersNativeNavigationWithoutRuntimeAttributes()
+    public function testDefaultTemplateRendersNativeNavigationWithoutRuntimeAttributes(): void
     {
         $html = $this->renderTheme(
             '@UXPagination/theme/default.html.twig',
@@ -71,7 +71,7 @@ final class TemplateIntegrationTest extends TestCase
     }
 
     #[DataProvider('themes')]
-    public function testEveryThemeKeepsTheSharedServerRenderedContract(string $theme)
+    public function testEveryThemeKeepsTheSharedServerRenderedContract(string $theme): void
     {
         $html = $this->renderTheme($theme, range(1, 50), 2, 10);
 
@@ -228,7 +228,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('Showing 11-20 of 50', $html);
     }
 
-    public function testStandardTemplateDoesNotEmitPaginationJavaScriptHooks()
+    public function testStandardTemplateDoesNotEmitPaginationJavaScriptHooks(): void
     {
         $pagination = new Pagination(
             source: range(1, 50),
@@ -245,7 +245,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('data-announcement-template=', $html);
     }
 
-    public function testIntegrationDataAttributesRemainPlain()
+    public function testIntegrationDataAttributesRemainPlain(): void
     {
         $pagination = new Pagination(
             source: range(1, 50),
@@ -263,7 +263,7 @@ final class TemplateIntegrationTest extends TestCase
     }
 
     #[DataProvider('themes')]
-    public function testAttributesAreRenderedByEveryTheme(string $theme)
+    public function testAttributesAreRenderedByEveryTheme(string $theme): void
     {
         $pagination = new Pagination(
             source: range(1, 50),
@@ -283,7 +283,7 @@ final class TemplateIntegrationTest extends TestCase
     }
 
     #[DataProvider('themes')]
-    public function testCustomClassAlwaysDecoratesTheNavigationElement(string $theme)
+    public function testCustomClassAlwaysDecoratesTheNavigationElement(string $theme): void
     {
         $pagination = new Pagination(
             source: range(1, 50),
@@ -302,7 +302,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertMatchesRegularExpression('/<nav[^>]+class="[^"]*product-pages[^"]*"/', $html);
     }
 
-    public function testDefaultTemplateRendersPageLinksWithoutClientState()
+    public function testDefaultTemplateRendersPageLinksWithoutClientState(): void
     {
         $html = $this->renderTheme(
             '@UXPagination/theme/default.html.twig',
@@ -317,7 +317,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringContainsString('aria-current="page"', $html);
     }
 
-    public function testDefaultTemplateRendersRelPrevNext()
+    public function testDefaultTemplateRendersRelPrevNext(): void
     {
         $html = $this->renderTheme(
             '@UXPagination/theme/default.html.twig',
@@ -330,7 +330,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringContainsString('rel="next"', $html);
     }
 
-    public function testBootstrapTemplateRendersWithBootstrapClasses()
+    public function testBootstrapTemplateRendersWithBootstrapClasses(): void
     {
         $html = $this->renderTheme(
             '@UXPagination/theme/bootstrap.html.twig',
@@ -345,7 +345,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('data-controller=', $html);
     }
 
-    public function testTailwindTemplateRendersFocusRingClasses()
+    public function testTailwindTemplateRendersFocusRingClasses(): void
     {
         $html = $this->renderTheme(
             '@UXPagination/theme/tailwind.html.twig',
@@ -358,7 +358,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('data-controller=', $html);
     }
 
-    public function testExplicitBundleThemePathIsRendered()
+    public function testExplicitBundleThemePathIsRendered(): void
     {
         $loader = new FilesystemLoader();
         $loader->addPath(__DIR__.'/../Fixtures/templates', 'UXPagination');
@@ -380,7 +380,7 @@ final class TemplateIntegrationTest extends TestCase
         );
     }
 
-    public function testApplicationTemplateCanComposePartials()
+    public function testApplicationTemplateCanComposePartials(): void
     {
         $twig = new Environment(new ArrayLoader([
             'pagination/product.html.twig' => <<<'TWIG'
@@ -423,7 +423,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringContainsString('rel="next"', $html);
     }
 
-    public function testApplicationTemplateCanExtendTheDefaultBlocks()
+    public function testApplicationTemplateCanExtendTheDefaultBlocks(): void
     {
         $bundleLoader = new FilesystemLoader();
         $bundleLoader->addPath(\dirname(__DIR__, 2).'/templates', 'UXPagination');
@@ -464,7 +464,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringContainsString('aria-current="page"', $html);
     }
 
-    public function testExtendedThemeOverridesTheLabelBlocks()
+    public function testExtendedThemeOverridesTheLabelBlocks(): void
     {
         $twig = $this->createExtendingEnvironment(<<<'TWIG'
             {% extends '@!UXPagination/theme/default.html.twig' %}
@@ -501,7 +501,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringContainsString('&lsaquo; Previous', $html);
     }
 
-    public function testExtendedThemeOverridesThePageLabelWithLinkContext()
+    public function testExtendedThemeOverridesThePageLabelWithLinkContext(): void
     {
         $twig = $this->createExtendingEnvironment(<<<'TWIG'
             {% extends '@!UXPagination/theme/default.html.twig' %}
@@ -618,7 +618,7 @@ final class TemplateIntegrationTest extends TestCase
         }
     }
 
-    public function testExplicitCustomTemplatePathIsPreserved()
+    public function testExplicitCustomTemplatePathIsPreserved(): void
     {
         $loader = new FilesystemLoader();
         $loader->addPath(__DIR__.'/../Fixtures/templates', 'App');
@@ -634,7 +634,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertSame('explicit template', trim(new PaginationRenderer($twig)->renderPagination($pagination, theme: '@App/explicit.html.twig')));
     }
 
-    public function testSinglePageDoesNotRenderNav()
+    public function testSinglePageDoesNotRenderNav(): void
     {
         $html = $this->renderTheme(
             '@UXPagination/theme/default.html.twig',
@@ -646,7 +646,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('<nav', $html);
     }
 
-    public function testCustomQueryParameterIsKeptInNativeLinks()
+    public function testCustomQueryParameterIsKeptInNativeLinks(): void
     {
         $pagination = new Pagination(
             source: range(1, 100),
@@ -666,7 +666,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('data-query-param=', $html);
     }
 
-    public function testApplicationCanAttachItsOwnControllerAttribute()
+    public function testApplicationCanAttachItsOwnControllerAttribute(): void
     {
         $pagination = new Pagination(
             source: range(1, 50),
@@ -683,7 +683,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringContainsString('data-controller="app--catalog"', $html);
     }
 
-    public function testDocumentedAdjacentLinkMarkupUsesGuardedResultUrls()
+    public function testDocumentedAdjacentLinkMarkupUsesGuardedResultUrls(): void
     {
         $pagination = new Pagination(
             source: range(1, 30),
@@ -707,7 +707,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringContainsString('href="/items?page=3" rel="next"', $html);
     }
 
-    public function testDefaultTemplateAdaptsToLookaheadPagination()
+    public function testDefaultTemplateAdaptsToLookaheadPagination(): void
     {
         $pagination = new Pagination(
             source: range(1, 100),
@@ -727,7 +727,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('data-page=', $html);
     }
 
-    public function testLookaheadPaginationKeepsTheCustomQueryParameter()
+    public function testLookaheadPaginationKeepsTheCustomQueryParameter(): void
     {
         $pagination = new Pagination(
             source: range(1, 100),
@@ -744,7 +744,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('data-query-param=', $html);
     }
 
-    public function testDefaultTemplateAdaptsToCursorPagination()
+    public function testDefaultTemplateAdaptsToCursorPagination(): void
     {
         $pagination = new CursorPagination(
             source: range(1, 100),
@@ -766,7 +766,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('data-query-param', $html);
     }
 
-    public function testLinkAttributesKeepHrefFallbackAndAddLiveActions()
+    public function testLinkAttributesKeepHrefFallbackAndAddLiveActions(): void
     {
         $pagination = new Pagination(
             source: range(1, 50),
@@ -793,7 +793,7 @@ final class TemplateIntegrationTest extends TestCase
         self::assertStringNotContainsString('symfony--ux-pagination--pagination', $html);
     }
 
-    public function testAttributeValuesAreEscapedAndClassesAreMerged()
+    public function testAttributeValuesAreEscapedAndClassesAreMerged(): void
     {
         $pagination = new Pagination(
             source: range(1, 50),
@@ -818,7 +818,7 @@ final class TemplateIntegrationTest extends TestCase
     }
 
     #[DataProvider('themes')]
-    public function testEveryThemeEscapesAttributeValues(string $theme)
+    public function testEveryThemeEscapesAttributeValues(string $theme): void
     {
         $pagination = new Pagination(
             source: range(1, 50),

--- a/src/Pagination/tests/UXPaginationBundleTest.php
+++ b/src/Pagination/tests/UXPaginationBundleTest.php
@@ -20,7 +20,7 @@ use Symfony\UX\Pagination\UXPaginationBundle;
 #[CoversClass(UXPaginationBundle::class)]
 final class UXPaginationBundleTest extends TestCase
 {
-    public function testGetContainerExtensionReturnsExtensionWithCorrectAlias()
+    public function testGetContainerExtensionReturnsExtensionWithCorrectAlias(): void
     {
         $bundle = new UXPaginationBundle();
         $extension = $bundle->getContainerExtension();
@@ -29,7 +29,7 @@ final class UXPaginationBundleTest extends TestCase
         self::assertSame('ux_pagination', $extension->getAlias());
     }
 
-    public function testGetPathReturnsParentDirectory()
+    public function testGetPathReturnsParentDirectory(): void
     {
         $bundle = new UXPaginationBundle();
         $path = $bundle->getPath();
@@ -39,7 +39,7 @@ final class UXPaginationBundleTest extends TestCase
         self::assertFileExists($path.'/composer.json');
     }
 
-    public function testPrependsAssetMapperPathOnlyWhenAvailable()
+    public function testPrependsAssetMapperPathOnlyWhenAvailable(): void
     {
         $container = new ContainerBuilder();
         $configurator = new \ReflectionClass(ContainerConfigurator::class)->newInstanceWithoutConstructor();

--- a/src/React/tests/AssetMapper/ReactControllerLoaderAssetCompilerTest.php
+++ b/src/React/tests/AssetMapper/ReactControllerLoaderAssetCompilerTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\React\AssetMapper\ReactControllerLoaderAssetCompiler;
 
 class ReactControllerLoaderAssetCompilerTest extends TestCase
 {
-    public function testCompileDynamicallyAddsContents()
+    public function testCompileDynamicallyAddsContents(): void
     {
         $assetMapper = $this->createMock(AssetMapperInterface::class);
         $assetMapper->expects($this->exactly(2))

--- a/src/React/tests/ReactBundleTest.php
+++ b/src/React/tests/ReactBundleTest.php
@@ -21,7 +21,7 @@ use Symfony\UX\React\Tests\Kernel\TwigAppKernel;
  */
 class ReactBundleTest extends TestCase
 {
-    public function testBootKernel()
+    public function testBootKernel(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/React/tests/Twig/ReactComponentExtensionTest.php
+++ b/src/React/tests/Twig/ReactComponentExtensionTest.php
@@ -23,7 +23,7 @@ use Symfony\UX\React\Twig\ReactComponentExtension;
  */
 class ReactComponentExtensionTest extends TestCase
 {
-    public function testRenderComponent()
+    public function testRenderComponent(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();
@@ -43,7 +43,7 @@ class ReactComponentExtensionTest extends TestCase
     }
 
     #[DataProvider('provideOptions')]
-    public function testRenderComponentWithOptions(array $options, string|false $expected)
+    public function testRenderComponentWithOptions(array $options, string|false $expected): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();
@@ -73,7 +73,7 @@ class ReactComponentExtensionTest extends TestCase
         yield 'no permanent' => [[], false];
     }
 
-    public function testRenderComponentWithoutProps()
+    public function testRenderComponentWithoutProps(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/StimulusBundle/tests/AssetMapper/AutoImportLocatorTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/AutoImportLocatorTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\StimulusBundle\Ux\UxPackageMetadata;
 
 class AutoImportLocatorTest extends TestCase
 {
-    public function testLocateAutoImportCanHandleAssetMapperPath()
+    public function testLocateAutoImportCanHandleAssetMapperPath(): void
     {
         $assetMapper = $this->createMock(AssetMapperInterface::class);
         $assetMapper->expects($this->once())
@@ -40,7 +40,7 @@ class AutoImportLocatorTest extends TestCase
         $this->assertFalse($autoImport->isBareImport);
     }
 
-    public function testLocateAutoImportHandlesFileInPackage()
+    public function testLocateAutoImportHandlesFileInPackage(): void
     {
         $packageMetadata = new UxPackageMetadata(
             __DIR__.'/../fixtures/vendor/fake-vendor/ux-package1/assets',
@@ -64,7 +64,7 @@ class AutoImportLocatorTest extends TestCase
         $this->assertFalse($autoImport->isBareImport);
     }
 
-    public function testLocateAutoImportFromImportMap()
+    public function testLocateAutoImportFromImportMap(): void
     {
         $importMapConfigReader = $this->createMock(ImportMapConfigReader::class);
         $importMapConfigReader->expects($this->once())

--- a/src/StimulusBundle/tests/AssetMapper/ControllersMapGeneratorTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/ControllersMapGeneratorTest.php
@@ -21,7 +21,7 @@ use Symfony\UX\StimulusBundle\Ux\UxPackageReader;
 
 class ControllersMapGeneratorTest extends TestCase
 {
-    public function testGetControllersMap()
+    public function testGetControllersMap(): void
     {
         $mapper = $this->createStub(AssetMapperInterface::class);
         $mapper->method('getAssetFromSourcePath')
@@ -119,7 +119,7 @@ class ControllersMapGeneratorTest extends TestCase
         $this->assertTrue($preservedComment->isLazy);
     }
 
-    public function testGetControllersMapThrowsOnUnmappedController()
+    public function testGetControllersMapThrowsOnUnmappedController(): void
     {
         $mapper = $this->createStub(AssetMapperInterface::class);
         $mapper->method('getAssetFromSourcePath')
@@ -158,7 +158,7 @@ class ControllersMapGeneratorTest extends TestCase
         $generator->getControllersMap();
     }
 
-    public function testCustomControllersAreSortedByName()
+    public function testCustomControllersAreSortedByName(): void
     {
         $mapper = $this->createMock(AssetMapperInterface::class);
         $mapper->expects($this->any())

--- a/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/StimulusControllerLoaderFunctionalTest.php
@@ -21,7 +21,7 @@ class StimulusControllerLoaderFunctionalTest extends WebTestCase
 {
     use HasBrowser;
 
-    public function testFullApplicationLoad()
+    public function testFullApplicationLoad(): void
     {
         if (InstalledVersions::getVersion('symfony/framework-bundle') < '6.3') {
             $this->markTestSkipped('This test requires symfony/framework-bundle 6.3+');

--- a/src/StimulusBundle/tests/AssetMapper/StimulusLoaderJavaScriptCompilerTest.php
+++ b/src/StimulusBundle/tests/AssetMapper/StimulusLoaderJavaScriptCompilerTest.php
@@ -20,7 +20,7 @@ use Symfony\UX\StimulusBundle\AssetMapper\StimulusLoaderJavaScriptCompiler;
 
 class StimulusLoaderJavaScriptCompilerTest extends TestCase
 {
-    public function testCompileDynamicallyAddsContents()
+    public function testCompileDynamicallyAddsContents(): void
     {
         $controllerMapGenerator = $this->createMock(ControllersMapGenerator::class);
         $controllerMapGenerator->expects($this->once())
@@ -74,7 +74,7 @@ class StimulusLoaderJavaScriptCompilerTest extends TestCase
         $this->assertCount(4, $loaderAsset->getDependencies());
     }
 
-    public function testDebugModeIsSetCorrectly()
+    public function testDebugModeIsSetCorrectly(): void
     {
         $controllerMapGenerator = $this->createMock(ControllersMapGenerator::class);
         $controllerMapGenerator->expects($this->any())

--- a/src/StimulusBundle/tests/Dto/StimulusAttributesTest.php
+++ b/src/StimulusBundle/tests/Dto/StimulusAttributesTest.php
@@ -26,21 +26,21 @@ final class StimulusAttributesTest extends TestCase
         $this->stimulusAttributes = new StimulusAttributes(new Environment(new ArrayLoader()));
     }
 
-    public function testAddAction()
+    public function testAddAction(): void
     {
         $this->stimulusAttributes->addAction('foo', 'bar', 'baz', ['qux' => '"']);
         $attributesHtml = (string) $this->stimulusAttributes;
         self::assertSame('data-action="baz->foo#bar" data-foo-qux-param="&quot;"', $attributesHtml);
     }
 
-    public function testAddActionToArrayNoEscapingAttributeValues()
+    public function testAddActionToArrayNoEscapingAttributeValues(): void
     {
         $this->stimulusAttributes->addAction('foo', 'bar', 'baz', ['qux' => '"']);
         $attributesArray = $this->stimulusAttributes->toArray();
         self::assertSame(['data-action' => 'baz->foo#bar', 'data-foo-qux-param' => '"'], $attributesArray);
     }
 
-    public function testAddActionWithMultiple()
+    public function testAddActionWithMultiple(): void
     {
         $this->stimulusAttributes->addAction('my-controller', 'onClick');
         $this->assertSame('data-action="my-controller#onClick"', (string) $this->stimulusAttributes);
@@ -53,7 +53,7 @@ final class StimulusAttributesTest extends TestCase
         );
     }
 
-    public function testAddControllerToStringEscapingAttributeValues()
+    public function testAddControllerToStringEscapingAttributeValues(): void
     {
         $this->stimulusAttributes->addController('foo', ['bar' => '"'], ['baz' => '"']);
         $attributesHtml = (string) $this->stimulusAttributes;
@@ -65,7 +65,7 @@ final class StimulusAttributesTest extends TestCase
         );
     }
 
-    public function testAddControllerToArrayNoEscapingAttributeValues()
+    public function testAddControllerToArrayNoEscapingAttributeValues(): void
     {
         $this->stimulusAttributes->addController('foo', ['bar' => '"'], ['baz' => '"']);
         $attributesArray = $this->stimulusAttributes->toArray();
@@ -79,7 +79,7 @@ final class StimulusAttributesTest extends TestCase
         );
     }
 
-    public function testAddControllerNormalizesControllerName()
+    public function testAddControllerNormalizesControllerName(): void
     {
         $this->stimulusAttributes->addController('@symfony/ux-dropzone/dropzone',
             ['my"Key"' => true],
@@ -102,21 +102,21 @@ final class StimulusAttributesTest extends TestCase
         );
     }
 
-    public function testAddTargetToStringEscapingAttributeValues()
+    public function testAddTargetToStringEscapingAttributeValues(): void
     {
         $this->stimulusAttributes->addTarget('foo', '"');
         $attributesHtml = (string) $this->stimulusAttributes;
         self::assertSame('data-foo-target="&quot;"', $attributesHtml);
     }
 
-    public function testAddTargetToArrayNoEscapingAttributeValues()
+    public function testAddTargetToArrayNoEscapingAttributeValues(): void
     {
         $this->stimulusAttributes->addTarget('foo', '"');
         $attributesArray = $this->stimulusAttributes->toArray();
         self::assertSame(['data-foo-target' => '"'], $attributesArray);
     }
 
-    public function testAddTargetWithMultiple()
+    public function testAddTargetWithMultiple(): void
     {
         $this->stimulusAttributes->addTarget('my-controller', 'myTarget');
         $this->assertSame('data-my-controller-target="myTarget"', (string) $this->stimulusAttributes);
@@ -129,21 +129,21 @@ final class StimulusAttributesTest extends TestCase
         );
     }
 
-    public function testAddMultipleTargetsAtOnce()
+    public function testAddMultipleTargetsAtOnce(): void
     {
         $this->stimulusAttributes->addTarget('my-controller', 'myTarget myOtherTarget');
         $this->assertSame('data-my-controller-target="myTarget myOtherTarget"', (string) $this->stimulusAttributes);
         $this->assertSame(['data-my-controller-target' => 'myTarget myOtherTarget'], $this->stimulusAttributes->toArray());
     }
 
-    public function testIsTraversable()
+    public function testIsTraversable(): void
     {
         $this->stimulusAttributes->addController('foo', ['bar' => 'baz']);
         $actualAttributes = iterator_to_array($this->stimulusAttributes);
         self::assertSame(['data-controller' => 'foo', 'data-foo-bar-value' => 'baz'], $actualAttributes);
     }
 
-    public function testAddAttribute()
+    public function testAddAttribute(): void
     {
         $this->stimulusAttributes->addAttribute('foo', 'bar baz');
         $this->assertSame('foo="bar baz"', (string) $this->stimulusAttributes);
@@ -151,7 +151,7 @@ final class StimulusAttributesTest extends TestCase
     }
 
     #[DataProvider('provideAddComplexActionData')]
-    public function testAddComplexAction(string $controllerName, string $actionName, ?string $eventName, string $expectedAction)
+    public function testAddComplexAction(string $controllerName, string $actionName, ?string $eventName, string $expectedAction): void
     {
         $this->stimulusAttributes->addAction($controllerName, $actionName, $eventName);
         $attributesHtml = (string) $this->stimulusAttributes;

--- a/src/StimulusBundle/tests/Helper/StimulusHelperTest.php
+++ b/src/StimulusBundle/tests/Helper/StimulusHelperTest.php
@@ -18,7 +18,7 @@ use Twig\Environment;
 
 final class StimulusHelperTest extends TestCase
 {
-    public function testCreateStimulusAttributes()
+    public function testCreateStimulusAttributes(): void
     {
         $helper = new StimulusHelper($this->createMock(Environment::class));
         $attributes = $helper->createStimulusAttributes();

--- a/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
+++ b/src/StimulusBundle/tests/Twig/StimulusTwigExtensionTest.php
@@ -31,7 +31,7 @@ final class StimulusTwigExtensionTest extends TestCase
     }
 
     #[DataProvider('provideRenderStimulusController')]
-    public function testRenderStimulusController(string $controllerName, array $controllerValues, array $controllerClasses, array $controllerOutlets, string $expectedString, array $expectedArray)
+    public function testRenderStimulusController(string $controllerName, array $controllerValues, array $controllerClasses, array $controllerOutlets, string $expectedString, array $expectedArray): void
     {
         $extension = new StimulusTwigExtension(new StimulusHelper($this->twig));
         $dto = $extension->renderStimulusController($controllerName, $controllerValues, $controllerClasses, $controllerOutlets);
@@ -129,7 +129,7 @@ final class StimulusTwigExtensionTest extends TestCase
         ];
     }
 
-    public function testAppendStimulusController()
+    public function testAppendStimulusController(): void
     {
         $extension = new StimulusTwigExtension(new StimulusHelper($this->twig));
         $dto = $extension->renderStimulusController('my-controller', ['myValue' => 'scalar-value']);
@@ -140,7 +140,7 @@ final class StimulusTwigExtensionTest extends TestCase
     }
 
     #[DataProvider('provideRenderStimulusAction')]
-    public function testRenderStimulusAction(string $controllerName, ?string $actionName, ?string $eventName, array $parameters, string $expectedString, array $expectedArray)
+    public function testRenderStimulusAction(string $controllerName, ?string $actionName, ?string $eventName, array $parameters, string $expectedString, array $expectedArray): void
     {
         $extension = new StimulusTwigExtension(new StimulusHelper($this->twig));
         $dto = $extension->renderStimulusAction($controllerName, $actionName, $eventName, $parameters);
@@ -205,7 +205,7 @@ final class StimulusTwigExtensionTest extends TestCase
         ];
     }
 
-    public function testAppendStimulusAction()
+    public function testAppendStimulusAction(): void
     {
         $extension = new StimulusTwigExtension(new StimulusHelper($this->twig));
         $dto = $extension->renderStimulusAction('my-controller', 'onClick', 'click');
@@ -216,7 +216,7 @@ final class StimulusTwigExtensionTest extends TestCase
     }
 
     #[DataProvider('provideRenderStimulusTarget')]
-    public function testRenderStimulusTarget(string $controllerName, ?string $targetName, string $expectedString, array $expectedArray)
+    public function testRenderStimulusTarget(string $controllerName, ?string $targetName, string $expectedString, array $expectedArray): void
     {
         $extension = new StimulusTwigExtension(new StimulusHelper($this->twig));
         $dto = $extension->renderStimulusTarget($controllerName, $targetName);
@@ -241,7 +241,7 @@ final class StimulusTwigExtensionTest extends TestCase
         ];
     }
 
-    public function testAppendStimulusTarget()
+    public function testAppendStimulusTarget(): void
     {
         $extension = new StimulusTwigExtension(new StimulusHelper($this->twig));
         $dto = $extension->renderStimulusTarget('my-controller', 'myTarget');
@@ -251,7 +251,7 @@ final class StimulusTwigExtensionTest extends TestCase
         );
     }
 
-    public function testAppendDifferentStimulusHelpers()
+    public function testAppendDifferentStimulusHelpers(): void
     {
         $extension = new StimulusTwigExtension(new StimulusHelper($this->twig));
         $dto = $extension->renderStimulusController('first-controller');

--- a/src/StimulusBundle/tests/Ux/UxPackageReaderTest.php
+++ b/src/StimulusBundle/tests/Ux/UxPackageReaderTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\StimulusBundle\Ux\UxPackageReader;
 
 class UxPackageReaderTest extends TestCase
 {
-    public function testReadPackageMetadata()
+    public function testReadPackageMetadata(): void
     {
         $reader = new UxPackageReader(__DIR__.'/../fixtures');
 
@@ -43,7 +43,7 @@ class UxPackageReaderTest extends TestCase
         $this->assertInstanceOf(UxPackageMetadata::class, $metadata2);
     }
 
-    public function testExceptionIsThrownIfPackageCannotBeFound()
+    public function testExceptionIsThrownIfPackageCannotBeFound(): void
     {
         $reader = new UxPackageReader(__DIR__.'/../fixtures');
 

--- a/src/Toolkit/tests/AssertTest.php
+++ b/src/Toolkit/tests/AssertTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\Toolkit\Assert;
 class AssertTest extends TestCase
 {
     #[DataProvider('provideValidKitNames')]
-    public function testValidKitName(string $name)
+    public function testValidKitName(string $name): void
     {
         $this->expectNotToPerformAssertions();
 
@@ -50,7 +50,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideInvalidKitNames')]
-    public function testInvalidKitName(string $name)
+    public function testInvalidKitName(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('Invalid kit name "%s".', $name));
@@ -80,7 +80,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideValidComponentNames')]
-    public function testValidComponentName(string $name)
+    public function testValidComponentName(string $name): void
     {
         $this->expectNotToPerformAssertions();
 
@@ -102,7 +102,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideInvalidComponentNames')]
-    public function testInvalidComponentName(string $name)
+    public function testInvalidComponentName(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('Invalid component name "%s".', $name));
@@ -137,7 +137,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideValidPhpPackageNames')]
-    public function testValidPhpPackageName(string $name)
+    public function testValidPhpPackageName(string $name): void
     {
         $this->expectNotToPerformAssertions();
 
@@ -151,7 +151,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideInvalidPhpPackageNames')]
-    public function testInvalidPhpPackageName(string $name)
+    public function testInvalidPhpPackageName(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('Invalid PHP package name "%s".', $name));
@@ -168,7 +168,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideValidNpmPackageNames')]
-    public function testValidNpmPackageName(string $name)
+    public function testValidNpmPackageName(string $name): void
     {
         $this->expectNotToPerformAssertions();
 
@@ -190,7 +190,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideInvalidNpmPackageNames')]
-    public function testInvalidNpmPackageName(string $name)
+    public function testInvalidNpmPackageName(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('Invalid NPM package name "%s".', $name));
@@ -211,7 +211,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideNonEscapingPaths')]
-    public function testPathDoesNotEscapeDirectoryWithValidPath(string $path)
+    public function testPathDoesNotEscapeDirectoryWithValidPath(string $path): void
     {
         $this->expectNotToPerformAssertions();
 
@@ -229,7 +229,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideEscapingPaths')]
-    public function testPathDoesNotEscapeDirectoryWithTraversingPath(string $path)
+    public function testPathDoesNotEscapeDirectoryWithTraversingPath(string $path): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('The path "%s" must not escape its target directory.', $path));
@@ -249,7 +249,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideValidPropNames')]
-    public function testValidPropName(string $name)
+    public function testValidPropName(string $name): void
     {
         $this->expectNotToPerformAssertions();
 
@@ -269,7 +269,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideInvalidPropNames')]
-    public function testInvalidPropName(string $name)
+    public function testInvalidPropName(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('Invalid prop name "%s".', $name));
@@ -293,7 +293,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideValidBlockNames')]
-    public function testValidBlockName(string $name)
+    public function testValidBlockName(string $name): void
     {
         $this->expectNotToPerformAssertions();
 
@@ -311,7 +311,7 @@ class AssertTest extends TestCase
     }
 
     #[DataProvider('provideInvalidBlockNames')]
-    public function testInvalidBlockName(string $name)
+    public function testInvalidBlockName(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('Invalid block name "%s".', $name));
@@ -332,7 +332,7 @@ class AssertTest extends TestCase
         yield ['has.dot'];
     }
 
-    public function testCommonMarkAvailableDoesNotThrowWhenInstalled()
+    public function testCommonMarkAvailableDoesNotThrowWhenInstalled(): void
     {
         $this->expectNotToPerformAssertions();
 

--- a/src/Toolkit/tests/Command/CreateKitCommandTest.php
+++ b/src/Toolkit/tests/Command/CreateKitCommandTest.php
@@ -41,7 +41,7 @@ class CreateKitCommandTest extends KernelTestCase
         $this->filesystem->remove($this->tmpDir);
     }
 
-    public function testShouldBeAbleToCreateAKit()
+    public function testShouldBeAbleToCreateAKit(): void
     {
         $this->bootKernel();
         $this->consoleCommand('ux:toolkit:create-kit')

--- a/src/Toolkit/tests/Command/DebugKitCommandTest.php
+++ b/src/Toolkit/tests/Command/DebugKitCommandTest.php
@@ -20,7 +20,7 @@ class DebugKitCommandTest extends KernelTestCase
     use InteractsWithConsole;
     use TestHelperTrait;
 
-    public function testShouldBeAbleToDebugShadcnKit()
+    public function testShouldBeAbleToDebugShadcnKit(): void
     {
         $this->bootKernel();
         $this->consoleCommand(\sprintf('ux:toolkit:debug-kit %s', self::getLocalKitPath('shadcn')))
@@ -61,7 +61,7 @@ class DebugKitCommandTest extends KernelTestCase
             ]));
     }
 
-    public function testShouldBeAbleToDebugFixtureKitWithManyDependencies()
+    public function testShouldBeAbleToDebugFixtureKitWithManyDependencies(): void
     {
         $this->bootKernel();
         $this->consoleCommand(\sprintf('ux:toolkit:debug-kit %s', self::getFixtureKitPath('with-many-dependencies')))

--- a/src/Toolkit/tests/Command/InstallCommandTest.php
+++ b/src/Toolkit/tests/Command/InstallCommandTest.php
@@ -34,7 +34,7 @@ class InstallCommandTest extends KernelTestCase
         $this->filesystem->mkdir($this->tmpDir);
     }
 
-    public function testShouldAbleToInstallComponentTableAndItsDependencies()
+    public function testShouldAbleToInstallComponentTableAndItsDependencies(): void
     {
         $expectedFiles = [
             'table/templates/components/Table.html.twig' => Path::normalize($this->tmpDir.'/templates/components/Table.html.twig'),
@@ -66,7 +66,7 @@ class InstallCommandTest extends KernelTestCase
         }
     }
 
-    public function testShouldSuggestFrontendInstallationCommands()
+    public function testShouldSuggestFrontendInstallationCommands(): void
     {
         $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
         mkdir($destination);
@@ -80,7 +80,7 @@ class InstallCommandTest extends KernelTestCase
         ;
     }
 
-    public function testShouldSuggestBootstrapDependencies()
+    public function testShouldSuggestBootstrapDependencies(): void
     {
         $this->consoleCommand(\sprintf('ux:install button --kit=bootstrap --destination="%s"', str_replace('\\', '\\\\', $this->tmpDir)))
             ->execute()
@@ -90,7 +90,7 @@ class InstallCommandTest extends KernelTestCase
         ;
     }
 
-    public function testShouldFailAndSuggestAlternativeRecipesWhenKitIsExplicit()
+    public function testShouldFailAndSuggestAlternativeRecipesWhenKitIsExplicit(): void
     {
         $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
         mkdir($destination);
@@ -104,7 +104,7 @@ class InstallCommandTest extends KernelTestCase
         ;
     }
 
-    public function testShouldResolveRecipeNameCaseInsensitively()
+    public function testShouldResolveRecipeNameCaseInsensitively(): void
     {
         $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
         mkdir($destination);
@@ -120,7 +120,7 @@ class InstallCommandTest extends KernelTestCase
         ;
     }
 
-    public function testShouldResolveRecipeNameCaseInsensitivelyWithExplicitKit()
+    public function testShouldResolveRecipeNameCaseInsensitivelyWithExplicitKit(): void
     {
         $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
         mkdir($destination);
@@ -135,7 +135,7 @@ class InstallCommandTest extends KernelTestCase
         ;
     }
 
-    public function testShouldFailWhenComponentDoesNotExist()
+    public function testShouldFailWhenComponentDoesNotExist(): void
     {
         $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
         mkdir($destination);
@@ -147,7 +147,7 @@ class InstallCommandTest extends KernelTestCase
             ->assertOutputContains('The recipe "unknown" does not exist');
     }
 
-    public function testShouldSuggestAlternativesFromAllKitsWhenRecipeDoesNotExist()
+    public function testShouldSuggestAlternativesFromAllKitsWhenRecipeDoesNotExist(): void
     {
         $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
         mkdir($destination);
@@ -162,7 +162,7 @@ class InstallCommandTest extends KernelTestCase
         ;
     }
 
-    public function testShouldWarnWhenComponentFileAlreadyExistsInNonInteractiveMode()
+    public function testShouldWarnWhenComponentFileAlreadyExistsInNonInteractiveMode(): void
     {
         $destination = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid();
         mkdir($destination);

--- a/src/Toolkit/tests/Command/LintKitCommandTest.php
+++ b/src/Toolkit/tests/Command/LintKitCommandTest.php
@@ -33,7 +33,7 @@ class LintKitCommandTest extends TestCase
         return new LintKitCommand($kitFactory, new KitLinter());
     }
 
-    public function testLintBrokenFixtureReportsErrors()
+    public function testLintBrokenFixtureReportsErrors(): void
     {
         $result = TestCommand::for($this->createCommand())
             ->addArgument(self::getFixtureKitPath('lint-broken'))
@@ -76,7 +76,7 @@ class LintKitCommandTest extends TestCase
         self::assertStringContainsString('[ERROR] 3 error(s), 3 warning(s).', $output);
     }
 
-    public function testWarningsOnlyExitsSuccessfullyByDefault()
+    public function testWarningsOnlyExitsSuccessfullyByDefault(): void
     {
         TestCommand::for($this->createCommand())
             ->addArgument(self::getFixtureKitPath('lint-stimulus'))
@@ -87,7 +87,7 @@ class LintKitCommandTest extends TestCase
         ;
     }
 
-    public function testFailOnWarningExitsAsFailure()
+    public function testFailOnWarningExitsAsFailure(): void
     {
         TestCommand::for($this->createCommand())
             ->addArgument(self::getFixtureKitPath('lint-stimulus'))

--- a/src/Toolkit/tests/Component/ComponentDocParserTest.php
+++ b/src/Toolkit/tests/Component/ComponentDocParserTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Toolkit\Component\ComponentDocParser;
 
 class ComponentDocParserTest extends TestCase
 {
-    public function testParsesNameTypeAndDescription()
+    public function testParsesNameTypeAndDescription(): void
     {
         $doc = new ComponentDocParser()->parse(<<<'TWIG'
             {# @prop id string Unique identifier. #}
@@ -31,7 +31,7 @@ class ComponentDocParserTest extends TestCase
         self::assertSame('Unique identifier.', $doc->props[0]->description);
     }
 
-    public function testDefaultIsSourcedFromThePropsDeclaration()
+    public function testDefaultIsSourcedFromThePropsDeclaration(): void
     {
         $doc = new ComponentDocParser()->parse(<<<'TWIG'
             {# @prop open boolean Whether it is open. #}
@@ -42,7 +42,7 @@ class ComponentDocParserTest extends TestCase
         self::assertSame('false', $doc->props[0]->default);
     }
 
-    public function testStringDefaultFromPropsIsQuoted()
+    public function testStringDefaultFromPropsIsQuoted(): void
     {
         $doc = new ComponentDocParser()->parse(<<<'TWIG'
             {# @prop variant 'default'|'line' The visual style variant. #}
@@ -53,7 +53,7 @@ class ComponentDocParserTest extends TestCase
         self::assertSame("'default'", $doc->props[0]->default);
     }
 
-    public function testDescriptionKeepsInlineBackticksAndIsWhitespaceNormalized()
+    public function testDescriptionKeepsInlineBackticksAndIsWhitespaceNormalized(): void
     {
         $doc = new ComponentDocParser()->parse(<<<'TWIG'
             {# @prop choices array List of choices:
@@ -65,7 +65,7 @@ class ComponentDocParserTest extends TestCase
         self::assertSame('[]', $doc->props[0]->default);
     }
 
-    public function testParsesBlocks()
+    public function testParsesBlocks(): void
     {
         $doc = new ComponentDocParser()->parse(<<<'TWIG'
             {# @prop id string Unique identifier. #}
@@ -78,7 +78,7 @@ class ComponentDocParserTest extends TestCase
         self::assertSame('The dialog structure.', $doc->blocks[0]->description);
     }
 
-    public function testReturnsEmptyDocWhenNoDocblocks()
+    public function testReturnsEmptyDocWhenNoDocblocks(): void
     {
         $doc = new ComponentDocParser()->parse('<div>Nothing here</div>');
 

--- a/src/Toolkit/tests/Component/PhpStanTypeValidatorTest.php
+++ b/src/Toolkit/tests/Component/PhpStanTypeValidatorTest.php
@@ -43,13 +43,13 @@ class PhpStanTypeValidatorTest extends TestCase
     }
 
     #[DataProvider('provideValidTypes')]
-    public function testValidTypesAreAccepted(string $type)
+    public function testValidTypesAreAccepted(string $type): void
     {
         self::assertTrue(new PhpStanTypeValidator()->isValid($type));
     }
 
     #[DataProvider('provideInvalidTypes')]
-    public function testInvalidTypesAreRejected(string $type)
+    public function testInvalidTypesAreRejected(string $type): void
     {
         self::assertFalse(new PhpStanTypeValidator()->isValid($type));
     }

--- a/src/Toolkit/tests/Component/PropsDeclarationParserTest.php
+++ b/src/Toolkit/tests/Component/PropsDeclarationParserTest.php
@@ -16,12 +16,12 @@ use Symfony\UX\Toolkit\Component\PropsDeclarationParser;
 
 class PropsDeclarationParserTest extends TestCase
 {
-    public function testReturnsNullWhenNoPropsTag()
+    public function testReturnsNullWhenNoPropsTag(): void
     {
         self::assertNull(new PropsDeclarationParser()->parse('<div>{{ foo }}</div>'));
     }
 
-    public function testParsesNamesInDeclarationOrder()
+    public function testParsesNamesInDeclarationOrder(): void
     {
         $decl = new PropsDeclarationParser()->parse('{%- props id, open = false -%}');
 
@@ -29,7 +29,7 @@ class PropsDeclarationParserTest extends TestCase
         self::assertSame(['id', 'open'], $decl->names());
     }
 
-    public function testRequiredPropIsFlaggedAsHavingNoDefault()
+    public function testRequiredPropIsFlaggedAsHavingNoDefault(): void
     {
         $decl = new PropsDeclarationParser()->parse('{%- props id, open = false -%}');
 
@@ -37,7 +37,7 @@ class PropsDeclarationParserTest extends TestCase
         self::assertTrue($decl->get('open')->hasDefault);
     }
 
-    public function testBooleanNumberAndNullDefaultsRenderBare()
+    public function testBooleanNumberAndNullDefaultsRenderBare(): void
     {
         $decl = new PropsDeclarationParser()->parse('{%- props open = false, spacing = 2, name = null -%}');
 
@@ -46,7 +46,7 @@ class PropsDeclarationParserTest extends TestCase
         self::assertSame('null', $decl->get('name')->default);
     }
 
-    public function testStringDefaultsRenderSingleQuoted()
+    public function testStringDefaultsRenderSingleQuoted(): void
     {
         $decl = new PropsDeclarationParser()->parse('{%- props variant = \'default\', label = "Loading", value = \'\' -%}');
 
@@ -55,14 +55,14 @@ class PropsDeclarationParserTest extends TestCase
         self::assertSame("''", $decl->get('value')->default);
     }
 
-    public function testArrayDefaultRendersAsIs()
+    public function testArrayDefaultRendersAsIs(): void
     {
         $decl = new PropsDeclarationParser()->parse('{%- props choices = [] -%}');
 
         self::assertSame('[]', $decl->get('choices')->default);
     }
 
-    public function testTopLevelCommaSplitIgnoresCommasInsideBracketsAndStrings()
+    public function testTopLevelCommaSplitIgnoresCommasInsideBracketsAndStrings(): void
     {
         $decl = new PropsDeclarationParser()->parse('{%- props items = [\'x\', \'y\'], label = \'a, b\', open = false -%}');
 
@@ -72,7 +72,7 @@ class PropsDeclarationParserTest extends TestCase
         self::assertSame('false', $decl->get('open')->default);
     }
 
-    public function testSupportsWhitespaceControlAndPlainTagForms()
+    public function testSupportsWhitespaceControlAndPlainTagForms(): void
     {
         $plain = new PropsDeclarationParser()->parse('{% props asIcon = false %}');
         $trimmed = new PropsDeclarationParser()->parse('{%- props asIcon = false -%}');
@@ -81,7 +81,7 @@ class PropsDeclarationParserTest extends TestCase
         self::assertSame('false', $trimmed->get('asIcon')->default);
     }
 
-    public function testNonLiteralDefaultExpressionIsStillFlaggedAsHavingADefault()
+    public function testNonLiteralDefaultExpressionIsStillFlaggedAsHavingADefault(): void
     {
         $decl = new PropsDeclarationParser()->parse('{%- props label = foo ~ bar -%}');
 

--- a/src/Toolkit/tests/Component/StimulusControllerDocParserTest.php
+++ b/src/Toolkit/tests/Component/StimulusControllerDocParserTest.php
@@ -20,7 +20,7 @@ use Symfony\UX\Toolkit\Component\StimulusControllerDocParser;
 // attribute, wiring descriptions) and honor the opt-in gate.
 class StimulusControllerDocParserTest extends TestCase
 {
-    public function testParsesValueNameTypeAndDerivedAttribute()
+    public function testParsesValueNameTypeAndDerivedAttribute(): void
     {
         $doc = new StimulusControllerDocParser()->parse(<<<'JS'
             /**
@@ -40,7 +40,7 @@ class StimulusControllerDocParserTest extends TestCase
         self::assertSame('Delay in milliseconds before the element removes itself.', $doc->values[0]->description);
     }
 
-    public function testParsesClassNameAndDerivedAttribute()
+    public function testParsesClassNameAndDerivedAttribute(): void
     {
         $doc = new StimulusControllerDocParser()->parse(<<<'JS'
             /**
@@ -57,7 +57,7 @@ class StimulusControllerDocParserTest extends TestCase
         self::assertSame('Applied to the element for a short window after a copy.', $doc->classes[0]->description);
     }
 
-    public function testParsesOutletNameAndDerivedAttribute()
+    public function testParsesOutletNameAndDerivedAttribute(): void
     {
         $doc = new StimulusControllerDocParser()->parse(<<<'JS'
             /**
@@ -74,7 +74,7 @@ class StimulusControllerDocParserTest extends TestCase
         self::assertSame('Status controller reflecting the copy result.', $doc->outlets[0]->description);
     }
 
-    public function testActionsAreOptInFromTags()
+    public function testActionsAreOptInFromTags(): void
     {
         $doc = new StimulusControllerDocParser()->parse(<<<'JS'
             /**
@@ -96,7 +96,7 @@ class StimulusControllerDocParserTest extends TestCase
         self::assertSame('cancel', $doc->actions[1]->name);
     }
 
-    public function testUndocumentedControllerYieldsEmptyDocEvenWithDeclaredValuesAndTargets()
+    public function testUndocumentedControllerYieldsEmptyDocEvenWithDeclaredValuesAndTargets(): void
     {
         $doc = new StimulusControllerDocParser()->parse(<<<'JS'
             export default class extends Controller {
@@ -110,7 +110,7 @@ class StimulusControllerDocParserTest extends TestCase
         self::assertTrue($doc->isEmpty());
     }
 
-    public function testReturnsEmptyDocWhenNothingDeclared()
+    public function testReturnsEmptyDocWhenNothingDeclared(): void
     {
         $doc = new StimulusControllerDocParser()->parse('export default class extends Controller {}', 'closeable');
 

--- a/src/Toolkit/tests/Component/StimulusControllerSourceTest.php
+++ b/src/Toolkit/tests/Component/StimulusControllerSourceTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Toolkit\Component\StimulusControllerSource;
 
 class StimulusControllerSourceTest extends TestCase
 {
-    public function testTags()
+    public function testTags(): void
     {
         $source = new StimulusControllerSource(<<<'JS'
             /**
@@ -36,7 +36,7 @@ class StimulusControllerSourceTest extends TestCase
         self::assertSame(['toggle' => 'Toggles it.'], $source->tags()['action']);
     }
 
-    public function testValuesReadTypeAndDefaultFromCode()
+    public function testValuesReadTypeAndDefaultFromCode(): void
     {
         $source = new StimulusControllerSource(<<<'JS'
             export default class extends Controller {
@@ -50,7 +50,7 @@ class StimulusControllerSourceTest extends TestCase
         ], $source->values());
     }
 
-    public function testTargets()
+    public function testTargets(): void
     {
         $source = new StimulusControllerSource(<<<'JS'
             export default class extends Controller {
@@ -61,7 +61,7 @@ class StimulusControllerSourceTest extends TestCase
         self::assertSame(['trigger', 'content'], $source->targets());
     }
 
-    public function testClasses()
+    public function testClasses(): void
     {
         $source = new StimulusControllerSource(<<<'JS'
             export default class extends Controller {
@@ -72,7 +72,7 @@ class StimulusControllerSourceTest extends TestCase
         self::assertSame(['loading', 'success'], $source->classes());
     }
 
-    public function testOutlets()
+    public function testOutlets(): void
     {
         $source = new StimulusControllerSource(<<<'JS'
             export default class extends Controller {
@@ -83,7 +83,7 @@ class StimulusControllerSourceTest extends TestCase
         self::assertSame(['user-status', 'flash'], $source->outlets());
     }
 
-    public function testEmptySourceYieldsNothing()
+    public function testEmptySourceYieldsNothing(): void
     {
         $source = new StimulusControllerSource('export default class extends Controller {}');
 
@@ -94,7 +94,7 @@ class StimulusControllerSourceTest extends TestCase
         self::assertSame([], $source->outlets());
     }
 
-    public function testTagWithoutDescriptionIsRecognizedWithEmptyDescription()
+    public function testTagWithoutDescriptionIsRecognizedWithEmptyDescription(): void
     {
         $source = new StimulusControllerSource(<<<'JS'
             /**
@@ -106,7 +106,7 @@ class StimulusControllerSourceTest extends TestCase
         self::assertSame(['save' => ''], $source->tags()['action']);
     }
 
-    public function testDescriptionStopsAtTheNextAnnotationLine()
+    public function testDescriptionStopsAtTheNextAnnotationLine(): void
     {
         $source = new StimulusControllerSource(<<<'JS'
             /**
@@ -122,7 +122,7 @@ class StimulusControllerSourceTest extends TestCase
         self::assertSame(['close' => 'Closes the element.'], $source->tags()['action']);
     }
 
-    public function testDescriptionKeepsInlineAtMentions()
+    public function testDescriptionKeepsInlineAtMentions(): void
     {
         $source = new StimulusControllerSource(<<<'JS'
             /**
@@ -135,7 +135,7 @@ class StimulusControllerSourceTest extends TestCase
         self::assertSame(['theme' => 'Theme forwarded to @hotwired/stimulus consumers.'], $source->tags()['value']);
     }
 
-    public function testEachDocblockIsParsedIndependently()
+    public function testEachDocblockIsParsedIndependently(): void
     {
         $source = new StimulusControllerSource(<<<'JS'
             /**

--- a/src/Toolkit/tests/Component/StimulusControllerTest.php
+++ b/src/Toolkit/tests/Component/StimulusControllerTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Toolkit\Component\StimulusController;
 
 class StimulusControllerTest extends TestCase
 {
-    public function testIsFilename()
+    public function testIsFilename(): void
     {
         self::assertTrue(StimulusController::isFilename('assets/controllers/alert_controller.js'));
         self::assertTrue(StimulusController::isFilename('closeable_controller.js'));
@@ -24,20 +24,20 @@ class StimulusControllerTest extends TestCase
         self::assertFalse(StimulusController::isFilename('alert.html.twig'));
     }
 
-    public function testIdentifierFromFilenameOrPath()
+    public function testIdentifierFromFilenameOrPath(): void
     {
         self::assertSame('closeable', StimulusController::identifier('closeable_controller.js'));
         self::assertSame('alert-dialog', StimulusController::identifier('alert_dialog_controller.js'));
         self::assertSame('hover-card', StimulusController::identifier('assets/controllers/hover_card_controller.js'));
     }
 
-    public function testFilenameFromIdentifier()
+    public function testFilenameFromIdentifier(): void
     {
         self::assertSame('closeable_controller.js', StimulusController::filename('closeable'));
         self::assertSame('alert_dialog_controller.js', StimulusController::filename('alert-dialog'));
     }
 
-    public function testValueAttributeDasherizesCamelCaseAndSnakeCase()
+    public function testValueAttributeDasherizesCamelCaseAndSnakeCase(): void
     {
         self::assertSame('data-widget-auto-close-value', StimulusController::valueAttribute('widget', 'autoClose'));
         self::assertSame('data-widget-open-value', StimulusController::valueAttribute('widget', 'open'));

--- a/src/Toolkit/tests/Dependency/ConstraintVersionTest.php
+++ b/src/Toolkit/tests/Dependency/ConstraintVersionTest.php
@@ -16,14 +16,14 @@ use Symfony\UX\Toolkit\Dependency\ConstraintVersion;
 
 final class ConstraintVersionTest extends TestCase
 {
-    public function testCanBeInstantiated()
+    public function testCanBeInstantiated(): void
     {
         $version = new ConstraintVersion('1.2.3');
 
         $this->assertSame('1.2.3', (string) $version);
     }
 
-    public function testCanBeCompared()
+    public function testCanBeCompared(): void
     {
         $this->assertTrue(new ConstraintVersion('1.2.3')->isHigherThan(new ConstraintVersion('1.2.2')));
         $this->assertFalse(new ConstraintVersion('1.2.3')->isHigherThan(new ConstraintVersion('1.2.4')));

--- a/src/Toolkit/tests/Dependency/DependencyParserTest.php
+++ b/src/Toolkit/tests/Dependency/DependencyParserTest.php
@@ -21,13 +21,13 @@ use Symfony\UX\Toolkit\Dependency\RecipeDependency;
 
 final class DependencyParserTest extends TestCase
 {
-    public function testParseNullReturnsEmptyList()
+    public function testParseNullReturnsEmptyList(): void
     {
         $this->assertSame([], DependencyParser::parse(null, allowRecipe: true));
         $this->assertSame([], DependencyParser::parse(null, allowRecipe: false));
     }
 
-    public function testParseTypedDependencies()
+    public function testParseTypedDependencies(): void
     {
         $dependencies = DependencyParser::parse([
             'composer' => ['tales-from-a-dev/twig-tailwind-extra:^1.0.0'],
@@ -43,14 +43,14 @@ final class DependencyParserTest extends TestCase
         ], $dependencies);
     }
 
-    public function testParseRecipeWhenAllowed()
+    public function testParseRecipeWhenAllowed(): void
     {
         $dependencies = DependencyParser::parse(['recipe' => ['Button']], allowRecipe: true);
 
         $this->assertEquals([new RecipeDependency('Button')], $dependencies);
     }
 
-    public function testParseRecipeWhenNotAllowedThrows()
+    public function testParseRecipeWhenNotAllowedThrows(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The dependency types "recipe" are not supported.');
@@ -58,7 +58,7 @@ final class DependencyParserTest extends TestCase
         DependencyParser::parse(['recipe' => ['Button']], allowRecipe: false);
     }
 
-    public function testParseRejectsNonObject()
+    public function testParseRejectsNonObject(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "dependencies" property must be an object.');
@@ -66,7 +66,7 @@ final class DependencyParserTest extends TestCase
         DependencyParser::parse(['foo'], allowRecipe: true);
     }
 
-    public function testParseRejectsUnsupportedType()
+    public function testParseRejectsUnsupportedType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The dependency types "unknown" are not supported.');

--- a/src/Toolkit/tests/Dependency/ImportmapPackageDependencyTest.php
+++ b/src/Toolkit/tests/Dependency/ImportmapPackageDependencyTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Toolkit\Dependency\ImportmapPackageDependency;
 
 class ImportmapPackageDependencyTest extends TestCase
 {
-    public function testShouldBeInstantiable()
+    public function testShouldBeInstantiable(): void
     {
         $dependency = new ImportmapPackageDependency('react');
         $this->assertSame('react', $dependency->package);

--- a/src/Toolkit/tests/Dependency/NpmPackageDependencyTest.php
+++ b/src/Toolkit/tests/Dependency/NpmPackageDependencyTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Toolkit\Dependency\NpmPackageDependency;
 
 class NpmPackageDependencyTest extends TestCase
 {
-    public function testShouldBeInstantiable()
+    public function testShouldBeInstantiable(): void
     {
         $dependency = new NpmPackageDependency('react');
         $this->assertSame('react', $dependency->name);
@@ -31,7 +31,7 @@ class NpmPackageDependencyTest extends TestCase
         $this->assertSame('react@^18.0.0', (string) $dependency);
     }
 
-    public function testShouldFailIfPackageNameIsInvalid()
+    public function testShouldFailIfPackageNameIsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid NPM package name "/foo".');

--- a/src/Toolkit/tests/Dependency/PhpPackageDependencyTest.php
+++ b/src/Toolkit/tests/Dependency/PhpPackageDependencyTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Toolkit\Dependency\PhpPackageDependency;
 
 final class PhpPackageDependencyTest extends TestCase
 {
-    public function testShouldBeInstantiable()
+    public function testShouldBeInstantiable(): void
     {
         $dependency = new PhpPackageDependency('twig/html-extra');
         $this->assertSame('twig/html-extra', $dependency->name);
@@ -31,7 +31,7 @@ final class PhpPackageDependencyTest extends TestCase
         $this->assertSame('twig/html-extra:^3.2.1', (string) $dependency);
     }
 
-    public function testShouldFailIfPackageNameIsInvalid()
+    public function testShouldFailIfPackageNameIsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid PHP package name "/foo".');

--- a/src/Toolkit/tests/Dependency/RecipeDependencyTest.php
+++ b/src/Toolkit/tests/Dependency/RecipeDependencyTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Toolkit\Dependency\RecipeDependency;
 
 final class RecipeDependencyTest extends TestCase
 {
-    public function testShouldBeInstantiable()
+    public function testShouldBeInstantiable(): void
     {
         $dependency = new RecipeDependency('Table');
         $this->assertSame('Table', $dependency->name);

--- a/src/Toolkit/tests/Doc/AllRecipesDocRenderTest.php
+++ b/src/Toolkit/tests/Doc/AllRecipesDocRenderTest.php
@@ -48,7 +48,7 @@ final class AllRecipesDocRenderTest extends KernelTestCase
     }
 
     #[DataProvider('provideDocumentedRecipes')]
-    public function testDocMdRenders(string $kitName, string $recipeName)
+    public function testDocMdRenders(string $kitName, string $recipeName): void
     {
         $kitFactory = self::getContainer()->get('ux_toolkit.kit.kit_factory');
         \assert($kitFactory instanceof KitFactory);

--- a/src/Toolkit/tests/Doc/InlineExamplesConverterTest.php
+++ b/src/Toolkit/tests/Doc/InlineExamplesConverterTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Toolkit\Doc\InlineExamplesConverter;
 
 class InlineExamplesConverterTest extends TestCase
 {
-    public function testConvertInlinesRunnableExampleWithPreviewAndOptions()
+    public function testConvertInlinesRunnableExampleWithPreviewAndOptions(): void
     {
         $readme = "## Examples\n\n::: example Basic {\"height\": \"150px\"}\n";
         $out = InlineExamplesConverter::convert($readme, static fn (string $name): string => "<twig:Avatar name=\"$name\" />");
@@ -26,7 +26,7 @@ class InlineExamplesConverterTest extends TestCase
         $this->assertStringNotContainsString('::: example', $out);
     }
 
-    public function testConvertKeepsUsageStaticWithoutPreview()
+    public function testConvertKeepsUsageStaticWithoutPreview(): void
     {
         $readme = "## Usage\n\n::: example Usage\n";
         $out = InlineExamplesConverter::convert($readme, static fn (string $name): string => '<twig:Avatar />');

--- a/src/Toolkit/tests/Doc/MdTwigConverterTest.php
+++ b/src/Toolkit/tests/Doc/MdTwigConverterTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Toolkit\Doc\MdTwigConverter;
 
 final class MdTwigConverterTest extends TestCase
 {
-    public function testProducesTheFullDocumentBodyWithDirectives()
+    public function testProducesTheFullDocumentBodyWithDirectives(): void
     {
         $doc = MdTwigConverter::convert(<<<'TWIG'
             {% extends 'toolkit/docs/_base_component.md.twig' %}
@@ -56,7 +56,7 @@ final class MdTwigConverterTest extends TestCase
         $this->assertStringContainsString('::: example RTL {"height": "450px", "collapseClass": true}', $doc);
     }
 
-    public function testConvertsUsageBlock()
+    public function testConvertsUsageBlock(): void
     {
         $doc = MdTwigConverter::convert(<<<'TWIG'
             {% block usage %}

--- a/src/Toolkit/tests/Doc/RecipeDocRendererTest.php
+++ b/src/Toolkit/tests/Doc/RecipeDocRendererTest.php
@@ -28,7 +28,7 @@ use Symfony\UX\Toolkit\Recipe\Recipe;
 
 final class RecipeDocRendererTest extends KernelTestCase
 {
-    public function testRenderAsMarkdownResolvesExamplesAndOmitsInteractiveDirectives()
+    public function testRenderAsMarkdownResolvesExamplesAndOmitsInteractiveDirectives(): void
     {
         [$kit, $recipe] = $this->loadPostLinkRecipe();
 
@@ -48,7 +48,7 @@ final class RecipeDocRendererTest extends KernelTestCase
         $this->assertStringContainsString('<twig:PostLink>', $markdown);
     }
 
-    public function testRenderAsHtmlProducesTabsAndALivePreview()
+    public function testRenderAsHtmlProducesTabsAndALivePreview(): void
     {
         [$kit, $recipe] = $this->loadPostLinkRecipe();
 
@@ -75,7 +75,7 @@ final class RecipeDocRendererTest extends KernelTestCase
         $this->assertContains('API Reference', array_column($rendered->tableOfContents, 'title'));
     }
 
-    public function testACustomDocMdControlsTheLayoutAndInjectsGeneratedContent()
+    public function testACustomDocMdControlsTheLayoutAndInjectsGeneratedContent(): void
     {
         [$kit, $recipe] = $this->loadPostLinkRecipe();
 
@@ -100,7 +100,7 @@ final class RecipeDocRendererTest extends KernelTestCase
         $this->assertStringNotContainsString('```twig', $markdown);
     }
 
-    public function testRenderAsMarkdownIncludesStimulusControllerApiReference()
+    public function testRenderAsMarkdownIncludesStimulusControllerApiReference(): void
     {
         [$kit, $recipe] = $this->loadWidgetRecipe();
 
@@ -122,7 +122,7 @@ final class RecipeDocRendererTest extends KernelTestCase
         $this->assertStringContainsString('| `toggle` | Toggles the widget open state. |', $markdown);
     }
 
-    public function testRenderAsHtmlIncludesStimulusControllerApiReference()
+    public function testRenderAsHtmlIncludesStimulusControllerApiReference(): void
     {
         [$kit, $recipe] = $this->loadWidgetRecipe();
 
@@ -146,7 +146,7 @@ final class RecipeDocRendererTest extends KernelTestCase
         $this->assertStringContainsString('Toggles the widget open state.', $html);
     }
 
-    public function testHtmlInstallationStepsCarryTheFileNameInTheInfoString()
+    public function testHtmlInstallationStepsCarryTheFileNameInTheInfoString(): void
     {
         [$kit, $recipe] = $this->loadPostLinkRecipe();
 

--- a/src/Toolkit/tests/FileTest.php
+++ b/src/Toolkit/tests/FileTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Toolkit\File;
 
 final class FileTest extends TestCase
 {
-    public function testShouldFailIfSourcePathIsNotRelative()
+    public function testShouldFailIfSourcePathIsNotRelative(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('The source path "%s" must be relative.', __FILE__.'/templates/components/Button.html.twig'));
@@ -24,7 +24,7 @@ final class FileTest extends TestCase
         new File(__FILE__.'/templates/components/Button.html.twig', __FILE__.'Button.html.twig');
     }
 
-    public function testShouldFailIfDestinationPathIsNotRelative()
+    public function testShouldFailIfDestinationPathIsNotRelative(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('The destination path "%s" must be relative.', __FILE__.'Button.html.twig'));
@@ -32,7 +32,7 @@ final class FileTest extends TestCase
         new File('templates/components/Button.html.twig', __FILE__.'Button.html.twig');
     }
 
-    public function testShouldFailIfSourcePathEscapesTargetDirectory()
+    public function testShouldFailIfSourcePathEscapesTargetDirectory(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The path "../../../../tmp/PWNED.html.twig" must not escape its target directory.');
@@ -40,7 +40,7 @@ final class FileTest extends TestCase
         new File('../../../../tmp/PWNED.html.twig', 'templates/components/Button.html.twig');
     }
 
-    public function testShouldFailIfDestinationPathEscapesTargetDirectory()
+    public function testShouldFailIfDestinationPathEscapesTargetDirectory(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The path "../../../../tmp/PWNED.html.twig" must not escape its target directory.');
@@ -48,7 +48,7 @@ final class FileTest extends TestCase
         new File('templates/components/Button.html.twig', '../../../../tmp/PWNED.html.twig');
     }
 
-    public function testCanInstantiateFile()
+    public function testCanInstantiateFile(): void
     {
         $file = new File('src-templates/components/Button.html.twig', 'dist-templates/components/Button.html.twig');
 
@@ -57,7 +57,7 @@ final class FileTest extends TestCase
         $this->assertSame('src-templates/components/Button.html.twig', (string) $file);
     }
 
-    public function testCanInstantiateFileWithSubComponent()
+    public function testCanInstantiateFileWithSubComponent(): void
     {
         $file = new File('src-templates/components/Table/Body.html.twig', 'dest-templates/components/Table/Body.html.twig');
 

--- a/src/Toolkit/tests/Functional/ComponentsRenderingTest.php
+++ b/src/Toolkit/tests/Functional/ComponentsRenderingTest.php
@@ -57,7 +57,7 @@ class ComponentsRenderingTest extends WebTestCase
 
     #[DataProvider('provideTestComponentRendering')]
     #[Group('skip-on-lowest')]
-    public function testComponentRendering(string $kitName, string $recipeName, string $code)
+    public function testComponentRendering(string $kitName, string $recipeName, string $code): void
     {
         $twig = self::getContainer()->get('twig');
         /** @var KitContextRunner $kitContextRunner */

--- a/src/Toolkit/tests/Installer/InstallerTest.php
+++ b/src/Toolkit/tests/Installer/InstallerTest.php
@@ -33,7 +33,7 @@ final class InstallerTest extends KernelTestCase
         $this->filesystem->mkdir($this->tmpDir);
     }
 
-    public function testCanInstallComponent()
+    public function testCanInstallComponent(): void
     {
         $installer = new Installer(self::getContainer()->get('filesystem'), static fn () => throw new \BadFunctionCallException('The installer should not ask for confirmation since the file does not exist.'));
         $kit = $this->createKit('shadcn');
@@ -49,7 +49,7 @@ final class InstallerTest extends KernelTestCase
         $this->assertSame(file_get_contents($this->tmpDir.'/templates/components/Button.html.twig'), file_get_contents(\sprintf('%s/templates/components/Button.html.twig', $recipe->absolutePath)));
     }
 
-    public function testShouldAskIfFileAlreadyExists()
+    public function testShouldAskIfFileAlreadyExists(): void
     {
         $askedCount = 0;
         $installer = new Installer(self::getContainer()->get('filesystem'), static function () use (&$askedCount) {
@@ -72,7 +72,7 @@ final class InstallerTest extends KernelTestCase
         $this->assertSame(1, $askedCount);
     }
 
-    public function testCanInstallComponentIfForced()
+    public function testCanInstallComponentIfForced(): void
     {
         $installer = new Installer(self::getContainer()->get('filesystem'), static fn () => throw new \BadFunctionCallException('The installer should not ask for confirmation since the file does not exist.'));
         $kit = $this->createKit('shadcn');
@@ -91,7 +91,7 @@ final class InstallerTest extends KernelTestCase
         $this->assertSame(file_get_contents($this->tmpDir.'/templates/components/Button.html.twig'), file_get_contents(\sprintf('%s/templates/components/Button.html.twig', $recipe->absolutePath)));
     }
 
-    public function testCanInstallComponentAndItsComponentDependencies()
+    public function testCanInstallComponentAndItsComponentDependencies(): void
     {
         $installer = new Installer(self::getContainer()->get('filesystem'), static fn () => throw new \BadFunctionCallException('The installer should not ask for confirmation since the file does not exist.'));
         $kit = $this->createKit('shadcn');

--- a/src/Toolkit/tests/Installer/PoolResolverTest.php
+++ b/src/Toolkit/tests/Installer/PoolResolverTest.php
@@ -27,7 +27,7 @@ final class PoolResolverTest extends TestCase
 {
     use TestHelperTrait;
 
-    public function testCanResolveDependencies()
+    public function testCanResolveDependencies(): void
     {
         $kitSynchronizer = new KitSynchronizer(new Filesystem(), new RecipeSynchronizer());
         $kit = self::createLocalKit('shadcn');
@@ -57,7 +57,7 @@ final class PoolResolverTest extends TestCase
         $this->assertCount(3, $pool->getPhpPackageDependencies());
     }
 
-    public function testCanHandleCircularRecipeDependencies()
+    public function testCanHandleCircularRecipeDependencies(): void
     {
         $kitSynchronizer = new KitSynchronizer(new Filesystem(), new RecipeSynchronizer());
         $kit = self::createFixtureKit('with-circular-components-dependencies');
@@ -82,7 +82,7 @@ final class PoolResolverTest extends TestCase
         $this->assertCount(0, $pool->getPhpPackageDependencies());
     }
 
-    public function testCanHandleAllPossibleDependencies()
+    public function testCanHandleAllPossibleDependencies(): void
     {
         $kitSynchronizer = new KitSynchronizer(new Filesystem(), new RecipeSynchronizer());
         $kit = self::createFixtureKit('with-many-dependencies');

--- a/src/Toolkit/tests/Installer/PoolTest.php
+++ b/src/Toolkit/tests/Installer/PoolTest.php
@@ -24,7 +24,7 @@ use Symfony\UX\Toolkit\Recipe\RecipeType;
 
 final class PoolTest extends TestCase
 {
-    public function testCanAddFiles()
+    public function testCanAddFiles(): void
     {
         $pool = new Pool();
 
@@ -42,7 +42,7 @@ final class PoolTest extends TestCase
         $this->assertCount(2, $pool->getFiles()[$recipe->absolutePath]);
     }
 
-    public function testCantAddSameFileTwice()
+    public function testCantAddSameFileTwice(): void
     {
         $pool = new Pool();
 
@@ -57,7 +57,7 @@ final class PoolTest extends TestCase
         $this->assertCount(1, $pool->getFiles());
     }
 
-    public function testCanAddPhpPackageDependencies()
+    public function testCanAddPhpPackageDependencies(): void
     {
         $pool = new Pool();
 
@@ -66,7 +66,7 @@ final class PoolTest extends TestCase
         $this->assertCount(1, $pool->getPhpPackageDependencies());
     }
 
-    public function testCantAddSamePhpPackageDependencyTwice()
+    public function testCantAddSamePhpPackageDependencyTwice(): void
     {
         $pool = new Pool();
 
@@ -76,7 +76,7 @@ final class PoolTest extends TestCase
         $this->assertCount(1, $pool->getPhpPackageDependencies());
     }
 
-    public function testCanAddPhpPackageDependencyWithHigherVersion()
+    public function testCanAddPhpPackageDependencyWithHigherVersion(): void
     {
         $pool = new Pool();
 
@@ -96,7 +96,7 @@ final class PoolTest extends TestCase
         $this->assertEquals('twig/html-extra:^3.12.0', (string) $pool->getPhpPackageDependencies()['twig/html-extra']);
     }
 
-    public function testCanAddNpmPackageDependencies()
+    public function testCanAddNpmPackageDependencies(): void
     {
         $pool = new Pool();
 
@@ -105,7 +105,7 @@ final class PoolTest extends TestCase
         $this->assertCount(1, $pool->getNpmPackageDependencies());
     }
 
-    public function testCantAddSameNpmPackageDependencyTwice()
+    public function testCantAddSameNpmPackageDependencyTwice(): void
     {
         $pool = new Pool();
 
@@ -115,7 +115,7 @@ final class PoolTest extends TestCase
         $this->assertCount(1, $pool->getNpmPackageDependencies());
     }
 
-    public function testCanAddNpmPackageDependencyWithHigherVersion()
+    public function testCanAddNpmPackageDependencyWithHigherVersion(): void
     {
         $pool = new Pool();
 
@@ -135,7 +135,7 @@ final class PoolTest extends TestCase
         $this->assertEquals('tailwindcss@^4.0.0', (string) $pool->getNpmPackageDependencies()['tailwindcss']);
     }
 
-    public function testCanAddImportmapPackageDependencies()
+    public function testCanAddImportmapPackageDependencies(): void
     {
         $pool = new Pool();
 
@@ -144,7 +144,7 @@ final class PoolTest extends TestCase
         $this->assertCount(1, $pool->getImportmapPackageDependencies());
     }
 
-    public function testCantAddSameImportmapPackageDependencyTwice()
+    public function testCantAddSameImportmapPackageDependencyTwice(): void
     {
         $pool = new Pool();
 

--- a/src/Toolkit/tests/Kit/KitContextRunnerTest.php
+++ b/src/Toolkit/tests/Kit/KitContextRunnerTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\TwigComponent\ComponentTemplateFinderInterface;
 
 class KitContextRunnerTest extends KernelTestCase
 {
-    public function testRunForKitShouldConfigureThenResetServices()
+    public function testRunForKitShouldConfigureThenResetServices(): void
     {
         $twig = self::getContainer()->get('twig');
         $initialTwigLoader = $twig->getLoader();

--- a/src/Toolkit/tests/Kit/KitFactoryTest.php
+++ b/src/Toolkit/tests/Kit/KitFactoryTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Toolkit\Kit\KitFactory;
 
 final class KitFactoryTest extends KernelTestCase
 {
-    public function testShouldFailIfPathIsNotAbsolute()
+    public function testShouldFailIfPathIsNotAbsolute(): void
     {
         $kitFactory = $this->createKitFactory();
 
@@ -26,7 +26,7 @@ final class KitFactoryTest extends KernelTestCase
         $kitFactory->createKitFromAbsolutePath('shadcn');
     }
 
-    public function testShouldFailIfKitDoesNotExist()
+    public function testShouldFailIfKitDoesNotExist(): void
     {
         $kitFactory = $this->createKitFactory();
 
@@ -36,7 +36,7 @@ final class KitFactoryTest extends KernelTestCase
         $kitFactory->createKitFromAbsolutePath(__DIR__.'/../../kits/does-not-exist');
     }
 
-    public function testCanCreateShadcnKit()
+    public function testCanCreateShadcnKit(): void
     {
         $kit = $this->createKitFactory()->createKitFromAbsolutePath(__DIR__.'/../../kits/shadcn');
 
@@ -50,7 +50,7 @@ final class KitFactoryTest extends KernelTestCase
         }
     }
 
-    public function testShouldRejectKitWithRecipeEscapingItsDirectory()
+    public function testShouldRejectKitWithRecipeEscapingItsDirectory(): void
     {
         // A malicious recipe whose "copy-files" tries to write outside the recipe directory
         // must be rejected when the kit (and its recipes) are loaded, before any file is touched.

--- a/src/Toolkit/tests/Kit/KitManifestTest.php
+++ b/src/Toolkit/tests/Kit/KitManifestTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Toolkit\Kit\KitManifest;
 
 final class KitManifestTest extends TestCase
 {
-    public function testFromJsonWithInvalidJson()
+    public function testFromJsonWithInvalidJson(): void
     {
         $this->expectException(\JsonException::class);
         $this->expectExceptionMessage('Syntax error');
@@ -27,7 +27,7 @@ final class KitManifestTest extends TestCase
         KitManifest::fromJson('test');
     }
 
-    public function testFromJsonWithEmpty()
+    public function testFromJsonWithEmpty(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Property "name" is required.');
@@ -35,7 +35,7 @@ final class KitManifestTest extends TestCase
         KitManifest::fromJson('{}');
     }
 
-    public function testFromJsonWithMissingDescription()
+    public function testFromJsonWithMissingDescription(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Property "description" is required.');
@@ -47,7 +47,7 @@ final class KitManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithMissingLicense()
+    public function testFromJsonWithMissingLicense(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Property "license" is required.');
@@ -60,7 +60,7 @@ final class KitManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithMissingHomepage()
+    public function testFromJsonWithMissingHomepage(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Property "homepage" is required.');
@@ -74,7 +74,7 @@ final class KitManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithInvalidHomepage()
+    public function testFromJsonWithInvalidHomepage(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid homepage URL "not-a-url".');
@@ -89,7 +89,7 @@ final class KitManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithValidData()
+    public function testFromJsonWithValidData(): void
     {
         $manifest = KitManifest::fromJson(<<<JSON
                 {
@@ -109,7 +109,7 @@ final class KitManifestTest extends TestCase
         $this->assertNull($manifest->icon);
     }
 
-    public function testFromJsonWithColorAndIcon()
+    public function testFromJsonWithColorAndIcon(): void
     {
         $manifest = KitManifest::fromJson(<<<JSON
                 {
@@ -126,7 +126,7 @@ final class KitManifestTest extends TestCase
         $this->assertSame('icon.svg', $manifest->icon);
     }
 
-    public function testFromJsonWithDependencies()
+    public function testFromJsonWithDependencies(): void
     {
         $manifest = KitManifest::fromJson(<<<JSON
                 {
@@ -148,7 +148,7 @@ final class KitManifestTest extends TestCase
         $this->assertInstanceOf(ImportmapPackageDependency::class, $manifest->dependencies[2]);
     }
 
-    public function testFromJsonRejectsRecipeDependency()
+    public function testFromJsonRejectsRecipeDependency(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The dependency types "recipe" are not supported.');

--- a/src/Toolkit/tests/Kit/KitSynchronizerTest.php
+++ b/src/Toolkit/tests/Kit/KitSynchronizerTest.php
@@ -30,7 +30,7 @@ final class KitSynchronizerTest extends KernelTestCase
         $this->bootKernel();
     }
 
-    public function testCanResolveDependencies()
+    public function testCanResolveDependencies(): void
     {
         $kitSynchronizer = new KitSynchronizer(new Filesystem(), new RecipeSynchronizer());
         $kit = self::createLocalKit('shadcn');

--- a/src/Toolkit/tests/Kit/KitTest.php
+++ b/src/Toolkit/tests/Kit/KitTest.php
@@ -20,7 +20,7 @@ use Symfony\UX\Toolkit\Recipe\RecipeType;
 
 final class KitTest extends TestCase
 {
-    public function testShouldFailIfKitNameIsInvalid()
+    public function testShouldFailIfKitNameIsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid kit name "-foobar".');
@@ -28,7 +28,7 @@ final class KitTest extends TestCase
         new Kit(__DIR__, new KitManifest('-foobar', 'Description', 'MIT', 'https://example.com'));
     }
 
-    public function testShouldFailIfKitPathIsNotAbsolute()
+    public function testShouldFailIfKitPathIsNotAbsolute(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('Kit path "./%s" is not absolute.', __DIR__));
@@ -36,7 +36,7 @@ final class KitTest extends TestCase
         new Kit(\sprintf('./%s', __DIR__), new KitManifest('foo', 'Description', 'MIT', 'https://example.com'));
     }
 
-    public function testCanAddRecipesToTheKit()
+    public function testCanAddRecipesToTheKit(): void
     {
         $kit = new Kit(__DIR__, new KitManifest('foo', 'Description', 'MIT', 'https://example.com'));
         $kit->addRecipe(new Recipe(
@@ -60,7 +60,7 @@ final class KitTest extends TestCase
         $this->assertCount(1, $kit->getRecipes(type: RecipeType::Block));
     }
 
-    public function testShouldFailIfComponentIsAlreadyRegisteredInTheKit()
+    public function testShouldFailIfComponentIsAlreadyRegisteredInTheKit(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Recipe "Alert" is already registered in the kit.');
@@ -78,7 +78,7 @@ final class KitTest extends TestCase
         ));
     }
 
-    public function testCanGetRecipeByName()
+    public function testCanGetRecipeByName(): void
     {
         $kit = new Kit(__DIR__, new KitManifest('foo', 'Description', 'MIT', 'https://example.com'));
         $kit->addRecipe(new Recipe(
@@ -96,7 +96,7 @@ final class KitTest extends TestCase
         $this->assertSame('Alert', $kit->getRecipe('alert')->manifest->name);
     }
 
-    public function testShouldReturnNullIfRecipeIsNotFound()
+    public function testShouldReturnNullIfRecipeIsNotFound(): void
     {
         $kit = new Kit(__DIR__, new KitManifest('foo', 'Description', 'MIT', 'https://example.com'));
 

--- a/src/Toolkit/tests/Kit/Lint/Checker/DocCheckerTest.php
+++ b/src/Toolkit/tests/Kit/Lint/Checker/DocCheckerTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Toolkit\Recipe\RecipeType;
 
 final class DocCheckerTest extends TestCase
 {
-    public function testFlagsOnlyRecipesWithoutDoc()
+    public function testFlagsOnlyRecipesWithoutDoc(): void
     {
         $kit = new Kit(__DIR__, new KitManifest('kit', 'A kit', 'MIT', 'https://example.com'));
         $kit->addRecipe(new Recipe('with-doc', __DIR__, $this->recipeManifest('WithDoc'), doc: '# Docs'));

--- a/src/Toolkit/tests/Kit/Lint/Checker/DocHeadingLevelCheckerTest.php
+++ b/src/Toolkit/tests/Kit/Lint/Checker/DocHeadingLevelCheckerTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Toolkit\Recipe\RecipeType;
 
 final class DocHeadingLevelCheckerTest extends TestCase
 {
-    public function testRequiresASingleLeadingLevelOneHeading()
+    public function testRequiresASingleLeadingLevelOneHeading(): void
     {
         $kit = new Kit(__DIR__, new KitManifest('kit', 'A kit', 'MIT', 'https://example.com'));
         // Valid: opens with the title as the only level-1 heading; a `#` inside a fence is ignored.

--- a/src/Toolkit/tests/Kit/Lint/ComponentDocCheckerTest.php
+++ b/src/Toolkit/tests/Kit/Lint/ComponentDocCheckerTest.php
@@ -46,19 +46,19 @@ class ComponentDocCheckerTest extends TestCase
         ));
     }
 
-    public function testValidComponentProducesNoIssues()
+    public function testValidComponentProducesNoIssues(): void
     {
         self::assertSame([], $this->issuesForFile($this->lintCases(), 'Valid.html.twig'));
     }
 
-    public function testAllIssuesAreWarnings()
+    public function testAllIssuesAreWarnings(): void
     {
         foreach ($this->lintCases()->getIssues() as $issue) {
             self::assertSame(LintSeverity::Warning, $issue->severity);
         }
     }
 
-    public function testInvalidPropNameIsReported()
+    public function testInvalidPropNameIsReported(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'InvalidName.html.twig');
 
@@ -67,7 +67,7 @@ class ComponentDocCheckerTest extends TestCase
         self::assertStringContainsString('Bad_Name', $issues[0]->message);
     }
 
-    public function testInvalidPhpDocTypeIsReported()
+    public function testInvalidPhpDocTypeIsReported(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'InvalidType.html.twig');
 
@@ -76,7 +76,7 @@ class ComponentDocCheckerTest extends TestCase
         self::assertStringContainsString('string|array<string', $issues[0]->message);
     }
 
-    public function testDescriptionMustStartWithCapitalAndEndWithPeriod()
+    public function testDescriptionMustStartWithCapitalAndEndWithPeriod(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'BadDescription.html.twig');
 
@@ -86,7 +86,7 @@ class ComponentDocCheckerTest extends TestCase
         }
     }
 
-    public function testDeclaredPropWithoutDocblockIsReported()
+    public function testDeclaredPropWithoutDocblockIsReported(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'MissingDoc.html.twig');
 
@@ -95,7 +95,7 @@ class ComponentDocCheckerTest extends TestCase
         self::assertStringContainsString('hidden', $issues[0]->message);
     }
 
-    public function testDocumentedPropNotDeclaredIsReported()
+    public function testDocumentedPropNotDeclaredIsReported(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'ExtraDoc.html.twig');
 
@@ -104,7 +104,7 @@ class ComponentDocCheckerTest extends TestCase
         self::assertStringContainsString('ghost', $issues[0]->message);
     }
 
-    public function testComponentWithPropsButNoDocblocksReportsEveryDeclaredProp()
+    public function testComponentWithPropsButNoDocblocksReportsEveryDeclaredProp(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'NoDocblocks.html.twig');
 
@@ -116,12 +116,12 @@ class ComponentDocCheckerTest extends TestCase
         self::assertStringContainsString('bar', $issues[0]->message.$issues[1]->message);
     }
 
-    public function testValidBlockProducesNoIssues()
+    public function testValidBlockProducesNoIssues(): void
     {
         self::assertSame([], $this->issuesForFile($this->lintCases(), 'ValidBlock.html.twig'));
     }
 
-    public function testBlockDescriptionMustEndWithPeriod()
+    public function testBlockDescriptionMustEndWithPeriod(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'BlockMissingPeriod.html.twig');
 
@@ -129,7 +129,7 @@ class ComponentDocCheckerTest extends TestCase
         self::assertSame('component.block.invalid', $issues[0]->category);
     }
 
-    public function testDocumentedBlockNotUsedInTemplateIsReported()
+    public function testDocumentedBlockNotUsedInTemplateIsReported(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'BlockDocumentedNotUsed.html.twig');
 
@@ -138,7 +138,7 @@ class ComponentDocCheckerTest extends TestCase
         self::assertStringContainsString('ghost', $issues[0]->message);
     }
 
-    public function testBlockUsedInTemplatebutNotDocumentedIsReported()
+    public function testBlockUsedInTemplatebutNotDocumentedIsReported(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'BlockUsedNotDocumented.html.twig');
 
@@ -147,7 +147,7 @@ class ComponentDocCheckerTest extends TestCase
         self::assertStringContainsString('content', $issues[0]->message);
     }
 
-    public function testBlockRenderedViaOuterBlocksIsRecognizedAsUsed()
+    public function testBlockRenderedViaOuterBlocksIsRecognizedAsUsed(): void
     {
         self::assertSame([], $this->issuesForFile($this->lintCases(), 'BlockViaOuterBlocks.html.twig'));
     }

--- a/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
+++ b/src/Toolkit/tests/Kit/Lint/KitLinterTest.php
@@ -72,7 +72,7 @@ class KitLinterTest extends TestCase
         ));
     }
 
-    public function testMissingRecipeManifestCheckerDetectsOrphanDirectory()
+    public function testMissingRecipeManifestCheckerDetectsOrphanDirectory(): void
     {
         $kit = $this->loadBrokenKit();
         $linter = new KitLinter([new MissingRecipeManifestChecker()]);
@@ -84,7 +84,7 @@ class KitLinterTest extends TestCase
         $this->assertSame(LintSeverity::Error, $issues[0]->severity);
     }
 
-    public function testCopyFilesExistenceCheckerDetectsMissingDirectory()
+    public function testCopyFilesExistenceCheckerDetectsMissingDirectory(): void
     {
         $kit = $this->loadBrokenKit();
         $linter = new KitLinter([new CopyFilesExistenceChecker()]);
@@ -96,7 +96,7 @@ class KitLinterTest extends TestCase
         $this->assertSame(LintSeverity::Error, $issues[0]->severity);
     }
 
-    public function testRecipeReferenceCheckerDetectsUnknownRecipe()
+    public function testRecipeReferenceCheckerDetectsUnknownRecipe(): void
     {
         $kit = $this->loadBrokenKit();
         $linter = new KitLinter([new RecipeReferenceChecker()]);
@@ -123,7 +123,7 @@ class KitLinterTest extends TestCase
     }
 
     #[DataProvider('provideStimulusCases')]
-    public function testStimulusControllerChecker(string $controllerName, bool $expectWarning, ?string $expectedFile)
+    public function testStimulusControllerChecker(string $controllerName, bool $expectWarning, ?string $expectedFile): void
     {
         $kit = $this->loadFixtureKit('lint-stimulus');
 
@@ -147,7 +147,7 @@ class KitLinterTest extends TestCase
         $this->assertStringContainsString($expectedFile, $matching[0]->file);
     }
 
-    public function testStimulusControllerSatisfiedByRecipeDependency()
+    public function testStimulusControllerSatisfiedByRecipeDependency(): void
     {
         $kit = $this->loadFixtureKit('lint-stimulus');
 
@@ -196,7 +196,7 @@ class KitLinterTest extends TestCase
     }
 
     #[DataProvider('provideComposerCases')]
-    public function testComposerSymbolChecker(string $recipe, ?string $category, ?string $needle)
+    public function testComposerSymbolChecker(string $recipe, ?string $category, ?string $needle): void
     {
         $kit = $this->loadFixtureKit('lint-composer-symbol');
         $issues = $this->findRecipeIssues(new KitLinter([new ComposerSymbolChecker()])->lint($kit), $recipe);
@@ -239,7 +239,7 @@ class KitLinterTest extends TestCase
     }
 
     #[DataProvider('provideJsImportCases')]
-    public function testJsImportChecker(string $recipe, ?string $category, ?string $needle)
+    public function testJsImportChecker(string $recipe, ?string $category, ?string $needle): void
     {
         $kit = $this->loadFixtureKit('lint-js-import');
         $issues = $this->findRecipeIssues(new KitLinter([new JsImportChecker()])->lint($kit), $recipe);
@@ -272,7 +272,7 @@ class KitLinterTest extends TestCase
     }
 
     #[DataProvider('provideAttributesDefaultsCases')]
-    public function testAttributesDefaultsChecker(string $file, int $expectedCount)
+    public function testAttributesDefaultsChecker(string $file, int $expectedCount): void
     {
         $kit = $this->loadFixtureKit('lint-attributes-defaults');
 

--- a/src/Toolkit/tests/Kit/Lint/StimulusControllerDocCheckerTest.php
+++ b/src/Toolkit/tests/Kit/Lint/StimulusControllerDocCheckerTest.php
@@ -46,25 +46,25 @@ class StimulusControllerDocCheckerTest extends TestCase
         ));
     }
 
-    public function testValidControllerProducesNoIssues()
+    public function testValidControllerProducesNoIssues(): void
     {
         self::assertSame([], $this->issuesForFile($this->lintCases(), 'valid_controller.js'));
     }
 
-    public function testUndocumentedControllerIsNotReported()
+    public function testUndocumentedControllerIsNotReported(): void
     {
         // Documentation is opt-in: a controller with no tags at all must be left alone.
         self::assertSame([], $this->issuesForFile($this->lintCases(), 'undocumented_controller.js'));
     }
 
-    public function testAllIssuesAreWarnings()
+    public function testAllIssuesAreWarnings(): void
     {
         foreach ($this->lintCases()->getIssues() as $issue) {
             self::assertSame(LintSeverity::Warning, $issue->severity);
         }
     }
 
-    public function testMismatchesAreReportedBothWays()
+    public function testMismatchesAreReportedBothWays(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'mismatch_controller.js');
         $messages = array_map(static fn (LintIssue $i) => $i->message, $issues);
@@ -77,7 +77,7 @@ class StimulusControllerDocCheckerTest extends TestCase
         self::assertStringContainsString('"autoClose" is declared in the controller but has no `@value', implode("\n", $messages));
     }
 
-    public function testClassMismatchesAreReportedBothWays()
+    public function testClassMismatchesAreReportedBothWays(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'class_conflict_controller.js');
         $messages = array_map(static fn (LintIssue $i) => $i->message, $issues);
@@ -90,7 +90,7 @@ class StimulusControllerDocCheckerTest extends TestCase
         self::assertStringContainsString('"loading" is declared in the controller but has no `@css-class', implode("\n", $messages));
     }
 
-    public function testOutletMismatchesAreReportedBothWays()
+    public function testOutletMismatchesAreReportedBothWays(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'outlet_conflict_controller.js');
         $messages = array_map(static fn (LintIssue $i) => $i->message, $issues);
@@ -103,7 +103,7 @@ class StimulusControllerDocCheckerTest extends TestCase
         self::assertStringContainsString('"flash" is declared in the controller but has no `@outlet', implode("\n", $messages));
     }
 
-    public function testBadDescriptionIsReported()
+    public function testBadDescriptionIsReported(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'bad_description_controller.js');
 
@@ -113,7 +113,7 @@ class StimulusControllerDocCheckerTest extends TestCase
         }
     }
 
-    public function testActionWithoutMatchingMethodIsReported()
+    public function testActionWithoutMatchingMethodIsReported(): void
     {
         $issues = $this->issuesForFile($this->lintCases(), 'orphan_action_controller.js');
 

--- a/src/Toolkit/tests/Markdown/AlertExtensionTest.php
+++ b/src/Toolkit/tests/Markdown/AlertExtensionTest.php
@@ -21,7 +21,7 @@ use Twig\Loader\FilesystemLoader;
 
 class AlertExtensionTest extends TestCase
 {
-    public function testRendersNoteAlert()
+    public function testRendersNoteAlert(): void
     {
         $converter = $this->createConverter();
 
@@ -36,7 +36,7 @@ class AlertExtensionTest extends TestCase
         );
     }
 
-    public function testRendersWarningAlert()
+    public function testRendersWarningAlert(): void
     {
         $converter = $this->createConverter();
 

--- a/src/Toolkit/tests/Markdown/CodeOptionsTest.php
+++ b/src/Toolkit/tests/Markdown/CodeOptionsTest.php
@@ -16,7 +16,7 @@ use Symfony\UX\Toolkit\Markdown\CodeOptions;
 
 class CodeOptionsTest extends TestCase
 {
-    public function testFromInfoJsonReadsFilenameAndCollapseClass()
+    public function testFromInfoJsonReadsFilenameAndCollapseClass(): void
     {
         $options = CodeOptions::fromInfoJson('{"filename": "templates/components/Alert.html.twig", "collapseClass": true}');
 
@@ -24,7 +24,7 @@ class CodeOptionsTest extends TestCase
         $this->assertTrue($options->collapseClass);
     }
 
-    public function testFromInfoJsonDefaultsToEmptyOptions()
+    public function testFromInfoJsonDefaultsToEmptyOptions(): void
     {
         $options = CodeOptions::fromInfoJson('{}');
 
@@ -32,35 +32,35 @@ class CodeOptionsTest extends TestCase
         $this->assertFalse($options->collapseClass);
     }
 
-    public function testFromInfoJsonIgnoresANonStringFilename()
+    public function testFromInfoJsonIgnoresANonStringFilename(): void
     {
         $this->assertNull(CodeOptions::fromInfoJson('{"filename": 42}')?->filename);
     }
 
-    public function testFromInfoJsonReturnsNullOnMalformedJson()
+    public function testFromInfoJsonReturnsNullOnMalformedJson(): void
     {
         $this->assertNull(CodeOptions::fromInfoJson('not json'));
         $this->assertNull(CodeOptions::fromInfoJson('"a string"'));
     }
 
-    public function testToInfoJsonCarriesTheFilenameWithUnescapedSlashes()
+    public function testToInfoJsonCarriesTheFilenameWithUnescapedSlashes(): void
     {
         $json = new CodeOptions(filename: 'templates/components/Alert.html.twig')->toInfoJson();
 
         $this->assertSame('{"filename":"templates/components/Alert.html.twig"}', $json);
     }
 
-    public function testToInfoJsonCarriesCollapseClass()
+    public function testToInfoJsonCarriesCollapseClass(): void
     {
         $this->assertSame('{"collapseClass":true}', new CodeOptions(collapseClass: true)->toInfoJson());
     }
 
-    public function testToInfoJsonIsNullWhenThereIsNothingToCarry()
+    public function testToInfoJsonIsNullWhenThereIsNothingToCarry(): void
     {
         $this->assertNull(new CodeOptions()->toInfoJson());
     }
 
-    public function testInfoJsonRoundTrips()
+    public function testInfoJsonRoundTrips(): void
     {
         $options = new CodeOptions(filename: 'assets/controllers/alert_controller.js', collapseClass: true);
 

--- a/src/Toolkit/tests/Markdown/CodePreviewExtensionTest.php
+++ b/src/Toolkit/tests/Markdown/CodePreviewExtensionTest.php
@@ -22,7 +22,7 @@ use Twig\Loader\FilesystemLoader;
 
 class CodePreviewExtensionTest extends TestCase
 {
-    public function testRendersLiveIframeWhenUrlGeneratorReturnsUrl()
+    public function testRendersLiveIframeWhenUrlGeneratorReturnsUrl(): void
     {
         $urlGenerator = new class implements PreviewUrlGenerator {
             public function generate(string $code, CodeOptions $options): ?string
@@ -37,7 +37,7 @@ class CodePreviewExtensionTest extends TestCase
         $this->assertStringContainsString('src="https://example.test/preview"', $html);
     }
 
-    public function testRendersStaticBlockWhenNoUrlGeneratorConfigured()
+    public function testRendersStaticBlockWhenNoUrlGeneratorConfigured(): void
     {
         $html = $this->render(new CodePreview('<twig:Button>Hi & bye</twig:Button>'), null);
 

--- a/src/Toolkit/tests/Markdown/FencedCodePreviewExtensionTest.php
+++ b/src/Toolkit/tests/Markdown/FencedCodePreviewExtensionTest.php
@@ -25,7 +25,7 @@ use Twig\Loader\FilesystemLoader;
 
 class FencedCodePreviewExtensionTest extends TestCase
 {
-    public function testPreviewFlaggedFenceBecomesPreviewAndCodeTabs()
+    public function testPreviewFlaggedFenceBecomesPreviewAndCodeTabs(): void
     {
         $html = $this->convert(<<<'MARKDOWN'
             ```twig {"preview": true, "height": "300px"}
@@ -41,7 +41,7 @@ class FencedCodePreviewExtensionTest extends TestCase
         $this->assertStringContainsString('twig:Button', $html);
     }
 
-    public function testPlainFenceIsLeftUntouched()
+    public function testPlainFenceIsLeftUntouched(): void
     {
         $html = $this->convert(<<<'MARKDOWN'
             ```twig
@@ -53,7 +53,7 @@ class FencedCodePreviewExtensionTest extends TestCase
         $this->assertStringContainsString('language-twig', $html);
     }
 
-    public function testJsonFenceWithoutPreviewOptInIsLeftUntouched()
+    public function testJsonFenceWithoutPreviewOptInIsLeftUntouched(): void
     {
         // A `filename` (or any non-preview JSON) must not turn the block into preview tabs — the info
         // string is left in place for the host's fenced-code renderer.
@@ -67,7 +67,7 @@ class FencedCodePreviewExtensionTest extends TestCase
         $this->assertStringContainsString('language-twig', $html);
     }
 
-    public function testJsonOptionsAreThreadedToTheLivePreview()
+    public function testJsonOptionsAreThreadedToTheLivePreview(): void
     {
         $urlGenerator = new class implements PreviewUrlGenerator {
             public function generate(string $code, CodeOptions $options): ?string

--- a/src/Toolkit/tests/Markdown/PopoverExtensionTest.php
+++ b/src/Toolkit/tests/Markdown/PopoverExtensionTest.php
@@ -21,7 +21,7 @@ use Twig\Loader\FilesystemLoader;
 
 class PopoverExtensionTest extends TestCase
 {
-    public function testRendersPopover()
+    public function testRendersPopover(): void
     {
         $converter = $this->createConverter();
 

--- a/src/Toolkit/tests/Markdown/PreviewTabsBuilderTest.php
+++ b/src/Toolkit/tests/Markdown/PreviewTabsBuilderTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Toolkit\Markdown\PreviewTabsBuilder;
 
 class PreviewTabsBuilderTest extends TestCase
 {
-    public function testCodeTabCarriesTheCollapseClassOptionForHostStyling()
+    public function testCodeTabCarriesTheCollapseClassOptionForHostStyling(): void
     {
         // The code tab is styled by the host (ux.symfony.com collapses long class attributes), so that
         // option travels through the FencedCode info string; height is a Preview-tab concern and stays out.
@@ -28,7 +28,7 @@ class PreviewTabsBuilderTest extends TestCase
         $this->assertSame('twig {"collapseClass":true}', $this->findFencedCode($tabs)?->getInfo());
     }
 
-    public function testCodeTabHasBareLanguageWhenCollapseClassIsOff()
+    public function testCodeTabHasBareLanguageWhenCollapseClassIsOff(): void
     {
         $tabs = PreviewTabsBuilder::build('<twig:Button />', new CodeOptions(), 'twig');
 

--- a/src/Toolkit/tests/Markdown/TabsExtensionTest.php
+++ b/src/Toolkit/tests/Markdown/TabsExtensionTest.php
@@ -21,7 +21,7 @@ use Twig\Loader\FilesystemLoader;
 
 class TabsExtensionTest extends TestCase
 {
-    public function testRendersTwoTabs()
+    public function testRendersTwoTabs(): void
     {
         $converter = $this->createConverter();
 

--- a/src/Toolkit/tests/Recipe/RecipeManifestTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeManifestTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Toolkit\Recipe\RecipeType;
 
 final class RecipeManifestTest extends TestCase
 {
-    public function testFromJsonWithInvalidJson()
+    public function testFromJsonWithInvalidJson(): void
     {
         $this->expectException(\JsonException::class);
         $this->expectExceptionMessage('Syntax error');
@@ -30,7 +30,7 @@ final class RecipeManifestTest extends TestCase
         RecipeManifest::fromJson('test');
     }
 
-    public function testFromJsonWithEmpty()
+    public function testFromJsonWithEmpty(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Property "type" is required.');
@@ -38,7 +38,7 @@ final class RecipeManifestTest extends TestCase
         RecipeManifest::fromJson('{}');
     }
 
-    public function testFromJsonWithInvalidType()
+    public function testFromJsonWithInvalidType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The recipe type "test" is not supported, valid types are "block", "component".');
@@ -50,7 +50,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithMissingName()
+    public function testFromJsonWithMissingName(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Property "name" is required.');
@@ -62,7 +62,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithInvalidDependencies()
+    public function testFromJsonWithInvalidDependencies(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "dependencies" property must be an object.');
@@ -79,7 +79,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithInvalidPhpDependency()
+    public function testFromJsonWithInvalidPhpDependency(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The dependency #0 of type "composer" must be a non-empty string.');
@@ -98,7 +98,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithInvalidNpmDependency()
+    public function testFromJsonWithInvalidNpmDependency(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The dependency #0 of type "npm" must be a non-empty string.');
@@ -118,7 +118,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithInvalidImportmapDependency()
+    public function testFromJsonWithInvalidImportmapDependency(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The dependency #0 of type "importmap" must be a non-empty string.');
@@ -139,7 +139,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithInvalidRecipeDependency()
+    public function testFromJsonWithInvalidRecipeDependency(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The dependency #0 of type "recipe" must be a non-empty string.');
@@ -161,7 +161,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithInvalidVersionAdded()
+    public function testFromJsonWithInvalidVersionAdded(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "version-added" property must be a non-empty string.');
@@ -178,7 +178,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithTraversalInCopyFilesSource()
+    public function testFromJsonWithTraversalInCopyFilesSource(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The path "../../../../tmp/PWNED" must not escape its target directory.');
@@ -194,7 +194,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithTraversalInCopyFilesDestination()
+    public function testFromJsonWithTraversalInCopyFilesDestination(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The path "../../../../tmp/PWNED" must not escape its target directory.');
@@ -210,7 +210,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithBackslashTraversalInCopyFilesDestination()
+    public function testFromJsonWithBackslashTraversalInCopyFilesDestination(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The path "..\\..\\tmp\\PWNED" must not escape its target directory.');
@@ -226,7 +226,7 @@ final class RecipeManifestTest extends TestCase
             JSON);
     }
 
-    public function testFromJsonWithMinimumValidData()
+    public function testFromJsonWithMinimumValidData(): void
     {
         $manifest = RecipeManifest::fromJson(<<<JSON
                 {
@@ -245,7 +245,7 @@ final class RecipeManifestTest extends TestCase
         $this->assertNull($manifest->versionAdded);
     }
 
-    public function testFromJsonWithValidData()
+    public function testFromJsonWithValidData(): void
     {
         $manifest = RecipeManifest::fromJson(<<<JSON
                 {

--- a/src/Toolkit/tests/Recipe/RecipeSynchronizerTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeSynchronizerTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Toolkit\Recipe\RecipeSynchronizer;
 
 final class RecipeSynchronizerTest extends TestCase
 {
-    public function testSynchronize()
+    public function testSynchronize(): void
     {
         $kit = new Kit(__DIR__, new KitManifest('foo', 'Description', 'MIT', 'https://example.com'));
         $recipeSynchronizer = new RecipeSynchronizer();

--- a/src/Toolkit/tests/Recipe/RecipeTest.php
+++ b/src/Toolkit/tests/Recipe/RecipeTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\Toolkit\Recipe\RecipeType;
 
 final class RecipeTest extends TestCase
 {
-    public function testShouldFailWhenPathIsNotAbsolute()
+    public function testShouldFailWhenPathIsNotAbsolute(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Kit path "relative/path" is not absolute.');
@@ -31,7 +31,7 @@ final class RecipeTest extends TestCase
         ));
     }
 
-    public function testShouldFailWhenInvalidCopyFiles()
+    public function testShouldFailWhenInvalidCopyFiles(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Copy file destination "/" must be a relative path.');
@@ -45,7 +45,7 @@ final class RecipeTest extends TestCase
         ));
     }
 
-    public function testGetCopyFiles()
+    public function testGetCopyFiles(): void
     {
         $recipe = new Recipe('test-recipe', __DIR__.'/../../kits/shadcn/table', new RecipeManifest(
             type: RecipeType::Component,
@@ -67,7 +67,7 @@ final class RecipeTest extends TestCase
         ], iterator_to_array($recipe->getFiles()));
     }
 
-    public function testGetCopyFilesWithDifferentDestDir()
+    public function testGetCopyFilesWithDifferentDestDir(): void
     {
         $recipe = new Recipe('test-recipe', __DIR__.'/../../kits/shadcn/table', new RecipeManifest(
             type: RecipeType::Component,
@@ -89,7 +89,7 @@ final class RecipeTest extends TestCase
         ], iterator_to_array($recipe->getFiles()));
     }
 
-    public function testGetDescriptionReadsTheReadmeFirstParagraph()
+    public function testGetDescriptionReadsTheReadmeFirstParagraph(): void
     {
         $manifest = new RecipeManifest(RecipeType::Component, 'Alert', []);
 
@@ -100,7 +100,7 @@ final class RecipeTest extends TestCase
         $this->assertNull(new Recipe('alert', __DIR__, $manifest, doc: "# Alert\n\n::: example Demo")->getDescription());
     }
 
-    public function testGetExamplesReturnsPreviewBlocksOnly()
+    public function testGetExamplesReturnsPreviewBlocksOnly(): void
     {
         $doc = <<<'MD'
             # Avatar
@@ -130,7 +130,7 @@ final class RecipeTest extends TestCase
         $this->assertFalse($examples[0]['options']->collapseClass);
     }
 
-    public function testGetExamplesIsEmptyWithoutDoc()
+    public function testGetExamplesIsEmptyWithoutDoc(): void
     {
         $recipe = new Recipe('x', __DIR__, new RecipeManifest(
             type: RecipeType::Component,

--- a/src/Toolkit/tests/Registry/GitHubRegistryTest.php
+++ b/src/Toolkit/tests/Registry/GitHubRegistryTest.php
@@ -34,7 +34,7 @@ final class GitHubRegistryTest extends KernelTestCase
         $this->filesystem->mkdir($this->tmpDir);
     }
 
-    public function testCanGetKitFromGithub()
+    public function testCanGetKitFromGithub(): void
     {
         $isHttpClientCalled = false;
         $zipShadcnMain = $this->createZip('repo', 'shadcn', 'main');
@@ -70,7 +70,7 @@ final class GitHubRegistryTest extends KernelTestCase
         $this->assertFileExists(Path::join($kit->absolutePath, 'button/templates/components/Button.html.twig'));
     }
 
-    public function testShouldThrowExceptionIfKitNotFound()
+    public function testShouldThrowExceptionIfKitNotFound(): void
     {
         $githubRegistry = new GitHubRegistry(
             self::getContainer()->get('ux_toolkit.kit.kit_factory'),

--- a/src/Toolkit/tests/Registry/LocalRegistryTest.php
+++ b/src/Toolkit/tests/Registry/LocalRegistryTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Toolkit\Registry\LocalRegistry;
 
 final class LocalRegistryTest extends KernelTestCase
 {
-    public function testCanGetKit()
+    public function testCanGetKit(): void
     {
         $localRegistry = new LocalRegistry(
             self::getContainer()->get('ux_toolkit.kit.kit_factory'),
@@ -30,7 +30,7 @@ final class LocalRegistryTest extends KernelTestCase
         $this->assertSame('Shadcn UI', $kit->manifest->name);
     }
 
-    public function testExists()
+    public function testExists(): void
     {
         $this->assertTrue(LocalRegistry::exists('shadcn'));
         $this->assertFalse(LocalRegistry::exists('does-not-exist'));
@@ -38,7 +38,7 @@ final class LocalRegistryTest extends KernelTestCase
         $this->assertFalse(LocalRegistry::exists('../../etc'));
     }
 
-    public function testGetAvailableKits()
+    public function testGetAvailableKits(): void
     {
         $localRegistry = new LocalRegistry(
             self::getContainer()->get('ux_toolkit.kit.kit_factory'),

--- a/src/Toolkit/tests/Registry/RegistryFactoryTest.php
+++ b/src/Toolkit/tests/Registry/RegistryFactoryTest.php
@@ -33,7 +33,7 @@ final class RegistryFactoryTest extends KernelTestCase
     }
 
     #[DataProvider('provideRegistryNames')]
-    public function testCanCreateRegistry(string $registryName, string $expectedRegistryClass)
+    public function testCanCreateRegistry(string $registryName, string $expectedRegistryClass): void
     {
         $registryFactory = self::getContainer()->get('ux_toolkit.registry.registry_factory');
 
@@ -53,7 +53,7 @@ final class RegistryFactoryTest extends KernelTestCase
     }
 
     #[DataProvider('provideInvalidRegistryNames')]
-    public function testShouldFailIfRegistryIsNotFound(string $registryName)
+    public function testShouldFailIfRegistryIsNotFound(string $registryName): void
     {
         $registryFactory = self::getContainer()->get('ux_toolkit.registry.registry_factory');
 

--- a/src/Toolkit/tests/UXToolkitBundleTest.php
+++ b/src/Toolkit/tests/UXToolkitBundleTest.php
@@ -18,7 +18,7 @@ use Twig\Environment;
 
 class UXToolkitBundleTest extends KernelTestCase
 {
-    public function testBundleBuildsSuccessfully()
+    public function testBundleBuildsSuccessfully(): void
     {
         self::bootKernel();
         $container = self::$kernel->getContainer();
@@ -26,7 +26,7 @@ class UXToolkitBundleTest extends KernelTestCase
         $this->assertInstanceOf(UXToolkitBundle::class, $container->get('kernel')->getBundles()['UXToolkitBundle']);
     }
 
-    public function testComponentDocParserIsRegisteredAsAPublicService()
+    public function testComponentDocParserIsRegisteredAsAPublicService(): void
     {
         self::bootKernel();
         $container = self::$kernel->getContainer();
@@ -34,7 +34,7 @@ class UXToolkitBundleTest extends KernelTestCase
         $this->assertInstanceOf(ComponentDocParser::class, $container->get('ux_toolkit.component.component_doc_parser'));
     }
 
-    public function testToolkitTemplateNamespaceResolves()
+    public function testToolkitTemplateNamespaceResolves(): void
     {
         self::bootKernel();
 

--- a/src/Translator/src/Intl/IntlMessageParser.php
+++ b/src/Translator/src/Intl/IntlMessageParser.php
@@ -974,7 +974,7 @@ final class IntlMessageParser
      *
      * @throws \Exception
      */
-    private function bumpTo(int $targetOffset)
+    private function bumpTo(int $targetOffset): void
     {
         if ($this->position->offset > $targetOffset) {
             throw new \Exception(\sprintf('targetOffset "%s" must be greater than or equal to the current offset %d', $targetOffset, $this->position->offset));
@@ -998,7 +998,7 @@ final class IntlMessageParser
     }
 
     /** advance the parser through all whitespace to the next non-whitespace code unit. */
-    private function bumpSpace()
+    private function bumpSpace(): void
     {
         while (!$this->isEOF() && Utils::isWhiteSpace($this->char())) {
             $this->bump();

--- a/src/Translator/tests/CacheWarmer/TranslationsCacheWarmerTest.php
+++ b/src/Translator/tests/CacheWarmer/TranslationsCacheWarmerTest.php
@@ -31,7 +31,7 @@ final class TranslationsCacheWarmerTest extends TestCase
         @rmdir(self::$cacheDir);
     }
 
-    public function test()
+    public function test(): void
     {
         $translatorBag = new TranslatorBag();
         $translatorBag->addCatalogue(

--- a/src/Translator/tests/Command/WarmCacheCommandTest.php
+++ b/src/Translator/tests/Command/WarmCacheCommandTest.php
@@ -20,7 +20,7 @@ use Symfony\UX\Translator\Command\WarmCacheCommand;
 
 final class WarmCacheCommandTest extends TestCase
 {
-    public function testWarmCache()
+    public function testWarmCache(): void
     {
         $cacheDir = '/tmp/cache';
         $cacheWarmer = $this->createMock(TranslationsCacheWarmer::class);

--- a/src/Translator/tests/Functional/DumpEnabledLocalesTest.php
+++ b/src/Translator/tests/Functional/DumpEnabledLocalesTest.php
@@ -21,7 +21,7 @@ class DumpEnabledLocalesTest extends KernelTestCase
         return FrameworkAppKernel::class;
     }
 
-    public function testShouldDumpOnlyEnabledLocales()
+    public function testShouldDumpOnlyEnabledLocales(): void
     {
         self::assertFileExists(__DIR__.'/../Fixtures/translations/messages.en.yaml');
         self::assertFileExists(__DIR__.'/../Fixtures/translations/messages.fr.yaml');

--- a/src/Translator/tests/Intl/IntlMessageParserTest.php
+++ b/src/Translator/tests/Intl/IntlMessageParserTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Translator\Intl\Type;
 class IntlMessageParserTest extends TestCase
 {
     #[DataProvider('provideParse')]
-    public function testIntlMessageParser(string $message, array $expectedAst)
+    public function testIntlMessageParser(string $message, array $expectedAst): void
     {
         $intlMessageParser = new IntlMessageParser($message);
 
@@ -375,7 +375,7 @@ class IntlMessageParserTest extends TestCase
         ];
     }
 
-    public function testParseWithUnclosedBracket()
+    public function testParseWithUnclosedBracket(): void
     {
         $intlMessageParser = new IntlMessageParser('Hello {name!');
 

--- a/src/Translator/tests/MessageParameters/Extractor/IntlMessageParametersExtractorTest.php
+++ b/src/Translator/tests/MessageParameters/Extractor/IntlMessageParametersExtractorTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\Translator\MessageParameters\Extractor\IntlMessageParametersExtra
 class IntlMessageParametersExtractorTest extends TestCase
 {
     #[DataProvider('provideExtract')]
-    public function testExtract(string $message, array $expectedParameters)
+    public function testExtract(string $message, array $expectedParameters): void
     {
         $intlMessageParametersExtractor = new IntlMessageParametersExtractor();
 

--- a/src/Translator/tests/MessageParameters/Extractor/MessageParametersExtractorTest.php
+++ b/src/Translator/tests/MessageParameters/Extractor/MessageParametersExtractorTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\Translator\MessageParameters\Extractor\MessageParametersExtractor
 class MessageParametersExtractorTest extends TestCase
 {
     #[DataProvider('provideExtract')]
-    public function testExtract(string $message, array $expectedParameters)
+    public function testExtract(string $message, array $expectedParameters): void
     {
         $messageParametersExtractor = new MessageParametersExtractor();
 

--- a/src/Translator/tests/MessageParameters/Printer/TypeScriptMessageParametersPrinterTest.php
+++ b/src/Translator/tests/MessageParameters/Printer/TypeScriptMessageParametersPrinterTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\Translator\MessageParameters\Printer\TypeScriptMessageParametersP
 class TypeScriptMessageParametersPrinterTest extends TestCase
 {
     #[DataProvider('providePrint')]
-    public function testPrint(array $parameters, string $expectedTypeScriptType)
+    public function testPrint(array $parameters, string $expectedTypeScriptType): void
     {
         $typeScriptMessageParametersPrinter = new TypeScriptMessageParametersPrinter();
 

--- a/src/Translator/tests/TranslationsDumperTest.php
+++ b/src/Translator/tests/TranslationsDumperTest.php
@@ -34,7 +34,7 @@ class TranslationsDumperTest extends TestCase
         @rmdir(self::$translationsDumpDir);
     }
 
-    public function testDump()
+    public function testDump(): void
     {
         $translationsDumper = new TranslationsDumper(
             new MessageParametersExtractor(),
@@ -112,7 +112,7 @@ class TranslationsDumperTest extends TestCase
             TS);
     }
 
-    public function testShouldNotDumpTypeScriptTypes()
+    public function testShouldNotDumpTypeScriptTypes(): void
     {
         $translationsDumper = new TranslationsDumper(
             new MessageParametersExtractor(),
@@ -130,7 +130,7 @@ class TranslationsDumperTest extends TestCase
         $this->assertFileDoesNotExist(self::$translationsDumpDir.'/index.d.ts');
     }
 
-    public function testDumpWithExcludedDomains()
+    public function testDumpWithExcludedDomains(): void
     {
         $translationsDumper = new TranslationsDumper(
             new MessageParametersExtractor(),
@@ -149,7 +149,7 @@ class TranslationsDumperTest extends TestCase
         $this->assertStringNotContainsString('foobar', file_get_contents(self::$translationsDumpDir.'/index.js'));
     }
 
-    public function testDumpIncludedDomains()
+    public function testDumpIncludedDomains(): void
     {
         $translationsDumper = new TranslationsDumper(
             new MessageParametersExtractor(),
@@ -168,7 +168,7 @@ class TranslationsDumperTest extends TestCase
         $this->assertStringNotContainsString('foobar', file_get_contents(self::$translationsDumpDir.'/index.js'));
     }
 
-    public function testSetBothIncludedAndExcludedDomains()
+    public function testSetBothIncludedAndExcludedDomains(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('You cannot set both "excluded_domains" and "included_domains" at the same time.');
@@ -188,7 +188,7 @@ class TranslationsDumperTest extends TestCase
         );
     }
 
-    public function testSetBothExcludedAndIncludedDomains()
+    public function testSetBothExcludedAndIncludedDomains(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('You cannot set both "excluded_domains" and "included_domains" at the same time.');
@@ -331,7 +331,7 @@ class TranslationsDumperTest extends TestCase
      * @dataProvider keysPatternProvider
      */
     #[DataProvider('keysPatternProvider')]
-    public function testDumpWithKeysPatterns(array $keysPatterns, callable $assertions)
+    public function testDumpWithKeysPatterns(array $keysPatterns, callable $assertions): void
     {
         $translationsDumper = new TranslationsDumper(
             new MessageParametersExtractor(),

--- a/src/Translator/tests/UxTranslatorBundleTest.php
+++ b/src/Translator/tests/UxTranslatorBundleTest.php
@@ -26,7 +26,7 @@ class UxTranslatorBundleTest extends TestCase
     }
 
     #[DataProvider('provideKernels')]
-    public function testBootKernel(Kernel $kernel)
+    public function testBootKernel(Kernel $kernel): void
     {
         $kernel->boot();
         $this->assertArrayHasKey('UxTranslatorBundle', $kernel->getBundles());

--- a/src/Turbo/tests/Bridge/Mercure/MercureStreamSourceRendererTest.php
+++ b/src/Turbo/tests/Bridge/Mercure/MercureStreamSourceRendererTest.php
@@ -21,7 +21,7 @@ final class MercureStreamSourceRendererTest extends KernelTestCase
      * @param array<mixed> $context
      */
     #[DataProvider('provideTestCases')]
-    public function testRenderTurboStreamFrom(string $template, array $context, string $expectedResult)
+    public function testRenderTurboStreamFrom(string $template, array $context, string $expectedResult): void
     {
         $twig = self::getContainer()->get('twig');
         self::assertInstanceOf(\Twig\Environment::class, $twig);

--- a/src/Turbo/tests/Bridge/Mercure/TurboStreamListenRendererTest.php
+++ b/src/Turbo/tests/Bridge/Mercure/TurboStreamListenRendererTest.php
@@ -22,7 +22,7 @@ final class TurboStreamListenRendererTest extends KernelTestCase
      * @param array<mixed> $context
      */
     #[DataProvider('provideTestCases')]
-    public function testRenderTurboStreamListen(string $template, array $context, string $expectedResult)
+    public function testRenderTurboStreamListen(string $template, array $context, string $expectedResult): void
     {
         $twig = self::getContainer()->get('twig');
         self::assertInstanceOf(\Twig\Environment::class, $twig);

--- a/src/Turbo/tests/Compiler/RegisterMercureHubsPassTest.php
+++ b/src/Turbo/tests/Compiler/RegisterMercureHubsPassTest.php
@@ -17,7 +17,7 @@ use Symfony\UX\Turbo\DependencyInjection\Compiler\RegisterMercureHubsPass;
 
 final class RegisterMercureHubsPassTest extends TestCase
 {
-    public function testProcess()
+    public function testProcess(): void
     {
         $pass = new RegisterMercureHubsPass();
 
@@ -32,7 +32,7 @@ final class RegisterMercureHubsPassTest extends TestCase
         $this->assertTrue($container->has('turbo.mercure.hub.broadcaster'));
     }
 
-    public function testProcessWithDefault()
+    public function testProcessWithDefault(): void
     {
         $pass = new RegisterMercureHubsPass();
 

--- a/src/Turbo/tests/Helper/TurboStreamTest.php
+++ b/src/Turbo/tests/Helper/TurboStreamTest.php
@@ -24,7 +24,7 @@ class TurboStreamTest extends TestCase
     #[TestWith(['update'])]
     #[TestWith(['before'])]
     #[TestWith(['after'])]
-    public function testStream(string $action)
+    public function testStream(string $action): void
     {
         $this->assertSame(<<<EOHTML
             <turbo-stream action="{$action}" targets="some[&quot;selector&quot;]">
@@ -37,7 +37,7 @@ class TurboStreamTest extends TestCase
 
     #[TestWith(['replace'])]
     #[TestWith(['update'])]
-    public function testStreamMorph(string $action)
+    public function testStreamMorph(string $action): void
     {
         $this->assertSame(<<<EOHTML
             <turbo-stream action="{$action}" targets="some[&quot;selector&quot;]" method="morph">
@@ -48,7 +48,7 @@ class TurboStreamTest extends TestCase
         );
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $this->assertSame(<<<EOHTML
             <turbo-stream action="remove" targets="some[&quot;selector&quot;]"></turbo-stream>
@@ -57,7 +57,7 @@ class TurboStreamTest extends TestCase
         );
     }
 
-    public function testRefreshWithoutId()
+    public function testRefreshWithoutId(): void
     {
         $this->assertSame(<<<EOHTML
             <turbo-stream action="refresh"></turbo-stream>
@@ -66,7 +66,7 @@ class TurboStreamTest extends TestCase
         );
     }
 
-    public function testRefreshWithId()
+    public function testRefreshWithId(): void
     {
         $this->assertSame(<<<EOHTML
             <turbo-stream action="refresh" request-id="a&quot;b"></turbo-stream>
@@ -75,7 +75,7 @@ class TurboStreamTest extends TestCase
         );
     }
 
-    public function testCustom()
+    public function testCustom(): void
     {
         $this->assertSame(<<<EOHTML
             <turbo-stream action="customAction" targets="some[&quot;selector&quot;]" someAttr="someValue" boolAttr intAttr="0" floatAttr="3.14">
@@ -90,7 +90,7 @@ class TurboStreamTest extends TestCase
      * @param array<string, string|int|float|null> $attr
      */
     #[DataProvider('customThrowsExceptionDataProvider')]
-    public function testCustomThrowsException(string $action, string $target, string $html, array $attr)
+    public function testCustomThrowsException(string $action, string $target, string $html, array $attr): void
     {
         $this->expectException(\InvalidArgumentException::class);
         TurboStream::action($action, $target, $html, $attr);

--- a/src/Turbo/tests/Request/RequestListenerTest.php
+++ b/src/Turbo/tests/Request/RequestListenerTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Turbo\TurboBundle;
  */
 class RequestListenerTest extends WebTestCase
 {
-    public function testAddsTurboRequestFormat()
+    public function testAddsTurboRequestFormat(): void
     {
         $client = static::createClient(server: [
             'HTTP_ACCEPT' => 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml',

--- a/src/Turbo/tests/Request/TurboFrameRequestFunctionalTest.php
+++ b/src/Turbo/tests/Request/TurboFrameRequestFunctionalTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class TurboFrameRequestFunctionalTest extends WebTestCase
 {
-    public function testIsNotTurboFrameRequestWithoutHeader()
+    public function testIsNotTurboFrameRequestWithoutHeader(): void
     {
         $client = static::createClient();
         $client->request('GET', '/turboFrameRequest');
@@ -33,7 +33,7 @@ class TurboFrameRequestFunctionalTest extends WebTestCase
         );
     }
 
-    public function testIsTurboFrameRequestWithHeader()
+    public function testIsTurboFrameRequestWithHeader(): void
     {
         $client = static::createClient();
         $client->request('GET', '/turboFrameRequest', [], [], ['HTTP_Turbo-Frame' => 'my_frame']);

--- a/src/Turbo/tests/TurboFrameRequestTest.php
+++ b/src/Turbo/tests/TurboFrameRequestTest.php
@@ -21,14 +21,14 @@ use Symfony\UX\Turbo\TurboFrame;
  */
 class TurboFrameRequestTest extends TestCase
 {
-    public function testIsRequestReturnsFalseWithoutHeader()
+    public function testIsRequestReturnsFalseWithoutHeader(): void
     {
         $turboFrame = $this->createTurboFrame(Request::create('/'));
 
         $this->assertFalse($turboFrame->isFrameRequest());
     }
 
-    public function testIsRequestReturnsTrueWithHeader()
+    public function testIsRequestReturnsTrueWithHeader(): void
     {
         $request = Request::create('/');
         $request->headers->set('Turbo-Frame', 'my_frame');
@@ -38,14 +38,14 @@ class TurboFrameRequestTest extends TestCase
         $this->assertTrue($turboFrame->isFrameRequest());
     }
 
-    public function testGetRequestIdReturnsNullWithoutHeader()
+    public function testGetRequestIdReturnsNullWithoutHeader(): void
     {
         $turboFrame = $this->createTurboFrame(Request::create('/'));
 
         $this->assertNull($turboFrame->getRequestId());
     }
 
-    public function testGetRequestIdReturnsFrameId()
+    public function testGetRequestIdReturnsFrameId(): void
     {
         $request = Request::create('/');
         $request->headers->set('Turbo-Frame', 'my_frame');
@@ -55,7 +55,7 @@ class TurboFrameRequestTest extends TestCase
         $this->assertSame('my_frame', $turboFrame->getRequestId());
     }
 
-    public function testGetRequestIdReturnsNullWithNoCurrentRequest()
+    public function testGetRequestIdReturnsNullWithNoCurrentRequest(): void
     {
         $requestStack = new RequestStack();
         $turboFrame = new TurboFrame($requestStack);

--- a/src/Turbo/tests/Twig/FrameLayoutTest.php
+++ b/src/Turbo/tests/Twig/FrameLayoutTest.php
@@ -31,7 +31,7 @@ class FrameLayoutTest extends TestCase
         $this->twig = new Environment($this->loader);
     }
 
-    public function testRendersMinimalHtmlStructure()
+    public function testRendersMinimalHtmlStructure(): void
     {
         $result = $this->twig->render('@Turbo/layouts/frame.html.twig');
 
@@ -41,7 +41,7 @@ class FrameLayoutTest extends TestCase
         $this->assertStringContainsString('<body>', $result);
     }
 
-    public function testHeadBlockIsOverridable()
+    public function testHeadBlockIsOverridable(): void
     {
         $this->loader->addLoader(new ArrayLoader([
             'child.html.twig' => '{% extends "@Turbo/layouts/frame.html.twig" %}{% block head %}<meta name="test" content="present">{% endblock %}',
@@ -53,7 +53,7 @@ class FrameLayoutTest extends TestCase
         $this->assertStringNotContainsString('<nav', $result);
     }
 
-    public function testBodyBlockIsOverridable()
+    public function testBodyBlockIsOverridable(): void
     {
         $this->loader->addLoader(new ArrayLoader([
             'child.html.twig' => '{% extends "@Turbo/layouts/frame.html.twig" %}{% block body %}<turbo-frame id="test">content</turbo-frame>{% endblock %}',
@@ -64,7 +64,7 @@ class FrameLayoutTest extends TestCase
         $this->assertStringContainsString('<turbo-frame id="test">content</turbo-frame>', $result);
     }
 
-    public function testHeadAndBodyBlocksAreIndependent()
+    public function testHeadAndBodyBlocksAreIndependent(): void
     {
         $this->loader->addLoader(new ArrayLoader([
             'child.html.twig' => '{% extends "@Turbo/layouts/frame.html.twig" %}{% block head %}<meta name="test" content="present">{% endblock %}{% block body %}<turbo-frame id="test">content</turbo-frame>{% endblock %}',

--- a/src/Turbo/tests/Twig/TurboRuntimeTest.php
+++ b/src/Turbo/tests/Twig/TurboRuntimeTest.php
@@ -23,7 +23,7 @@ use Twig\Environment;
 
 final class TurboRuntimeTest extends TestCase
 {
-    public function testRenderTurboStreamFrom()
+    public function testRenderTurboStreamFrom(): void
     {
         $twig = $this->createStub(Environment::class);
         $renderer = $this->createMock(StreamSourceRendererInterface::class);
@@ -48,7 +48,7 @@ final class TurboRuntimeTest extends TestCase
         );
     }
 
-    public function testRenderTurboStreamFromPrivate()
+    public function testRenderTurboStreamFromPrivate(): void
     {
         $twig = $this->createStub(Environment::class);
         $renderer = $this->createMock(StreamSourceRendererInterface::class);
@@ -73,7 +73,7 @@ final class TurboRuntimeTest extends TestCase
         );
     }
 
-    public function testRenderTurboStreamFromUsesCustomRenderer()
+    public function testRenderTurboStreamFromUsesCustomRenderer(): void
     {
         $twig = $this->createStub(Environment::class);
         $renderer = $this->createStub(StreamSourceRendererInterface::class);
@@ -94,7 +94,7 @@ final class TurboRuntimeTest extends TestCase
         );
     }
 
-    public function testRenderTurboStreamFromUnknownTransport()
+    public function testRenderTurboStreamFromUnknownTransport(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -110,7 +110,7 @@ final class TurboRuntimeTest extends TestCase
         $runtime->renderTurboStreamFrom($twig, 'a_topic');
     }
 
-    public function testRenderTurboStreamListen()
+    public function testRenderTurboStreamListen(): void
     {
         $twig = $this->createStub(Environment::class);
         $renderer = $this->createMock(TurboStreamListenRendererInterface::class);
@@ -129,7 +129,7 @@ final class TurboRuntimeTest extends TestCase
         $runtime->renderTurboStreamListen($twig, 'a_topic');
     }
 
-    public function testRenderTurboStreamListenWithMultipleHubs()
+    public function testRenderTurboStreamListenWithMultipleHubs(): void
     {
         $twig = $this->createStub(Environment::class);
         $renderer1 = $this->createStub(TurboStreamListenRendererInterface::class);
@@ -150,7 +150,7 @@ final class TurboRuntimeTest extends TestCase
         $runtime->renderTurboStreamListen($twig, 'a_topic', 'hub2');
     }
 
-    public function testRenderTurboStreamListenWithDifferentsHub()
+    public function testRenderTurboStreamListenWithDifferentsHub(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/src/TwigComponent/src/ComponentStack.php
+++ b/src/TwigComponent/src/ComponentStack.php
@@ -23,7 +23,7 @@ class ComponentStack implements \IteratorAggregate
      */
     private array $components = [];
 
-    public function push(MountedComponent $components)
+    public function push(MountedComponent $components): void
     {
         $this->components[] = $components;
     }

--- a/src/TwigComponent/tests/Integration/Command/TwigComponentDebugCommandTest.php
+++ b/src/TwigComponent/tests/Integration/Command/TwigComponentDebugCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class TwigComponentDebugCommandTest extends KernelTestCase
 {
-    public function testWithNoComponent()
+    public function testWithNoComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute([]);
@@ -32,7 +32,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Type', $display);
     }
 
-    public function testWithNoMatchComponent()
+    public function testWithNoMatchComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $result = $commandTester->execute(['name' => 'NoMatchComponent']);
@@ -41,7 +41,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Unknown component "NoMatchComponent".', $commandTester->getDisplay());
     }
 
-    public function testNotComponentsIsNotListed()
+    public function testNotComponentsIsNotListed(): void
     {
         $commandTester = $this->createCommandTester();
         $result = $commandTester->execute(['name' => 'NotAComponent']);
@@ -50,7 +50,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Unknown component "NotAComponent".', $commandTester->getDisplay());
     }
 
-    public function testWithOnePartialMatchComponent()
+    public function testWithOnePartialMatchComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->setInputs([]);
@@ -64,7 +64,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Component\\DivComponentNoPass', $commandTester->getDisplay());
     }
 
-    public function testWithMultiplePartialMatchComponent()
+    public function testWithMultiplePartialMatchComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->setInputs(['DivComponent5']);
@@ -82,7 +82,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringNotContainsString('Component\\DivComponent6', $commandTester->getDisplay());
     }
 
-    public function testComponentWithClass()
+    public function testComponentWithClass(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'BasicComponent']);
@@ -97,7 +97,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('components/BasicComponent.html.twig', $display);
     }
 
-    public function testComponentWithClassPropertiesAndCustomName()
+    public function testComponentWithClassPropertiesAndCustomName(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'component_c']);
@@ -116,7 +116,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Mount', $display);
     }
 
-    public function testComponentWithClassPropertiesCustomNameAndCustomTemplate()
+    public function testComponentWithClassPropertiesCustomNameAndCustomTemplate(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'component_b']);
@@ -133,7 +133,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('string $postValue', $display);
     }
 
-    public function testWithAnonymousComponent()
+    public function testWithAnonymousComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'Button']);
@@ -150,7 +150,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('primary = true', $display);
     }
 
-    public function testWithBundleAnonymousComponent()
+    public function testWithBundleAnonymousComponent(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'Acme:Button']);
@@ -165,7 +165,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Anonymous', $display);
     }
 
-    public function testWithBundleAnonymousComponentSubDir()
+    public function testWithBundleAnonymousComponentSubDir(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'Acme:Table:Header']);
@@ -180,7 +180,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringContainsString('Anonymous', $display);
     }
 
-    public function testWithoutPublicProps()
+    public function testWithoutPublicProps(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'no_public_props']);
@@ -194,7 +194,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringNotContainsString('prop1', $display);
     }
 
-    public function testWithExposedVariables()
+    public function testWithExposedVariables(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'with_exposed_variables']);
@@ -212,7 +212,7 @@ class TwigComponentDebugCommandTest extends KernelTestCase
         $this->assertStringNotContainsString('prop3', $display);
     }
 
-    public function testWithUnionTypeProps()
+    public function testWithUnionTypeProps(): void
     {
         $commandTester = $this->createCommandTester();
         $commandTester->execute(['name' => 'union_type_props']);

--- a/src/TwigComponent/tests/Integration/ComponentEventTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentEventTest.php
@@ -24,7 +24,7 @@ use Twig\Loader\ArrayLoader;
 final class ComponentEventTest extends KernelTestCase
 {
     #[DataProvider('provideFooBarSyntaxes')]
-    public function testTemplateIsUpdatedByEventListener(string $syntax)
+    public function testTemplateIsUpdatedByEventListener(string $syntax): void
     {
         /** @var Environment $environment */
         $environment = self::getContainer()->get(Environment::class);

--- a/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentExtensionTest.php
@@ -25,7 +25,7 @@ use Twig\Extra\Html\HtmlAttr\MergeableInterface;
  */
 final class ComponentExtensionTest extends KernelTestCase
 {
-    public function testCanRenderComponent()
+    public function testCanRenderComponent(): void
     {
         $output = $this->renderComponent('component_a', [
             'propA' => 'prop a value',
@@ -37,7 +37,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('service: service a value', $output);
     }
 
-    public function testCanRenderTheSameComponentMultipleTimes()
+    public function testCanRenderTheSameComponentMultipleTimes(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('multi_render.html.twig');
 
@@ -50,7 +50,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('service: service a value', $output);
     }
 
-    public function testCanRenderComponentWithMoreAdvancedTwigExpressions()
+    public function testCanRenderComponentWithMoreAdvancedTwigExpressions(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('flexible_component_attributes.html.twig');
 
@@ -65,28 +65,28 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('service: service a value', $output);
     }
 
-    public function testCanNotRenderComponentWithInvalidExpressions()
+    public function testCanNotRenderComponentWithInvalidExpressions(): void
     {
         $this->expectException(\Throwable::class);
 
         self::getContainer()->get(Environment::class)->render('invalid_flexible_component.html.twig');
     }
 
-    public function testCanCustomizeTemplateWithAttribute()
+    public function testCanCustomizeTemplateWithAttribute(): void
     {
         $output = $this->renderComponent('component_b', ['value' => 'b value 1']);
 
         $this->assertStringContainsString('Custom template 1', $output);
     }
 
-    public function testCanCustomizeTemplateWithServiceTag()
+    public function testCanCustomizeTemplateWithServiceTag(): void
     {
         $output = $this->renderComponent('component_d', ['value' => 'b value 1']);
 
         $this->assertStringContainsString('Custom template 2', $output);
     }
 
-    public function testCanRenderComponentWithAttributes()
+    public function testCanRenderComponentWithAttributes(): void
     {
         $output = $this->renderComponent('with_attributes', [
             'prop' => 'prop value 1',
@@ -110,14 +110,14 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('<button class="foo baz" type="submit" style="color:red;">', $output);
     }
 
-    public function testCanSetCustomAttributesVariable()
+    public function testCanSetCustomAttributesVariable(): void
     {
         $output = $this->renderComponent('custom_attributes', ['class' => 'from-custom']);
 
         $this->assertStringContainsString('<div class="from-custom"></div>', $output);
     }
 
-    public function testRenderComponentWithExposedVariables()
+    public function testRenderComponentWithExposedVariables(): void
     {
         $output = $this->renderComponent('with_exposed_variables');
 
@@ -129,7 +129,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('customMethod: customMethod value', $output);
     }
 
-    public function testCanUseComputedMethods()
+    public function testCanUseComputedMethods(): void
     {
         $output = $this->renderComponent('computed_component');
 
@@ -142,14 +142,14 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('propComputed: value', $output);
     }
 
-    public function testCanDisableExposingPublicProps()
+    public function testCanDisableExposingPublicProps(): void
     {
         $output = $this->renderComponent('no_public_props');
 
         $this->assertStringContainsString('NoPublicProp1: default', $output);
     }
 
-    public function testCanRenderEmbeddedComponent()
+    public function testCanRenderEmbeddedComponent(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('embedded_component.html.twig');
 
@@ -158,7 +158,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('custom td (1)', $output);
     }
 
-    public function testCanRenderEmbeddedComponentWithDynamicNameBuiltInLoop()
+    public function testCanRenderEmbeddedComponentWithDynamicNameBuiltInLoop(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('{% set prefix = "DynamicNameComponent" %}{% for i in 1..2 %}{% component (prefix ~ i) %}{% endcomponent %}{% endfor %}');
@@ -169,7 +169,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('DynamicNameComponent2 rendered', $output);
     }
 
-    public function testThrowsWhenDynamicComponentNameDoesNotExist()
+    public function testThrowsWhenDynamicComponentNameDoesNotExist(): void
     {
         $this->expectException(RuntimeError::class);
         $this->expectExceptionMessage('Unknown component "DynamicNameComponent3".');
@@ -180,7 +180,7 @@ final class ComponentExtensionTest extends KernelTestCase
     }
 
     #[DataProvider('provideDynamicComponentNameExpressions')]
-    public function testCanRenderEmbeddedComponentFromExpression(string $template, array $context, array $expectedComponents)
+    public function testCanRenderEmbeddedComponentFromExpression(string $template, array $context, array $expectedComponents): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $output = $environment->createTemplate($template)->render($context);
@@ -209,7 +209,7 @@ final class ComponentExtensionTest extends KernelTestCase
         ];
     }
 
-    public function testThrowsWhenStringVariableExpressionIsNotWrappedInParentheses()
+    public function testThrowsWhenStringVariableExpressionIsNotWrappedInParentheses(): void
     {
         $this->expectException(RuntimeError::class);
         $this->expectExceptionMessage('Unknown component "stringVariable"');
@@ -221,7 +221,7 @@ final class ComponentExtensionTest extends KernelTestCase
         ]);
     }
 
-    public function testBareComponentNameStaysStaticWhenSameNamedVariableExists()
+    public function testBareComponentNameStaysStaticWhenSameNamedVariableExists(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('{% component DynamicNameComponent1 %}{% endcomponent %}');
@@ -233,7 +233,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringNotContainsString('DynamicNameComponent2 rendered', $output);
     }
 
-    public function testThrowsWhenExpressionDoesNotEvaluateToAComponentName()
+    public function testThrowsWhenExpressionDoesNotEvaluateToAComponentName(): void
     {
         $this->expectException(SyntaxError::class);
         $this->expectExceptionMessage('must evaluate to a component name (string/scalar/Stringable)');
@@ -244,7 +244,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $template->render(['obj' => new \stdClass()]);
     }
 
-    public function testCanRenderSelfClosingDynamicComponentWithStaticIs()
+    public function testCanRenderSelfClosingDynamicComponentWithStaticIs(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('<twig:component is="DynamicNameComponent1" />');
@@ -253,7 +253,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
     }
 
-    public function testCanRenderSelfClosingDynamicComponentWithDynamicIs()
+    public function testCanRenderSelfClosingDynamicComponentWithDynamicIs(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('<twig:component :is="componentName" />');
@@ -262,7 +262,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
     }
 
-    public function testCanRenderPairedDynamicComponentWithStaticIs()
+    public function testCanRenderPairedDynamicComponentWithStaticIs(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('<twig:component is="DynamicNameComponent1">content</twig:component>');
@@ -271,7 +271,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
     }
 
-    public function testCanRenderPairedDynamicComponentWithDynamicIs()
+    public function testCanRenderPairedDynamicComponentWithDynamicIs(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('<twig:component :is="componentName">content</twig:component>');
@@ -280,7 +280,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
     }
 
-    public function testCanRenderDynamicComponentWithDynamicIsInLoop()
+    public function testCanRenderDynamicComponentWithDynamicIsInLoop(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('{% set prefix = "DynamicNameComponent" %}{% for i in 1..2 %}<twig:component :is="prefix ~ i" />{% endfor %}');
@@ -290,7 +290,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('DynamicNameComponent2 rendered', $output);
     }
 
-    public function testCanRenderDynamicComponentWithDynamicIsFromArray()
+    public function testCanRenderDynamicComponentWithDynamicIsFromArray(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('{% for i in 0..1 %}<twig:component :is="names[i]" />{% endfor %}');
@@ -300,7 +300,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('DynamicNameComponent2 rendered', $output);
     }
 
-    public function testCanRenderDynamicComponentWithPropsViaStaticIs()
+    public function testCanRenderDynamicComponentWithPropsViaStaticIs(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('<twig:component is="component_a" propA="A" propB="B" />');
@@ -310,7 +310,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('propB: B', $output);
     }
 
-    public function testCanRenderDynamicComponentWithPropsViaDynamicIs()
+    public function testCanRenderDynamicComponentWithPropsViaDynamicIs(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('<twig:component :is="name" propA="A" propB="B" />');
@@ -320,7 +320,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('propB: B', $output);
     }
 
-    public function testThrowsWhenDynamicComponentHtmlSyntaxNameDoesNotExist()
+    public function testThrowsWhenDynamicComponentHtmlSyntaxNameDoesNotExist(): void
     {
         $this->expectException(RuntimeError::class);
         $this->expectExceptionMessage('Unknown component "NonExistent"');
@@ -330,7 +330,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $template->render(['name' => 'NonExistent']);
     }
 
-    public function testCanRenderDynamicComponentInsideRegularComponent()
+    public function testCanRenderDynamicComponentInsideRegularComponent(): void
     {
         $environment = self::getContainer()->get(Environment::class);
         $template = $environment->createTemplate('<twig:BasicComponent><twig:component :is="name" /></twig:BasicComponent>');
@@ -339,14 +339,14 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('DynamicNameComponent1 rendered', $output);
     }
 
-    public function testComponentWithNamespace()
+    public function testComponentWithNamespace(): void
     {
         $output = $this->renderComponent('foo:bar:baz');
 
         $this->assertStringContainsString('Content...', $output);
     }
 
-    public function testRenderAnonymousComponent()
+    public function testRenderAnonymousComponent(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component.html.twig');
 
@@ -354,7 +354,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('class="primary"', $output);
     }
 
-    public function testRenderAnonymousComponentOverwriteProps()
+    public function testRenderAnonymousComponentOverwriteProps(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_overwrite_props.html.twig');
 
@@ -362,7 +362,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('class="secondary"', $output);
     }
 
-    public function testRenderAnonymousComponentInNestedDirectory()
+    public function testRenderAnonymousComponentInNestedDirectory(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_nested_directory.html.twig');
 
@@ -370,7 +370,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('class="primary"', $output);
     }
 
-    public function testRenderAnonymousComponentWithNonScalarProps()
+    public function testRenderAnonymousComponentWithNonScalarProps(): void
     {
         $user = new User('Fabien', 'test@test.com');
 
@@ -382,7 +382,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('class variable defined? no', $output);
     }
 
-    public function testRenderComponentTagWithNullsafeProps()
+    public function testRenderComponentTagWithNullsafeProps(): void
     {
         if (Environment::VERSION_ID < 32300) {
             $this->markTestSkipped('The "?." operator requires Twig 3.23+.');
@@ -402,28 +402,28 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertSame(3, substr_count($output, '- Title'));
     }
 
-    public function testComponentPropsOverwriteContextValue()
+    public function testComponentPropsOverwriteContextValue(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_variable_already_in_context.html.twig');
 
         $this->assertStringContainsString('<p>foo</p>', $output);
     }
 
-    public function testComponentPropsOverwriteContextValueWithInputProp()
+    public function testComponentPropsOverwriteContextValueWithInputProp(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_input_prop_with_same_name_in_context.html.twig');
 
         $this->assertStringContainsString('<p>bar</p>', $output);
     }
 
-    public function testComponentPropWithoutDefaultAcceptsNullValue()
+    public function testComponentPropWithoutDefaultAcceptsNullValue(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_null_props.html.twig');
 
         $this->assertStringContainsString('<p>required: NULL</p>', $output);
     }
 
-    public function testComponentPropWithoutDefaultAndWithoutValueThrows()
+    public function testComponentPropWithoutDefaultAndWithoutValueThrows(): void
     {
         $this->expectException(RuntimeError::class);
         $this->expectExceptionMessage('Prop "required" should be defined in "components/NullableProps.html.twig" at line 1.');
@@ -431,21 +431,21 @@ final class ComponentExtensionTest extends KernelTestCase
         self::getContainer()->get(Environment::class)->render('anonymous_component_with_missing_required_prop.html.twig');
     }
 
-    public function testComponentPropWithDefaultKeepsNullValueExplicitlyPassed()
+    public function testComponentPropWithDefaultKeepsNullValueExplicitlyPassed(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_null_props.html.twig');
 
         $this->assertStringContainsString('<p>withDefault: NULL</p>', $output);
     }
 
-    public function testComponentPropWithDefaultIgnoresNullValueFromContext()
+    public function testComponentPropWithDefaultIgnoresNullValueFromContext(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_null_variable_already_in_context.html.twig');
 
         $this->assertStringContainsString('<p>withDefault: default</p>', $output);
     }
 
-    public function testComponentClassPropertyWithDefaultKeepsNullValueExplicitlyPassed()
+    public function testComponentClassPropertyWithDefaultKeepsNullValueExplicitlyPassed(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('class_component_with_null_props.html.twig');
 
@@ -453,7 +453,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('<p>mounted: NULL</p>', $output);
     }
 
-    public function testComponentClassPropertyWithDefaultKeepsItWhenPropIsNotPassed()
+    public function testComponentClassPropertyWithDefaultKeepsItWhenPropIsNotPassed(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('class_component_with_omitted_props.html.twig');
 
@@ -461,7 +461,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('<p>mounted: default</p>', $output);
     }
 
-    public function testComponentPropsWithTrailingComma()
+    public function testComponentPropsWithTrailingComma(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_props_trailing_comma.html.twig');
 
@@ -470,7 +470,7 @@ final class ComponentExtensionTest extends KernelTestCase
     }
 
     #[DataProvider('renderingAttributesManuallyProvider')]
-    public function testRenderingAttributesManually(array $attributes, string $expected)
+    public function testRenderingAttributesManually(array $attributes, string $expected): void
     {
         $actual = trim($this->renderComponent('RenderAttributes', $attributes));
 
@@ -512,7 +512,7 @@ final class ComponentExtensionTest extends KernelTestCase
         ];
     }
 
-    public function testRenderingComponentWithNestedAttributes()
+    public function testRenderingComponentWithNestedAttributes(): void
     {
         $output = $this->renderComponent('NestedAttributes');
 
@@ -552,7 +552,7 @@ final class ComponentExtensionTest extends KernelTestCase
     }
 
     #[DataProvider('providePrefixedAttributesCases')]
-    public function testRenderPrefixedAttributes(string $attributes, bool $expectContains)
+    public function testRenderPrefixedAttributes(string $attributes, bool $expectContains): void
     {
         /** @var Environment $twig */
         $twig = self::getContainer()->get(Environment::class);
@@ -601,7 +601,7 @@ final class ComponentExtensionTest extends KernelTestCase
         yield ['z-bind:id', false]; // Nested
     }
 
-    public function testRenderingHtmlSyntaxComponentWithNestedAttributes()
+    public function testRenderingHtmlSyntaxComponentWithNestedAttributes(): void
     {
         $output = self::getContainer()
             ->get(Environment::class)
@@ -644,7 +644,7 @@ final class ComponentExtensionTest extends KernelTestCase
         );
     }
 
-    public function testComponentWithPropsFromTemplateAndClass()
+    public function testComponentWithPropsFromTemplateAndClass(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('component_with_props_from_template_and_class.html.twig');
 
@@ -653,7 +653,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('Congrats !', $output);
     }
 
-    public function testComponentWithConflictBetweenPropsFromTemplateAndClass()
+    public function testComponentWithConflictBetweenPropsFromTemplateAndClass(): void
     {
         $this->expectException(RuntimeError::class);
         $this->expectExceptionMessage('Cannot define prop "name" in template "components/Conflict.html.twig". Property already defined in component class "Symfony\UX\TwigComponent\Tests\Fixtures\Component\Conflict"');
@@ -661,7 +661,7 @@ final class ComponentExtensionTest extends KernelTestCase
         self::getContainer()->get(Environment::class)->render('component_with_conflict_between_props_from_template_and_class.html.twig');
     }
 
-    public function testComponentWithConflictBetweenNullPropFromTemplateAndClass()
+    public function testComponentWithConflictBetweenNullPropFromTemplateAndClass(): void
     {
         $this->expectException(RuntimeError::class);
         $this->expectExceptionMessage('Cannot define prop "name" in template "components/NullableConflict.html.twig". Property already defined in component class "Symfony\\UX\\TwigComponent\\Tests\\Fixtures\\Component\\NullableConflict"');
@@ -669,7 +669,7 @@ final class ComponentExtensionTest extends KernelTestCase
         self::getContainer()->get(Environment::class)->render('component_with_conflict_between_null_prop_from_template_and_class.html.twig');
     }
 
-    public function testComponentWithEmptyProps()
+    public function testComponentWithEmptyProps(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('anonymous_component_with_empty_props.html.twig');
 
@@ -677,7 +677,7 @@ final class ComponentExtensionTest extends KernelTestCase
     }
 
     #[DataProvider('provideUnsafeAttributes')]
-    public function testHtmlSyntaxEscapesAttributeValues(string $input)
+    public function testHtmlSyntaxEscapesAttributeValues(string $input): void
     {
         $output = self::getContainer()->get(Environment::class)->render(
             'anonymous_component_with_html_syntax.html.twig',
@@ -689,7 +689,7 @@ final class ComponentExtensionTest extends KernelTestCase
     }
 
     #[DataProvider('provideUnsafeAttributes')]
-    public function testDynamicSyntaxEscapesAttributeValues(string $input)
+    public function testDynamicSyntaxEscapesAttributeValues(string $input): void
     {
         $output = self::getContainer()->get(Environment::class)->render(
             'anonymous_component_with_dynamic_syntax.html.twig',
@@ -710,7 +710,7 @@ final class ComponentExtensionTest extends KernelTestCase
         ]);
     }
 
-    public function testHigherOrderComponentWithAttributeDefaults()
+    public function testHigherOrderComponentWithAttributeDefaults(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('higher_order_component.html.twig');
 
@@ -735,7 +735,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('Confirm deletion?', $output);
     }
 
-    public function testPropsAreRemovedFromAttributesInSingleCall()
+    public function testPropsAreRemovedFromAttributesInSingleCall(): void
     {
         $output = $this->renderComponent('PropsAndAttributesSeparation', [
             'propA' => 'valueA',
@@ -775,7 +775,7 @@ final class ComponentExtensionTest extends KernelTestCase
      * This is a regression test for the optimization that iterates directly over
      * attributes->all() instead of iterating over the entire context.
      */
-    public function testExtraAttributesAreCleanedFromContext()
+    public function testExtraAttributesAreCleanedFromContext(): void
     {
         $output = $this->renderComponent('PropsAndAttributesSeparation', [
             'propA' => 'A',
@@ -799,7 +799,7 @@ final class ComponentExtensionTest extends KernelTestCase
     /**
      * Test that props with default values work correctly when not provided.
      */
-    public function testPropsWithDefaultValuesWhenNotProvided()
+    public function testPropsWithDefaultValuesWhenNotProvided(): void
     {
         $output = $this->renderComponent('PropsAndAttributesSeparation', [
             'propA' => 'A',
@@ -823,7 +823,7 @@ final class ComponentExtensionTest extends KernelTestCase
      * attributes->all() to unset context variables, ensuring non-prop attributes
      * are properly cleaned from the context.
      */
-    public function testAttributesDoNotLeakToTemplateContext()
+    public function testAttributesDoNotLeakToTemplateContext(): void
     {
         $output = $this->renderComponent('AttributesNotLeakingToContext', [
             'name' => 'test-name',
@@ -846,7 +846,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('data_foo-var-defined=no', $output);
     }
 
-    public function testPropsWithHtmlAttrMergeFilter()
+    public function testPropsWithHtmlAttrMergeFilter(): void
     {
         if (!interface_exists(AttributeValueInterface::class)) {
             $this->markTestSkipped('Test requires Twig HTML extra >= 3.24.');
@@ -861,7 +861,7 @@ final class ComponentExtensionTest extends KernelTestCase
         $this->assertStringContainsString('data-html-attr-type-cst="dialog, trigger"', $output);
     }
 
-    public function testDefaultsWithMergeableFilter()
+    public function testDefaultsWithMergeableFilter(): void
     {
         if (!interface_exists(MergeableInterface::class)) {
             $this->markTestSkipped('Test requires Twig HTML extra >= 3.24.');

--- a/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentFactoryTest.php
@@ -26,7 +26,7 @@ use Symfony\UX\TwigComponent\Tests\Fixtures\Component\WithSlots;
  */
 final class ComponentFactoryTest extends KernelTestCase
 {
-    public function testCreatedComponentsAreNotShared()
+    public function testCreatedComponentsAreNotShared(): void
     {
         /** @var ComponentA $componentA */
         $componentA = $this->createComponent('component_a', ['propA' => 'A', 'propB' => 'B']);
@@ -42,7 +42,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertSame('D', $componentB->getPropB());
     }
 
-    public function testNonAutoConfiguredCreatedComponentsAreNotShared()
+    public function testNonAutoConfiguredCreatedComponentsAreNotShared(): void
     {
         /** @var ComponentB $componentA */
         $componentA = $this->createComponent('component_b');
@@ -53,7 +53,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertNotSame(spl_object_id($componentA), spl_object_id($componentB));
     }
 
-    public function testCanGetUnmountedComponent()
+    public function testCanGetUnmountedComponent(): void
     {
         /** @var ComponentA $component */
         $component = $this->factory()->get('component_a');
@@ -62,7 +62,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertNull($component->getPropB());
     }
 
-    public function testMountCanHaveOptionalParameters()
+    public function testMountCanHaveOptionalParameters(): void
     {
         /** @var ComponentC $component */
         $component = $this->createComponent('component_c', [
@@ -85,7 +85,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertSame('default', $component->propC);
     }
 
-    public function testExceptionThrownIfRequiredMountParameterIsMissingFromPassedData()
+    public function testExceptionThrownIfRequiredMountParameterIsMissingFromPassedData(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('"Symfony\UX\TwigComponent\Tests\Fixtures\Component\ComponentC::mount()" has a required $propA parameter. Make sure to pass it or give it a default value.');
@@ -93,7 +93,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->createComponent('component_c');
     }
 
-    public function testStringableObjectCanBePassedToComponent()
+    public function testStringableObjectCanBePassedToComponent(): void
     {
         $attributes = $this->factory()->create('component_a', ['propB' => 'B', 'data-item-id-param' => new class {
             public function __toString(): string
@@ -105,7 +105,7 @@ final class ComponentFactoryTest extends KernelTestCase
         self::assertSame(['data-item-id-param' => 'test'], $attributes);
     }
 
-    public function testTwigComponentServiceTagWithoutKeyUsesShortClassName()
+    public function testTwigComponentServiceTagWithoutKeyUsesShortClassName(): void
     {
         // boots ComponentB, but with no key on the tag
         self::bootKernel(['environment' => 'missing_key']);
@@ -113,7 +113,7 @@ final class ComponentFactoryTest extends KernelTestCase
         self::assertInstanceOf(ComponentB::class, $component);
     }
 
-    public function testTwigComponentServiceTagWithoutKeyButCollissionCausesAnException()
+    public function testTwigComponentServiceTagWithoutKeyButCollissionCausesAnException(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Failed creating the "Symfony\UX\TwigComponent\Tests\Fixtures\Component\ComponentB" component with the automatic name "ComponentB": another component already has this name. To fix this, give the component an explicit name (hint: using "ComponentB" will override the existing component).');
@@ -123,7 +123,7 @@ final class ComponentFactoryTest extends KernelTestCase
         self::assertInstanceOf(ComponentB::class, $component);
     }
 
-    public function testAnonymous()
+    public function testAnonymous(): void
     {
         self::bootKernel(['environment' => 'anonymous_directory']);
 
@@ -140,7 +140,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->factory()->metadataFor('anonymous:AButton');
     }
 
-    public function testLoadingAnonymousComponentFromBundle()
+    public function testLoadingAnonymousComponentFromBundle(): void
     {
         $metadata = $this->factory()->metadataFor('Acme:Button');
 
@@ -149,7 +149,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertNull($metadata->get('class'));
     }
 
-    public function testLoadingAnonymousComponentFromBundleWithFallback()
+    public function testLoadingAnonymousComponentFromBundleWithFallback(): void
     {
         // Component from external bundle with index.html.twig
         $metadata = $this->factory()->metadataFor('Acme:Menu');
@@ -176,7 +176,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertNull($metadata->get('class'));
     }
 
-    public function testLoadingAnonymousComponentWithFallback()
+    public function testLoadingAnonymousComponentWithFallback(): void
     {
         self::bootKernel(['environment' => 'anonymous_directory']);
 
@@ -199,14 +199,14 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertNull($metadata->get('class'));
     }
 
-    public function testAutoNamingInSubDirectory()
+    public function testAutoNamingInSubDirectory(): void
     {
         $metadata = $this->factory()->metadataFor('SubDirectory:ComponentInSubDirectory');
         $this->assertSame('SubDirectory:ComponentInSubDirectory', $metadata->getName());
         $this->assertSame('components/SubDirectory/ComponentInSubDirectory.html.twig', $metadata->getTemplate());
     }
 
-    public function testAutoNamingWithNamePrefixAndDirectory()
+    public function testAutoNamingWithNamePrefixAndDirectory(): void
     {
         $metadata = $this->factory()->metadataFor('AcmePrefix:AcmeRootComponent');
         $this->assertSame('AcmePrefix:AcmeRootComponent', $metadata->getName());
@@ -217,7 +217,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertSame('acme_components/AcmeSubDir/AcmeOtherComponent.html.twig', $metadata->getTemplate());
     }
 
-    public function testAutoNamingWithNamePrefixOnly()
+    public function testAutoNamingWithNamePrefixOnly(): void
     {
         self::bootKernel(['environment' => 'no_template_directory']);
         $metadata = $this->factory()->metadataFor('AcmePrefix:AcmeRootComponent');
@@ -227,7 +227,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertSame('components/AcmeRootComponent.html.twig', $metadata->getTemplate());
     }
 
-    public function testCanGetMetadataForComponentByName()
+    public function testCanGetMetadataForComponentByName(): void
     {
         $metadata = $this->factory()->metadataFor('component_a');
 
@@ -237,7 +237,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertSame(ComponentA::class, $metadata->getClass());
     }
 
-    public function testCanGetMetadataForSameComponentWithDifferentName()
+    public function testCanGetMetadataForSameComponentWithDifferentName(): void
     {
         $metadata = $this->factory()->metadataFor('component_d');
 
@@ -247,7 +247,7 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->assertSame(ComponentB::class, $metadata->getClass());
     }
 
-    public function testCannotGetConfigByNameForNonRegisteredComponent()
+    public function testCannotGetConfigByNameForNonRegisteredComponent(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown component "tabler". Did you mean this: "table"?');
@@ -260,7 +260,7 @@ final class ComponentFactoryTest extends KernelTestCase
     #[TestWith(['basic', 'Unknown component "basic". Did you mean this: "BasicComponent"?'])]
     #[TestWith(['with', 'Unknown component "with". Did you mean one of these: "with_attributes", "WithExposedTraitChild", "WithExposedTraitParent", "with_exposed_variables", "WithSlots"?'])]
     #[TestWith(['anonAnon', 'Unknown component "anonAnon". And no matching anonymous component template was found.'])]
-    public function testCannotGetInvalidComponent(string $name, string $expectedExceptionMessage)
+    public function testCannotGetInvalidComponent(string $name, string $expectedExceptionMessage): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
@@ -268,14 +268,14 @@ final class ComponentFactoryTest extends KernelTestCase
         $this->factory()->get($name);
     }
 
-    public function testInputPropsStoredOnMountedComponent()
+    public function testInputPropsStoredOnMountedComponent(): void
     {
         $mountedComponent = $this->factory()->create('component_a', ['propA' => 'A', 'propB' => 'B']);
         $this->assertSame(['propA' => 'A', 'propB' => 'B'], $mountedComponent->getInputProps());
     }
 
     #[DoesNotPerformAssertions]
-    public function testGetComponentWithClassName()
+    public function testGetComponentWithClassName(): void
     {
         $factory = $this->factory();
 

--- a/src/TwigComponent/tests/Integration/ComponentLexerTest.php
+++ b/src/TwigComponent/tests/Integration/ComponentLexerTest.php
@@ -21,7 +21,7 @@ use Twig\Environment;
  */
 class ComponentLexerTest extends KernelTestCase
 {
-    public function testComponentSyntaxOpenTags()
+    public function testComponentSyntaxOpenTags(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('tags/open_tag.html.twig');
 
@@ -29,14 +29,14 @@ class ComponentLexerTest extends KernelTestCase
         $this->assertStringContainsString('propB: hello', $output);
     }
 
-    public function testComponentSyntaxSelfCloseTags()
+    public function testComponentSyntaxSelfCloseTags(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('tags/self_close_tag.html.twig');
         $this->assertStringContainsString('propA: 1', $output);
         $this->assertStringContainsString('propB: hello', $output);
     }
 
-    public function testComponentSyntaxCanRenderEmbeddedComponent()
+    public function testComponentSyntaxCanRenderEmbeddedComponent(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('tags/embedded_component.html.twig');
 

--- a/src/TwigComponent/tests/Integration/DynamicTemplateTest.php
+++ b/src/TwigComponent/tests/Integration/DynamicTemplateTest.php
@@ -18,7 +18,7 @@ class DynamicTemplateTest extends KernelTestCase
 {
     use InteractsWithTwigComponents;
 
-    public function testTemplateResolvedAutomaticallyWhenNotProvided()
+    public function testTemplateResolvedAutomaticallyWhenNotProvided(): void
     {
         // When no template is explicitly configured, the default resolution mechanism should be applied.
         $rendered = (string) $this->renderTwigComponent('default_template_component');
@@ -26,7 +26,7 @@ class DynamicTemplateTest extends KernelTestCase
         $this->assertStringContainsString('Default Template Works!', $rendered);
     }
 
-    public function testTemplateResolvedFromString()
+    public function testTemplateResolvedFromString(): void
     {
         // Ensures that a template defined as a string is properly resolved.
         $rendered = (string) $this->renderTwigComponent('string_template_component');
@@ -34,7 +34,7 @@ class DynamicTemplateTest extends KernelTestCase
         $this->assertStringContainsString('String Template Works!', $rendered);
     }
 
-    public function testTemplateChangesBasedOnComponentProps()
+    public function testTemplateChangesBasedOnComponentProps(): void
     {
         // 1. Default Type props
         $html = $this->renderTwigComponent('method_template_component', ['type' => 'default']);
@@ -45,7 +45,7 @@ class DynamicTemplateTest extends KernelTestCase
         $this->assertStringContainsString('Custom', $html);
     }
 
-    public function testTemplateFromMethodThrowsExceptionWhenMethodIsMissing()
+    public function testTemplateFromMethodThrowsExceptionWhenMethodIsMissing(): void
     {
         // Using FromMethod with a non-existing or non-callable method must throw a LogicException.
         $this->expectException(\Twig\Error\RuntimeError::class);

--- a/src/TwigComponent/tests/Integration/EmbeddedComponentTest.php
+++ b/src/TwigComponent/tests/Integration/EmbeddedComponentTest.php
@@ -23,7 +23,7 @@ final class EmbeddedComponentTest extends KernelTestCase
      * Rule 1: A block is not passed into an embedded component, since it would be rendered in place ànd in the
      * component's template.
      */
-    public function testABlockIsNotPassedIntoAnEmbeddedComponent()
+    public function testABlockIsNotPassedIntoAnEmbeddedComponent(): void
     {
         $output = self::render('embedded_component_blocks_basic.html.twig');
 
@@ -35,7 +35,7 @@ final class EmbeddedComponentTest extends KernelTestCase
     /**
      * Rule 2: An embedded component has access to the (outer) context.
      */
-    public function testAnEmbeddedComponentHasContextAccess()
+    public function testAnEmbeddedComponentHasContextAccess(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             '<div class="divComponent">Hello Fabien!',
@@ -47,7 +47,7 @@ final class EmbeddedComponentTest extends KernelTestCase
      * Rule 3: A block is only passed one level down, via the display() function on the embedded Template that's
      * representing a component instance.
      */
-    public function testABlockIsOnlyPassedOneLevelDown()
+    public function testABlockIsOnlyPassedOneLevelDown(): void
     {
         $output = self::render('embedded_component_blocks_no_pass.html.twig');
 
@@ -60,7 +60,7 @@ final class EmbeddedComponentTest extends KernelTestCase
      * Rule 4: Inside that component's template you can use it, but NOT within a nested component. The latter is
      * repeating rule 1.
      */
-    public function testABlockIsNotPassedToNestedComponents()
+    public function testABlockIsNotPassedToNestedComponents(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             'Hello world!<div class="divComponent"><span class="foo">The Generic Element default foo block</span></div>',
@@ -75,7 +75,7 @@ final class EmbeddedComponentTest extends KernelTestCase
      * Rule 7: If you want to pass that outer block along to the template of that nested component,
      *         You can use it inside the block definition with the embedded component.
      */
-    public function testBlockCanBeUsedWithinNestedViaTheOuterBlocks()
+    public function testBlockCanBeUsedWithinNestedViaTheOuterBlocks(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             'Hello world!<div class="divComponent">Hello world!<span class="foo">Override foo & Override foo</span></div>',
@@ -87,7 +87,7 @@ final class EmbeddedComponentTest extends KernelTestCase
      * Rule 5 bis: A block inside an extending template can be use inside a component in that template and is NOT
      * rendered in the original location.
      */
-    public function testBlockCanBeUsedViaTheOuterBlocks()
+    public function testBlockCanBeUsedViaTheOuterBlocks(): void
     {
         $output = self::render('embedded_component_blocks_outer_blocks_extended_template.html.twig');
 
@@ -100,7 +100,7 @@ final class EmbeddedComponentTest extends KernelTestCase
      * template. This also means that when passing block down that you will lose that default content. That can be
      * avoided by using {{ parent() }} like you normally would.
      */
-    public function testBlockDefinitionsPassingDownOuterBlocksOverrideDefaultContent()
+    public function testBlockDefinitionsPassingDownOuterBlocksOverrideDefaultContent(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             '<div class="divComponent">Hello world!<span class="foo">The Generic Element default foo block + Override foo</span></div>',
@@ -111,7 +111,7 @@ final class EmbeddedComponentTest extends KernelTestCase
     /**
      * Rule 9: Passing blocks also works with nesting a component inside another instance of the same component.
      */
-    public function testDeepNesting()
+    public function testDeepNesting(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             '<div class="divComponent">Content 1<div class="divComponent">Content 2<div class="divComponent">Content 3<span class="foo">Override foo3</span></div><span class="foo">Override foo2</span></div><span class="foo">Override foo1</span></div>',
@@ -123,7 +123,7 @@ final class EmbeddedComponentTest extends KernelTestCase
      * Rule 10: Missing outer blocks use a fallback block so that nothing is rendered, and no unknown block error
      * occurs.
      */
-    public function testItCanHandleMissingOuterBlocks()
+    public function testItCanHandleMissingOuterBlocks(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             '<div class="divComponent">Content 1<div class="divComponent">Content 2<div class="divComponent">Content 3<span class="foo">Override foo3</span></div><span class="foo"></span></div><span class="foo">Override foo1</span></div>',
@@ -137,7 +137,7 @@ final class EmbeddedComponentTest extends KernelTestCase
      *          Not defining a block (and not passing said block along) will be considered as a missing block (see rule
      *          10).
      */
-    public function testPassingDownBlocksMultipleLevelsNeedsToBeDoneManually()
+    public function testPassingDownBlocksMultipleLevelsNeedsToBeDoneManually(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             '<div class="divComponent">DIV CONTENT: WRAPPER CONTENT: Content from wrapper<span class="foo">I\'m fixing foo content</span></div><div class="divComponent">DIV CONTENT: WRAPPER CONTENT: Content from wrapperI don\'t have a foo block, so it will be considered empty.<span class="foo"></span></div>',
@@ -150,7 +150,7 @@ final class EmbeddedComponentTest extends KernelTestCase
      * Rule 13: Blocks defined within an embedded component can access the context of components up the hierarchy (up
      * to their own level) via "outerScope".
      */
-    public function testBlockDefinitionCanAccessTheContextOfTheDestinationBlocks()
+    public function testBlockDefinitionCanAccessTheContextOfTheDestinationBlocks(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             '<div class="divComponent">I can access my own properties: foo.I can access the id of the Generic Element: symfonyIsAwesome.This refers to the Generic Element: calling GenericElement.To access my own functions I can use outerScope.this: calling DivComponent.I have access to outer context variables like Fabien.I can access the id from Generic Element as well: symfonyIsAwesome.I can access the properties from DivComponent as well: foo.And of course the properties from DivComponentWrapper: bar.The less obvious thing is that at this level "this" refers to the component where the content block is used, i.e. the Generic Element.Therefore, functions through this will be calling GenericElement.Calls to outerScope.this will be calling DivComponent.Even I can access the id from Generic Element as well: symfonyIsAwesome.Even I can access the properties from DivComponent as well: foo.Even I can access the properties from DivComponentWrapper as well: bar.Even I can access the functions of DivComponent via outerScope.this: calling DivComponent.Since we are nesting two levels deep, calls to outerScope.outerScope.this will be calling DivComponentWrapper.<span class="foo">The Generic Element default foo block</span></div>',
@@ -158,7 +158,7 @@ final class EmbeddedComponentTest extends KernelTestCase
         );
     }
 
-    public function testAccessingTheHierarchyTooHighThrowsAnException()
+    public function testAccessingTheHierarchyTooHighThrowsAnException(): void
     {
         // Twig renamed "array" into "sequence" in 3.11
         $this->expectExceptionMessage('Key "$this" for ');
@@ -166,7 +166,7 @@ final class EmbeddedComponentTest extends KernelTestCase
         self::render('embedded_component_hierarchy_exception.html.twig');
     }
 
-    public function testANonEmbeddedComponentRendersOuterBlocksEmpty()
+    public function testANonEmbeddedComponentRendersOuterBlocksEmpty(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             '<div class="divComponent"><span class="foo"></span></div>',
@@ -174,7 +174,7 @@ final class EmbeddedComponentTest extends KernelTestCase
         );
     }
 
-    public function testANonEmbeddedComponentCanRenderParentBlocksAsFallback()
+    public function testANonEmbeddedComponentCanRenderParentBlocksAsFallback(): void
     {
         $this->assertStringContainsStringIgnoringIndentation(
             '<div class="divComponent">The Generic Element could have some default content, although it does not make sense in this example.<span class="foo">The Generic Element default foo block</span></div>',

--- a/src/TwigComponent/tests/Integration/ExposeInTemplateTraitInheritanceTest.php
+++ b/src/TwigComponent/tests/Integration/ExposeInTemplateTraitInheritanceTest.php
@@ -31,7 +31,7 @@ final class ExposeInTemplateTraitInheritanceTest extends KernelTestCase
      * Sanity check: the parent component itself must expose the trait property.
      * This works in all versions because the parent directly uses the trait.
      */
-    public function testParentComponentExposesTraitProperty()
+    public function testParentComponentExposesTraitProperty(): void
     {
         self::bootKernel();
 
@@ -47,7 +47,7 @@ final class ExposeInTemplateTraitInheritanceTest extends KernelTestCase
      * Before the fix, this throws:
      *   Variable "exposed_from_trait" does not exist in ...WithExposedTraitChild.html.twig
      */
-    public function testChildComponentExposesInheritedTraitProperty()
+    public function testChildComponentExposesInheritedTraitProperty(): void
     {
         self::bootKernel();
 

--- a/src/TwigComponent/tests/Integration/ProvideInjectTest.php
+++ b/src/TwigComponent/tests/Integration/ProvideInjectTest.php
@@ -17,14 +17,14 @@ use Twig\Error\RuntimeError;
 
 final class ProvideInjectTest extends KernelTestCase
 {
-    public function testSlotInjectsMaxLengthFromInputOtpRoot()
+    public function testSlotInjectsMaxLengthFromInputOtpRoot(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_direct_parent.html.twig');
 
         $this->assertStringContainsString('name="otp[0]" maxlength="1" data-index="1" data-max-length="6"', $output);
     }
 
-    public function testSlotInjectsAcrossNonProvidingGroup()
+    public function testSlotInjectsAcrossNonProvidingGroup(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_across_group.html.twig');
 
@@ -33,7 +33,7 @@ final class ProvideInjectTest extends KernelTestCase
         $this->assertStringContainsString('name="code[2]" maxlength="1" data-index="3" data-max-length="6"', $output);
     }
 
-    public function testNearestAncestorWins()
+    public function testNearestAncestorWins(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_nearest_wins.html.twig');
 
@@ -41,14 +41,14 @@ final class ProvideInjectTest extends KernelTestCase
         $this->assertStringNotContainsString('aria-selected="false"', $output);
     }
 
-    public function testInjectReturnsDefaultWhenMissing()
+    public function testInjectReturnsDefaultWhenMissing(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_default.html.twig');
 
         $this->assertStringContainsString('name="otp[0]" maxlength="1" data-index="1" data-max-length="4"', $output);
     }
 
-    public function testProvideOutsideComponentThrows()
+    public function testProvideOutsideComponentThrows(): void
     {
         try {
             self::getContainer()->get(Environment::class)->render('provide_inject_outside_component.html.twig');
@@ -59,14 +59,14 @@ final class ProvideInjectTest extends KernelTestCase
         }
     }
 
-    public function testInjectOutsideComponentReturnsDefault()
+    public function testInjectOutsideComponentReturnsDefault(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_inject_outside_component.html.twig');
 
         $this->assertStringContainsString('fallback=fallback-value', $output);
     }
 
-    public function testProvideNullIsDistinctFromMissing()
+    public function testProvideNullIsDistinctFromMissing(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_null_distinct.html.twig');
 
@@ -74,7 +74,7 @@ final class ProvideInjectTest extends KernelTestCase
         $this->assertStringContainsString('name="[0]" maxlength="1" data-index="1" data-max-length="4"', $output);
     }
 
-    public function testProvideOverwritesPreviousValueInSameComponent()
+    public function testProvideOverwritesPreviousValueInSameComponent(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_overwrite.html.twig');
 
@@ -84,21 +84,21 @@ final class ProvideInjectTest extends KernelTestCase
         $this->assertSame(1, substr_count($output, 'data-value="first" aria-selected="false"'));
     }
 
-    public function testGrandchildInjectsThroughIntermediateComponent()
+    public function testGrandchildInjectsThroughIntermediateComponent(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_deep_nesting.html.twig');
 
         $this->assertStringContainsString('name="deep[0]" maxlength="1" data-index="1" data-max-length="9"', $output);
     }
 
-    public function testProvideAcceptsComplexValues()
+    public function testProvideAcceptsComplexValues(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_complex_values.html.twig');
 
         $this->assertStringContainsString('list:a+b+c;config:value/42', $output);
     }
 
-    public function testInjectInsidePassedContentSkipsWrappingComponent()
+    public function testInjectInsidePassedContentSkipsWrappingComponent(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_passed_content_skips_self.html.twig');
 
@@ -108,7 +108,7 @@ final class ProvideInjectTest extends KernelTestCase
         $this->assertStringNotContainsString('inline:A', $output);
     }
 
-    public function testSameComponentRenderedTwiceDoesNotLeakProvidedValues()
+    public function testSameComponentRenderedTwiceDoesNotLeakProvidedValues(): void
     {
         $first = self::getContainer()->get(Environment::class)->render('provide_inject_render_first.html.twig');
         $second = self::getContainer()->get(Environment::class)->render('provide_inject_render_second.html.twig');
@@ -119,7 +119,7 @@ final class ProvideInjectTest extends KernelTestCase
         $this->assertStringNotContainsString('data-max-length="6"', $second);
     }
 
-    public function testDeepDescendantCannotReachSiblingTreeContext()
+    public function testDeepDescendantCannotReachSiblingTreeContext(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_cross_tree.html.twig');
 
@@ -130,7 +130,7 @@ final class ProvideInjectTest extends KernelTestCase
         $this->assertStringContainsString('name="otp[0]" maxlength="1" data-index="1" data-max-length="4"', $output);
     }
 
-    public function testSiblingComponentsDoNotLeakContext()
+    public function testSiblingComponentsDoNotLeakContext(): void
     {
         $output = self::getContainer()->get(Environment::class)->render('provide_inject_siblings.html.twig');
 

--- a/src/TwigComponent/tests/Integration/Test/InteractsWithTwigComponentsTest.php
+++ b/src/TwigComponent/tests/Integration/Test/InteractsWithTwigComponentsTest.php
@@ -23,7 +23,7 @@ final class InteractsWithTwigComponentsTest extends KernelTestCase
     use InteractsWithTwigComponents;
 
     #[DataProvider('componentANameProvider')]
-    public function testCanMountComponent(string $name)
+    public function testCanMountComponent(string $name): void
     {
         $component = $this->mountTwigComponent($name, [
             'propA' => 'prop a value',
@@ -37,7 +37,7 @@ final class InteractsWithTwigComponentsTest extends KernelTestCase
     }
 
     #[DataProvider('componentANameProvider')]
-    public function testCanRenderComponent(string $name)
+    public function testCanRenderComponent(string $name): void
     {
         $rendered = $this->renderTwigComponent($name, [
             'propA' => 'prop a value',
@@ -51,7 +51,7 @@ final class InteractsWithTwigComponentsTest extends KernelTestCase
     }
 
     #[DataProvider('withSlotsNameProvider')]
-    public function testCanRenderComponentWithSlots(string $name)
+    public function testCanRenderComponentWithSlots(string $name): void
     {
         $rendered = $this->renderTwigComponent(
             name: $name,

--- a/src/TwigComponent/tests/Integration/Twig/ComponentParserTest.php
+++ b/src/TwigComponent/tests/Integration/Twig/ComponentParserTest.php
@@ -26,7 +26,7 @@ use Twig\TemplateWrapper;
 final class ComponentParserTest extends KernelTestCase
 {
     #[DataProvider('provideValidComponentNames')]
-    public function testAcceptTwigComponentTagWithValidComponentName(string $name)
+    public function testAcceptTwigComponentTagWithValidComponentName(string $name): void
     {
         $environment = $this->createEnvironment();
         $source = str_replace('XXX', $name, "{% component 'XXX' %}{% endcomponent %}");
@@ -37,7 +37,7 @@ final class ComponentParserTest extends KernelTestCase
     }
 
     #[DataProvider('provideValidBareComponentNames')]
-    public function testAcceptTwigComponentTagWithValidBareComponentName(string $name)
+    public function testAcceptTwigComponentTagWithValidBareComponentName(string $name): void
     {
         $environment = $this->createEnvironment();
         $source = str_replace('XXX', $name, '{% component XXX %}{% endcomponent %}');
@@ -48,7 +48,7 @@ final class ComponentParserTest extends KernelTestCase
     }
 
     #[DataProvider('provideValidComponentNames')]
-    public function testAcceptHtmlComponentTagWithValidComponentName(string $name)
+    public function testAcceptHtmlComponentTagWithValidComponentName(string $name): void
     {
         $environment = $this->createEnvironment();
         $source = \sprintf('<twig:%s></twig:%s>', $name, $name);
@@ -59,7 +59,7 @@ final class ComponentParserTest extends KernelTestCase
     }
 
     #[DataProvider('provideValidComponentNames')]
-    public function testAcceptHtmlSelfClosingComponentTagWithValidComponentName(string $name)
+    public function testAcceptHtmlSelfClosingComponentTagWithValidComponentName(string $name): void
     {
         $environment = $this->createEnvironment();
         $source = \sprintf('<twig:%s />', $name);
@@ -69,7 +69,7 @@ final class ComponentParserTest extends KernelTestCase
         $this->assertInstanceOf(TemplateWrapper::class, $template);
     }
 
-    public function testItThrowsWhenComponentNameCannotBeParsed()
+    public function testItThrowsWhenComponentNameCannotBeParsed(): void
     {
         $environment = $this->createEnvironment();
         $source = '{% component [] %}{% endcomponent %}';
@@ -82,7 +82,7 @@ final class ComponentParserTest extends KernelTestCase
     }
 
     #[DataProvider('provideValidDynamicComponentExpressions')]
-    public function testItAcceptsParenthesizedDynamicComponentExpression(string $expression)
+    public function testItAcceptsParenthesizedDynamicComponentExpression(string $expression): void
     {
         $environment = $this->createEnvironment();
         $source = \sprintf('{%% component %s %%}{%% endcomponent %%}', $expression);
@@ -93,7 +93,7 @@ final class ComponentParserTest extends KernelTestCase
     }
 
     #[DataProvider('provideInvalidUnparenthesizedDynamicComponentExpressions')]
-    public function testItRejectsUnparenthesizedDynamicComponentExpression(string $expression)
+    public function testItRejectsUnparenthesizedDynamicComponentExpression(string $expression): void
     {
         $environment = $this->createEnvironment();
         $source = \sprintf('{%% component %s %%}{%% endcomponent %%}', $expression);

--- a/src/TwigComponent/tests/Integration/Twig/ComponentPropsParserTest.php
+++ b/src/TwigComponent/tests/Integration/Twig/ComponentPropsParserTest.php
@@ -28,7 +28,7 @@ use Twig\Source;
 class ComponentPropsParserTest extends KernelTestCase
 {
     #[DataProvider('providePropsData')]
-    public function testPropsData(string $template, array $props, string $text)
+    public function testPropsData(string $template, array $props, string $text): void
     {
         $loader = new ArrayLoader(['template' => $template]);
 
@@ -63,7 +63,7 @@ class ComponentPropsParserTest extends KernelTestCase
         $this->assertSame($text, $body->getNode(1)->getAttribute('data'));
     }
 
-    public function testPropDocumentationIsCaptured()
+    public function testPropDocumentationIsCaptured(): void
     {
         if (!method_exists(\Twig\Token::class, 'getDocumentation')) {
             $this->markTestSkipped('Documentation comments require twig/twig >= 3.29.');

--- a/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentAttributesTest.php
@@ -27,7 +27,7 @@ use Twig\Runtime\EscaperRuntime;
  */
 final class ComponentAttributesTest extends TestCase
 {
-    public function testCanConvertToString()
+    public function testCanConvertToString(): void
     {
         $attributes = new ComponentAttributes([
             'class' => 'foo',
@@ -44,7 +44,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(' class="foo" style="color:black;" value="" autofocus', (string) $attributes);
     }
 
-    public function testThrowsOnNullAttributeValue()
+    public function testThrowsOnNullAttributeValue(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Attribute "data-foo" value cannot be null.');
@@ -53,7 +53,7 @@ final class ComponentAttributesTest extends TestCase
         (string) $attributes;
     }
 
-    public function testCanSetDefaults()
+    public function testCanSetDefaults(): void
     {
         $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;'], new EscaperRuntime());
 
@@ -69,7 +69,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(['class' => 'foo'], new ComponentAttributes([], new EscaperRuntime())->defaults(['class' => 'foo'])->all());
     }
 
-    public function testDefaultsMergesMergeableDefaultViaAppendFrom()
+    public function testDefaultsMergesMergeableDefaultViaAppendFrom(): void
     {
         if (!interface_exists(MergeableInterface::class)) {
             $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
@@ -85,7 +85,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame('base-1 base-2 override', $merged->render('class'));
     }
 
-    public function testDefaultsMergesMergeableCallerViaMergeInto()
+    public function testDefaultsMergesMergeableCallerViaMergeInto(): void
     {
         if (!interface_exists(MergeableInterface::class)) {
             $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
@@ -99,7 +99,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(' class="base override"', (string) $merged);
     }
 
-    public function testRenderReturnsNullWhenMergeableValueResolvesToNull()
+    public function testRenderReturnsNullWhenMergeableValueResolvesToNull(): void
     {
         if (!interface_exists(MergeableInterface::class)) {
             $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
@@ -110,7 +110,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertNull($attributes->render('class'));
     }
 
-    public function testDefaultsMergesMergeableDefaultOnNonSpecialKey()
+    public function testDefaultsMergesMergeableDefaultOnNonSpecialKey(): void
     {
         if (!interface_exists(MergeableInterface::class)) {
             $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
@@ -125,7 +125,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame('base caller', $merged->render('data-foo'));
     }
 
-    public function testDefaultsMergesRealMergeableOnNonSpecialKey()
+    public function testDefaultsMergesRealMergeableOnNonSpecialKey(): void
     {
         if (!class_exists(InlineStyle::class)) {
             $this->markTestSkipped('Requires twig/html-extra >= 3.24.');
@@ -174,14 +174,14 @@ final class ComponentAttributesTest extends TestCase
         };
     }
 
-    public function testCanGetOnly()
+    public function testCanGetOnly(): void
     {
         $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;'], new EscaperRuntime());
 
         $this->assertSame(['class' => 'foo'], $attributes->only('class')->all());
     }
 
-    public function testCanGetWithout()
+    public function testCanGetWithout(): void
     {
         $attributes = new ComponentAttributes(['class' => 'foo', 'style' => 'color:black;', 'data-foo' => 'bar'], new EscaperRuntime());
 
@@ -189,7 +189,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(['class' => 'foo'], $attributes->without('style', 'data-foo')->all());
     }
 
-    public function testCanAddStimulusControllerViaStimulusAttributes()
+    public function testCanAddStimulusControllerViaStimulusAttributes(): void
     {
         $attributes = new ComponentAttributes([
             'class' => 'foo',
@@ -212,7 +212,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(' data-controller="foo live" data-foo-name-value="ryan" data-foo-some-array-value="[&quot;a&quot;,&quot;b&quot;]" data-foo-some-array-with-keys-value="{&quot;key1&quot;:&quot;value1&quot;,&quot;key2&quot;:&quot;value2&quot;}" class="foo" data-live-data-value="{}"', (string) $attributes);
     }
 
-    public function testCanAddStimulusActionViaStimulusAttributes()
+    public function testCanAddStimulusActionViaStimulusAttributes(): void
     {
         $attributes = new ComponentAttributes([
             'class' => 'foo',
@@ -230,7 +230,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(' data-action="foo#barMethod live#foo" class="foo"', (string) $attributes);
     }
 
-    public function testBooleanBehaviour()
+    public function testBooleanBehaviour(): void
     {
         $attributes = new ComponentAttributes(['disabled' => true], new EscaperRuntime());
 
@@ -243,7 +243,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame('', (string) $attributes);
     }
 
-    public function testIsTraversableAndCountable()
+    public function testIsTraversableAndCountable(): void
     {
         $attributes = new ComponentAttributes(['foo' => 'bar'], new EscaperRuntime());
 
@@ -251,7 +251,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertCount(1, $attributes);
     }
 
-    public function testRenderSingleAttribute()
+    public function testRenderSingleAttribute(): void
     {
         $attributes = new ComponentAttributes(['attr1' => 'value1', 'attr2' => 'value2'], new EscaperRuntime());
 
@@ -259,7 +259,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertNull($attributes->render('attr3'));
     }
 
-    public function testRenderingSingleAttributeExcludesFromString()
+    public function testRenderingSingleAttributeExcludesFromString(): void
     {
         $attributes = new ComponentAttributes([
             'attr1' => new class {
@@ -275,7 +275,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame(' attr2="value2"', (string) $attributes);
     }
 
-    public function testCannotRenderNonStringAttribute()
+    public function testCannotRenderNonStringAttribute(): void
     {
         $attributes = new ComponentAttributes(['attr1' => false], new EscaperRuntime());
 
@@ -284,14 +284,14 @@ final class ComponentAttributesTest extends TestCase
         $attributes->render('attr1');
     }
 
-    public function testCanCheckIfAttributeExists()
+    public function testCanCheckIfAttributeExists(): void
     {
         $attributes = new ComponentAttributes(['foo' => 'bar'], new EscaperRuntime());
 
         $this->assertTrue($attributes->has('foo'));
     }
 
-    public function testNestedAttributes()
+    public function testNestedAttributes(): void
     {
         $attributes = new ComponentAttributes([
             'class' => 'foo',
@@ -305,7 +305,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame('', (string) $attributes->nested('invalid'));
     }
 
-    public function testPrefixedAttributes()
+    public function testPrefixedAttributes(): void
     {
         $attributes = new ComponentAttributes([
             'x-click' => 'x+',
@@ -318,7 +318,7 @@ final class ComponentAttributesTest extends TestCase
         $this->assertSame('', (string) $attributes->nested('invalid'));
     }
 
-    public function testConvertTrueAriaAttributeValue()
+    public function testConvertTrueAriaAttributeValue(): void
     {
         $attributes = new ComponentAttributes([
             'aria-bar' => false,
@@ -347,7 +347,7 @@ final class ComponentAttributesTest extends TestCase
     }
 
     #[DataProvider('provideSpecialSyntaxAttributeNames')]
-    public function testAllowsSpecialSyntaxAttributeNames(string $name)
+    public function testAllowsSpecialSyntaxAttributeNames(string $name): void
     {
         $attributes = new ComponentAttributes([$name => 'value'], new EscaperRuntime());
 
@@ -364,14 +364,14 @@ final class ComponentAttributesTest extends TestCase
         yield ['@input.debounce.500ms'];
     }
 
-    public function testThrowsTypeErrorWithoutEscaperRuntime()
+    public function testThrowsTypeErrorWithoutEscaperRuntime(): void
     {
         $this->expectException(\TypeError::class);
         new ComponentAttributes([]);
     }
 
     #[DataProvider('nameProvider')]
-    public function testEscapeName(string $input, string $expected)
+    public function testEscapeName(string $input, string $expected): void
     {
         $runtime = new EscaperRuntime();
         $attributes = new ComponentAttributes([$input => 'foo'], $runtime);
@@ -380,7 +380,7 @@ final class ComponentAttributesTest extends TestCase
     }
 
     #[DataProvider('valueProvider')]
-    public function testEscapeValue(string $input, string $expected)
+    public function testEscapeValue(string $input, string $expected): void
     {
         $runtime = new EscaperRuntime();
         $attributes = new ComponentAttributes(['foo' => $input], $runtime);

--- a/src/TwigComponent/tests/Unit/ComponentFactoryTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentFactoryTest.php
@@ -24,7 +24,7 @@ use Twig\Environment;
  */
 class ComponentFactoryTest extends TestCase
 {
-    public function testMetadataForConfig()
+    public function testMetadataForConfig(): void
     {
         $factory = new ComponentFactory(
             $this->createMock(ComponentTemplateFinderInterface::class),
@@ -42,7 +42,7 @@ class ComponentFactoryTest extends TestCase
         $this->assertSame('bar.html.twig', $metadata->getTemplate());
     }
 
-    public function testMetadataForResolveAlias()
+    public function testMetadataForResolveAlias(): void
     {
         $factory = new ComponentFactory(
             $this->createMock(ComponentTemplateFinderInterface::class),
@@ -63,7 +63,7 @@ class ComponentFactoryTest extends TestCase
         $this->assertSame('bar.html.twig', $metadata->getTemplate());
     }
 
-    public function testMetadataForReuseAnonymousConfig()
+    public function testMetadataForReuseAnonymousConfig(): void
     {
         $templateFinder = $this->createMock(ComponentTemplateFinderInterface::class);
         $templateFinder->expects($this->atLeastOnce())

--- a/src/TwigComponent/tests/Unit/ComponentStackTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentStackTest.php
@@ -19,7 +19,7 @@ use Twig\Runtime\EscaperRuntime;
 
 final class ComponentStackTest extends TestCase
 {
-    public function testPushAndPopAndFetchingComponents()
+    public function testPushAndPopAndFetchingComponents(): void
     {
         $stack = new ComponentStack();
         $component1 = new MountedComponent('component1', new \stdClass(), new ComponentAttributes([], new EscaperRuntime()));

--- a/src/TwigComponent/tests/Unit/ComponentTemplateFinderTest.php
+++ b/src/TwigComponent/tests/Unit/ComponentTemplateFinderTest.php
@@ -22,7 +22,7 @@ use Twig\Loader\LoaderInterface;
  */
 final class ComponentTemplateFinderTest extends TestCase
 {
-    public function testFindTemplate()
+    public function testFindTemplate(): void
     {
         $templates = [
             'components/aa.html.twig',
@@ -46,7 +46,7 @@ final class ComponentTemplateFinderTest extends TestCase
         $this->assertNull($finder->findAnonymousComponentTemplate('c'));
     }
 
-    public function testFindTemplateWithinDirectory()
+    public function testFindTemplateWithinDirectory(): void
     {
         $templates = [
             'bar.html.twig',
@@ -67,7 +67,7 @@ final class ComponentTemplateFinderTest extends TestCase
         $this->assertEquals('foo/foo/baz/index.html.twig', $finder->findAnonymousComponentTemplate('foo:baz'));
     }
 
-    public function testFindTemplateFromExternalBundle()
+    public function testFindTemplateFromExternalBundle(): void
     {
         $templates = [
             '@Acme/components/Button.html.twig',
@@ -141,7 +141,7 @@ final class ComponentTemplateFinderTest extends TestCase
         $this->assertSame('@Acme/components/Index/index.html.twig', $finderWithoutIndexHtml->findAnonymousComponentTemplate('Acme:Index'));
     }
 
-    public function testFindTemplateFromExternalBundleWithPrecedence()
+    public function testFindTemplateFromExternalBundleWithPrecedence(): void
     {
         $templates = [
             '@Acme/components/Button.html.twig',

--- a/src/TwigComponent/tests/Unit/ComputedPropertiesProxyTest.php
+++ b/src/TwigComponent/tests/Unit/ComputedPropertiesProxyTest.php
@@ -19,7 +19,7 @@ use Symfony\UX\TwigComponent\ComputedPropertiesProxy;
  */
 final class ComputedPropertiesProxyTest extends TestCase
 {
-    public function testProxyCachesGetMethodReturns()
+    public function testProxyCachesGetMethodReturns(): void
     {
         $proxy = new ComputedPropertiesProxy(new class {
             private int $count = 0;
@@ -35,7 +35,7 @@ final class ComputedPropertiesProxyTest extends TestCase
         $this->assertSame(1, $proxy->count());
     }
 
-    public function testProxyCachesIsMethodReturns()
+    public function testProxyCachesIsMethodReturns(): void
     {
         $proxy = new ComputedPropertiesProxy(new class {
             private int $count = 0;
@@ -51,7 +51,7 @@ final class ComputedPropertiesProxyTest extends TestCase
         $this->assertSame(1, $proxy->count());
     }
 
-    public function testProxyCachesHasMethodReturns()
+    public function testProxyCachesHasMethodReturns(): void
     {
         $proxy = new ComputedPropertiesProxy(new class {
             private int $count = 0;
@@ -67,7 +67,7 @@ final class ComputedPropertiesProxyTest extends TestCase
         $this->assertSame(1, $proxy->count());
     }
 
-    public function testCanProxyPublicProperties()
+    public function testCanProxyPublicProperties(): void
     {
         $proxy = new ComputedPropertiesProxy(new class {
             public $foo = 'bar';
@@ -76,7 +76,7 @@ final class ComputedPropertiesProxyTest extends TestCase
         $this->assertSame('bar', $proxy->foo());
     }
 
-    public function testCanProxyArrayAccess()
+    public function testCanProxyArrayAccess(): void
     {
         $proxy = new ComputedPropertiesProxy(new class implements \ArrayAccess {
             private $array = ['foo' => 'bar'];
@@ -103,7 +103,7 @@ final class ComputedPropertiesProxyTest extends TestCase
         $this->assertSame('bar', $proxy->foo());
     }
 
-    public function testCannotProxyMethodsThatDoNotExist()
+    public function testCannotProxyMethodsThatDoNotExist(): void
     {
         $proxy = new ComputedPropertiesProxy(new class {});
 
@@ -112,7 +112,7 @@ final class ComputedPropertiesProxyTest extends TestCase
         $proxy->getSomething();
     }
 
-    public function testCannotPassArgumentsToProxiedMethods()
+    public function testCannotPassArgumentsToProxiedMethods(): void
     {
         $proxy = new ComputedPropertiesProxy(new class {});
 
@@ -121,7 +121,7 @@ final class ComputedPropertiesProxyTest extends TestCase
         $proxy->getSomething('foo');
     }
 
-    public function testCannotProxyMethodsWithRequiredArguments()
+    public function testCannotProxyMethodsWithRequiredArguments(): void
     {
         $proxy = new ComputedPropertiesProxy(new class {
             public function getValue(int $value): int

--- a/src/TwigComponent/tests/Unit/DataCollector/TwigComponentDataCollectorTest.php
+++ b/src/TwigComponent/tests/Unit/DataCollector/TwigComponentDataCollectorTest.php
@@ -31,7 +31,7 @@ use Twig\Runtime\EscaperRuntime;
  */
 class TwigComponentDataCollectorTest extends TestCase
 {
-    public function testCollectDoesNothing()
+    public function testCollectDoesNothing(): void
     {
         $logger = new TwigComponentLoggerListener();
         $twig = $this->createMock(Environment::class);
@@ -43,7 +43,7 @@ class TwigComponentDataCollectorTest extends TestCase
         $this->assertSame([], $dataCollector->getData());
     }
 
-    public function testLateCollectWithNoCollectedData()
+    public function testLateCollectWithNoCollectedData(): void
     {
         $logger = new TwigComponentLoggerListener();
         $twig = $this->createMock(Environment::class);
@@ -64,7 +64,7 @@ class TwigComponentDataCollectorTest extends TestCase
 
     #[TestWith([true])]
     #[TestWith([false])]
-    public function testLateCollectWithCollectedData(bool $collectComponents)
+    public function testLateCollectWithCollectedData(bool $collectComponents): void
     {
         $logger = new TwigComponentLoggerListener();
         $twig = new Environment(new ArrayLoader());
@@ -98,7 +98,7 @@ class TwigComponentDataCollectorTest extends TestCase
         $this->assertGreaterThan(0.0, $dataCollector->getRenderTime());
     }
 
-    public function testReset()
+    public function testReset(): void
     {
         $logger = new TwigComponentLoggerListener();
         $twig = $this->createMock(Environment::class);
@@ -111,7 +111,7 @@ class TwigComponentDataCollectorTest extends TestCase
         $this->assertSame([], $dataCollector->getData());
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
         $logger = new TwigComponentLoggerListener();
         $twig = $this->createMock(Environment::class);

--- a/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
+++ b/src/TwigComponent/tests/Unit/DependencyInjection/TwigComponentExtensionTest.php
@@ -25,7 +25,7 @@ use Symfony\UX\TwigComponent\TwigComponentBundle;
  */
 class TwigComponentExtensionTest extends TestCase
 {
-    public function testDataCollectorWithDebugMode()
+    public function testDataCollectorWithDebugMode(): void
     {
         $container = $this->createContainer();
         $container->setParameter('kernel.debug', true);
@@ -40,7 +40,7 @@ class TwigComponentExtensionTest extends TestCase
         $this->assertTrue($container->getDefinition('ux.twig_component.data_collector')->getArgument(2));
     }
 
-    public function testDataCollectorWithCollectComponentsDisabled()
+    public function testDataCollectorWithCollectComponentsDisabled(): void
     {
         $container = $this->createContainer();
         $container->setParameter('kernel.debug', true);
@@ -58,7 +58,7 @@ class TwigComponentExtensionTest extends TestCase
         $this->assertFalse($container->getDefinition('ux.twig_component.data_collector')->getArgument(2));
     }
 
-    public function testDataCollectorNotLoadedInProductionByDefault()
+    public function testDataCollectorNotLoadedInProductionByDefault(): void
     {
         $container = $this->createContainer();
         $container->setParameter('kernel.debug', false);
@@ -72,7 +72,7 @@ class TwigComponentExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition('ux.twig_component.data_collector'));
     }
 
-    public function testDataCollectorWithDebugModeCanBeDisabled()
+    public function testDataCollectorWithDebugModeCanBeDisabled(): void
     {
         $container = $this->createContainer();
         $container->setParameter('kernel.debug', true);
@@ -87,7 +87,7 @@ class TwigComponentExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition('ux.twig_component.data_collector'));
     }
 
-    public function testSafeClassPassIntegration()
+    public function testSafeClassPassIntegration(): void
     {
         if (!class_exists(SafeClassPass::class)) {
             $this->markTestSkipped('Requires symfony/twig-bundle >= 8.1 with SafeClassPass support');
@@ -108,7 +108,7 @@ class TwigComponentExtensionTest extends TestCase
         $this->assertSame([['strategy' => 'html']], $def->getTag('twig.safe_class'));
     }
 
-    public function testFallbackToEnvironmentConfiguratorWithoutSafeClassPass()
+    public function testFallbackToEnvironmentConfiguratorWithoutSafeClassPass(): void
     {
         if (class_exists(SafeClassPass::class)) {
             $this->markTestSkipped('Only relevant with symfony/twig-bundle < 8.1 without SafeClassPass support');
@@ -143,7 +143,7 @@ class TwigComponentExtensionTest extends TestCase
         return $container;
     }
 
-    private function compileContainer(ContainerBuilder $container)
+    private function compileContainer(ContainerBuilder $container): void
     {
         $container->getCompilerPassConfig()->setOptimizationPasses([]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);

--- a/src/TwigComponent/tests/Unit/EventListener/TwigComponentLoggerListenerTest.php
+++ b/src/TwigComponent/tests/Unit/EventListener/TwigComponentLoggerListenerTest.php
@@ -25,7 +25,7 @@ use Twig\Runtime\EscaperRuntime;
  */
 class TwigComponentLoggerListenerTest extends TestCase
 {
-    public function testLoggerStoreEvents()
+    public function testLoggerStoreEvents(): void
     {
         $logger = new TwigComponentLoggerListener();
         $this->assertSame([], $logger->getEvents());
@@ -39,7 +39,7 @@ class TwigComponentLoggerListenerTest extends TestCase
         $this->assertSame([$eventA, $eventB], array_column($logger->getEvents(), 0));
     }
 
-    public function testLoggerReset()
+    public function testLoggerReset(): void
     {
         $logger = new TwigComponentLoggerListener();
         $escaper = new EscaperRuntime();

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -19,14 +19,14 @@ use Twig\Error\SyntaxError;
 final class TwigPreLexerTest extends TestCase
 {
     #[DataProvider('getLexTests')]
-    public function testPreLex(string $input, string $expectedOutput)
+    public function testPreLex(string $input, string $expectedOutput): void
     {
         $lexer = new TwigPreLexer();
         $this->assertSame($expectedOutput, $lexer->preLexComponents($input));
     }
 
     #[DataProvider('getInvalidSyntaxTests')]
-    public function testPreLexThrowsExceptionOnInvalidSyntax(string $input, string $expectedMessage)
+    public function testPreLexThrowsExceptionOnInvalidSyntax(string $input, string $expectedMessage): void
     {
         $this->expectException(SyntaxError::class);
         $this->expectExceptionMessage($expectedMessage);

--- a/src/Vue/tests/AssetMapper/VueControllerLoaderAssetCompilerTest.php
+++ b/src/Vue/tests/AssetMapper/VueControllerLoaderAssetCompilerTest.php
@@ -18,7 +18,7 @@ use Symfony\UX\Vue\AssetMapper\VueControllerLoaderAssetCompiler;
 
 class VueControllerLoaderAssetCompilerTest extends TestCase
 {
-    public function testCompileDynamicallyAddsContents()
+    public function testCompileDynamicallyAddsContents(): void
     {
         $assetMapper = $this->createMock(AssetMapperInterface::class);
         $assetMapper->expects($this->exactly(2))

--- a/src/Vue/tests/Twig/VueComponentExtensionTest.php
+++ b/src/Vue/tests/Twig/VueComponentExtensionTest.php
@@ -23,7 +23,7 @@ use Symfony\UX\Vue\Twig\VueComponentExtension;
  */
 class VueComponentExtensionTest extends TestCase
 {
-    public function testRenderComponent()
+    public function testRenderComponent(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();
@@ -42,7 +42,7 @@ class VueComponentExtensionTest extends TestCase
         );
     }
 
-    public function testRenderComponentWithoutProps()
+    public function testRenderComponentWithoutProps(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();

--- a/src/Vue/tests/VueBundleTest.php
+++ b/src/Vue/tests/VueBundleTest.php
@@ -22,7 +22,7 @@ use Symfony\UX\Vue\Tests\Kernel\TwigAppKernel;
  */
 class VueBundleTest extends TestCase
 {
-    public function testBootKernel()
+    public function testBootKernel(): void
     {
         $kernel = new TwigAppKernel('test', true);
         $kernel->boot();


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations?  | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Documentation? | no <!-- required for new features, or documentation updates -->
| Issues         | Fix #3833 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

This PR's adds back `: void` return type to `test*` methods, as stated in #3833.

It also touch two source files which were _kind of forgotten_, `src/TwigComponent/src/ComponentStack.php` and `src/Translator/src/Intl/IntlMessageParser.php` which are internal, so it's fine.