### PR TITLE
[StimulusBundle] Bound the test kernel cache directory and drop dead phpunit env vars

### DIFF
--- a/src/StimulusBundle/phpunit.dist.xml
+++ b/src/StimulusBundle/phpunit.dist.xml
@@ -13,8 +13,6 @@
     <php>
         <ini name="error_reporting" value="-1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
-        <env name="KERNEL_CLASS" value="Symfony\UX\Autocomplete\Tests\Fixtures\Kernel"/>
-        <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data.db"/>
     </php>
 
     <testsuites>

--- a/src/StimulusBundle/tests/StimulusIntegrationTestKernel.php
+++ b/src/StimulusBundle/tests/StimulusIntegrationTestKernel.php
@@ -58,11 +58,11 @@ final class StimulusIntegrationTestKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir().'/cache'.spl_object_hash($this);
+        return sys_get_temp_dir().'/sf_ux_stimulus_tests/cache';
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir().'/logs'.spl_object_hash($this);
+        return sys_get_temp_dir().'/sf_ux_stimulus_tests/logs';
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         |
| License        | MIT

`StimulusIntegrationTestKernel::getCacheDir()` derived its path from `spl_object_hash($this)`, the object handle, so the directory changed whenever the allocation pattern did, and nothing ever removed it. On the machine this was written on, the temp directory had accumulated 655 of these directories, 514 MB. The path is now fixed, so there's one known location holding one cache; `getLogDir()` gets the same treatment for consistency. This is about bounding the accumulation, not about test speed: the suite runs in about the same time either way.

`phpunit.dist.xml` carried two environment variables inherited from Autocomplete's configuration: `KERNEL_CLASS`, pointing at a `Symfony\UX\Autocomplete\Tests\Fixtures\Kernel` class this package can't autoload, and `DATABASE_URL`, for a database it has no dependency on. Nothing reads either one, since the only `WebTestCase` here overrides `getKernelClass()`. Both are removed.
