### PR TITLE
[Translator] Cover the parent locale fallback in the dumper tests

### DIFF
--- a/src/Translator/tests/TranslationsDumperTest.php
+++ b/src/Translator/tests/TranslationsDumperTest.php
@@ -14,7 +14,9 @@ namespace Symfony\UX\Translator\Tests;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Translator;
 use Symfony\UX\Translator\MessageParameters\Extractor\IntlMessageParametersExtractor;
 use Symfony\UX\Translator\MessageParameters\Extractor\MessageParametersExtractor;
 use Symfony\UX\Translator\MessageParameters\Printer\TypeScriptMessageParametersPrinter;
@@ -349,6 +351,31 @@ class TranslationsDumperTest extends TestCase
         $content = file_get_contents(self::$translationsDumpDir.'/index.js');
 
         $assertions($this, $content);
+    }
+
+    public function testDumpParentLocaleFallback(): void
+    {
+        $translator = new Translator('de_AT');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', ['symfony.great' => 'Symfony ist großartig!'], 'de');
+        $translator->addResource('array', ['symfony.great' => 'Symfony ist leiwand!'], 'de_AT');
+
+        $translationsDumper = new TranslationsDumper(
+            new MessageParametersExtractor(),
+            new IntlMessageParametersExtractor(),
+            new TypeScriptMessageParametersPrinter(),
+            new Filesystem(),
+        );
+
+        $translationsDumper->dump(
+            catalogues: [$translator->getCatalogue('de_AT'), $translator->getCatalogue('de')],
+            dumpDir: self::$translationsDumpDir,
+        );
+
+        $this->assertStringContainsString(
+            'export const localeFallbacks = {"de_AT":"de","de":null};',
+            file_get_contents(self::$translationsDumpDir.'/index.js'),
+        );
     }
 
     /**


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | Fix #2017
| License        | MIT

Issue #2017 reported that a regional locale did not fall back to its parent, so `de_AT` would not reuse the `de` messages it does not override. Turns out this already works: Symfony computes `de` as the fallback catalogue of `de_AT`, `TranslationsDumper::getLocaleFallbacks()` reads that chain, and the emitted `localeFallbacks` map drives the lookup loop in `translator_controller.ts`. The JavaScript side is already covered, with `fr_FR`, `en_GB` and `de_DE` cases.

What was missing is a test on the PHP side. Every existing `TranslationsDumperTest` case builds its `MessageCatalogue` objects by hand, so none of them has a fallback catalogue at all and the dumped map is always `{"en":null,"fr":null}`. Nothing pinned the parent locale case down.

This adds one test that goes through a real `Translator` instead, so the catalogues carry the fallback chain Symfony builds rather than one wired by hand, and passes them in the order the cache warmer does, so the asserted line is the one a real dump produces: `export const localeFallbacks = {"de_AT":"de","de":null};`. Replacing the body of `getLocaleFallbacks()` with `null` makes it fail, so it holds the behavior rather than just restating it.

