### PR TITLE
[StimulusBundle] Make StimulusHelper autowirable and document PHP usage

### DIFF
--- a/src/StimulusBundle/CHANGELOG.md
+++ b/src/StimulusBundle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.5.0
+
+- Alias the `StimulusHelper` service to its class name so it can be autowired
+
 ## 3.3.0
 
 - Detect the `stimulusFetch: 'lazy'` directive inside preserved comments (`/*! ... */`)

--- a/src/StimulusBundle/config/services.php
+++ b/src/StimulusBundle/config/services.php
@@ -29,6 +29,8 @@ return static function (ContainerConfigurator $container): void {
                 service(Environment::class)->nullOnInvalid(),
             ])
 
+        ->alias(StimulusHelper::class, 'stimulus.helper')
+
         ->set('stimulus.twig_extension', StimulusTwigExtension::class)
             ->args([
                 service('stimulus.helper'),

--- a/src/StimulusBundle/doc/index.rst
+++ b/src/StimulusBundle/doc/index.rst
@@ -370,6 +370,56 @@ once, whichever function the chain started with:
         Hello
     </div>
 
+Stimulus Attributes from PHP
+----------------------------
+
+The same attributes are available from PHP through the ``StimulusHelper``
+service, which you can autowire. Reach for it when the element you want to
+decorate is not written in a template, a form field for instance::
+
+    // src/Form/EventType.php
+    namespace App\Form;
+
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Extension\Core\Type\CountryType;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
+
+    class EventType extends AbstractType
+    {
+        public function __construct(private StimulusHelper $stimulusHelper)
+        {
+        }
+
+        public function buildForm(FormBuilderInterface $builder, array $options): void
+        {
+            $attributes = $this->stimulusHelper->createStimulusAttributes();
+            $attributes->addController('country-picker', ['locale' => 'fr']);
+            $attributes->addTarget('country-picker', 'select');
+            $attributes->addAction('country-picker', 'refresh', 'change');
+
+            $builder->add('country', CountryType::class, [
+                'attr' => $attributes->toArray(),
+            ]);
+        }
+    }
+
+The field then renders with the attributes the Twig helpers would have
+produced:
+
+.. code-block:: html
+
+    <select
+        data-controller="country-picker"
+        data-action="change->country-picker#refresh"
+        data-country-picker-target="select"
+        data-country-picker-locale-value="fr"
+    >
+
+Cast the object to a string when you need the rendered attributes rather than
+an array, and use ``addAttribute()`` to carry along an attribute that is not a
+Stimulus one.
+
 .. _configuration:
 
 Configuration

--- a/src/StimulusBundle/tests/Helper/StimulusHelperTest.php
+++ b/src/StimulusBundle/tests/Helper/StimulusHelperTest.php
@@ -14,6 +14,8 @@ namespace Symfony\UX\StimulusBundle\Tests\Helper;
 use PHPUnit\Framework\TestCase;
 use Symfony\UX\StimulusBundle\Dto\StimulusAttributes;
 use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
+use Symfony\UX\StimulusBundle\Tests\fixtures\AutowiredStimulusHelperConsumer;
+use Symfony\UX\StimulusBundle\Tests\StimulusIntegrationTestKernel;
 use Twig\Environment;
 
 final class StimulusHelperTest extends TestCase
@@ -24,5 +26,25 @@ final class StimulusHelperTest extends TestCase
         $attributes = $helper->createStimulusAttributes();
 
         $this->assertInstanceOf(StimulusAttributes::class, $attributes);
+    }
+
+    public function testIsAutowirable(): void
+    {
+        $kernel = new StimulusIntegrationTestKernel();
+        $kernel->boot();
+
+        $consumer = $kernel->getContainer()->get(AutowiredStimulusHelperConsumer::class);
+        $attributes = $consumer->stimulusHelper->createStimulusAttributes();
+        $attributes->addController('country-picker', ['locale' => 'fr']);
+        $attributes->addTarget('country-picker', 'select');
+        $attributes->addAction('country-picker', 'refresh', 'change');
+
+        // the exact attributes the documented form type example claims to produce
+        $this->assertSame([
+            'data-controller' => 'country-picker',
+            'data-action' => 'change->country-picker#refresh',
+            'data-country-picker-target' => 'select',
+            'data-country-picker-locale-value' => 'fr',
+        ], $attributes->toArray());
     }
 }

--- a/src/StimulusBundle/tests/StimulusIntegrationTestKernel.php
+++ b/src/StimulusBundle/tests/StimulusIntegrationTestKernel.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\UX\StimulusBundle\StimulusBundle;
+use Symfony\UX\StimulusBundle\Tests\fixtures\AutowiredStimulusHelperConsumer;
 
 final class StimulusIntegrationTestKernel extends Kernel
 {
@@ -49,6 +50,10 @@ final class StimulusIntegrationTestKernel extends Kernel
         $container->loadFromExtension('framework', $frameworkConfig);
 
         $container->loadFromExtension('twig');
+
+        $container->register(AutowiredStimulusHelperConsumer::class)
+            ->setAutowired(true)
+            ->setPublic(true);
     }
 
     public function getCacheDir(): string

--- a/src/StimulusBundle/tests/fixtures/AutowiredStimulusHelperConsumer.php
+++ b/src/StimulusBundle/tests/fixtures/AutowiredStimulusHelperConsumer.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\StimulusBundle\Tests\fixtures;
+
+use Symfony\UX\StimulusBundle\Helper\StimulusHelper;
+
+/**
+ * Stands in for the form type the documentation tells you to autowire the helper into.
+ *
+ * @internal
+ */
+final class AutowiredStimulusHelperConsumer
+{
+    public function __construct(public StimulusHelper $stimulusHelper)
+    {
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | Fix #737
| License        | MIT

#737 asks for a way to set Stimulus attributes on form fields from PHP instead of a template. That's already possible: `StimulusHelper::createStimulusAttributes()` returns a `StimulusAttributes` object with `addController()`, `addAction()`, `addTarget()` and `addAttribute()`, and its `toArray()` method feeds straight into a form field's `attr` option.

Two things kept it out of reach: the `stimulus.helper` service had no alias to its class name, so it couldn't be autowired into a form type, and the PHP side appeared nowhere in the documentation. This PR adds the alias and a new documentation section built around a form type example.

Thanks to @19Gerhard85, who opened #2450 for this and reworked it after review. The syntactic sugar explored there, dedicated `stimulus_controller` and `stimulus_target` form options, remains open on top of this.
