### PR TITLE
[Icons] Move the Accessibility section under Rendering Icons

### DIFF
--- a/src/Icons/doc/index.rst
+++ b/src/Icons/doc/index.rst
@@ -448,6 +448,58 @@ Now, all icons will have the ``fill`` attribute set to ``currentColor`` by defau
     # renders "user-profile.svg" with fill="red"
     {{ ux_icon('user-profile', {fill: 'red'}) }}
 
+Accessibility
+~~~~~~~~~~~~~
+
+Icons add visual elements to your website and they can be a challenge for accessibility.
+According to the `W3C guide about SVG icon accessibility`_, there are
+three methods to improve icons accessibility, depending on the context.
+
+**Informative icons**
+    They convey information or a function. They should define a text alternative
+    that presents the same content or function via the ``aria-label`` attribute
+    used by screen readers and other assistive technologies:
+
+    .. code-block:: twig
+
+        Today's weather:
+        {{ ux_icon('cloud-rain', {'aria-label': 'Rainy weather'}) }}
+
+**Functional icons**
+    They are interactive and perform a function. They should define a text alternative
+    that presents the same content or function via the ``aria-label`` attribute
+    used by screen readers and other assistive technologies:
+
+    .. code-block:: twig
+
+        {{ ux_icon('user-profile', {class: 'w-4 h-4', 'aria-label': 'User Profile'}) }}
+
+**Decorative icons**
+    They are purely decorative and do not convey any meaning or function. They
+    should be hidden from screen readers using the ``aria-hidden`` attribute.
+
+    .. code-block:: html
+
+        <a href="/profile">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 h-4" aria-hidden="true">
+                <!-- ... -->
+            </svg>
+            Back to profile
+        </a>
+
+That is why the ``ux_icon()`` function and the ``<twig:ux:icon>`` component add
+``aria-hidden="true"`` attribute **automatically** to icons not having at least one
+of the following attributes: ``aria-label``, ``aria-labelledby`` or ``title``.
+
+.. note::
+
+    If you don't want to set ``aria-hidden="true"`` for a specific icon, you can
+    explicitly set the ``aria-hidden`` attribute to ``false``:
+
+    .. code-block:: html+twig
+
+        <twig:ux:icon name="user-profile" aria-hidden="false" />
+
 Icon Aliases
 ~~~~~~~~~~~~
 
@@ -537,58 +589,6 @@ by setting the ``ignore_not_found`` configuration option to ``true``:
     # config/packages/ux_icons.yaml
     ux_icons:
         ignore_not_found: true
-
-Accessibility
--------------
-
-Icons add visual elements to your website and they can be a challenge for accessibility.
-According to the `W3C guide about SVG icon accessibility`_, there are
-three methods to improve icons accessibility, depending on the context.
-
-**Informative icons**
-    They convey information or a function. They should define a text alternative
-    that presents the same content or function via the ``aria-label`` attribute
-    used by screen readers and other assistive technologies:
-
-    .. code-block:: twig
-
-        Today's weather:
-        {{ ux_icon('cloud-rain', {'aria-label': 'Rainy weather'}) }}
-
-**Functional icons**
-    They are interactive and perform a function. They should define a text alternative
-    that presents the same content or function via the ``aria-label`` attribute
-    used by screen readers and other assistive technologies:
-
-    .. code-block:: twig
-
-        {{ ux_icon('user-profile', {class: 'w-4 h-4', 'aria-label': 'User Profile'}) }}
-
-**Decorative icons**
-    They are purely decorative and do not convey any meaning or function. They
-    should be hidden from screen readers using the ``aria-hidden`` attribute.
-
-    .. code-block:: html
-
-        <a href="/profile">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 h-4" aria-hidden="true">
-                <!-- ... -->
-            </svg>
-            Back to profile
-        </a>
-
-That is why the ``ux_icon()`` function and the ``<twig:ux:icon>`` component add
-``aria-hidden="true"`` attribute **automatically** to icons not having at least one
-of the following attributes: ``aria-label``, ``aria-labelledby`` or ``title``.
-
-.. note::
-
-    If you don't want to set ``aria-hidden="true"`` for a specific icon, you can
-    explicitly set the ``aria-hidden`` attribute to ``false``:
-
-    .. code-block:: html+twig
-
-        <twig:ux:icon name="user-profile" aria-hidden="false" />
 
 Performance
 -----------


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | Fix #1818
| License        | MIT

Accessibility used to sit at the root of the UX Icons documentation, alongside `SVG Icons` and `Rendering Icons`, even though it's really about how icons render rather than a separate topic on its own. Issue #1818 flagged this back in May 2024 as part of a broader outline rework, and smnandre called this particular move the main idea of the whole proposal; everything else in that issue has already landed (`Basic Usage`, `Icon Names` and `Icon Sets` under `SVG Icons`, `HTML Syntax` and `Default Attributes` under `Rendering Icons`).

This PR closes the gap: `Accessibility` moves under `Rendering Icons`, right after `Default Attributes`, since that's where the `aria-hidden="true"` the bundle adds automatically is explained. Only the heading level and position change, the section content itself is untouched.
