### PR TITLE
[LiveComponent] Update doc about deprecation with property-info

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -559,13 +559,6 @@ library. Make sure it is installed in you application:
 
     $ composer require phpdocumentor/reflection-docblock
 
-To get rid of deprecations about ``PropertyInfoExtractor::getTypes()`` from the `Symfony PropertyInfo`_ component,
-ensure to upgrade ``symfony/property-info`` to at least 7.1, which requires **PHP 8.2**::
-
-.. code-block:: terminal
-
-    $ composer require symfony/property-info:^7.1
-
 Writable Object Properties or Array Keys
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         | 
| License        | MIT

According to composer requirements for LiveComponent 3.x, it's no longer possible to have `property-info <7.1`
I think this note in doc in no longer needed too 