### PR TITLE
[Toolkit][Shadcn] Add carousel recipe

### DIFF
--- a/src/Toolkit/CHANGELOG.md
+++ b/src/Toolkit/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [Shadcn] Add `sheet` recipe
 - [Shadcn] Add `form` recipe
 - [Shadcn] Add `sidebar` recipe
+- [Shadcn] Add `carousel` recipe
 - [Shadcn][Flowbite] Merge component classes with `attributes.defaults({ class: '...'|tailwind_classes })` instead of `tailwind_merge` (consumer classes now override component variants)
 - [Shadcn] Fix Field/Label, InputGroup and Pagination silently dropping their own base classes when forwarding to a child component (their checked/disabled/nested/dark styles now apply)
 - [Shadcn] Fix `dialog` opening on initial render when `open` is `false`

--- a/src/Toolkit/kits/shadcn/carousel/README.md
+++ b/src/Toolkit/kits/shadcn/carousel/README.md
@@ -1,0 +1,261 @@
+# Carousel
+
+A carousel with motion and swipe, driven by a Stimulus controller.
+
+```twig {"preview":true,"height":"320px"}
+<twig:Carousel class="mx-auto w-full max-w-[12rem] sm:max-w-xs">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item>
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-4xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+
+## Installation
+
+::: installation
+
+## Usage
+
+```twig
+<twig:Carousel orientation="horizontal | vertical" align="start | center | end" loop>
+    <twig:Carousel:Content>
+        <twig:Carousel:Item>...</twig:Carousel:Item>
+        <twig:Carousel:Item>...</twig:Carousel:Item>
+        <twig:Carousel:Item>...</twig:Carousel:Item>
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+
+## Examples
+
+### Sizes
+
+To set the size of the slides, use a `basis-*` utility on the `Carousel:Item`.
+
+```twig {"preview":true,"height":"260px"}
+<twig:Carousel align="start" class="mx-auto w-full max-w-[12rem] sm:max-w-xs md:max-w-sm">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item class="basis-1/2 lg:basis-1/3">
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-3xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+
+### Spacing
+
+To set the spacing between the slides, use a `ps-*` utility on the `Carousel:Item` and the matching negative `-ms-*` on the `Carousel:Content`.
+
+```twig {"preview":true,"height":"260px"}
+<twig:Carousel class="mx-auto w-full max-w-[12rem] sm:max-w-xs md:max-w-sm">
+    <twig:Carousel:Content class="-ms-1">
+        {% for i in 1..5 %}
+            <twig:Carousel:Item class="basis-1/2 ps-1 lg:basis-1/3">
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-2xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+
+### Multiple Items
+
+```twig {"preview":true,"height":"260px"}
+<twig:Carousel align="start" class="mx-auto max-w-xs sm:max-w-sm">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item class="sm:basis-1/2 lg:basis-1/3">
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-3xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous class="hidden sm:inline-flex" />
+    <twig:Carousel:Next class="hidden sm:inline-flex" />
+</twig:Carousel>
+```
+
+### Orientation
+
+Use the `orientation` prop to set the axis the slides scroll along. A vertical carousel needs an explicit height on the `Carousel:Content`.
+
+```twig {"preview":true,"height":"420px"}
+<twig:Carousel orientation="vertical" align="start" class="mx-auto w-full max-w-xs">
+    <twig:Carousel:Content class="-mt-1 h-[270px]">
+        {% for i in 1..5 %}
+            <twig:Carousel:Item class="basis-1/2 pt-1">
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex items-center justify-center p-6">
+                            <span class="text-3xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+
+### Options
+
+Use the `align` prop to choose where the selected slide rests inside the viewport, and the `loop` prop to wrap around after the last slide.
+
+```twig {"preview":true,"height":"320px"}
+<twig:Carousel align="start" loop class="mx-auto w-full max-w-[12rem] sm:max-w-xs">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item>
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-4xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+
+### API
+
+The carousel dispatches a `carousel:select` event whenever the selected slide changes, carrying the slide `index` and the slide `count` in its detail. The `carousel-display` controller shipped with this recipe listens to it to render the current position.
+
+```twig {"preview":true,"height":"360px"}
+<div class="mx-auto w-full max-w-[10rem] sm:max-w-xs" data-controller="carousel-display" data-action="carousel:select->carousel-display#update">
+    <twig:Carousel>
+        <twig:Carousel:Content>
+            {% for i in 1..5 %}
+                <twig:Carousel:Item>
+                    <twig:Card class="m-px">
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-4xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </twig:Carousel:Item>
+            {% endfor %}
+        </twig:Carousel:Content>
+        <twig:Carousel:Previous />
+        <twig:Carousel:Next />
+    </twig:Carousel>
+    <div class="py-2 text-center text-sm text-muted-foreground" data-carousel-display-target="output">Slide 1 of 5</div>
+</div>
+```
+
+### Autoplay
+
+Use the `autoplay` prop to advance the slides automatically, with a delay in milliseconds. Autoplay pauses while the carousel is hovered or focused, and restarts from a full delay after any interaction.
+
+```twig {"preview":true,"height":"320px"}
+<twig:Carousel autoplay="2000" class="mx-auto w-full max-w-[10rem] sm:max-w-xs">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item>
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-4xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+```twig {"preview":true,"height":"620px"}
+{% set arabicNumerals = ['١', '٢', '٣', '٤', '٥'] %}
+<div class="flex flex-col items-center gap-12">
+    {# Arabic #}
+    <twig:Carousel dir="rtl" class="w-full max-w-[12rem] sm:max-w-xs">
+        <twig:Carousel:Content>
+            {% for i in 1..5 %}
+                <twig:Carousel:Item>
+                    <div class="p-1">
+                        <twig:Card>
+                            <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                                <span class="text-4xl font-semibold">{{ arabicNumerals[i - 1] }}</span>
+                            </twig:Card:Content>
+                        </twig:Card>
+                    </div>
+                </twig:Carousel:Item>
+            {% endfor %}
+        </twig:Carousel:Content>
+        <twig:Carousel:Previous text="الشريحة السابقة" />
+        <twig:Carousel:Next text="الشريحة التالية" />
+    </twig:Carousel>
+
+    {# Hebrew #}
+    <twig:Carousel dir="rtl" class="w-full max-w-[12rem] sm:max-w-xs">
+        <twig:Carousel:Content>
+            {% for i in 1..5 %}
+                <twig:Carousel:Item>
+                    <div class="p-1">
+                        <twig:Card>
+                            <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                                <span class="text-4xl font-semibold">{{ i }}</span>
+                            </twig:Card:Content>
+                        </twig:Card>
+                    </div>
+                </twig:Carousel:Item>
+            {% endfor %}
+        </twig:Carousel:Content>
+        <twig:Carousel:Previous text="השקופית הקודמת" />
+        <twig:Carousel:Next text="השקופית הבאה" />
+    </twig:Carousel>
+</div>
+```
+
+## API Reference
+
+::: api-reference

--- a/src/Toolkit/kits/shadcn/carousel/assets/controllers/carousel_controller.js
+++ b/src/Toolkit/kits/shadcn/carousel/assets/controllers/carousel_controller.js
@@ -1,0 +1,377 @@
+import { Controller } from '@hotwired/stimulus';
+
+// Pointer travel, in pixels, before a press turns into a drag rather than a click.
+const DRAG_THRESHOLD = 5;
+// How far, in milliseconds, the release velocity is projected to pick the landing slide.
+const DRAG_MOMENTUM = 120;
+
+/**
+ * Motion and swipe behavior for the `Carousel` component: a flex track translated with a CSS
+ * transform, whose snap positions are measured from the rendered slides rather than configured,
+ * so any `basis-*` utility on a `Carousel:Item` works out of the box.
+ *
+ * Positions are expressed along the logical axis (0 is the first slide, growing towards the last
+ * one), so the same math drives horizontal, vertical and RTL carousels; only the sign of the
+ * applied transform changes.
+ */
+export default class extends Controller {
+    static targets = ['viewport', 'track', 'item', 'previous', 'next'];
+
+    static values = {
+        orientation: { type: String, default: 'horizontal' },
+        align: { type: String, default: 'center' },
+        loop: { type: Boolean, default: false },
+        autoplay: { type: Number, default: 0 },
+    };
+
+    connect() {
+        this._index = 0;
+        this._position = 0;
+        this._snaps = [0];
+        this._maxPosition = 0;
+        this._rtl = false;
+        this._dragging = false;
+        this._pointerId = null;
+        this._autoplayPaused = false;
+        this._autoplayTimer = null;
+
+        this._abortController = new AbortController();
+        const { signal } = this._abortController;
+
+        this._resizeObserver = new ResizeObserver(() => this._onResize());
+        this._resizeObserver.observe(this.viewportTarget);
+        this._resizeObserver.observe(this.trackTarget);
+
+        if (this.autoplayValue > 0) {
+            this.element.addEventListener('mouseenter', () => this.pauseAutoplay(), { signal });
+            this.element.addEventListener('mouseleave', () => this.resumeAutoplay(), { signal });
+            this.element.addEventListener('focusin', () => this.pauseAutoplay(), { signal });
+            this.element.addEventListener('focusout', () => this.resumeAutoplay(), { signal });
+        }
+
+        this.measure();
+        this.select(0, false);
+        this._restartAutoplay();
+    }
+
+    disconnect() {
+        this._abortController?.abort();
+        this._abortController = null;
+        this._dragAbortController?.abort();
+        this._dragAbortController = null;
+        this._resizeObserver?.disconnect();
+        this._resizeObserver = null;
+        this._pointerId = null;
+        this._stopAutoplay();
+    }
+
+    scrollPrev() {
+        this.select(this._index - 1);
+        this._restartAutoplay();
+    }
+
+    scrollNext() {
+        this.select(this._index + 1);
+        this._restartAutoplay();
+    }
+
+    select(index, animate = true) {
+        const count = this._snaps.length;
+
+        this._index = this.loopValue ? ((index % count) + count) % count : Math.min(Math.max(index, 0), count - 1);
+        this._position = this._snaps[this._index];
+
+        if (animate) {
+            this._translate();
+        } else {
+            this._translateWithoutAnimation();
+        }
+
+        this._sync();
+    }
+
+    handleKeydown(event) {
+        if (event.target.closest('input, textarea, select, [contenteditable]')) {
+            return;
+        }
+
+        let forward;
+        if (this._isHorizontal) {
+            if ('ArrowLeft' === event.key) {
+                forward = this._rtl;
+            } else if ('ArrowRight' === event.key) {
+                forward = !this._rtl;
+            } else {
+                return;
+            }
+        } else if ('ArrowUp' === event.key) {
+            forward = false;
+        } else if ('ArrowDown' === event.key) {
+            forward = true;
+        } else {
+            return;
+        }
+
+        event.preventDefault();
+
+        if (forward) {
+            this.scrollNext();
+        } else {
+            this.scrollPrev();
+        }
+    }
+
+    dragStart(event) {
+        if (0 !== event.button || this._snaps.length < 2) {
+            return;
+        }
+
+        this._dragAbortController?.abort();
+        this._dragAbortController = new AbortController();
+        const { signal } = this._dragAbortController;
+
+        this._pointerId = event.pointerId;
+        this._dragOrigin = this._pointerCoordinate(event);
+        this._dragStartPosition = this._position;
+        this._dragMoved = false;
+        this._dragLastCoordinate = this._dragOrigin;
+        this._dragLastTime = event.timeStamp;
+        this._dragVelocity = 0;
+
+        window.addEventListener('pointermove', (e) => this._onDragMove(e), { signal, passive: false });
+        window.addEventListener('pointerup', (e) => this._onDragEnd(e), { signal });
+        window.addEventListener('pointercancel', (e) => this._onDragEnd(e), { signal });
+
+        this.pauseAutoplay();
+    }
+
+    pauseAutoplay() {
+        this._autoplayPaused = true;
+        this._stopAutoplay();
+    }
+
+    resumeAutoplay() {
+        this._autoplayPaused = false;
+        this._restartAutoplay();
+    }
+
+    /**
+     * Offsets are taken from the track rather than the viewport so the negative margin carrying
+     * the gutter is already accounted for, and the track's own size is what slides align against.
+     */
+    measure() {
+        this._rtl = 'rtl' === getComputedStyle(this.element).direction;
+
+        const horizontal = this._isHorizontal;
+        const trackRect = this.trackTarget.getBoundingClientRect();
+        const viewportSize = horizontal ? trackRect.width : trackRect.height;
+
+        const slides = this.itemTargets.map((item) => {
+            const rect = item.getBoundingClientRect();
+
+            if (!horizontal) {
+                return { start: rect.top - trackRect.top, size: rect.height };
+            }
+
+            return this._rtl
+                ? { start: trackRect.right - rect.right, size: rect.width }
+                : { start: rect.left - trackRect.left, size: rect.width };
+        });
+
+        const contentSize = slides.reduce((size, slide) => Math.max(size, slide.start + slide.size), 0);
+        this._maxPosition = Math.max(0, contentSize - viewportSize);
+
+        // Snaps clamped to the same position — the trailing slides of a multi-item carousel,
+        // typically — collapse into a single one.
+        const snaps = [];
+        slides.forEach(({ start, size }) => {
+            let target = start;
+            if ('end' === this.alignValue) {
+                target = start - (viewportSize - size);
+            } else if ('start' !== this.alignValue) {
+                target = start - (viewportSize - size) / 2;
+            }
+
+            target = Math.min(Math.max(target, 0), this._maxPosition);
+
+            if (0 === snaps.length || Math.abs(snaps[snaps.length - 1] - target) > 1) {
+                snaps.push(target);
+            }
+        });
+
+        this._snaps = snaps.length > 0 ? snaps : [0];
+        this._index = Math.min(this._index, this._snaps.length - 1);
+    }
+
+    get _isHorizontal() {
+        return 'vertical' !== this.orientationValue;
+    }
+
+    /** The sign turning a logical position (or a pointer delta) into a physical one. */
+    get _axisSign() {
+        return this._isHorizontal && this._rtl ? 1 : -1;
+    }
+
+    _translate() {
+        const offset = this._axisSign * this._position;
+
+        this.trackTarget.style.transform = this._isHorizontal
+            ? `translate3d(${offset}px, 0, 0)`
+            : `translate3d(0, ${offset}px, 0)`;
+    }
+
+    _translateWithoutAnimation() {
+        const track = this.trackTarget;
+
+        track.style.transitionDuration = '0ms';
+        this._translate();
+        // Flush the transform so the transition restored below does not animate it.
+        track.getBoundingClientRect();
+        track.style.transitionDuration = '';
+    }
+
+    _sync() {
+        const count = this._snaps.length;
+        const canScrollPrev = this.loopValue ? count > 1 : this._index > 0;
+        const canScrollNext = this.loopValue ? count > 1 : this._index < count - 1;
+
+        this.previousTargets.forEach((button) => {
+            button.disabled = !canScrollPrev;
+        });
+        this.nextTargets.forEach((button) => {
+            button.disabled = !canScrollNext;
+        });
+
+        if (this._lastIndex !== this._index || this._lastCount !== count) {
+            this._lastIndex = this._index;
+            this._lastCount = count;
+            this.dispatch('select', { detail: { index: this._index, count } });
+        }
+    }
+
+    _onResize() {
+        if (this._dragging) {
+            return;
+        }
+
+        this.measure();
+        this._position = this._snaps[this._index];
+        this._translateWithoutAnimation();
+        this._sync();
+    }
+
+    _onDragMove(event) {
+        if (event.pointerId !== this._pointerId) {
+            return;
+        }
+
+        const coordinate = this._pointerCoordinate(event);
+        const delta = coordinate - this._dragOrigin;
+
+        if (!this._dragMoved) {
+            if (Math.abs(delta) < DRAG_THRESHOLD) {
+                return;
+            }
+
+            this._dragMoved = true;
+            this._dragging = true;
+            this.trackTarget.style.transitionDuration = '0ms';
+        }
+
+        if (event.cancelable) {
+            event.preventDefault();
+        }
+
+        let position = this._dragStartPosition + this._axisSign * delta;
+        // Rubber band the drag past the first and last slide.
+        if (position < 0) {
+            position /= 3;
+        } else if (position > this._maxPosition) {
+            position = this._maxPosition + (position - this._maxPosition) / 3;
+        }
+
+        this._position = position;
+        this._translate();
+
+        const elapsed = event.timeStamp - this._dragLastTime;
+        if (elapsed > 0) {
+            this._dragVelocity = (coordinate - this._dragLastCoordinate) / elapsed;
+            this._dragLastCoordinate = coordinate;
+            this._dragLastTime = event.timeStamp;
+        }
+    }
+
+    _onDragEnd(event) {
+        if (event.pointerId !== this._pointerId) {
+            return;
+        }
+
+        this._dragAbortController?.abort();
+        this._dragAbortController = null;
+        this._pointerId = null;
+
+        if (!this._dragMoved) {
+            this.resumeAutoplay();
+
+            return;
+        }
+
+        this._dragMoved = false;
+        this._dragging = false;
+        this.trackTarget.style.transitionDuration = '';
+        this._suppressNextClick();
+
+        const projected = this._position + this._axisSign * this._dragVelocity * DRAG_MOMENTUM;
+        let nearest = 0;
+        let smallestDistance = Number.POSITIVE_INFINITY;
+        this._snaps.forEach((snap, index) => {
+            const distance = Math.abs(snap - projected);
+            if (distance < smallestDistance) {
+                smallestDistance = distance;
+                nearest = index;
+            }
+        });
+
+        this.select(nearest);
+        this.resumeAutoplay();
+    }
+
+    /** Swallows the click a drag ends with, so dragging over a link or a button does not activate it. */
+    _suppressNextClick() {
+        const suppress = (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+        };
+
+        this.viewportTarget.addEventListener('click', suppress, { capture: true });
+        window.setTimeout(() => this.viewportTarget.removeEventListener('click', suppress, { capture: true }), 0);
+    }
+
+    _pointerCoordinate(event) {
+        return this._isHorizontal ? event.clientX : event.clientY;
+    }
+
+    _restartAutoplay() {
+        this._stopAutoplay();
+
+        if (this.autoplayValue <= 0 || this._autoplayPaused) {
+            return;
+        }
+
+        this._autoplayTimer = window.setInterval(() => {
+            if (document.hidden) {
+                return;
+            }
+
+            // Autoplay always rewinds to the first slide, even when the carousel does not loop.
+            this.select(this._index >= this._snaps.length - 1 ? 0 : this._index + 1);
+        }, this.autoplayValue);
+    }
+
+    _stopAutoplay() {
+        if (this._autoplayTimer) {
+            window.clearInterval(this._autoplayTimer);
+            this._autoplayTimer = null;
+        }
+    }
+}

--- a/src/Toolkit/kits/shadcn/carousel/assets/controllers/carousel_display_controller.js
+++ b/src/Toolkit/kits/shadcn/carousel/assets/controllers/carousel_display_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * @value  template  The output text, where `%index%` and `%count%` are replaced by the current slide number and the total number of slides.
+ * @target output    The element whose text content displays the carousel position.
+ * @action update    Writes the carousel's current position into the output target.
+ */
+export default class extends Controller {
+    static targets = ['output'];
+    static values = {
+        template: { type: String, default: 'Slide %index% of %count%' },
+    };
+
+    update(event) {
+        const { index, count } = event.detail;
+
+        this.outputTarget.textContent = this.templateValue
+            .replace('%index%', String(index + 1))
+            .replace('%count%', String(count));
+    }
+}

--- a/src/Toolkit/kits/shadcn/carousel/manifest.json
+++ b/src/Toolkit/kits/shadcn/carousel/manifest.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "../../../schema-kit-recipe-v1.json",
+    "type": "component",
+    "name": "Carousel",
+    "version-added": "3.5",
+    "copy-files": {
+        "assets/": "assets/",
+        "templates/": "templates/"
+    },
+    "dependencies": {
+        "recipe": ["button"],
+        "composer": [
+            "twig/html-extra:^3.24.0",
+            "symfony/ux-icons",
+            "symfony/ux-twig-component:^3.5",
+            "tales-from-a-dev/twig-tailwind-extra:^1.3.0"
+        ]
+    }
+}

--- a/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel.html.twig
+++ b/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel.html.twig
@@ -1,0 +1,27 @@
+{# @prop orientation 'horizontal'|'vertical' The axis the slides scroll along. #}
+{# @prop align 'start'|'center'|'end' The alignment of the selected slide inside the viewport. #}
+{# @prop loop boolean Whether the carousel wraps around after the last slide. #}
+{# @prop autoplay int The delay, in milliseconds, between two automatic slide changes. Zero disables autoplay. #}
+{# @prop label string The accessible name of the carousel region. #}
+{# @block content The carousel structure, typically includes `Carousel:Content`, `Carousel:Previous` and `Carousel:Next`. #}
+{%- props orientation = 'horizontal', align = 'center', loop = false, autoplay = 0, label = 'Carousel' -%}
+{%- do provide('carousel.orientation', orientation) -%}
+{%- do provide('carousel.loop', loop) -%}
+<div
+    role="region"
+    aria-roledescription="carousel"
+    aria-label="{{ label }}"
+    data-slot="carousel"
+    data-orientation="{{ orientation }}"
+    data-carousel-orientation-value="{{ orientation }}"
+    data-carousel-align-value="{{ align }}"
+    data-carousel-loop-value="{{ loop ? 'true' : 'false' }}"
+    data-carousel-autoplay-value="{{ autoplay }}"
+    {{ attributes.defaults({
+        class: 'relative'|tailwind_classes,
+        'data-controller': 'carousel',
+        'data-action': 'keydown->carousel#handleKeydown',
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel/Content.html.twig
+++ b/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel/Content.html.twig
@@ -1,0 +1,17 @@
+{# @block content The carousel slides, typically multiple `Carousel:Item` components. #}
+{%- set _carousel_orientation = inject('carousel.orientation', 'horizontal') -%}
+<div
+    data-slot="carousel-content"
+    data-carousel-target="viewport"
+    data-action="pointerdown->carousel#dragStart"
+    class="overflow-hidden {{ _carousel_orientation == 'vertical' ? 'touch-pan-x' : 'touch-pan-y' }}"
+>
+    <div
+        data-carousel-target="track"
+        {{ attributes.defaults({
+            class: ('flex transition-transform duration-500 ease-out ' ~ (_carousel_orientation == 'vertical' ? '-mt-4 flex-col' : '-ms-4'))|tailwind_classes,
+        }) }}
+    >
+        {%- block content %}{% endblock -%}
+    </div>
+</div>

--- a/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel/Item.html.twig
+++ b/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel/Item.html.twig
@@ -1,0 +1,13 @@
+{# @block content The slide content. #}
+{%- set _carousel_orientation = inject('carousel.orientation', 'horizontal') -%}
+<div
+    role="group"
+    aria-roledescription="slide"
+    data-slot="carousel-item"
+    data-carousel-target="item"
+    {{ attributes.defaults({
+        class: ('min-w-0 shrink-0 grow-0 basis-full ' ~ (_carousel_orientation == 'vertical' ? 'pt-4' : 'ps-4'))|tailwind_classes,
+    }) }}
+>
+    {%- block content %}{% endblock -%}
+</div>

--- a/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel/Next.html.twig
+++ b/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel/Next.html.twig
@@ -1,0 +1,18 @@
+{# @prop variant 'default'|'secondary'|'destructive'|'outline'|'ghost'|'link' The button style variant. #}
+{# @prop size 'default'|'xs'|'sm'|'lg'|'icon'|'icon-xs'|'icon-sm'|'icon-lg' The button size. #}
+{# @prop text string The accessible label of the button. #}
+{%- props variant = 'outline', size = 'icon-sm', text = 'Next slide' -%}
+{%- set _carousel_orientation = inject('carousel.orientation', 'horizontal') -%}
+<twig:Button
+    variant="{{ variant }}"
+    size="{{ size }}"
+    data-slot="carousel-next"
+    data-carousel-target="next"
+    {{ ...attributes.defaults({
+        class: ('absolute touch-manipulation ' ~ (_carousel_orientation == 'vertical' ? '-bottom-12 start-1/2 -translate-x-1/2 rtl:translate-x-1/2 rotate-90' : 'inset-y-0 -end-12 my-auto'))|tailwind_classes,
+        'data-action': 'click->carousel#scrollNext',
+    }) }}
+>
+    <twig:ux:icon name="lucide:chevron-right" class="rtl:rotate-180" />
+    <span class="sr-only">{{ text }}</span>
+</twig:Button>

--- a/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel/Previous.html.twig
+++ b/src/Toolkit/kits/shadcn/carousel/templates/components/Carousel/Previous.html.twig
@@ -1,0 +1,20 @@
+{# @prop variant 'default'|'secondary'|'destructive'|'outline'|'ghost'|'link' The button style variant. #}
+{# @prop size 'default'|'xs'|'sm'|'lg'|'icon'|'icon-xs'|'icon-sm'|'icon-lg' The button size. #}
+{# @prop text string The accessible label of the button. #}
+{%- props variant = 'outline', size = 'icon-sm', text = 'Previous slide' -%}
+{%- set _carousel_orientation = inject('carousel.orientation', 'horizontal') -%}
+{%- set _carousel_loop = inject('carousel.loop', false) -%}
+<twig:Button
+    variant="{{ variant }}"
+    size="{{ size }}"
+    data-slot="carousel-previous"
+    data-carousel-target="previous"
+    {{ ...attributes.defaults({
+        class: ('absolute touch-manipulation ' ~ (_carousel_orientation == 'vertical' ? '-top-12 start-1/2 -translate-x-1/2 rtl:translate-x-1/2 rotate-90' : 'inset-y-0 -start-12 my-auto'))|tailwind_classes,
+        'data-action': 'click->carousel#scrollPrev',
+        disabled: not _carousel_loop,
+    }) }}
+>
+    <twig:ux:icon name="lucide:chevron-left" class="rtl:rotate-180" />
+    <span class="sr-only">{{ text }}</span>
+</twig:Button>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 0__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 0__1.html
@@ -1,0 +1,82 @@
+<!--
+- Kit: Shadcn UI
+- Component: Carousel
+- Code:
+```twig
+<twig:Carousel class="mx-auto w-full max-w-[12rem] sm:max-w-xs">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item>
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-4xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="horizontal" data-carousel-orientation-value="horizontal" data-carousel-align-value="center" data-carousel-loop-value="false" data-carousel-autoplay-value="0" class="relative mx-auto w-full max-w-[12rem] sm:max-w-xs" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-y">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out -ms-4">            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">1</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">2</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">3</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">4</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">5</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            </div>
+</div>
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -start-12 my-auto" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev" disabled><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">Previous slide</span>
+</button>
+
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -end-12 my-auto" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">Next slide</span>
+</button>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 1__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 1__1.html
@@ -1,0 +1,82 @@
+<!--
+- Kit: Shadcn UI
+- Component: Carousel
+- Code:
+```twig
+<twig:Carousel align="start" class="mx-auto w-full max-w-[12rem] sm:max-w-xs md:max-w-sm">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item class="basis-1/2 lg:basis-1/3">
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-3xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="horizontal" data-carousel-orientation-value="horizontal" data-carousel-align-value="start" data-carousel-loop-value="false" data-carousel-autoplay-value="0" class="relative mx-auto w-full max-w-[12rem] sm:max-w-xs md:max-w-sm" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-y">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out -ms-4">            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 ps-4 basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">1</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 ps-4 basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">2</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 ps-4 basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">3</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 ps-4 basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">4</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 ps-4 basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">5</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            </div>
+</div>
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -start-12 my-auto" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev" disabled><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">Previous slide</span>
+</button>
+
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -end-12 my-auto" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">Next slide</span>
+</button>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 2__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 2__1.html
@@ -1,0 +1,82 @@
+<!--
+- Kit: Shadcn UI
+- Component: Carousel
+- Code:
+```twig
+<twig:Carousel class="mx-auto w-full max-w-[12rem] sm:max-w-xs md:max-w-sm">
+    <twig:Carousel:Content class="-ms-1">
+        {% for i in 1..5 %}
+            <twig:Carousel:Item class="basis-1/2 ps-1 lg:basis-1/3">
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-2xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="horizontal" data-carousel-orientation-value="horizontal" data-carousel-align-value="center" data-carousel-loop-value="false" data-carousel-autoplay-value="0" class="relative mx-auto w-full max-w-[12rem] sm:max-w-xs md:max-w-sm" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-y">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out -ms-1">            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 ps-1 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-2xl font-semibold">1</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 ps-1 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-2xl font-semibold">2</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 ps-1 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-2xl font-semibold">3</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 ps-1 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-2xl font-semibold">4</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 ps-1 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-2xl font-semibold">5</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            </div>
+</div>
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -start-12 my-auto" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev" disabled><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">Previous slide</span>
+</button>
+
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -end-12 my-auto" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">Next slide</span>
+</button>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 3__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 3__1.html
@@ -1,0 +1,82 @@
+<!--
+- Kit: Shadcn UI
+- Component: Carousel
+- Code:
+```twig
+<twig:Carousel align="start" class="mx-auto max-w-xs sm:max-w-sm">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item class="sm:basis-1/2 lg:basis-1/3">
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-3xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous class="hidden sm:inline-flex" />
+    <twig:Carousel:Next class="hidden sm:inline-flex" />
+</twig:Carousel>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="horizontal" data-carousel-orientation-value="horizontal" data-carousel-align-value="start" data-carousel-loop-value="false" data-carousel-autoplay-value="0" class="relative mx-auto max-w-xs sm:max-w-sm" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-y">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out -ms-4">            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4 sm:basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">1</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4 sm:basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">2</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4 sm:basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">3</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4 sm:basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">4</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4 sm:basis-1/2 lg:basis-1/3">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-3xl font-semibold">5</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            </div>
+</div>
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -start-12 my-auto hidden sm:inline-flex" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev" disabled><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">Previous slide</span>
+</button>
+
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -end-12 my-auto hidden sm:inline-flex" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">Next slide</span>
+</button>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 4__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 4__1.html
@@ -1,0 +1,82 @@
+<!--
+- Kit: Shadcn UI
+- Component: Carousel
+- Code:
+```twig
+<twig:Carousel orientation="vertical" align="start" class="mx-auto w-full max-w-xs">
+    <twig:Carousel:Content class="-mt-1 h-[270px]">
+        {% for i in 1..5 %}
+            <twig:Carousel:Item class="basis-1/2 pt-1">
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex items-center justify-center p-6">
+                            <span class="text-3xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="vertical" data-carousel-orientation-value="vertical" data-carousel-align-value="start" data-carousel-loop-value="false" data-carousel-autoplay-value="0" class="relative mx-auto w-full max-w-xs" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-x">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out flex-col -mt-1 h-[270px]">            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 pt-1">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex items-center justify-center p-6">
+<span class="text-3xl font-semibold">1</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 pt-1">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex items-center justify-center p-6">
+<span class="text-3xl font-semibold">2</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 pt-1">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex items-center justify-center p-6">
+<span class="text-3xl font-semibold">3</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 pt-1">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex items-center justify-center p-6">
+<span class="text-3xl font-semibold">4</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-1/2 pt-1">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex items-center justify-center p-6">
+<span class="text-3xl font-semibold">5</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            </div>
+</div>
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation -top-12 start-1/2 -translate-x-1/2 rtl:translate-x-1/2 rotate-90" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev" disabled><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">Previous slide</span>
+</button>
+
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation -bottom-12 start-1/2 -translate-x-1/2 rtl:translate-x-1/2 rotate-90" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">Next slide</span>
+</button>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 5__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 5__1.html
@@ -1,0 +1,82 @@
+<!--
+- Kit: Shadcn UI
+- Component: Carousel
+- Code:
+```twig
+<twig:Carousel align="start" loop class="mx-auto w-full max-w-[12rem] sm:max-w-xs">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item>
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-4xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="horizontal" data-carousel-orientation-value="horizontal" data-carousel-align-value="start" data-carousel-loop-value="true" data-carousel-autoplay-value="0" class="relative mx-auto w-full max-w-[12rem] sm:max-w-xs" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-y">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out -ms-4">            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">1</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">2</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">3</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">4</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">5</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            </div>
+</div>
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -start-12 my-auto" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">Previous slide</span>
+</button>
+
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -end-12 my-auto" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">Next slide</span>
+</button>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 6__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 6__1.html
@@ -1,0 +1,76 @@
+<!--
+- Kit: Shadcn UI
+- Component: Carousel
+- Code:
+```twig
+<div class="mx-auto w-full max-w-[10rem] sm:max-w-xs" data-controller="carousel-display" data-action="carousel:select->carousel-display#update">
+    <twig:Carousel>
+        <twig:Carousel:Content>
+            {% for i in 1..5 %}
+                <twig:Carousel:Item>
+                    <twig:Card class="m-px">
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-4xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </twig:Carousel:Item>
+            {% endfor %}
+        </twig:Carousel:Content>
+        <twig:Carousel:Previous />
+        <twig:Carousel:Next />
+    </twig:Carousel>
+    <div class="py-2 text-center text-sm text-muted-foreground" data-carousel-display-target="output">Slide 1 of 5</div>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="mx-auto w-full max-w-[10rem] sm:max-w-xs" data-controller="carousel-display" data-action="carousel:select-&gt;carousel-display#update">
+    <div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="horizontal" data-carousel-orientation-value="horizontal" data-carousel-align-value="center" data-carousel-loop-value="false" data-carousel-autoplay-value="0" class="relative" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-y">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out -ms-4">                <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl m-px">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">1</span>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl m-px">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">2</span>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl m-px">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">3</span>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl m-px">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">4</span>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl m-px">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">5</span>
+                        </div>
+                    </div>
+                </div>
+                    </div>
+</div>
+        <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -start-12 my-auto" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev" disabled><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">Previous slide</span>
+</button>
+
+        <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -end-12 my-auto" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">Next slide</span>
+</button>
+
+    </div>
+    <div class="py-2 text-center text-sm text-muted-foreground" data-carousel-display-target="output">Slide 1 of 5</div>
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 7__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 7__1.html
@@ -1,0 +1,82 @@
+<!--
+- Kit: Shadcn UI
+- Component: Carousel
+- Code:
+```twig
+<twig:Carousel autoplay="2000" class="mx-auto w-full max-w-[10rem] sm:max-w-xs">
+    <twig:Carousel:Content>
+        {% for i in 1..5 %}
+            <twig:Carousel:Item>
+                <div class="p-1">
+                    <twig:Card>
+                        <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                            <span class="text-4xl font-semibold">{{ i }}</span>
+                        </twig:Card:Content>
+                    </twig:Card>
+                </div>
+            </twig:Carousel:Item>
+        {% endfor %}
+    </twig:Carousel:Content>
+    <twig:Carousel:Previous />
+    <twig:Carousel:Next />
+</twig:Carousel>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="horizontal" data-carousel-orientation-value="horizontal" data-carousel-align-value="center" data-carousel-loop-value="false" data-carousel-autoplay-value="2000" class="relative mx-auto w-full max-w-[10rem] sm:max-w-xs" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-y">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out -ms-4">            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">1</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">2</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">3</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">4</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                    <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                    <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">5</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            </div>
+</div>
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -start-12 my-auto" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev" disabled><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">Previous slide</span>
+</button>
+
+    <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -end-12 my-auto" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">Next slide</span>
+</button>
+
+</div>

--- a/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 8__1.html
+++ b/src/Toolkit/tests/Functional/__snapshots__/ComponentsRenderingTest__testComponentRendering with data set Kit shadcn, component carousel, example 8__1.html
@@ -1,0 +1,166 @@
+<!--
+- Kit: Shadcn UI
+- Component: Carousel
+- Code:
+```twig
+{% set arabicNumerals = ['١', '٢', '٣', '٤', '٥'] %}
+<div class="flex flex-col items-center gap-12">
+    {# Arabic #}
+    <twig:Carousel dir="rtl" class="w-full max-w-[12rem] sm:max-w-xs">
+        <twig:Carousel:Content>
+            {% for i in 1..5 %}
+                <twig:Carousel:Item>
+                    <div class="p-1">
+                        <twig:Card>
+                            <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                                <span class="text-4xl font-semibold">{{ arabicNumerals[i - 1] }}</span>
+                            </twig:Card:Content>
+                        </twig:Card>
+                    </div>
+                </twig:Carousel:Item>
+            {% endfor %}
+        </twig:Carousel:Content>
+        <twig:Carousel:Previous text="الشريحة السابقة" />
+        <twig:Carousel:Next text="الشريحة التالية" />
+    </twig:Carousel>
+
+    {# Hebrew #}
+    <twig:Carousel dir="rtl" class="w-full max-w-[12rem] sm:max-w-xs">
+        <twig:Carousel:Content>
+            {% for i in 1..5 %}
+                <twig:Carousel:Item>
+                    <div class="p-1">
+                        <twig:Card>
+                            <twig:Card:Content class="flex aspect-square items-center justify-center p-6">
+                                <span class="text-4xl font-semibold">{{ i }}</span>
+                            </twig:Card:Content>
+                        </twig:Card>
+                    </div>
+                </twig:Carousel:Item>
+            {% endfor %}
+        </twig:Carousel:Content>
+        <twig:Carousel:Previous text="השקופית הקודמת" />
+        <twig:Carousel:Next text="השקופית הבאה" />
+    </twig:Carousel>
+</div>
+```
+- Rendered code (prettified for testing purposes, run "php vendor/bin/phpunit -d --update-snapshots" to update snapshots): -->
+<div class="flex flex-col items-center gap-12">
+        <div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="horizontal" data-carousel-orientation-value="horizontal" data-carousel-align-value="center" data-carousel-loop-value="false" data-carousel-autoplay-value="0" class="relative w-full max-w-[12rem] sm:max-w-xs" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown" dir="rtl">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-y">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out -ms-4">                <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">١</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">٢</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">٣</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">٤</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">٥</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                    </div>
+</div>
+        <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -start-12 my-auto" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev" disabled><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">الشريحة السابقة</span>
+</button>
+
+        <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -end-12 my-auto" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">الشريحة التالية</span>
+</button>
+
+    </div>
+
+        <div role="region" aria-roledescription="carousel" aria-label="Carousel" data-slot="carousel" data-orientation="horizontal" data-carousel-orientation-value="horizontal" data-carousel-align-value="center" data-carousel-loop-value="false" data-carousel-autoplay-value="0" class="relative w-full max-w-[12rem] sm:max-w-xs" data-controller="carousel" data-action="keydown-&gt;carousel#handleKeydown" dir="rtl">
+<div data-slot="carousel-content" data-carousel-target="viewport" data-action="pointerdown-&gt;carousel#dragStart" class="overflow-hidden touch-pan-y">
+    <div data-carousel-target="track" class="flex transition-transform duration-500 ease-out -ms-4">                <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">1</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">2</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">3</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">4</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                            <div role="group" aria-roledescription="slide" data-slot="carousel-item" data-carousel-target="item" class="min-w-0 shrink-0 grow-0 basis-full ps-4">
+<div class="p-1">
+                        <div data-slot="card" data-size="default" class="group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl">
+<div data-slot="card-content" class="group-data-[size=sm]/card:px-3 flex aspect-square items-center justify-center p-6">
+<span class="text-4xl font-semibold">5</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                    </div>
+</div>
+        <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -start-12 my-auto" type="button" data-carousel-target="previous" data-action="click-&gt;carousel#scrollPrev" disabled><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"></path></svg>
+    <span class="sr-only">השקופית הקודמת</span>
+</button>
+
+        <button data-slot="button" data-size="icon-sm" data-variant="outline" class="group/button inline-flex shrink-0 items-center justify-center border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*='size-'])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg absolute touch-manipulation inset-y-0 -end-12 my-auto" type="button" data-carousel-target="next" data-action="click-&gt;carousel#scrollNext"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 24 24" fill="currentColor" class="rtl:rotate-180" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"></path></svg>
+    <span class="sr-only">השקופית הבאה</span>
+</button>
+
+    </div>
+</div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Documentation? | yes
| Issues         | Part of #3233
| License        | MIT

Adds the `carousel` recipe to the Shadcn kit.

```twig
<twig:Carousel orientation="horizontal | vertical" align="start | center | end" loop>
    <twig:Carousel:Content>
        <twig:Carousel:Item>...</twig:Carousel:Item>
        <twig:Carousel:Item>...</twig:Carousel:Item>
        <twig:Carousel:Item>...</twig:Carousel:Item>
    </twig:Carousel:Content>
    <twig:Carousel:Previous />
    <twig:Carousel:Next />
</twig:Carousel>
```

### Embla

Upstream shadcn builds `Carousel` on [Embla Carousel](https://www.embla-carousel.com/), an npm dependency. No Toolkit recipe ships one — every controller in the kit imports only `@hotwired/stimulus` — so the behaviour is reimplemented as a self-contained `carousel` controller: a flex track translated with a CSS transform, whose snap positions are **measured** from the rendered slides rather than configured, so any `basis-*` utility on a `Carousel:Item` works with no extra wiring, and they are re-measured on resize.

Consequences for the public API:

- Embla's `opts` become props on `Carousel`: `align` and `loop`.
- Embla's Autoplay **plugin** becomes an `autoplay` prop (delay in ms). The upstream "Plugins" section is therefore documented as **Autoplay**.
- Embla's `setApi` becomes a `carousel:select` event carrying `{ index, count }`. The recipe ships a small `carousel-display` controller that renders the current position from it, mirroring what `slider` does with `slider-display`.

### Notes

- Positions are expressed along the logical axis, so the same math drives horizontal, vertical and RTL carousels; only the sign of the applied transform changes. Directional classes are logical (`-ms-4`, `ps-4`, `-start-12`, `-end-12`), which also keeps the "Spacing" example overridable in both directions.
- `Carousel:Previous` renders `disabled` when the carousel does not loop, so the first slide has no enabled → disabled flash on load; the controller then syncs both buttons on every change.
- Arrow keys follow the carousel axis **and** the text direction (in RTL, <kbd>←</kbd> advances).
- A click that terminates a drag is swallowed, so dragging over a link or a button inside a slide does not activate it.

### Testing

Snapshots regenerated; `bin/ux-toolkit-kit-lint --fail-on-warning kits/shadcn`, `twig-cs-fixer`, `oxfmt` and `oxlint` are clean.

Behaviour driven in headless Chromium against a real Tailwind v4 build of the rendered examples, with no console errors:

| | Result |
|---|---|
| LTR / vertical / RTL stepping | correct transforms and snap counts per orientation |
| prev/next disabled sync | disabled at both ends, both enabled in between |
| arrow keys | follow the axis and the text direction |
| pointer drag | works on all three axes, with rubber-band and momentum snap |
| click after drag | swallowed |
| resize | re-measures and stays on the same slide |
| loop + autoplay | wraps, pauses on hover/focus, resets after interaction |
| disconnect/reconnect | no leaked timers or listeners |

[symfony-ux-toolkit-shadcn-carousel.webm](https://github.com/user-attachments/assets/074152a0-ac3c-422b-bf20-7c47060e95ff)
