### PR TITLE
[Toolkit] Fix `ux:install` reporting the source path of the installed files

### DIFF
--- a/src/Toolkit/src/Command/InstallCommand.php
+++ b/src/Toolkit/src/Command/InstallCommand.php
@@ -197,7 +197,7 @@ class InstallCommand extends Command
         $this->io->success('The recipe has been installed.');
 
         $this->io->section('Installed files');
-        $this->io->listing(array_map(static fn (File $file) => Path::join($destinationPath, $file->sourceRelativePathName), $installationReport->newFiles));
+        $this->io->listing(array_map(static fn (File $file) => Path::join($destinationPath, $file->destinationRelativePathName), $installationReport->newFiles));
 
         if ([] !== $installationReport->suggestedPhpPackages || [] !== $installationReport->suggestedNpmPackages || [] !== $installationReport->suggestedImportmapPackages) {
             $this->io->section('Next steps');

--- a/src/Toolkit/tests/Command/InstallCommandTest.php
+++ b/src/Toolkit/tests/Command/InstallCommandTest.php
@@ -12,13 +12,22 @@
 namespace Symfony\UX\Toolkit\Tests\Command;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
+use Symfony\UX\Toolkit\Command\InstallCommand;
+use Symfony\UX\Toolkit\Kit\Kit;
+use Symfony\UX\Toolkit\Registry\RegistryFactory;
+use Symfony\UX\Toolkit\Registry\RegistryInterface;
+use Symfony\UX\Toolkit\Registry\Type;
+use Symfony\UX\Toolkit\Tests\TestHelperTrait;
 use Zenstruck\Console\Test\InteractsWithConsole;
 
 class InstallCommandTest extends KernelTestCase
 {
     use InteractsWithConsole;
+    use TestHelperTrait;
 
     private Filesystem $filesystem;
     private string $tmpDir;
@@ -64,6 +73,25 @@ class InstallCommandTest extends KernelTestCase
             $this->assertFileExists($expectedFile);
             $this->assertEquals(file_get_contents(__DIR__.'/../../kits/shadcn/'.$fileName), file_get_contents($expectedFile));
         }
+    }
+
+    /**
+     * A recipe is free to copy its files to a directory that is not named after the source one,
+     * so the report must name where each file landed, not where it came from.
+     */
+    public function testShouldReportWhereTheInstalledFilesLanded(): void
+    {
+        $kit = self::getContainer()->get('ux_toolkit.kit.kit_factory')->createKitFromAbsolutePath(self::getFixtureKitPath('with-renamed-copy-files'));
+
+        $tester = new CommandTester($this->createInstallCommand($kit));
+        $tester->execute(['recipe' => 'notice', '--kit' => 'with-renamed-copy-files', '--destination' => $this->tmpDir], ['interactive' => false]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertFileExists($this->tmpDir.'/templates/components/Notice.html.twig');
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString(Path::normalize($this->tmpDir.'/templates/components/Notice.html.twig'), $display);
+        $this->assertStringNotContainsString(Path::normalize($this->tmpDir.'/ui/Notice.html.twig'), $display);
     }
 
     public function testShouldSuggestFrontendInstallationCommands(): void
@@ -177,5 +205,32 @@ class InstallCommandTest extends KernelTestCase
             ->assertFaulty()
             ->assertOutputContains('[WARNING] The recipe has not been installed.')
         ;
+    }
+
+    private function createInstallCommand(Kit $kit): InstallCommand
+    {
+        $registry = new class($kit) implements RegistryInterface {
+            public function __construct(private readonly Kit $kit)
+            {
+            }
+
+            public static function supports(string $kitName): bool
+            {
+                return true;
+            }
+
+            public function getKit(string $kitName): Kit
+            {
+                return $this->kit;
+            }
+        };
+
+        $command = new InstallCommand(
+            new RegistryFactory(new ServiceLocator([Type::Local->value => static fn () => $registry])),
+            self::getContainer()->get('filesystem'),
+        );
+        $command->setName('ux:install');
+
+        return $command;
     }
 }

--- a/src/Toolkit/tests/Fixtures/kits/with-renamed-copy-files/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/with-renamed-copy-files/manifest.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../../../schema-kit-v1.json",
+    "name": "With renamed copy files",
+    "description": "Kit used as a test fixture, copying files to a directory that is not named after the source one.",
+    "license": "MIT",
+    "homepage": "https://ux.symfony.com/"
+}

--- a/src/Toolkit/tests/Fixtures/kits/with-renamed-copy-files/notice/manifest.json
+++ b/src/Toolkit/tests/Fixtures/kits/with-renamed-copy-files/notice/manifest.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Notice",
+    "description": "Component Notice",
+    "copy-files": {
+        "ui/": "templates/components/"
+    }
+}

--- a/src/Toolkit/tests/Fixtures/kits/with-renamed-copy-files/notice/ui/Notice.html.twig
+++ b/src/Toolkit/tests/Fixtures/kits/with-renamed-copy-files/notice/ui/Notice.html.twig
@@ -1,0 +1,3 @@
+<div{{ attributes.defaults({class: 'notice'}) }}>
+    {% block content %}{% endblock %}
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | no
| Issues         | -
| License        | MIT

The "Installed files" listing printed by `ux:install` is built from
`File::$sourceRelativePathName`, so it names the file *inside the kit* rather than the path it
was actually written to:

```php
$this->io->listing(array_map(static fn (File $file) => Path::join($destinationPath, $file->sourceRelativePathName), $installationReport->newFiles));
```

The two sides are independent by design — `File` carries a source *and* a destination, and a
recipe manifest maps them freely through `copy-files` — but every recipe shipped today maps
`"templates/": "templates/"`, so the two happen to be identical and the mistake is invisible.

A recipe that copies, say, `ui/` to `templates/components/` reports paths that do not exist on
disk:

```
Installed files
---------------

 * /path/to/app/ui/Notice.html.twig        ← nothing was written here
```

while the file actually landed in `/path/to/app/templates/components/Notice.html.twig`.

The fix reports `destinationRelativePathName`. The regression test installs a fixture kit whose
`copy-files` maps a source directory to a differently named destination, and asserts the
listing names the destination and not the source; it fails on `3.x` before the fix.
