### PR TITLE
[LiveComponent] Remove the orphan `Symfony PropertyInfo` link definition

### DIFF
--- a/src/LiveComponent/doc/index.rst
+++ b/src/LiveComponent/doc/index.rst
@@ -4274,6 +4274,5 @@ promise. However, any internal implementation in the JavaScript files
 .. _`setting the locale in the request`: https://symfony.com/doc/current/translation.html#translation-locale
 .. _`Stimulus action parameter`: https://stimulus.hotwired.dev/reference/actions#action-parameters
 .. _`@symfony/ux-live-component npm package`: https://www.npmjs.com/package/@symfony/ux-live-component
-.. _`Symfony PropertyInfo`: https://symfony.com/doc/current/components/property_info.html
 .. _`credentials option of the fetch() API`: https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials
 .. _`Symfony MakerBundle`: https://github.com/symfony/maker-bundle


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Documentation? | yes
| Issues         |
| License        | MIT

Commit 95a59e11ceb removed the paragraph in `src/LiveComponent/doc/index.rst` linking to `Symfony PropertyInfo`_ but left its link definition behind, which now makes DOCtor-RST fail on 3.x with "The following link definitions aren't used anymore and should be removed". This PR removes the orphan link definition.
