### PR TITLE
Ignore the generated config/schema.json, and check .gitattributes stay in sync

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -136,6 +136,29 @@ jobs:
                       done
                   done
 
+            - name: Setup PHP
+              if: always()
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+              with:
+                  php-version: '8.4'
+
+            - name: Install root dependencies
+              if: always()
+              uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+              with:
+                  working-directory: ${{ github.workspace }}
+
+            - name: Check all .gitattributes are in sync
+              if: always()
+              run: |
+                  php .github/sync-packages.php
+
+                  if ! git diff --quiet; then
+                      echo "Some .gitattributes are out of sync, run 'php .github/sync-packages.php' and commit the result:";
+                      git --no-pager diff;
+                      exit 1;
+                  fi
+
     code-format-js:
         name: JavaScript Formatting
         runs-on: ubuntu-latest

--- a/src/Autocomplete/.gitignore
+++ b/src/Autocomplete/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/CalendarLink/.gitignore
+++ b/src/CalendarLink/.gitignore
@@ -1,4 +1,5 @@
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/Chartjs/.gitignore
+++ b/src/Chartjs/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/Cropperjs/.gitignore
+++ b/src/Cropperjs/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/Dropzone/.gitignore
+++ b/src/Dropzone/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/Icons/.gitignore
+++ b/src/Icons/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/LiveComponent/.gitignore
+++ b/src/LiveComponent/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/Map/.gitignore
+++ b/src/Map/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/Pagination/.gitattributes
+++ b/src/Pagination/.gitattributes
@@ -1,7 +1,8 @@
 /.git* export-ignore
 /.symfony.bundle.yaml export-ignore
+/assets/src export-ignore
+/assets/tsconfig.json export-ignore
+/doc export-ignore
 /phpstan.dist.neon export-ignore
 /phpunit.dist.xml export-ignore
-/assets/src export-ignore
-/doc export-ignore
 /tests export-ignore

--- a/src/Pagination/.gitignore
+++ b/src/Pagination/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/React/.gitignore
+++ b/src/React/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/StimulusBundle/.gitignore
+++ b/src/StimulusBundle/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/Toolkit/.gitattributes
+++ b/src/Toolkit/.gitattributes
@@ -1,4 +1,5 @@
 /.git* export-ignore
 /CONTRIBUTING.md export-ignore
+/doc export-ignore
 /phpunit.dist.xml export-ignore
 /tests export-ignore

--- a/src/Translator/.gitignore
+++ b/src/Translator/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/Turbo/.gitignore
+++ b/src/Turbo/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /drivers/

--- a/src/TwigComponent/.gitignore
+++ b/src/TwigComponent/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml

--- a/src/Vue/.gitignore
+++ b/src/Vue/.gitignore
@@ -1,5 +1,6 @@
 /assets/node_modules/
 /config/reference.php
+/config/schema.json
 /vendor/
 /composer.lock
 /phpunit.xml


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

Running `composer install` in a package writes a `config/schema.json` next to the `config/reference.php` that is already ignored, so it shows up as an untracked file and is easy to commit by accident. Toolkit already ignored it; this adds the same line to the fifteen other packages that ignore `config/reference.php`, right below it. Native and Notify are left alone, since Notify has no `config/` directory and Native ignores neither of the two.

While checking that `.github/sync-packages.php` had nothing to say about this (it regenerates `.gitattributes`, not `.gitignore`), it turned out two packages had drifted: `Pagination` was missing `/assets/tsconfig.json` and had `/assets/src` and `/doc` out of canonical order, and `Toolkit` was missing `/doc`. Both are now published with files that should be excluded from their archives. This regenerates them.

Nothing ran that script in CI, which is why the drift went unnoticed, so the "Validate packages definition" job now runs it and fails when the working tree changes. It needs PHP and the root dependencies, set up the same way the PHPStan job already does.

